### PR TITLE
Introduce seed in image classifier and stabilize unit test

### DIFF
--- a/src/unity/python/turicreate/test/test_image_classifier.py
+++ b/src/unity/python/turicreate/test/test_image_classifier.py
@@ -64,7 +64,7 @@ def _get_data():
 
 class ImageClassifierTest(unittest.TestCase):
     @classmethod
-    def setUpClass(self, model='resnet-50', input_image_shape=(3, 224, 224), tol=0.005):
+    def setUpClass(self, model='resnet-50', input_image_shape=(3, 224, 224), tol=0.02):
         self.feature = 'awesome_image'
         self.target = 'awesome_label'
         self.input_image_shape = input_image_shape
@@ -73,7 +73,8 @@ class ImageClassifierTest(unittest.TestCase):
 
         self.sf = _get_data()
         self.model = tc.image_classifier.create(self.sf, target=self.target,
-                                                model=self.pre_trained_model)
+                                                model=self.pre_trained_model,
+                                                seed=42)
         self.nn_model = self.model.feature_extractor
         self.lm_model = self.model.classifier
         self.max_iterations = 10

--- a/src/unity/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/unity/python/turicreate/toolkits/_supervised_learning.py
@@ -295,7 +295,8 @@ def print_validation_track_notification():
 
 
 def create(dataset, target, model_name, features=None,
-           validation_set='auto', verbose=True, distributed='auto', **kwargs):
+           validation_set='auto', distributed='auto',
+           seed=None, verbose=True, **kwargs):
     """
     Create a :class:`~turicreate.toolkits.SupervisedLearningModel`,
 
@@ -332,6 +333,10 @@ def create(dataset, target, model_name, features=None,
     distributed: env
         The distributed environment
 
+    seed : int, optional
+        Seed for random number generation. Set this value to ensure that the
+        same model is created every time.
+
     verbose : boolean
         whether print out messages during training
 
@@ -347,7 +352,7 @@ def create(dataset, target, model_name, features=None,
             if dataset.num_rows() >= 100:
                 if verbose:
                     print_validation_track_notification()
-                dataset, validation_set = dataset.random_split(.95)
+                dataset, validation_set = dataset.random_split(.95, seed=seed)
             else:
                 validation_set = None
         else:

--- a/src/unity/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/unity/python/turicreate/toolkits/_supervised_learning.py
@@ -296,7 +296,7 @@ def print_validation_track_notification():
 
 def create(dataset, target, model_name, features=None,
            validation_set='auto', distributed='auto',
-           seed=None, verbose=True, **kwargs):
+           verbose=True, seed=None, **kwargs):
     """
     Create a :class:`~turicreate.toolkits.SupervisedLearningModel`,
 
@@ -333,12 +333,12 @@ def create(dataset, target, model_name, features=None,
     distributed: env
         The distributed environment
 
+    verbose : boolean
+        whether print out messages during training
+
     seed : int, optional
         Seed for random number generation. Set this value to ensure that the
         same model is created every time.
-
-    verbose : boolean
-        whether print out messages during training
 
     kwargs : dict
         Additional parameter options that can be passed

--- a/src/unity/python/turicreate/toolkits/classifier/logistic_classifier.py
+++ b/src/unity/python/turicreate/toolkits/classifier/logistic_classifier.py
@@ -36,6 +36,7 @@ def create(dataset, target, features=None,
     max_iterations = _DEFAULT_SOLVER_OPTIONS['max_iterations'],
     class_weights = None,
     validation_set = 'auto',
+    seed=None,
     verbose=True):
     """
     Create a :class:`~turicreate.logistic_classifier.LogisticClassifier` (using
@@ -193,6 +194,9 @@ def create(dataset, target, features=None,
         validation_set is set to None, then no additional metrics
         are computed. The default value is 'auto'.
 
+    seed : int, optional
+        Seed for random number generation. Set this value to ensure that the
+        same model is created every time.
 
     verbose : bool, optional
         If True, print progress updates.
@@ -304,7 +308,8 @@ def create(dataset, target, features=None,
                         solver = solver,
                         lbfgs_memory_level = lbfgs_memory_level,
                         max_iterations = max_iterations,
-                        class_weights = class_weights)
+                        class_weights = class_weights,
+                        seed=seed)
 
     return LogisticClassifier(model.__proxy__)
 

--- a/src/unity/python/turicreate/toolkits/classifier/logistic_classifier.py
+++ b/src/unity/python/turicreate/toolkits/classifier/logistic_classifier.py
@@ -36,8 +36,8 @@ def create(dataset, target, features=None,
     max_iterations = _DEFAULT_SOLVER_OPTIONS['max_iterations'],
     class_weights = None,
     validation_set = 'auto',
-    seed=None,
-    verbose=True):
+    verbose=True,
+    seed=None):
     """
     Create a :class:`~turicreate.logistic_classifier.LogisticClassifier` (using
     logistic regression as a classifier) to predict the class of a discrete
@@ -194,12 +194,12 @@ def create(dataset, target, features=None,
         validation_set is set to None, then no additional metrics
         are computed. The default value is 'auto'.
 
+    verbose : bool, optional
+        If True, print progress updates.
+
     seed : int, optional
         Seed for random number generation. Set this value to ensure that the
         same model is created every time.
-
-    verbose : bool, optional
-        If True, print progress updates.
 
     Returns
     -------

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -28,7 +28,7 @@ from turicreate.toolkits._internal_utils import (_raise_error_if_not_sframe,
                                                  _numeric_param_check_range)
 
 def create(dataset, target, feature = None, model = 'resnet-50',
-           max_iterations=10, seed=None, verbose=True):
+           max_iterations=10, verbose=True, seed=None):
     """
     Create a :class:`ImageClassifier` model.
 
@@ -68,12 +68,12 @@ def create(dataset, target, feature = None, model = 'resnet-50',
         increasing this (the default value is 10) if the training accuracy is
         low and the *Grad-Norm* in the display is large.
 
+    verbose : bool, optional
+        If True, prints progress updates and model details.
+
     seed : int, optional
         Seed for random number generation. Set this value to ensure that the
         same model is created every time.
-
-    verbose : bool, optional
-        If True, prints progress updates and model details.
 
     Returns
     -------
@@ -124,8 +124,12 @@ def create(dataset, target, feature = None, model = 'resnet-50',
 
     # Train a classifier using the extracted features
     extracted_features[target] = dataset[target]
-    lr_model = _tc.logistic_classifier.create(extracted_features, features = ['__image_features__'],
-            target = target, max_iterations =  max_iterations, seed=seed, verbose=verbose)
+    lr_model = _tc.logistic_classifier.create(extracted_features,
+                                              features=['__image_features__'],
+                                              target=target,
+                                              max_iterations=max_iterations,
+                                              seed=seed,
+                                              verbose=verbose)
 
     # Save the model
     state = {

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -27,7 +27,8 @@ from .. import _image_feature_extractor
 from turicreate.toolkits._internal_utils import (_raise_error_if_not_sframe,
                                                  _numeric_param_check_range)
 
-def create(dataset, target, feature = None, model = 'resnet-50', max_iterations = 10, verbose = True):
+def create(dataset, target, feature = None, model = 'resnet-50',
+           max_iterations=10, seed=None, verbose=True):
     """
     Create a :class:`ImageClassifier` model.
 
@@ -66,6 +67,10 @@ def create(dataset, target, feature = None, model = 'resnet-50', max_iterations 
         the data can result in a more accurately trained model. Consider
         increasing this (the default value is 10) if the training accuracy is
         low and the *Grad-Norm* in the display is large.
+
+    seed : int, optional
+        Seed for random number generation. Set this value to ensure that the
+        same model is created every time.
 
     verbose : bool, optional
         If True, prints progress updates and model details.
@@ -120,7 +125,7 @@ def create(dataset, target, feature = None, model = 'resnet-50', max_iterations 
     # Train a classifier using the extracted features
     extracted_features[target] = dataset[target]
     lr_model = _tc.logistic_classifier.create(extracted_features, features = ['__image_features__'],
-            target = target, max_iterations =  max_iterations, verbose=verbose)
+            target = target, max_iterations =  max_iterations, seed=seed, verbose=verbose)
 
     # Save the model
     state = {


### PR DESCRIPTION
The unit test `ImageClassifierTest::test_export_coreml_with_predict` failed with high probability. To address this, this PR increases the test tolerance and makes model creation optionally deterministic by exposing a seed parameter.

I changed the tolerance from 0.005 to the much higher 0.02. This is after running 25 trials and collecting some statistics. Only 3 times was it below 0.005 and the highest was around 0.015.

Note however that even though this tolerance seems awfully high, separate tests indicate that the error is many orders of magnitude smaller when the network is fed natural images (instead of randomly generated input as in this unit test).