### PR TITLE
Fix object detection user guide example typo

### DIFF
--- a/userguide/object_detection/introduction.md
+++ b/userguide/object_detection/introduction.md
@@ -22,7 +22,7 @@ data =  tc.SFrame('cats-dogs.sframe')
 train_data, test_data = data.random_split(0.8)
 
 # Create a model
-model = tc.object_detector.create(train_data, target='label')
+model = tc.object_detector.create(train_data)
 
 # Save predictions to an SArray
 predictions = model.predict(test_data)


### PR DESCRIPTION
The object detector does not take `target` (it takes `annotations`). In this example, instead show that you can omit these altogether in the typical case.