### PR TITLE
Miscellaneous Python 3 fixes

### DIFF
--- a/src/unity/python/turicreate/extensions.py
+++ b/src/unity/python/turicreate/extensions.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import as _
 # This is a fake meta namespace which contains toolkit functions and toolkit
 # models implemented as extensions in C++
 
+import sys as _sys
 from . import SArray as _SArray, SFrame as _SFrame, SGraph as _SGraph
 from .connect.main import get_unity as _get_unity
 from .util import _make_internal_url
@@ -32,6 +33,11 @@ from .toolkits._main import ToolkitError as _ToolkitError
 from .cython.context import debug_trace as cython_context
 from sys import version_info as _version_info
 import types as _types
+if _sys.version_info.major == 2:
+    from types import ClassType as _ClassType
+    _class_type = _ClassType
+else:
+    _class_type = type
 
 
 # Now. a bit of magic hackery is going to happen to this module.
@@ -380,7 +386,7 @@ def _publish():
         # default construct correctly
         new_class['__init__'].tkclass_name = tkclass
 
-        newclass = _types.ClassType(tkclass, (), new_class)
+        newclass = _class_type(tkclass, (), new_class)
         setattr(newclass, '__glmeta__', {'extension_name':tkclass})
         class_uid_to_class[m['uid']] = newclass
         modpath = tkclass.split('.')

--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -135,7 +135,7 @@ class ActivityClassifierTest(unittest.TestCase):
             'batch_size' : lambda x: x == self.def_opts['batch_size'],
             'classes': lambda x: sorted(x) == sorted(self.data[self.target].unique())
         }
-        self.exposed_fields_ans = self.get_ans.keys()
+        self.exposed_fields_ans = list(self.get_ans.keys())
         self.fields_ans = self.exposed_fields_ans + ['_recalibrated_batch_size',
                 '_loss_model', '_pred_model', '_id_target_map',
                 '_predictions_in_chunk', '_target_id_map']
@@ -287,7 +287,7 @@ class ActivityClassifierTest(unittest.TestCase):
                     pass
                 except Exception as e:
                     self.assertTrue(False, "After model save and load, method " + test_method +
-                                    " has failed with error: " + e.message)
+                                    " has failed with error: " + str(e))
 
 
 @unittest.skipIf(tc.util._num_available_gpus() == 0, 'Requires GPU')

--- a/src/unity/python/turicreate/test/test_logistic_classifier.py
+++ b/src/unity/python/turicreate/test/test_logistic_classifier.py
@@ -182,8 +182,8 @@ def multiclass_integer_target(cls):
 
     # Predict
     raw_predictions = sm_model.predict()
-    cls.yhat_class = map(np.argmax, raw_predictions)
-    cls.yhat_max_prob = map(np.max, raw_predictions)
+    cls.yhat_class = raw_predictions.argmax(-1)
+    cls.yhat_max_prob = raw_predictions.max(-1)
     cls.sm_accuracy = np.diag(sm_model.pred_table()).sum() / sm_model.nobs
     cls.sm_cf_matrix = sm_model.pred_table().flatten()
 
@@ -452,12 +452,12 @@ class LogisticRegressionClassiferModelTest(unittest.TestCase):
         # class
         ans =  model.predict(self.sf, output_type='class')
         self.assertEqual(ans.dtype, self.type)
-        self.assertTrue((ans == tc.SArray(map(self.type, self.yhat_class))).all())
+        self.assertTrue((ans == tc.SArray(list(map(self.type, self.yhat_class)))).all())
 
         # Default is class
         ans =  model.predict(self.sf)
         self.assertEqual(ans.dtype, self.type)
-        self.assertTrue((ans == tc.SArray(map(self.type, self.yhat_class))).all())
+        self.assertTrue((ans == tc.SArray(list(map(self.type, self.yhat_class)))).all())
 
     def test_classify(self):
         """
@@ -468,7 +468,7 @@ class LogisticRegressionClassiferModelTest(unittest.TestCase):
         ans =  model.classify(self.sf)
         tol = 1e-3
         self.assertEqual(ans['class'].dtype, self.type)
-        self.assertTrue((ans['class'] == tc.SArray(map(self.type, self.yhat_class))).all())
+        self.assertTrue((ans['class'] == tc.SArray(list(map(self.type, self.yhat_class)))).all())
         self.assertTrue(np.allclose(ans['probability'], self.yhat_max_prob, tol, tol))
 
     def test_evaluate(self):

--- a/src/unity/python/turicreate/toolkits/_feature_engineering/_internal_utils.py
+++ b/src/unity/python/turicreate/toolkits/_feature_engineering/_internal_utils.py
@@ -11,7 +11,7 @@ from turicreate.util import _raise_error_if_not_of_type
 import logging as _logging
 import os as _os
 from distutils.version import LooseVersion
-from urllib import urlretrieve
+from six.moves.urllib.request import urlretrieve
 import zipfile
 
 NoneType = type(None)

--- a/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
+++ b/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
@@ -162,5 +162,5 @@ class MXFeatureExtractor(ImageFeatureExtractor):
         preprocessor_args = {'image_input_names': [self.data_layer]}
         return _mxnet_converter.convert(model, mode = 'classifier',
                 input_shape={self.data_layer: (1, ) + self.image_shape},
-                class_labels = map(str, xrange(self.ptModel.num_classes)),
+                class_labels = map(str, range(self.ptModel.num_classes)),
                 preprocessor_args = preprocessor_args, verbose = False)

--- a/src/unity/python/turicreate/toolkits/_model.py
+++ b/src/unity/python/turicreate/toolkits/_model.py
@@ -22,6 +22,7 @@ from turicreate.toolkits._main import ToolkitError
 import turicreate.util.file_util as file_util
 import os
 from copy import copy as _copy
+import six as _six
 
 MODEL_NAME_MAP = {}
 
@@ -323,6 +324,7 @@ class ExposeAttributesFromProxy(object):
         else:
             return object.__getattribute__(self, attr)
 
+@_six.add_metaclass(RegistrationMetaClass)
 class Model(ExposeAttributesFromProxy):
     """
     This class defines the minimal interface of a model object which is 
@@ -350,8 +352,6 @@ class Model(ExposeAttributesFromProxy):
         def _native_name(cls):
             return ["nearest_neighbors_ball_tree", "nearest_neighbors_brute_force", "nearest_neighbors_lsh"]
     """
-
-    __metaclass__ = RegistrationMetaClass
 
     def _name(self):
         """
@@ -461,6 +461,7 @@ class Model(ExposeAttributesFromProxy):
         return self.__repr__()
 
 
+@_six.add_metaclass(RegistrationMetaClass)
 class CustomModel(ExposeAttributesFromProxy):
     """
     This class is used to implement Python-only models. 
@@ -559,8 +560,6 @@ class CustomModel(ExposeAttributesFromProxy):
     >>> model.save('my_model_file')
     >>> loaded_model = tc.load_model('my_model_file')
     """
-
-    __metaclass__ = RegistrationMetaClass
 
     def __init__(self):
         pass

--- a/src/unity/python/turicreate/toolkits/_mxnet_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mxnet_utils.py
@@ -7,6 +7,7 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 import sys as _sys
+import six as _six
 from turicreate import config as _tc_config
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _numeric_param_check_range
@@ -81,7 +82,7 @@ def assert_valid_num_gpus():
     num_gpus = _tc_config.get_num_gpus()
     if _sys.platform == 'darwin' and num_gpus > 0:
         raise _ToolkitError('Using GPUs is currently not supported on Mac')
-    _numeric_param_check_range('num_gpus', num_gpus, -1, _sys.maxint)
+    _numeric_param_check_range('num_gpus', num_gpus, -1, _six.MAXSIZE)
 
 def load_mxnet_model_from_state(state, data, labels=None, existing_module=None, ctx = None):
     import mxnet as _mx

--- a/src/unity/python/turicreate/toolkits/_pre_trained_models.py
+++ b/src/unity/python/turicreate/toolkits/_pre_trained_models.py
@@ -10,8 +10,8 @@ import os as _os
 import sys as _sys
 import requests as _requests
 import turicreate as _tc
-import urlparse as _urlparse
 import hashlib as _hashlib
+from six.moves.urllib import parse as _urlparse
 
 MODELS_URL_ROOT = 'https://docs-assets.developer.apple.com/turicreate/models/'
 

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -13,6 +13,7 @@ from __future__ import division as _
 import numpy as _np
 import time as _time
 import sys as _sys
+import six as _six
 
 from turicreate import SArray as _SArray, SFrame as _SFrame
 from turicreate import aggregate as _agg
@@ -141,7 +142,7 @@ def create(dataset, session_id, target, features=None, prediction_window=100,
         raise _ToolkitError('session_id must be of type str')
     _tkutl._raise_error_if_sframe_empty(dataset, 'dataset')
     _tkutl._numeric_param_check_range('prediction_window', prediction_window, 1, 400)
-    _tkutl._numeric_param_check_range('max_iterations', max_iterations, 0, _sys.maxint)
+    _tkutl._numeric_param_check_range('max_iterations', max_iterations, 0, _six.MAXSIZE)
 
     if features is None:
         features = _fe_tkutl.get_column_names(dataset,

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -125,7 +125,10 @@ class SFrameDetectionIter(_mx.io.DataIter):
         self.cur_batch = 0
 
     def __next__(self):
-        return next(self)
+        return self._next()
+
+    def next(self):
+        return self._next()
 
     @property
     def provide_data(self):
@@ -135,7 +138,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
     def provide_label(self):
         return self._provide_label
 
-    def next(self):
+    def _next(self):
         images = []
         ymaps = []
         indices = []

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -9,11 +9,11 @@ Class definition and utilities for the object detection toolkit.
 from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
-import sys as _sys
 import time as _time
 import itertools as _itertools
 from datetime import datetime as _datetime
 
+import six as _six
 import turicreate as _tc
 import numpy as _np
 
@@ -149,7 +149,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
     if len(dataset) == 0:
         raise _ToolkitError('Unable to train on empty dataset')
 
-    _numeric_param_check_range('max_iterations', max_iterations, 0, _sys.maxint)
+    _numeric_param_check_range('max_iterations', max_iterations, 0, _six.MAXSIZE)
     start_time = _time.time()
 
     supported_detectors = ['darknet-yolo']

--- a/src/unity/python/turicreate/util/file_util.py
+++ b/src/unity/python/turicreate/util/file_util.py
@@ -18,7 +18,6 @@ import shutil
 import tempfile
 import subprocess
 import re
-from urlparse import urlparse
 from subprocess import PIPE
 from .type_checks import _is_string
 from . import _get_s3_endpoint, _get_aws_credentials


### PR DESCRIPTION
A round of Python 3 fixes.

All tests still passing on Python 2.7 (tested on macOS 10.13 and Ubuntu 16.04).