### PR TITLE
Add context on how to retrieve MulitArrays

### DIFF
--- a/userguide/object_detection/advanced-usage.md
+++ b/userguide/object_detection/advanced-usage.md
@@ -185,6 +185,11 @@ you and your user experience and corresponds to the `confidence_threshold`
 parameter in `predict` inside Turi Create:
 
 ```swift
+let results = request.results as! [VNCoreMLFeatureValueObservation]
+
+let coordinates = results[0].featureValue.multiArrayValue!
+let confidence = results[1].featureValue.multiArrayValue!
+
 let confidenceThreshold = 0.25
 var unorderedPredictions = [Prediction]()
 let numBoundingBoxes = confidence.shape[0].intValue


### PR DESCRIPTION
Currently, the guide on using the object detection MLModel in Swift simply uses the variable `coordinates` and `confidence` without explaining how to retrieve them from the VNCoreMLRequest.

I added three lines of code to give a hint.

The force cast may not be best practice but everything else would be overkill for this guide in my opinion.