### PR TITLE
Add data preparation code to AC UG

### DIFF
--- a/userguide/activity_classifier/advanced-usage.md
+++ b/userguide/activity_classifier/advanced-usage.md
@@ -14,29 +14,29 @@ Commonly, an application using an activity classifier would provide the user wit
 
 Each set of consecutive samples produced from a single recording of a subject is called a **session**. A session can contain demonstrations of multiple activities. However, sessions aren't required to contain all activities or be of the same length. The input data to the activity classifier must contain a column to uniquely assign each sample to a session. **The activity classifier in Turi Create expects the samples associated with each session id to be in an ascending order by time**. More sessions from more subjects allow the activity classifier to generalize better to new sessions it has not seen before.
 
-Below is an example of an input SFrame expected by the activity classifier, taken from the HAPT dataset. The example contains 2 sessions, distinguished by the ```user_id``` column. In this example, the first session contains samples for walking only, while the second session contains samples for standing and sitting.
+Below is an example of an input SFrame expected by the activity classifier, taken from the HAPT dataset. The example contains 2 sessions, distinguished by the ```exp_id``` column. In this example, the first session contains samples for walking only, while the second session contains samples for standing and sitting.
 
 ```no-highlight
-+---------+----------+----------+-----------+----------+-----------+-----------+-----------+
-| user_id | activity |  acc_x   |   acc_y   |  acc_z   |   gyro_x  |   gyro_y  |   gyro_z  |
-+---------+----------+----------+-----------+----------+-----------+-----------+-----------+
-|    1    | walking  | 0.708333 | -0.197222 | 0.095833 | -0.751059 |  0.345444 |  0.038179 |
-|    1    | walking  | 0.756944 | -0.173611 | 0.169444 | -0.545503 |  0.218995 |  0.046426 |
-|    1    | walking  | 0.902778 | -0.169444 | 0.147222 | -0.465785 |  0.440128 | -0.045815 |
-|    1    | walking  | 0.970833 | -0.183333 | 0.118056 | -0.357662 |  0.503964 | -0.206472 |
-|    1    | walking  | 0.972222 | -0.176389 | 0.166667 | -0.312763 |  0.64263  | -0.309709 |
-|    2    | standing | 1.036111 | -0.290278 | 0.130556 |  0.039095 | -0.021075 |  0.034208 |
-|    2    | standing | 1.047222 | -0.252778 |   0.15   |  0.135612 |  0.015272 | -0.045815 |
-|    2    | standing |  1.0375  | -0.209722 | 0.152778 |  0.171042 |  0.009468 | -0.094073 |
-|    2    | standing | 1.026389 |  -0.1875  | 0.148611 |  0.210138 | -0.039706 | -0.094073 |
-|    2    | sitting  | 1.013889 | -0.065278 | 0.127778 | -0.020464 | -0.142332 |  0.091324 |
-|    2    | sitting  | 1.005556 | -0.058333 | 0.127778 | -0.059254 | -0.138972 |  0.055589 |
-|    2    | sitting  |   1.0    | -0.070833 | 0.147222 | -0.058948 | -0.124922 |  0.026878 |
-+---------+----------+----------+-----------+----------+-----------+-----------+-----------+
++--------+----------+----------+-----------+----------+-----------+-----------+-----------+
+| exp_id | activity |  acc_x   |   acc_y   |  acc_z   |   gyro_x  |   gyro_y  |   gyro_z  |
++--------+----------+----------+-----------+----------+-----------+-----------+-----------+
+|   1    | walking  | 0.708333 | -0.197222 | 0.095833 | -0.751059 |  0.345444 |  0.038179 |
+|   1    | walking  | 0.756944 | -0.173611 | 0.169444 | -0.545503 |  0.218995 |  0.046426 |
+|   1    | walking  | 0.902778 | -0.169444 | 0.147222 | -0.465785 |  0.440128 | -0.045815 |
+|   1    | walking  | 0.970833 | -0.183333 | 0.118056 | -0.357662 |  0.503964 | -0.206472 |
+|   1    | walking  | 0.972222 | -0.176389 | 0.166667 | -0.312763 |  0.64263  | -0.309709 |
+|   2    | standing | 1.036111 | -0.290278 | 0.130556 |  0.039095 | -0.021075 |  0.034208 |
+|   2    | standing | 1.047222 | -0.252778 |   0.15   |  0.135612 |  0.015272 | -0.045815 |
+|   2    | standing |  1.0375  | -0.209722 | 0.152778 |  0.171042 |  0.009468 | -0.094073 |
+|   2    | standing | 1.026389 |  -0.1875  | 0.148611 |  0.210138 | -0.039706 | -0.094073 |
+|   2    | sitting  | 1.013889 | -0.065278 | 0.127778 | -0.020464 | -0.142332 |  0.091324 |
+|   2    | sitting  | 1.005556 | -0.058333 | 0.127778 | -0.059254 | -0.138972 |  0.055589 |
+|   2    | sitting  |   1.0    | -0.070833 | 0.147222 | -0.058948 | -0.124922 |  0.026878 |
++--------+----------+----------+-----------+----------+-----------+-----------+-----------+
 [12 rows x 8 columns]
 ```
 
-In this example, if ```prediction_window``` is set to 2, then every 2 rows within a session will be considered for a single prediction. Less than ```prediction_window``` rows at the end of a session also produce a single prediction. A ```prediction_window``` of 2 will produce 3 predictions for ```user_id``` 1 and 4 predictions for ```user_id ``` 2, while a ```prediction_window``` of 5 will produce a single prediction for ```user_id``` 1 and 2 predictions for ```user_id ``` 2.
+In this example, if ```prediction_window``` is set to 2, then every 2 rows within a session will be considered for a single prediction. Less than ```prediction_window``` rows at the end of a session also produce a single prediction. A ```prediction_window``` of 2 will produce 3 predictions for ```exp_id``` 1 and 4 predictions for ```exp_id``` 2, while a ```prediction_window``` of 5 will produce a single prediction for ```exp_id``` 1 and 2 predictions for ```exp_id``` 2.
 
 #### Prediction Frequency
 
@@ -46,13 +46,13 @@ Remember the prediction frequency of the activity classifier is determined by th
 model.predict(walking_3_sec, output_frequency='per_window')
 ```
 ```no-highlight
-+---------------+---------+---------+
-| prediction_id | user_id |  class  |
-+---------------+---------+---------+
-|       0       |    1    | walking |
-|       1       |    1    | walking |
-|       2       |    1    | walking |
-+---------------+---------+---------+
++---------------+--------+---------+
+| prediction_id | exp_id |  class  |
++---------------+--------+---------+
+|       0       |   1    | walking |
+|       1       |   1    | walking |
+|       2       |   1    | walking |
++---------------+--------+---------+
 [3 rows x 3 columns]
 ```
 

--- a/userguide/activity_classifier/data-preperation.md
+++ b/userguide/activity_classifier/data-preperation.md
@@ -1,0 +1,98 @@
+# HAPT Data Preparation
+
+In this section we will see how to get the [HAPT experiment](http://archive.ics.uci.edu/ml/datasets/Smartphone-Based+Recognition+of+Human+Activities+and+Postural+Transitions) data into the SFrame format expected by the activity classifier.
+
+First we need to download the data from [here](http://archive.ics.uci.edu/ml/machine-learning-databases/00341/HAPT%20Data%20Set.zip) in zip format. The code below assumes the data was unzipped into a directory named `HAPT Data Set`. This folder contains 3 types of files - a file containing the performed activities for each experiment, files containing the collected accelerometer samples, and files containing the collected gyroscope samples.
+
+The first file is `labels.txt`, which contains activities performed for each experiment. The labels are specified by sample index ranges. For example, in experiment 1 the subject was performing activity number 5 between the 250th collected sample and the 1232th collected sample. The activities are encoded between numbers 1 and 6. We convert these to strings at the end of this section. The code below imports Turi Create, loads `labels.txt` into an SFrame, and defines a function to find the label given a sample index.
+
+```python
+import turicreate as tc
+
+data_dir = './HAPT Data Set/RawData/'
+
+def find_label_for_containing_interval(intervals, index):
+    containing_interval = intervals[:, 0][(intervals[:, 1] <= index) & (index <= intervals[:, 2])]
+    if len(containing_interval) == 1:
+        return containing_interval[0]
+
+# Load labels
+labels = tc.SFrame.read_csv(data_dir + 'labels.txt', delimiter=' ', header=False, verbose=False)
+labels = labels.rename({'X1': 'exp_id', 'X2': 'user_id', 'X3': 'activity_id', 'X4': 'start', 'X5': 'end'})
+labels
+```
+
+```no-highlight
++--------+---------+-------------+-------+------+
+| exp_id | user_id | activity_id | start | end  |
++--------+---------+-------------+-------+------+
+|   1    |    1    |      5      |  250  | 1232 |
+|   1    |    1    |      7      |  1233 | 1392 |
+|   1    |    1    |      4      |  1393 | 2194 |
+|   1    |    1    |      8      |  2195 | 2359 |
+|   1    |    1    |      5      |  2360 | 3374 |
+|   1    |    1    |      11     |  3375 | 3662 |
+|   1    |    1    |      6      |  3663 | 4538 |
+|   1    |    1    |      10     |  4539 | 4735 |
+|   1    |    1    |      4      |  4736 | 5667 |
+|   1    |    1    |      9      |  5668 | 5859 |
++--------+---------+-------------+-------+------+
+[1214 rows x 5 columns]
+```
+
+Next, we need to get the accelerometer and gyroscope data for each experiment. For each experiment, every sensor's data is in a separate file. In the code below we load the accelerometer and gyroscope data from all experiments into a single SFrame. While loading the collected samples, we also calculate the label for each sample using our previously defined function. The final SFrame contains a column named `exp_id` to identify each unique sessions. 
+
+```python
+from glob import glob
+
+acc_files = glob(data_dir + 'acc_*.txt')
+gyro_files = glob(data_dir + 'gyro_*.txt')
+
+# Load data
+data = tc.SFrame()
+files = zip(sorted(acc_files), sorted(gyro_files))
+for acc_file, gyro_file in files:
+    exp_id = int(acc_file.split('_')[1][-2:])
+    user_id = int(acc_file.split('_')[2][4:6])
+    
+    # Load accel data
+    sf = tc.SFrame.read_csv(acc_file, delimiter=' ', header=False, verbose=False)
+    sf = sf.rename({'X1': 'acc_x', 'X2': 'acc_y', 'X3': 'acc_z'})
+    sf['exp_id'] = exp_id
+    sf['user_id'] = user_id
+    
+    # Load gyro data
+    gyro_sf = tc.SFrame.read_csv(gyro_file, delimiter=' ', header=False, verbose=False)
+    gyro_sf = gyro_sf.rename({'X1': 'gyro_x', 'X2': 'gyro_y', 'X3': 'gyro_z'})
+    sf = sf.add_columns(gyro_sf)
+    
+    # Calc labels
+    exp_labels = labels[labels['exp_id'] == exp_id][['activity_id', 'start', 'end']].to_numpy()
+    sf = sf.add_row_number()
+    sf['activity_id'] = sf['id'].apply(lambda x: find_label_for_containing_interval(exp_labels, x))
+    sf = sf.remove_columns(['id'])
+    
+    data = data.append(sf)
+```
+
+Finally, we encode the labels back into a readable string format, and save the resulting SFrame.
+
+```python
+target_map = {
+    1.: 'walking',          
+    2.: 'climbing_upstairs',
+    3.: 'climbing_downstairs',
+    4.: 'sitting',
+    5.: 'standing',
+    6.: 'laying'
+}
+
+# Use the same labels used in the experiment
+data = data.filter_by(target_map.keys(), 'activity_id')
+data['activity'] = data['activity_id'].apply(lambda x: target_map[x])
+data = data.remove_column('activity_id')
+
+data.save('hapt_data.sframe')
+```
+
+To learn more about the expected input format of the activity classifier please visit the [advanced usage](advanced-usage.md) section.

--- a/userguide/activity_classifier/introduction.md
+++ b/userguide/activity_classifier/introduction.md
@@ -20,7 +20,7 @@ In contrast, here is a 3-seconds example of 'sitting' data:
 
 <img src="images/sitting.png"></img>
 
-The goal of an activity classifier is to distinguish between such samples. Let's see how we can do that with Turi Create. Here is a complete example of loading the HAPT dataset, and creating an activity classifier to distinguish between these examples. 
+The goal of an activity classifier is to distinguish between such samples. Let's see how we can do that with Turi Create. Below is a complete example of loading the HAPT dataset, and creating an activity classifier to distinguish between these examples. The code for getting the data into an SFrame can be found [here](data-preperation.md).
 
 ```python
 import turicreate as tc
@@ -29,10 +29,10 @@ import turicreate as tc
 data = tc.SFrame('hapt_data.sframe')
 
 # Train/test split by recording sessions
-train, test = tc.activity_classifier.util.random_split_by_session(data, session_id='user_id', fraction=0.8)
+train, test = tc.activity_classifier.util.random_split_by_session(data, session_id='exp_id', fraction=0.8)
 
 # Create an activity classifier
-model = tc.activity_classifier.create(train, session_id='user_id', target='activity', prediction_window=50)
+model = tc.activity_classifier.create(train, session_id='exp_id', target='activity', prediction_window=50)
 
 # Evaluate the model and save the results into a dictionary
 metrics = model.evaluate(test)
@@ -48,17 +48,17 @@ model.export_coreml('MyActivityClassifier.mlmodel')
 Since we have created the model with samples taken at 50Hz and set the ```prediction_window``` to 50, we will get one prediction per second. Invoking our newly created model on the above 3-seconds walking example produces the following per-second predictions:
 
 ```python
-walking_3_sec = data[(data['activity'] == 'walking') & (data['user_id'] == 1)][50:200]
+walking_3_sec = data[(data['activity'] == 'walking') & (data['exp_id'] == 1)][1000:1150]
 model.predict(walking_3_sec, output_frequency='per_window')
 ```
 ```no-highlight
-+---------------+---------+---------+
-| prediction_id | user_id |  class  |
-+---------------+---------+---------+
-|       0       |    1    | walking |
-|       1       |    1    | walking |
-|       2       |    1    | walking |
-+---------------+---------+---------+
++---------------+--------+---------+
+| prediction_id | exp_id |  class  |
++---------------+--------+---------+
+|       0       |   1    | walking |
+|       1       |   1    | walking |
+|       2       |   1    | walking |
++---------------+--------+---------+
 [3 rows x 3 columns]
 ```
 


### PR DESCRIPTION
Added code to the userguide to prepare the raw HAPT data into an SFrame format expected by the activity classifier.
The walking_3_sec example in introduction.md is now more robust as the performance of the predictions is better when not looking at the beginning of a session due to transitions from a different activity.
In reference to issues https://github.com/apple/turicreate/issues/41 and https://github.com/apple/turicreate/issues/59.