### PR TITLE
Cleanup

### DIFF
--- a/scenario-tests/tests/driver_test/driver_test.py
+++ b/scenario-tests/tests/driver_test/driver_test.py
@@ -9,4 +9,4 @@ class DriverTest(unittest.TestCase):
         raise unittest.SkipTest("expected skip")
 
     def test_driver_passthrough(self):
-        self.assertTrue(os.environ.get("TEST_ENVIRON_SET") == None)
+        self.assertTrue(os.environ.get("TEST_ENVIRON_SET") is None)

--- a/src/gl_numpy/numpy.py
+++ b/src/gl_numpy/numpy.py
@@ -60,7 +60,7 @@ def _sframe_to_nparray(sf):
     # only sframes have save_reference
     sf._save_reference(temp_dir)
     unity_dll = _get_unity_dll()
-    if unity_dll == None:
+    if unity_dll is None:
         raise RuntimeError("fast Converter not loaded")
     if all(d in [int] for d in sf.dtype()):
         ptr = unity_dll.pointer_from_sframe(temp_dir.encode(), True)
@@ -241,7 +241,7 @@ def _fast_numpy_to_sarray(arr):
     """
 
     unity_dll = _get_unity_dll()
-    if unity_dll == None:
+    if unity_dll is None:
         raise RuntimeError("Fast Conversion cannot be performed")
 
     import numpy as np

--- a/src/gl_numpy/numpy_loader.py
+++ b/src/gl_numpy/numpy_loader.py
@@ -14,7 +14,7 @@ def _get_unity_dll():
     if sys.platform == 'win32':
         _load_attempted = True
         return None
-    if _unity_dll == None and _load_attempted == False:
+    if _unity_dll is None and not _load_attempted:
         import ctypes
         import os
         import sys
@@ -31,7 +31,7 @@ def _get_unity_dll():
                 good_file = sopath
                 break
 
-        if good_file == None:
+        if good_file is None:
             return
 
         _unity_dll=ctypes.CDLL(good_file, mode=ctypes.RTLD_GLOBAL)
@@ -148,7 +148,7 @@ def numpy_activation_successful():
 
     np.arange(100)
     unity_dll = _get_unity_dll()
-    if unity_dll == None:
+    if unity_dll is None:
         return False
     try:
         return unity_dll.malloc_injection_successful()

--- a/src/unity/python/turicreate/_minipsutil.py
+++ b/src/unity/python/turicreate/_minipsutil.py
@@ -41,14 +41,14 @@ def cpu_count():
 
 def pid_is_running(i):
     global _lib
-    if _lib == None:
+    if _lib is None:
         return True
     else:
         return _lib.pid_is_running(_ctypes.c_int32(i)) == 1
 
 def kill_process(i):
     global _lib
-    if _lib == None:
+    if _lib is None:
         return True
     else:
         return _lib.kill_process(_ctypes.c_int32(i)) == 1

--- a/src/unity/python/turicreate/aggregate.py
+++ b/src/unity/python/turicreate/aggregate.py
@@ -217,7 +217,7 @@ def CONCAT(src_column, dict_value_column = None):
   "count" into a dictionary with keys being words and values being
   counts.
   """
-  if dict_value_column == None:
+  if dict_value_column is None:
     return ("__builtin__concat__list__", [src_column])
   else:
     return ("__builtin__concat__dict__", [src_column, dict_value_column])

--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -323,7 +323,6 @@ cdef dict _code_by_name_lookup = {
     'uint64'   : FT_INT_TYPE     + FT_SAFE,
     'uint128'  : FT_INT_TYPE     + FT_SAFE,
     'short'    : FT_INT_TYPE     + FT_SAFE,
-    'bool_'    : FT_INT_TYPE     + FT_SAFE,
     'float'    : FT_FLOAT_TYPE   + FT_SAFE,
     'double'   : FT_FLOAT_TYPE   + FT_SAFE,
     'float16'  : FT_FLOAT_TYPE   + FT_SAFE,

--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1251,7 +1251,7 @@ cdef inline tr_datetime_to_ft(flexible_type& ret, v):
     # before the introduction of the Gregorian calendar
     if(v.year < 1400 or v.year > 10000):
         raise TypeError('Year is out of valid range: 1400..10000')
-    if(v.tzinfo != None):
+    if(v.tzinfo is not None):
         offset = int(v.tzinfo.utcoffset(v).total_seconds() / TIMEZONE_RESOLUTION_IN_SECONDS) #store timezone offset at the granularity of half an hour.
         ret.set_date_time((<long long>(calendar.timegm(v.utctimetuple())),offset), v.microsecond)
     else:

--- a/src/unity/python/turicreate/data_structures/gframe.py
+++ b/src/unity/python/turicreate/data_structures/gframe.py
@@ -87,7 +87,7 @@ class GFrame(SFrame):
         if not isinstance(column_name, str):
             raise TypeError("Invalid column name: must be str")
 
-        if inplace == True:
+        if inplace:
             self.__is_dirty__ = True
             with cython_context():
                 if self._is_vertex_frame():
@@ -146,7 +146,7 @@ class GFrame(SFrame):
             if not all([isinstance(x, str) for x in column_names]):
                 raise TypeError("Invalid column name in list : must all be str")
 
-        if inplace == True:
+        if inplace:
             for (data, name) in zip(datalist, column_names):
                 self.add_column(data, name)
             return self
@@ -174,7 +174,7 @@ class GFrame(SFrame):
         """
         if column_name not in self.column_names():
             raise KeyError('Cannot find column %s' % column_name)
-        if inplace == True:
+        if inplace:
             self.__is_dirty__ = True
             try:
                 with cython_context():
@@ -229,7 +229,7 @@ class GFrame(SFrame):
         inplace : bool, optional. Defaults to False.
             Whether the SFrame is modified in place.
         """
-        if inplace == True:
+        if inplace:
             self.__is_dirty__ = True
             with cython_context():
                 if self._is_vertex_frame():
@@ -265,7 +265,7 @@ class GFrame(SFrame):
         if (type(names) is not dict):
             raise TypeError('names must be a dictionary: oldname -> newname')
 
-        if inplace == True:
+        if inplace:
             self.__is_dirty__ = True
             with cython_context():
                 if self._is_vertex_frame():
@@ -287,7 +287,7 @@ class GFrame(SFrame):
 
         if type(start) is not int:
             raise TypeError("Must give start as int")
-        if inplace == True:
+        if inplace:
             the_col = _create_sequential_sarray(self.num_rows(), start)
 
             self[column_name] = the_col

--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -690,7 +690,7 @@ class SArray(object):
         """
         from .sframe import SFrame as _SFrame
 
-        if format == None:
+        if format is None:
             if filename.endswith(('.csv', '.csv.gz', 'txt')):
                 format = 'text'
             else:
@@ -1405,7 +1405,7 @@ class SArray(object):
         """
         if (self.dtype != array.array) and (self.dtype != list):
             raise RuntimeError("Only Vector type can be sliced")
-        if end == None:
+        if end is None:
             end = start + 1
 
         with cython_context():
@@ -1855,7 +1855,7 @@ class SArray(object):
         assert callable(fn), "Input function must be callable."
 
         dryrun = [fn(i) for i in self.head(100) if i is not None]
-        if dtype == None:
+        if dtype is None:
             dtype = infer_type_of_list(dryrun)
         if seed is None:
             seed = abs(hash("%0.20f" % time.time())) % (2 ** 31)
@@ -2711,7 +2711,7 @@ class SArray(object):
             raise TypeError("summary() is not supported for arrays of image type")
         if (type(background) != bool):
             raise TypeError("'background' parameter has to be a boolean value")
-        if (sub_sketch_keys != None):
+        if (sub_sketch_keys is not None):
             if (self.dtype != dict and self.dtype != array.array):
                 raise TypeError("sub_sketch_keys is only supported for SArray of dictionary or array type")
             if not _is_non_string_iterable(sub_sketch_keys):
@@ -3042,13 +3042,13 @@ class SArray(object):
         if self.dtype != datetime.datetime:
             raise TypeError("Only column of datetime type is supported.")
 
-        if column_name_prefix == None:
+        if column_name_prefix is None:
             column_name_prefix = ""
         if type(column_name_prefix) != str:
             raise TypeError("'column_name_prefix' must be a string")
 
         # convert limit to column_keys
-        if limit != None:
+        if limit is not None:
             if not _is_non_string_iterable(limit):
                 raise TypeError("'limit' must be a list");
 
@@ -3064,7 +3064,7 @@ class SArray(object):
 
         column_types = []
 
-        if(limit == None):
+        if(limit is None):
             limit = ['year','month','day','hour','minute','second']
 
         column_types = [int] * len(limit)
@@ -3208,13 +3208,13 @@ class SArray(object):
         if self.dtype not in [dict, array.array, list]:
             raise TypeError("Only SArray of dict/list/array type supports unpack")
 
-        if column_name_prefix == None:
+        if column_name_prefix is None:
             column_name_prefix = ""
         if type(column_name_prefix) != str:
             raise TypeError("'column_name_prefix' must be a string")
 
         # validdate 'limit'
-        if limit != None:
+        if limit is not None:
             if (not _is_non_string_iterable(limit)):
                 raise TypeError("'limit' must be a list");
 
@@ -3229,7 +3229,7 @@ class SArray(object):
             if len(set(limit)) != len(limit):
                 raise ValueError("'limit' contains duplicate values")
 
-        if (column_types != None):
+        if (column_types is not None):
             if not _is_non_string_iterable(column_types):
                 raise TypeError("column_types must be a list");
 
@@ -3237,7 +3237,7 @@ class SArray(object):
                 if (column_type not in (int, float, str, list, dict, array.array)):
                     raise TypeError("column_types contains unsupported types. Supported types are ['float', 'int', 'list', 'dict', 'str', 'array.array']")
 
-            if limit != None:
+            if limit is not None:
                 if len(limit) != len(column_types):
                     raise ValueError("limit and column_types do not have the same length")
             elif self.dtype == dict:
@@ -3254,7 +3254,7 @@ class SArray(object):
             # infer column types for dict type at server side, for list and array, infer from client side
             if self.dtype != dict:
                 length = max(lengths)
-                if limit == None:
+                if limit is None:
                     limit = range(length)
                 else:
                     # adjust the length
@@ -3270,8 +3270,8 @@ class SArray(object):
 
 
         with cython_context():
-            if (self.dtype == dict and column_types == None):
-                limit = limit if limit != None else []
+            if (self.dtype == dict and column_types is None):
+                limit = limit if limit is not None else []
                 return _SFrame(_proxy=self.__proxy__.unpack_dict(column_name_prefix.encode(), limit, na_value))
             else:
                 return _SFrame(_proxy=self.__proxy__.unpack(column_name_prefix.encode(), limit, column_types, na_value))

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -990,7 +990,7 @@ class SFrame(object):
                                  verbose=verbose)
                 column_type_hints = SFrame._infer_column_types_from_lines(first_rows)
                 typelist = '[' + ','.join(t.__name__ for t in column_type_hints) + ']'
-                if verbose != False:
+                if verbose:
                     print("------------------------------------------------------")
                     print("Inferred types from first %d line(s) of file as " % nrows_to_infer)
                     print("column_type_hints="+ typelist)
@@ -1004,7 +1004,7 @@ class SFrame(object):
                     raise e
                 # If the above fails, default back to str for all columns.
                 column_type_hints = str
-                if verbose != False:
+                if verbose:
                     print('Could not detect types. Using str for each column.')
 
         if type(column_type_hints) is type:
@@ -1040,7 +1040,7 @@ class SFrame(object):
                 if type(e) == RuntimeError and ("cancel" in e.message or "Cancel" in e.message):
                     raise e
                 # If the above fails, default back to str for unmatched columns
-                if verbose != False:
+                if verbose:
                     print('Could not detect types. Using str for all unspecified columns.')
             type_hints = column_type_hints
         else:
@@ -1064,7 +1064,7 @@ class SFrame(object):
                 raise e
             if column_type_inference_was_used:
                 # try again
-                if verbose != False:
+                if verbose:
                     print("Unable to parse the file with automatic type inference.")
                     print("Defaulting to column_type_hints=str")
                 type_hints = {'__all_columns__': str}

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -962,7 +962,7 @@ class SFrame(object):
         if na_values is not None and len(na_values) > 0:
             parsing_config["na_values"] = na_values
 
-        if nrows != None:
+        if nrows is not None:
           parsing_config["row_limit"] = nrows
 
         proxy = UnitySFrameProxy()
@@ -2769,7 +2769,7 @@ class SFrame(object):
         >>> sf.save('data/training_data.csv', format='csv')
         """
 
-        if format == None:
+        if format is None:
             if filename.endswith(('.csv', '.csv.gz')):
                 format = 'csv'
             else:
@@ -4393,7 +4393,7 @@ class SFrame(object):
                 tmp = SFrame(_proxy=self.__proxy__.join(value_sf.__proxy__,
                                                      'left',
                                                      {column_name:column_name}))
-                ret_sf = tmp[tmp[id_name] == None]
+                ret_sf = tmp[tmp[id_name] is None]
                 del ret_sf[id_name]
                 return ret_sf
             else:
@@ -4623,19 +4623,19 @@ class SFrame(object):
         [4 rows x 2 columns]
         """
 
-        if column_names != None and column_name_prefix != None:
+        if column_names is not None and column_name_prefix is not None:
             raise ValueError("'column_names' and 'column_name_prefix' parameter cannot be given at the same time.")
 
-        if new_column_name == None and column_name_prefix != None:
+        if new_column_name is None and column_name_prefix is not None:
             new_column_name = column_name_prefix
 
-        if column_name_prefix != None:
+        if column_name_prefix is not None:
             if type(column_name_prefix) != str:
                 raise TypeError("'column_name_prefix' must be a string")
             column_names = [name for name in self.column_names() if name.startswith(column_name_prefix)]
             if len(column_names) == 0:
                 raise ValueError("There is no column starts with prefix '" + column_name_prefix + "'")
-        elif column_names == None:
+        elif column_names is None:
             column_names = self.column_names()
         else:
             if not _is_non_string_iterable(column_names):
@@ -4655,7 +4655,7 @@ class SFrame(object):
 
         # fill_na value for array needs to be numeric
         if dtype == array.array:
-            if (fill_na != None) and (type(fill_na) not in (int, float)):
+            if (fill_na is not None) and (type(fill_na) not in (int, float)):
                 raise ValueError("fill_na value for array needs to be numeric type")
             # all column_names have to be numeric type
             for column in column_names:
@@ -4666,7 +4666,7 @@ class SFrame(object):
         # we try to be smart here
         # if all column names are like: a.b, a.c, a.d,...
         # we then use "b", "c", "d", etc as the dictionary key during packing
-        if (dtype == dict) and (column_name_prefix != None) and (remove_prefix == True):
+        if (dtype == dict) and (column_name_prefix is not None) and (remove_prefix == True):
             size_prefix = len(column_name_prefix)
             first_char = set([c[size_prefix:size_prefix+1] for c in column_names])
             if ((len(first_char) == 1) and first_char.pop() in ['.','-','_']):
@@ -4678,7 +4678,7 @@ class SFrame(object):
             dict_keys = column_names
 
         rest_columns = [name for name in self.column_names() if name not in column_names]
-        if new_column_name != None:
+        if new_column_name is not None:
             if type(new_column_name) != str:
                 raise TypeError("'new_column_name' has to be a string")
             if new_column_name in rest_columns:
@@ -4765,7 +4765,7 @@ class SFrame(object):
         if column_name not in self.column_names():
             raise KeyError("column '" + column_name + "' does not exist in current SFrame")
 
-        if column_name_prefix == None:
+        if column_name_prefix is None:
             column_name_prefix = column_name
 
         new_sf = self[column_name].split_datetime(column_name_prefix, limit, timezone)
@@ -4905,7 +4905,7 @@ class SFrame(object):
         if column_name not in self.column_names():
             raise KeyError("column '" + column_name + "' does not exist in current SFrame")
 
-        if column_name_prefix == None:
+        if column_name_prefix is None:
             column_name_prefix = column_name
 
         new_sf = self[column_name].unpack(column_name_prefix, column_types, na_value, limit)
@@ -5055,7 +5055,7 @@ class SFrame(object):
             raise TypeError("Stack is only supported for column of dict/list/array type.")
 
         # user defined types. do some checking
-        if new_column_type != None:
+        if new_column_type is not None:
             # if new_column_type is a single type, just make it a list of one type
             if type(new_column_type) is type:
                 new_column_type = [new_column_type]
@@ -5066,7 +5066,7 @@ class SFrame(object):
             if (stack_column_type in [dict]) and len(new_column_type) != 2:
                 raise ValueError("Expecting two column types to unpack a dict column")
 
-        if (new_column_name != None):
+        if (new_column_name is not None):
             if stack_column_type == dict:
                 if (type(new_column_name) is not list):
                     raise TypeError("new_column_name has to be a list to stack dict type")
@@ -5092,7 +5092,7 @@ class SFrame(object):
         if (len(head_row) == 0):
             raise ValueError("Cannot infer column type because there is not enough rows to infer value")
 
-        if new_column_type == None:
+        if new_column_type is None:
             # we have to perform type inference
             if stack_column_type == dict:
                 # infer key/value type
@@ -5100,7 +5100,7 @@ class SFrame(object):
                 for row in head_row:
                     for val in row:
                         keys.append(val)
-                        if val != None: values.append(row[val])
+                        if val is not None: values.append(row[val])
 
                 new_column_type = [
                     infer_type_of_list(keys),
@@ -5195,13 +5195,13 @@ class SFrame(object):
         with cython_context():
             if type(column_names) == str:
                 key_columns = [i for i in self.column_names() if i != column_names]
-                if new_column_name != None:
+                if new_column_name is not None:
                     return self.groupby(key_columns, {new_column_name : aggregate.CONCAT(column_names)})
                 else:
                     return self.groupby(key_columns, aggregate.CONCAT(column_names))
             elif len(column_names) == 2:
                 key_columns = [i for i in self.column_names() if i not in column_names]
-                if new_column_name != None:
+                if new_column_name is not None:
                     return self.groupby(key_columns, {new_column_name: aggregate.CONCAT(column_names[0], column_names[1])})
                 else:
                     return self.groupby(key_columns, aggregate.CONCAT(column_names[0], column_names[1]))

--- a/src/unity/python/turicreate/data_structures/sketch.py
+++ b/src/unity/python/turicreate/data_structures/sketch.py
@@ -715,7 +715,7 @@ class Sketch(object):
          +-----+-----+-----+-----+-----+-----+-----+-----+------+}
         """
         single_val = False
-        if keys == None:
+        if keys is None:
             keys = []
         else:
             if not isinstance(keys, list):

--- a/src/unity/python/turicreate/extensions.py
+++ b/src/unity/python/turicreate/extensions.py
@@ -152,7 +152,7 @@ def _run_toolkit_function(fnname, arguments, args, kwargs):
     with cython_context():
         ret = _get_unity().run_toolkit(fnname, argument_dict)
     # handle errors
-    if ret[0] != True:
+    if not ret[0]:
         if len(ret[1]) > 0:
             raise _ToolkitError(ret[1])
         else:

--- a/src/unity/python/turicreate/extensions.py
+++ b/src/unity/python/turicreate/extensions.py
@@ -492,7 +492,7 @@ def _add_meta_path():
     """
     import sys
     global _ext_meta_path_singleton
-    if _ext_meta_path_singleton == None:
+    if _ext_meta_path_singleton is None:
         _ext_meta_path_singleton = _ExtMetaPath()
         sys.meta_path += [_ext_meta_path_singleton]
 

--- a/src/unity/python/turicreate/meta/decompiler/simple_instructions.py
+++ b/src/unity/python/turicreate/meta/decompiler/simple_instructions.py
@@ -637,7 +637,7 @@ class SimpleInstructions(object):
         else:
             print_ = None
 
-        if isinstance(print_, _ast_Print) and not print_.nl and print_.dest == None:
+        if isinstance(print_, _ast_Print) and not print_.nl and print_.dest is None:
             print_.values.append(item)
         else:
             print_ = _ast_Print(dest=None, values=[item], nl=False, lineno=instr.lineno, col_offset=0)
@@ -646,7 +646,7 @@ class SimpleInstructions(object):
     def PRINT_NEWLINE(self, instr):
         item = self.ast_stack[-1]
 
-        if isinstance(item, _ast_Print) and not item.nl and item.dest == None:
+        if isinstance(item, _ast_Print) and not item.nl and item.dest is None:
             item.nl = True
         else:
             print_ = _ast_Print(dest=None, values=[], nl=True, lineno=instr.lineno, col_offset=0)

--- a/src/unity/python/turicreate/mx/_mx_sframe_iter.py
+++ b/src/unity/python/turicreate/mx/_mx_sframe_iter.py
@@ -227,14 +227,14 @@ class SFrameIter(DataIter):
             return False
 
     def getdata(self):
-        if self.data_mx_ndarray == None:
+        if self.data_mx_ndarray is None:
             self.data_mx_ndarray = array(self.data_ndarray)
         return [self.data_mx_ndarray]
 
     def getlabel(self):
-        if self.label_field == None:
+        if self.label_field is None:
             return None
-        if self.label_mx_ndarray == None:
+        if self.label_mx_ndarray is None:
             self.label_mx_ndarray = array(self.label_ndarray)
         return [self.label_mx_ndarray]
 

--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -123,8 +123,6 @@ class ActivityClassifierTest(unittest.TestCase):
             'training_time': lambda x: x > 0,
             'target': lambda x: x == self.target,
             'verbose': lambda x: x == True,
-            'target': lambda x: x == self.target,
-            'features': lambda x: x == self.features,
             'session_id': lambda x: x == self.session_id,
             'prediction_window': lambda x: x == self.prediction_window,
             'training_accuracy': lambda x: x >= 0 and x <= 1 ,

--- a/src/unity/python/turicreate/test/test_boosted_trees.py
+++ b/src/unity/python/turicreate/test/test_boosted_trees.py
@@ -99,8 +99,8 @@ class BoostedTreesRegressionTest(unittest.TestCase):
                 'metric': lambda x: x == 'auto',
                 'early_stopping_rounds': lambda x: x is None,
                 'model_checkpoint_interval': lambda x: x == 5,
-                'model_checkpoint_path': lambda x: x == None,
-                'resume_from_checkpoint': lambda x: x == None,
+                'model_checkpoint_path': lambda x: x is None,
+                'resume_from_checkpoint': lambda x: x is None,
                 }
 
         self.metrics = ["rmse", "max_error"]
@@ -384,8 +384,8 @@ def binary_classification_integer_target(cls):
             'metric': lambda x: x == 'auto',
             'early_stopping_rounds': lambda x: x is None,
             'model_checkpoint_interval': lambda x: x == 5,
-            'model_checkpoint_path': lambda x: x == None,
-            'resume_from_checkpoint': lambda x: x == None,
+            'model_checkpoint_path': lambda x: x is None,
+            'resume_from_checkpoint': lambda x: x is None,
             }
     cls.fields_ans = cls.get_ans.keys()
 

--- a/src/unity/python/turicreate/test/test_knn_classifier.py
+++ b/src/unity/python/turicreate/test/test_knn_classifier.py
@@ -486,8 +486,8 @@ class KnnClassifierPredictTest(unittest.TestCase):
         ystar = self.model.classify(self.sf_test, max_neighbors=None,
                                     radius=1e-6, verbose=False)
 
-        self.assertTrue(all(ystar['class'] == None))
-        self.assertTrue(all(ystar['probability'] == None))
+        self.assertTrue(all(ystar['class'] is None))
+        self.assertTrue(all(ystar['probability'] is None))
 
         ## Check that the results are correct if *some*, but not *all* of the
         #  test points have no qualified neighbors in the training set.
@@ -585,8 +585,8 @@ class KnnClassifierPredictTest(unittest.TestCase):
         cf_mat = evals['confusion_matrix']
 
         self.assertTrue(acc == 0.)
-        self.assertTrue(all(cf_mat['target_label'] != None))
-        self.assertTrue(all(cf_mat['predicted_label'] == None))
+        self.assertTrue(all(cf_mat['target_label'] is not None))
+        self.assertTrue(all(cf_mat['predicted_label'] is None))
         self.assertItemsEqual(cf_mat.column_types(), [str, float, int])
         self.assertEqual(cf_mat['count'].sum(), self.sf_test.num_rows())
 

--- a/src/unity/python/turicreate/test/test_linear_regression.py
+++ b/src/unity/python/turicreate/test/test_linear_regression.py
@@ -291,7 +291,7 @@ class LinearRegressionCreateTest(unittest.TestCase):
       coefs = model.coefficients
       coef_list = list(coefs['value'])
       self.assertTrue(np.allclose(coef_list, self.coef, rtol=1e-01, atol=1e-01))
-      if test_stderr == True:
+      if test_stderr:
         stderr_list = list(coefs['stderr'])
         self.assertTrue(np.allclose(stderr_list, self.stderr, rtol=1e-03, atol=1e-03))
       else:

--- a/src/unity/python/turicreate/test/test_python_decision_tree.py
+++ b/src/unity/python/turicreate/test/test_python_decision_tree.py
@@ -244,7 +244,7 @@ class PythonDecisionTreeAllModelsTest(unittest.TestCase):
             tree = DecisionTree.from_model(m)
             for nid, node in tree.nodes.items():
                 val = tree.get_prediction_score(nid)
-                if node.is_leaf == True:
+                if node.is_leaf:
                     self.assertTrue(type(val) in {float, int})
                 else:
                     self.assertEquals(val, None)

--- a/src/unity/python/turicreate/test/test_python_decision_tree.py
+++ b/src/unity/python/turicreate/test/test_python_decision_tree.py
@@ -157,7 +157,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 7)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'dict2', 'split_feature_index': '1',
             'value': 2.05, 'node_type': 'float', 'missing_id': 1})
 
@@ -177,7 +177,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 9)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'num1', 'split_feature_index': None,
             'value': 4.5, 'node_type': 'float', 'missing_id': 1})
 
@@ -197,7 +197,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 9)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'num1', 'split_feature_index': None,
             'value': 4.5, 'node_type': 'float', 'missing_id': 1})
 
@@ -222,7 +222,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 7)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'dict[2]', 'split_feature_index': '1',
             'value': 2.05, 'node_type': 'float', 'missing_id': 1})
 

--- a/src/unity/python/turicreate/test/test_random_forest.py
+++ b/src/unity/python/turicreate/test/test_random_forest.py
@@ -94,8 +94,8 @@ class RandomForestRegressionTest(unittest.TestCase):
            'progress': lambda x: isinstance(x, tc.SFrame) or (x is None),
            'metric': lambda x: x == 'auto',
            'model_checkpoint_interval': lambda x: x == 5,
-           'model_checkpoint_path': lambda x: x == None,
-           'resume_from_checkpoint': lambda x: x == None,
+           'model_checkpoint_path': lambda x: x is None,
+           'resume_from_checkpoint': lambda x: x is None,
            }
         self.metrics = ["rmse", "max_error"]
         self.fields_ans = self.get_ans.keys()
@@ -404,8 +404,8 @@ def binary_classification_integer_target(cls):
             'progress': lambda x: isinstance(x, tc.SFrame) or (x is None),
             'metric': lambda x: x == 'auto',
             'model_checkpoint_interval': lambda x: x == 5,
-            'model_checkpoint_path': lambda x: x == None,
-            'resume_from_checkpoint': lambda x: x == None,
+            'model_checkpoint_path': lambda x: x is None,
+            'resume_from_checkpoint': lambda x: x is None,
             }
     cls.fields_ans = cls.get_ans.keys()
 

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -339,7 +339,7 @@ class SArrayTest(unittest.TestCase):
     def test_transform_dict(self):
         # lambda accesses dict
         sa_dict = SArray([{'a':1}, {1:2}, {'c': 'a'}, None], dict)
-        sa_bool_r = sa_dict.apply(lambda x: 'a' in x if x != None else None, skip_na=False)
+        sa_bool_r = sa_dict.apply(lambda x: 'a' in x if x is not None else None, skip_na=False)
         expected_output = [1, 0, 0, None]
         self.__test_equal(sa_bool_r, expected_output, int)
 
@@ -843,8 +843,8 @@ class SArrayTest(unittest.TestCase):
         self.__test_equal(s * 2, [array.array('d', [float(j) * 2 for j in i]) for i in self.vec_data], array.array)
         self.__test_equal(s / 2, [array.array('d', [float(j) / 2 for j in i]) for i in self.vec_data], array.array)
         s = SArray([1,2,3,4,None])
-        self.__test_equal(s == None, [0,0,0,0,1], int)
-        self.__test_equal(s != None, [1,1,1,1,0], int)
+        self.__test_equal(s is None, [0, 0, 0, 0, 1], int)
+        self.__test_equal(s is not None, [1, 1, 1, 1, 0], int)
 
     def test_modulus_operator(self):
         l = [-5,-4,-3,-2,-1,0,1,2,3,4,5]
@@ -1746,7 +1746,7 @@ class SArrayTest(unittest.TestCase):
         expected = [float(x.microsecond) / 1000000.0 if x is not None else x for x in self.datetime_data2]
         self.assertEqual(len(res), len(expected))
         for i in range(len(res)):
-            if res[i] == None:
+            if res[i] is None:
                 self.assertEqual(res[i], expected[i])
             else:
                 self.assertAlmostEqual(res[i], expected[i], places=6)

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -94,7 +94,7 @@ class SFrameTest(unittest.TestCase):
         for i in range(len(l1)):
             v1 = l1[i]
             v2 = l2[i]
-            if v1 == None:
+            if v1 is None:
                 self.assertEqual(v2, None)
             else:
                 if type(v1) == dict:
@@ -1376,17 +1376,17 @@ class SFrameTest(unittest.TestCase):
             self.assertEqual(len(c1), len(c2))
             if (column in list_columns):
                 for i in range(len(c1)):
-                    if (c1[i] == None):
-                        self.assertTrue(c2[i] == None)
+                    if (c1[i] is None):
+                        self.assertTrue(c2[i] is None)
                         continue
                     if (c1.dtype == dict):
                         for k in c1[i]:
                             self.assertEqual(c2[i][k], c1[i][k])
                     else:
                         s1 = list(c1[i]);
-                        if s1 != None: s1.sort()
+                        if s1 is not None: s1.sort()
                         s2 = list(c2[i]);
-                        if s2 != None: s2.sort()
+                        if s2 is not None: s2.sort()
                         self.assertEqual(s1, s2)
             else:
                 self.assertEqual(list(c1),list(c2))

--- a/src/unity/python/turicreate/test/util.py
+++ b/src/unity/python/turicreate/test/util.py
@@ -38,8 +38,8 @@ class SFrameComparer():
         for i in range(len(l1)):
             v1 = l1[i]
             v2 = l2[i]
-            if v1 == None:
-                assert v2 == None
+            if v1 is None:
+                assert v2 is None
             else:
                 if type(v1) == dict:
                     assert len(v1) == len(v2)
@@ -87,7 +87,7 @@ class TempDirectory():
     def __enter__(self):
         return self.name
     def __exit__(self, type, value, traceback):
-        if self.name != None:
+        if self.name is not None:
             shutil.rmtree(self.name)
 
 

--- a/src/unity/python/turicreate/toolkits/_decision_tree.py
+++ b/src/unity/python/turicreate/toolkits/_decision_tree.py
@@ -295,7 +295,7 @@ class DecisionTree:
 
         # Set the root_id.
         for nid, n in self.nodes.items():
-            if n.parent == None:
+            if n.parent is None:
                 self._root_id = n.node_id
                 break
 
@@ -364,10 +364,10 @@ class DecisionTree:
 
         node = self.nodes[root_id]
         output = node.to_dict()
-        if node.left_id != None:
+        if node.left_id is not None:
             j = node.left_id
             output['left'] = self.to_json(j, output)
-        if node.right_id != None:
+        if node.right_id is not None:
             j = node.right_id
             output['right'] = self.to_json(j, output)
         return output

--- a/src/unity/python/turicreate/toolkits/_feature_engineering/_ngram_counter.py
+++ b/src/unity/python/turicreate/toolkits/_feature_engineering/_ngram_counter.py
@@ -456,7 +456,7 @@ class NGramCounter(Transformer):
         _raise_error_if_not_of_type(delimiters, [list, _NoneType])
         _raise_error_if_not_of_type(output_column_prefix, [str, _NoneType])
 
-        if delimiters != None:
+        if delimiters is not None:
             for delim in delimiters:
                 _raise_error_if_not_of_type(delim, str, "delimiters")
                 if (len(delim) != 1):

--- a/src/unity/python/turicreate/toolkits/_feature_engineering/_tokenizer.py
+++ b/src/unity/python/turicreate/toolkits/_feature_engineering/_tokenizer.py
@@ -272,7 +272,7 @@ class Tokenizer(Transformer):
         _raise_error_if_not_of_type(delimiters, [list, _NoneType])
         _raise_error_if_not_of_type(output_column_prefix, [str, _NoneType])
 
-        if delimiters != None:
+        if delimiters is not None:
             for delim in delimiters:
                 _raise_error_if_not_of_type(delim, str, "delimiters")
                 if (len(delim) != 1):

--- a/src/unity/python/turicreate/toolkits/_feature_engineering/_transformer_chain.py
+++ b/src/unity/python/turicreate/toolkits/_feature_engineering/_transformer_chain.py
@@ -139,7 +139,7 @@ class TransformerChain(_TransformerBase):
         if 'features' in fields:
             fields.remove('features')
             features = obj.get("features")
-            if features != None:
+            if features is not None:
                 post_repr_string = ' on %s feature(s)' % len(features)
         if 'excluded_features' in fields:
             fields.remove('excluded_features')

--- a/src/unity/python/turicreate/toolkits/_feature_engineering/_word_counter.py
+++ b/src/unity/python/turicreate/toolkits/_feature_engineering/_word_counter.py
@@ -325,7 +325,7 @@ class WordCounter(Transformer):
         _raise_error_if_not_of_type(delimiters, [list, _NoneType])
         _raise_error_if_not_of_type(output_column_prefix, [str, _NoneType])
 
-        if delimiters != None:
+        if delimiters is not None:
             for delim in delimiters:
                 _raise_error_if_not_of_type(delim, str, "delimiters")
                 if (len(delim) != 1):

--- a/src/unity/python/turicreate/toolkits/_feature_engineering/_word_trimmer.py
+++ b/src/unity/python/turicreate/toolkits/_feature_engineering/_word_trimmer.py
@@ -314,7 +314,7 @@ output_column_prefix = None):
         _raise_error_if_not_of_type(to_lower, [bool])
         _raise_error_if_not_of_type(delimiters, [list, type(None)])
 
-        if delimiters != None:
+        if delimiters is not None:
             for delim in delimiters:
                 _raise_error_if_not_of_type(delim, str, "delimiters")
                 if (len(delim) != 1):

--- a/src/unity/python/turicreate/toolkits/_internal_utils.py
+++ b/src/unity/python/turicreate/toolkits/_internal_utils.py
@@ -152,7 +152,7 @@ def _summarize_coefficients(top_coefs, bottom_coefs):
     """
 
     def get_row_name(row):
-        if row['index'] == None:
+        if row['index'] is None:
             return row['name']
         else:
             return "%s[%s]" % (row['name'], row['index'])

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -420,7 +420,6 @@ class ActivityClassifier(_CustomModel):
                 'session_id': self.session_id,
                 'target': self.target,
                 'features': ','.join(self.features),
-                'prediction_window': str(self.prediction_window),
                 'max_iterations': str(self.max_iterations),
             }, version=ActivityClassifier._PYTHON_ACTIVITY_CLASSIFIER_VERSION)
         spec = mlmodel.get_spec()

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -474,9 +474,9 @@ class ImageClassifier(_CustomModel):
         del bias.floatValue[:]
 
         import numpy as np
-        W = np.array(coefs[coefs['index'] != None]['value'], ndmin = 2).reshape(
+        W = np.array(coefs[coefs['index'] is not None]['value'], ndmin = 2).reshape(
                                           inputChannels, num_classes - 1, order = 'F')
-        b =  coefs[coefs['index'] == None]['value']
+        b =  coefs[coefs['index'] is None]['value']
         Wa = np.hstack((np.zeros((inputChannels, 1)), W))
         weights.floatValue.extend(Wa.flatten(order = 'F'))
         bias.floatValue.extend([0.0] + list(b))

--- a/src/unity/python/turicreate/util/lambda_closure_capture.py
+++ b/src/unity/python/turicreate/util/lambda_closure_capture.py
@@ -283,7 +283,7 @@ def translate(fn):
         pass
 
     try:
-        if ast_node == None:
+        if ast_node is None:
             ast_node = meta.decompiler.decompile_func(fn)
     except:
         pass

--- a/subtree/xgboost/subtree/rabit/tracker/rabit_hadoop_streaming.py
+++ b/subtree/xgboost/subtree/rabit/tracker/rabit_hadoop_streaming.py
@@ -23,15 +23,15 @@ hadoop_streaming_jar = None
 
 # code 
 hadoop_home = os.getenv('HADOOP_HOME')
-if hadoop_home != None:
-    if hadoop_binary == None:
+if hadoop_home is not None:
+    if hadoop_binary is None:
         hadoop_binary = hadoop_home + '/bin/hadoop'
         assert os.path.exists(hadoop_binary), "HADOOP_HOME does not contain the hadoop binary"
-    if hadoop_streaming_jar == None:
+    if hadoop_streaming_jar is None:
         hadoop_streaming_jar = hadoop_home + '/lib/hadoop-streaming.jar'
         assert os.path.exists(hadoop_streaming_jar), "HADOOP_HOME does not contain the hadoop streaming jar"
 
-if hadoop_binary == None or hadoop_streaming_jar == None:
+if hadoop_binary is None or hadoop_streaming_jar is None:
     warnings.warn('Warning: Cannot auto-detect path to hadoop or hadoop-streaming jar\n'\
                       '\tneed to set them via arguments -hs and -hb\n'\
                       '\tTo enable auto-detection, you can set enviroment variable HADOOP_HOME'\
@@ -69,14 +69,14 @@ parser.add_argument('-mem', '--memory_mb', default=-1, type=int,
                     help = 'maximum memory used by the process. Guide: set it large (near mapred.cluster.max.map.memory.mb)'\
                         'if you are running multi-threading rabit,'\
                         'so that each node can occupy all the mapper slots in a machine for maximum performance')
-if hadoop_binary == None:
+if hadoop_binary is None:
     parser.add_argument('-hb', '--hadoop_binary', required = True,
                         help="path to hadoop binary file")  
 else:
     parser.add_argument('-hb', '--hadoop_binary', default = hadoop_binary, 
                         help="path to hadoop binary file")  
 
-if hadoop_streaming_jar == None:
+if hadoop_streaming_jar is None:
     parser.add_argument('-hs', '--hadoop_streaming_jar', required = True,
                         help='path to hadoop streamimg jar file')
 else:
@@ -152,7 +152,7 @@ def hadoop_streaming(nworker, worker_args, worker_envs, use_yarn):
 
     cmd += ' -input %s -output %s' % (args.input, args.output)
     cmd += ' -mapper \"%s\" -reducer \"/bin/cat\" ' % (' '.join(args.command + worker_args))
-    if args.files != None:
+    if args.files is not None:
         for flst in args.files:
             for f in flst.split('#'):
                 fset.add(f)

--- a/subtree/xgboost/subtree/rabit/tracker/rabit_tracker.py
+++ b/subtree/xgboost/subtree/rabit/tracker/rabit_tracker.py
@@ -269,7 +269,7 @@ class Tracker:
                 continue
             assert s.cmd == 'start' or s.cmd == 'recover'
             # lazily initialize the slaves
-            if tree_map == None:
+            if tree_map is None:
                 assert s.cmd == 'start'
                 if s.world_size > 0:
                     nslave = s.world_size

--- a/subtree/xgboost/subtree/rabit/tracker/rabit_yarn.py
+++ b/subtree/xgboost/subtree/rabit/tracker/rabit_yarn.py
@@ -26,8 +26,8 @@ hadoop_binary  = None
 # code 
 hadoop_home = os.getenv('HADOOP_HOME')
 
-if hadoop_home != None:
-    if hadoop_binary == None:
+if hadoop_home is not None:
+    if hadoop_binary is None:
         hadoop_binary = hadoop_home + '/bin/hadoop'
         assert os.path.exists(hadoop_binary), "HADOOP_HOME does not contain the hadoop binary"
 
@@ -71,7 +71,7 @@ args = parser.parse_args()
 if args.jobname == 'auto':
     args.jobname = ('Rabit[nworker=%d]:' % args.nworker) + args.command[0].split('/')[-1];
 
-if hadoop_binary == None:
+if hadoop_binary is None:
     parser.add_argument('-hb', '--hadoop_binary', required = True,
                         help="path to hadoop binary file")  
 else:
@@ -123,7 +123,7 @@ def submit_yarn(nworker, worker_args, worker_env):
     env['rabit_hdfs_opts'] = str(args.libhdfs_opts)
     env['rabit_hdfs_namenode'] = str(args.name_node)
 
-    if args.files != None:
+    if args.files is not None:
         for flst in args.files:
             for f in flst.split('#'):
                 fset.add(f)

--- a/subtree/xgboost/subtree/rabit/wrapper/rabit.py
+++ b/subtree/xgboost/subtree/rabit/wrapper/rabit.py
@@ -25,7 +25,7 @@ _LIB = None
 def _loadlib(lib='standard'):
     """Load rabit library."""
     global _LIB
-    if _LIB != None:
+    if _LIB is not None:
         warnings.warn('rabit.int call was ignored because it has'\
                           ' already been initialized', level=2)
         return


### PR DESCRIPTION
1. Use `is` or `is not` for comparisons to `None`: 124f130
    > Comparisons to singletons like None should always be done with is or is not, never the equality operators.
2. Simplify boolean variable checks: 63a8f26
    > Don’t compare boolean values to True or False using ==:
    >
    > Yes:
    > if greeting:
    >
    > No:
    > if greeting == True:
    >
    > Worse: 
    > if greeting is True:

3. Remove duplicate dictionary key/value pairs: b3ddc2f

[(source for 1 & 2)](http://pep8.org/#programming-recommendations)
