### PR TITLE
Updated macOS supported versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Supported Platforms
 
 Turi Create supports:
 
-* macOS 10.11+
+* macOS 10.12+
 * Linux (with glibc 2.12+)
 * Windows 10 (via WSL)
 


### PR DESCRIPTION
As long as `coremltools==0.6.3` is a hard dependency, we do not support macOS 10.11. This PR updates the README.

I opened up an issue to track macOS 10.11 support: #23