### PR TITLE
Update README.md - user may use conda venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ For detailed instructions for different varieties of Linux see [LINUX\_INSTALL.m
 For common installation issues see [INSTALL\_ISSUES.md](INSTALL_ISSUES.md).
 
 We recommend using virtualenv to use, install, or build Turi Create. 
-Be sure to install virtualenv using your system pip.
 
 ```shell
 pip install virtualenv
@@ -84,20 +83,24 @@ pip install virtualenv
 
 The method for installing *Turi Create* follows the
 [standard python package installation steps](https://packaging.python.org/installing/).
-To create a Python virtual environment called `venv` follow these steps:
+To create and activate a Python virtual environment called `venv` follow these steps:
 
 ```shell
 # Create a Python virtual environment
 cd ~
 virtualenv venv
-```
 
-To activate your new virtual environment and install `Turi Create` in this environment, follow these steps:
-```shell
 # Activate your virtual environment
 source ~/venv/bin/activate
+```
+Alternatively, if you are using Anaconda, you may use its virtual environment:
+```shell
+conda create -n venv python=2.7 anaconda
+source activate venv
+```
 
-# Install Turi Create in the new virtual environment, pythonenv
+To install `Turi Create` within your virtual environment:
+```shell
 (venv) pip install -U turicreate
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ virtualenv venv
 # Activate your virtual environment
 source ~/venv/bin/activate
 ```
-Alternatively, if you are using Anaconda, you may use its virtual environment:
+Alternatively, if you are using [Anaconda](https://www.anaconda.com/what-is-anaconda/), you may use its virtual environment:
 ```shell
 conda create -n venv python=2.7 anaconda
 source activate venv


### PR DESCRIPTION
Following discussion in https://github.com/apple/turicreate/pull/54, I updated that readme that user may use any `virtualenv` and `pip` installations, including `conda` ones. 
This is also to further clarify that the user doesn't have to user the "system" pip per-se.