### PR TITLE
Doctest quote characters

### DIFF
--- a/src/unity/python/turicreate/toolkits/recommender/factorization_recommender.py
+++ b/src/unity/python/turicreate/toolkits/recommender/factorization_recommender.py
@@ -154,7 +154,7 @@ def create(observation_data,
     >>> user_info = turicreate.SFrame({'user_id': ["0", "1", "2"],
     ...                              'name': ["Alice", "Bob", "Charlie"],
     ...                              'numeric_feature': [0.1, 12, 22]})
-    >>> item_info = turicreate.SFrame({'item_id': ["a", "b", "c", d"],
+    >>> item_info = turicreate.SFrame({'item_id': ["a", "b", "c", "d"],
     ...                              'name': ["item1", "item2", "item3", "item4"],
     ...                              'dict_feature': [{'a' : 23}, {'a' : 13},
     ...                                               {'b' : 1},

--- a/src/unity/python/turicreate/toolkits/recommender/ranking_factorization_recommender.py
+++ b/src/unity/python/turicreate/toolkits/recommender/ranking_factorization_recommender.py
@@ -177,7 +177,7 @@ def create(observation_data,
     >>> user_info = turicreate.SFrame({'user_id': ["0", "1", "2"],
     ...                              'name': ["Alice", "Bob", "Charlie"],
     ...                              'numeric_feature': [0.1, 12, 22]})
-    >>> item_info = turicreate.SFrame({'item_id': ["a", "b", "c", d"],
+    >>> item_info = turicreate.SFrame({'item_id': ["a", "b", "c", "d"],
     ...                              'name': ["item1", "item2", "item3", "item4"],
     ...                              'dict_feature': [{'a' : 23}, {'a' : 13},
     ...                                               {'b' : 1},
@@ -525,7 +525,7 @@ class RankingFactorizationRecommender(_Recommender):
     >>> user_info = turicreate.SFrame({'user_id': ["0", "1", "2"],
     ...                              'name': ["Alice", "Bob", "Charlie"],
     ...                              'numeric_feature': [0.1, 12, 22]})
-    >>> item_info = turicreate.SFrame({'item_id': ["a", "b", "c", d"],
+    >>> item_info = turicreate.SFrame({'item_id': ["a", "b", "c", "d"],
     ...                              'name': ["item1", "item2", "item3", "item4"],
     ...                              'dict_feature': [{'a' : 23}, {'a' : 13},
     ...                                               {'b' : 1},

--- a/src/unity/python/turicreate/toolkits/text_analytics/_util.py
+++ b/src/unity/python/turicreate/toolkits/text_analytics/_util.py
@@ -459,7 +459,7 @@ def tokenize(sa, to_lower=False,
         >>> import turicreate
 
         >>> docs = turicreate.SArray(['This is the first sentence.',
-        ...                         'This one, it\'s the second sentence.'])
+        ...                         "This one, it's the second sentence."])
 
         # Default tokenization by space characters
         >>> turicreate.text_analytics.tokenize(docs)


### PR DESCRIPTION
There were three missing double quotes which this PR fixes.

I also replaced two single quotes with double-quotes for readability.

> [When a string contains single or double quote characters, however, use the other one to avoid backslashes in the string. It improves readability.](http://pep8.org/#string-quotes)
