### PR TITLE
[AC] Bugfix - the last session was sometimes not counted

### DIFF
--- a/src/unity/toolkits/activity_classification/sequence_iterator.cpp
+++ b/src/unity/toolkits/activity_classification/sequence_iterator.cpp
@@ -247,8 +247,11 @@ variant_map_type _activity_classifier_prepare_data_impl(const gl_sframe &data,
                        feature_size,
                        predictions_in_chunk,
                        use_target);
-        number_of_sessions++;
     }
+
+    // Update the count of the last session in the dataset
+    number_of_sessions++;
+
 
     if (verbose) {
         logprogress_stream << "Processed a total of " << number_of_sessions << " sessions." << std::endl;


### PR DESCRIPTION
In the sequence_iterator's prep_data() function, we've only counted the last session of each dataset
if it wasn't divisible by chunk_len.
This could theoretically lead to setting num_gpus (which depends on the number of sessions) incorrectly, and even zero.

I've fixed it so the last session is always counted.
