### PR TITLE
Fix MXNET_CPU_WORKER_NTHREADS upper bound bug

### DIFF
--- a/src/unity/python/turicreate/_sys_util.py
+++ b/src/unity/python/turicreate/_sys_util.py
@@ -66,7 +66,8 @@ def make_unity_server_env():
 
     # Set mxnet envvars
     if 'MXNET_CPU_WORKER_NTHREADS' not in env:
-        env['MXNET_CPU_WORKER_NTHREADS'] = max(2, env.get('OMP_NUM_THREADS', str(_sys_info.NUM_CPUS)))
+        num_workers = min(2, int(env.get('OMP_NUM_THREADS', _sys_info.NUM_CPUS)))
+        env['MXNET_CPU_WORKER_NTHREADS'] = str(num_workers)
 
     ## set local to be c standard so that unity_server will run ##
     env['LC_ALL']='C'


### PR DESCRIPTION
The value `MXNET_CPU_WORKER_NTHREADS` should be automatically set to no more than 2, so as not to cause potential OpenBLAS memory issues. However, right now there are two bugs preventing this to work correctly:

- Should use `min` to set an upper bound.
- Should compare `int` and `int` (intead of `int` and `str`). This is also a fatal error in Python 3.