### PR TITLE
Remove duplicate dictionary key/value pairs

### DIFF
--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -323,7 +323,6 @@ cdef dict _code_by_name_lookup = {
     'uint64'   : FT_INT_TYPE     + FT_SAFE,
     'uint128'  : FT_INT_TYPE     + FT_SAFE,
     'short'    : FT_INT_TYPE     + FT_SAFE,
-    'bool_'    : FT_INT_TYPE     + FT_SAFE,
     'float'    : FT_FLOAT_TYPE   + FT_SAFE,
     'double'   : FT_FLOAT_TYPE   + FT_SAFE,
     'float16'  : FT_FLOAT_TYPE   + FT_SAFE,

--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -123,8 +123,6 @@ class ActivityClassifierTest(unittest.TestCase):
             'training_time': lambda x: x > 0,
             'target': lambda x: x == self.target,
             'verbose': lambda x: x == True,
-            'target': lambda x: x == self.target,
-            'features': lambda x: x == self.features,
             'session_id': lambda x: x == self.session_id,
             'prediction_window': lambda x: x == self.prediction_window,
             'training_accuracy': lambda x: x >= 0 and x <= 1 ,

--- a/src/unity/python/turicreate/test/test_python_decision_tree.py
+++ b/src/unity/python/turicreate/test/test_python_decision_tree.py
@@ -157,7 +157,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 7)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'dict2', 'split_feature_index': '1',
             'value': 2.05, 'node_type': 'float', 'missing_id': 1})
 
@@ -177,7 +177,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 9)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'num1', 'split_feature_index': None,
             'value': 4.5, 'node_type': 'float', 'missing_id': 1})
 
@@ -197,7 +197,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 9)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'num1', 'split_feature_index': None,
             'value': 4.5, 'node_type': 'float', 'missing_id': 1})
 
@@ -222,7 +222,7 @@ class PythonDecisionTreeCorrectness(unittest.TestCase):
         # Assert.
         self.assertEquals(len(tree.nodes), 7)
         self.assertEquals(root.to_dict(), {'is_leaf': False, 'left_id': 1,
-            'node_id': 0, 'node_type': u'float', 'parent_id': None, 'right_id':
+            'node_id': 0, 'parent_id': None, 'right_id':
             2, 'split_feature_column': 'dict[2]', 'split_feature_index': '1',
             'value': 2.05, 'node_type': 'float', 'missing_id': 1})
 

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -420,7 +420,6 @@ class ActivityClassifier(_CustomModel):
                 'session_id': self.session_id,
                 'target': self.target,
                 'features': ','.join(self.features),
-                'prediction_window': str(self.prediction_window),
                 'max_iterations': str(self.max_iterations),
             }, version=ActivityClassifier._PYTHON_ACTIVITY_CLASSIFIER_VERSION)
         spec = mlmodel.get_spec()


### PR DESCRIPTION
(cherry picked from commit b3ddc2f)

There were a few instances of duplicate key/value pairs and this PR removes them.
