### PR TITLE
Raise `RuntimeError` instead of bare strings

### DIFF
--- a/src/unity/python/turicreate/test/test_nearest_neighbors.py
+++ b/src/unity/python/turicreate/test/test_nearest_neighbors.py
@@ -1588,7 +1588,7 @@ class NearestNeighborsSparseQueryTest(unittest.TestCase):
             elif distance == 'manhattan':
                 ans = manhattan(query, ref)
             else:
-                raise "Unknown distance"
+                raise RuntimeError("Unknown distance")
             self.assertAlmostEqual(score, ans)
 
     def test_query_distances(self):

--- a/src/unity/python/turicreate/util/config.py
+++ b/src/unity/python/turicreate/util/config.py
@@ -52,7 +52,7 @@ class TuriConfig:
                 if "TEMP" in os.environ:
                     log_dir = os.environ["TEMP"]
                 else:
-                    raise "Please set the TEMP environment variable"
+                    raise RuntimeError("Please set the TEMP environment variable")
             else:
                 log_dir = "/tmp"
 


### PR DESCRIPTION
Fix #38 

I found two more instances of raising strings (other than the two fixed by this PR) but they are both under `deps` so I was hesitant to touch them.
