### PR TITLE
Inconsistent indentation (mix of tabs and spaces)

### DIFF
--- a/src/nnvm/dmlc-core/tracker/dmlc_tracker/slurm.py
+++ b/src/nnvm/dmlc-core/tracker/dmlc_tracker/slurm.py
@@ -4,9 +4,12 @@ DMLC submission script, SLURM version
 # pylint: disable=invalid-name
 from __future__ import absolute_import
 
-import subprocess, logging
+import logging
+import subprocess
 from threading import Thread
+
 from . import tracker
+
 
 def get_mpi_env(envs):
     """get the slurm command for setting the environment
@@ -30,35 +33,34 @@ def submit(args):
         pass_envs['DMLC_JOB_CLUSTER'] = 'slurm'
 
         if args.slurm_worker_nodes is None:
-	  nworker_nodes = nworker
+            nworker_nodes = nworker
         else:
-          nworker_nodes=args.slurm_worker_nodes
- 
+            nworker_nodes = args.slurm_worker_nodes
 
         # start workers
         if nworker > 0:
-          logging.info('Start %d workers by srun' % nworker)
-          pass_envs['DMLC_ROLE'] = 'worker'
-          prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (get_mpi_env(pass_envs), nworker_nodes, nworker, cmd)
-          thread = Thread(target=run, args=(prog,))
-          thread.setDaemon(True)
-          thread.start()
-
+            logging.info('Start %d workers by srun' % nworker)
+            pass_envs['DMLC_ROLE'] = 'worker'
+            prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (
+                get_mpi_env(pass_envs), nworker_nodes, nworker, cmd)
+            thread = Thread(target=run, args=(prog,))
+            thread.setDaemon(True)
+            thread.start()
 
         if args.slurm_server_nodes is None:
-	  nserver_nodes = nserver
+            nserver_nodes = nserver
         else:
-          nserver_nodes=args.slurm_server_nodes
+            nserver_nodes = args.slurm_server_nodes
 
         # start servers
         if nserver > 0:
-          logging.info('Start %d servers by srun' % nserver)
-          pass_envs['DMLC_ROLE'] = 'server'
-          prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (get_mpi_env(pass_envs), nserver_nodes, nserver, cmd)
-          thread = Thread(target=run, args=(prog,))
-          thread.setDaemon(True)
-          thread.start()
-
+            logging.info('Start %d servers by srun' % nserver)
+            pass_envs['DMLC_ROLE'] = 'server'
+            prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (
+                get_mpi_env(pass_envs), nserver_nodes, nserver, cmd)
+            thread = Thread(target=run, args=(prog,))
+            thread.setDaemon(True)
+            thread.start()
 
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=mpi_submit,

--- a/src/nnvm/tvm/dmlc-core/tracker/dmlc_tracker/slurm.py
+++ b/src/nnvm/tvm/dmlc-core/tracker/dmlc_tracker/slurm.py
@@ -4,9 +4,12 @@ DMLC submission script, SLURM version
 # pylint: disable=invalid-name
 from __future__ import absolute_import
 
-import subprocess, logging
+import logging
+import subprocess
 from threading import Thread
+
 from . import tracker
+
 
 def get_mpi_env(envs):
     """get the slurm command for setting the environment
@@ -30,35 +33,34 @@ def submit(args):
         pass_envs['DMLC_JOB_CLUSTER'] = 'slurm'
 
         if args.slurm_worker_nodes is None:
-	  nworker_nodes = nworker
+            nworker_nodes = nworker
         else:
-          nworker_nodes=args.slurm_worker_nodes
- 
+            nworker_nodes = args.slurm_worker_nodes
 
         # start workers
         if nworker > 0:
-          logging.info('Start %d workers by srun' % nworker)
-          pass_envs['DMLC_ROLE'] = 'worker'
-          prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (get_mpi_env(pass_envs), nworker_nodes, nworker, cmd)
-          thread = Thread(target=run, args=(prog,))
-          thread.setDaemon(True)
-          thread.start()
-
+            logging.info('Start %d workers by srun' % nworker)
+            pass_envs['DMLC_ROLE'] = 'worker'
+            prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (
+                get_mpi_env(pass_envs), nworker_nodes, nworker, cmd)
+            thread = Thread(target=run, args=(prog,))
+            thread.setDaemon(True)
+            thread.start()
 
         if args.slurm_server_nodes is None:
-	  nserver_nodes = nserver
+            nserver_nodes = nserver
         else:
-          nserver_nodes=args.slurm_server_nodes
+            nserver_nodes = args.slurm_server_nodes
 
         # start servers
         if nserver > 0:
-          logging.info('Start %d servers by srun' % nserver)
-          pass_envs['DMLC_ROLE'] = 'server'
-          prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (get_mpi_env(pass_envs), nserver_nodes, nserver, cmd)
-          thread = Thread(target=run, args=(prog,))
-          thread.setDaemon(True)
-          thread.start()
-
+            logging.info('Start %d servers by srun' % nserver)
+            pass_envs['DMLC_ROLE'] = 'server'
+            prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (
+                get_mpi_env(pass_envs), nserver_nodes, nserver, cmd)
+            thread = Thread(target=run, args=(prog,))
+            thread.setDaemon(True)
+            thread.start()
 
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=mpi_submit,


### PR DESCRIPTION
Mixing tabs and spaces for indentation raises [`TabError: inconsistent use of tabs and spaces in indentation`](https://docs.python.org/3/library/exceptions.html#TabError) in Python 3. This PR replaces them with spaces.

> [Python 3 disallows mixing the use of tabs and spaces for indentation.](http://pep8.org/#tabs-or-spaces)

While fixing the tabs I also made a few minor fixes to get rid of PEP8 warnings:
* [Use 4 space indentation throughout (it was a mix of 2 space & 4 space previously)](http://pep8.org/#indentation)
* [Add whitespace around `=` operator (where applicable)](http://pep8.org/#whitespace-in-expressions-and-statements)
* [Use one import per line and group them properly (standard, third-party, local)](http://pep8.org/#imports)
* [Two blank lines above top-level function definitions](http://pep8.org/#blank-lines)
* [Remove excess blank lines inside of functions](http://pep8.org/#blank-lines)
* [Adjust `prog` lines so max line length < 80 chars](http://pep8.org/#maximum-line-length)

---
There are other instances of tabs being used as indentation but I was hesitant to touch them since they are under `deps`.
