### PR TITLE
Fix typo: `deamon` -> `daemon`

### DIFF
--- a/src/nnvm/tvm/python/tvm/contrib/rpc.py
+++ b/src/nnvm/tvm/python/tvm/contrib/rpc.py
@@ -89,7 +89,7 @@ def _listen_loop(sock):
             conn.sendall(struct.pack("@i", RPC_MAGIC))
         logging.info("Connection from %s", addr)
         process = multiprocessing.Process(target=_serve_loop, args=(conn, addr))
-        process.deamon = True
+        process.daemon = True
         process.start()
         # close from our side.
         conn.close()
@@ -112,7 +112,7 @@ def _connect_proxy_loop(addr, key):
             raise RuntimeError("%s is not RPC Proxy" % str(addr))
         logging.info("RPCProxy connected to %s", str(addr))
         process = multiprocessing.Process(target=_serve_loop, args=(sock, addr))
-        process.deamon = True
+        process.daemon = True
         process.start()
         process.join()
 
@@ -171,7 +171,7 @@ class Server(object):
         else:
             self.proc = multiprocessing.Process(
                 target=_connect_proxy_loop, args=((host, port), key))
-        self.proc.deamon = True
+        self.proc.daemon = True
         self.proc.start()
 
     def terminate(self):

--- a/src/nnvm/tvm/tests/python/contrib/test_rpc_proxy.py
+++ b/src/nnvm/tvm/tests/python/contrib/test_rpc_proxy.py
@@ -34,7 +34,7 @@ def rpc_proxy_check():
                 args=("ws://localhost:%d/ws" % web_port,"x1"))
             # Need to make sure that the connection start after proxy comes up
             time.sleep(0.1)
-            server.deamon = True
+            server.daemon = True
             server.start()
             client = rpc.connect(prox.host, prox.port, key="x1")
             f1 = client.get_function("rpc.test2.addone")


### PR DESCRIPTION
I just came across this by accident but in four different places `daemon` was being spelled as `deamon`.

* https://docs.python.org/2/library/multiprocessing.html#multiprocessing.Process.daemon

```python

Python 2.7.12 (default, Nov 20 2017, 18:23:56) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from multiprocessing import Process
>>> p = Process()
>>> p.deamon = True
>>> p.daemon
False

Python 3.5.2 (default, Nov 23 2017, 16:37:01) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from multiprocessing import Process
>>> p = Process()
>>> p.deamon = True
>>> p.daemon
False
```
