### PR TITLE
Improve mxnet support for activity classifier save/load

### DIFF
--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -137,7 +137,7 @@ class ActivityClassifierTest(unittest.TestCase):
         }
         self.exposed_fields_ans = list(self.get_ans.keys())
         self.fields_ans = self.exposed_fields_ans + ['_recalibrated_batch_size',
-                '_loss_model', '_pred_model', '_id_target_map',
+                '_pred_model', '_id_target_map',
                 '_predictions_in_chunk', '_target_id_map']
 
 

--- a/src/unity/python/turicreate/toolkits/_internal_utils.py
+++ b/src/unity/python/turicreate/toolkits/_internal_utils.py
@@ -528,6 +528,20 @@ def _validate_row_label(dataset, label=None, default_label='__id'):
     ## Return the modified dataset and label
     return dataset, label
 
+def _model_version_check(file_version, code_version):
+    """
+    Checks if a saved model file with version (file_version)
+    is compatible with the current code version (code_version).
+    Throws an exception telling the user to upgrade.
+    """
+    if (file_version > code_version):
+        raise RuntimeError("Failed to load model file.\n\n"
+           "The model that you are trying to load was saved with a newer version of\n"
+           "Turi Create than what you have. Please upgrade before attempting to load\n"
+           "the file again:\n"
+           "\n"
+           "    pip install -U turicreate\n")
+
 def _mac_ver():
     """
     Returns Mac version as a tuple of integers, making it easy to do proper

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -273,8 +273,7 @@ class ActivityClassifier(_CustomModel):
 
     @classmethod
     def _load_version(cls, state, version):
-        if (version > cls._PYTHON_ACTIVITY_CLASSIFIER_VERSION):
-            raise RuntimeError("Corrupted model. Cannot load a model with this version.")
+        _tkutl._model_version_check(version, cls._PYTHON_ACTIVITY_CLASSIFIER_VERSION)
 
         data_seq_len = state['prediction_window'] * state['_predictions_in_chunk']
         data = {'data': (state['_recalibrated_batch_size'], data_seq_len, len(state['features']))}

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -182,11 +182,12 @@ class ImageClassifier(_CustomModel):
         return state
 
     @classmethod
-    def _load_version(self, state, version):
+    def _load_version(cls, state, version):
         """
         A function to load a previously saved ImageClassifier
         instance.
         """
+        _tkutl._model_version_check(version, cls._PYTHON_IMAGE_CLASSIFIER_VERSION)
         from turicreate.toolkits.classifier.logistic_classifier import LogisticClassifier
         state['classifier'] = LogisticClassifier(state['classifier'])
         state['classes'] = state['classifier'].classes

--- a/src/unity/python/turicreate/toolkits/image_similarity/image_similarity.py
+++ b/src/unity/python/turicreate/toolkits/image_similarity/image_similarity.py
@@ -178,7 +178,7 @@ class ImageSimilarityModel(_CustomModel):
         return state
 
     @classmethod
-    def _load_version(self, state, version):
+    def _load_version(cls, state, version):
         """
         A function to load a previously saved ImageClassifier
         instance.
@@ -191,6 +191,7 @@ class ImageSimilarityModel(_CustomModel):
         version : int
             Version number maintained by the class writer.
         """
+        _tkutl._model_version_check(version, cls._PYTHON_IMAGE_SIMILARITY_VERSION)
         from turicreate.toolkits.nearest_neighbors import NearestNeighborsModel
         state['similarity_model'] = NearestNeighborsModel(state['similarity_model'])
         # Load pre-trained model & feature extractor

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -411,9 +411,8 @@ class ObjectDetector(_CustomModel):
 
     @classmethod
     def _load_version(cls, state, version):
+        _tkutl._model_version_check(version, cls._PYTHON_OBJECT_DETECTOR_VERSION)
         from ._model import tiny_darknet as _tiny_darknet
-        if (version > cls._PYTHON_OBJECT_DETECTOR_VERSION):
-            raise RuntimeError("Corrupted model. Cannot load a model with this version.")
 
         num_anchors = len(state['anchors'])
         num_classes = state['num_classes']


### PR DESCRIPTION
This PR updates the activity classifier (AC) save/load to work with more versions of mxnet. There are still some issues with export to Core ML for newer versions of mxnet, so this PR alone does not expand support yet (#17).

The issue with the AC is that it saves and loads the network graph using mxnet json files. MXNet is pretty good at backward compatibility, but not forward compatibility. If we support more than one version of mxnet at a time, this creates a problem for us where we can't even be same-version compatible:

1. User 1 (turicreate==4.0.0 and mxnet==0.12.1) saves a model.
2. User 2 (turicreate==4.0.0 and mxnet==0.11.0) loads the model.

This won't work due to forward incompatibility in mxnet. The solution is to avoid saving and loading the graph and simply building it up and copying over the weights. This has much better forward compatibility.

# Support (old and new)

Let's look at current support and support after this PR. I'll show my testing as matrices where:

* rows: model saved in
* columns: model loaded in

Classifier (IC)/Similarity (IS)/Detector (OD): (all work on all combinations of save/load, although currently you get warnings if you do not use MXNet 0.11.0. This PR will eliminate those warnings. This broad support is thanks to the same changes that I'm making to the AC in this PR)

TC/MXNet|4/0.11.0|4/0.12.1|4/1post1
---|:-:|:-:|:-:
v4/0.11.0|:white_check_mark:|:white_check_mark:|:white_check_mark:
v4/0.12.1|:white_check_mark:|:white_check_mark:|:white_check_mark:
v4/1post1|:white_check_mark:|:white_check_mark:|:white_check_mark:

Activity Classifier (AC): (since this PR changes the AC saver/loader, I tested a bunch of combinations)

TC/MXNet|4/0.11.0|4/0.12.1|4/1post1|PR/0.11.0|PR/0.12.1|PR/1post1
---|:-:|:-:|:-:|:-:|:-:|:-:
v4/0.11.0|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:
v4/0.12.1|:no_entry_sign:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:
v4/1post1|:no_entry_sign:|:no_entry_sign:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:
PR/0.11.0|:warning:|:warning:|:warning:|:white_check_mark:|:white_check_mark:|:white_check_mark:
PR/0.12.1|:warning:|:warning:|:warning:|:white_check_mark:|:white_check_mark:|:white_check_mark:
PR/1post1|:warning:|:warning:|:warning:|:white_check_mark:|:white_check_mark:|:white_check_mark:

:white_check_mark: Works
:no_entry_sign: Does not work (ugly error)
:warning: Does not work (fails gracefully)

"PR" refers to the Turi Create model as defined by this PR's commit. "1post1" is short for 1.0.0.post1 (1.0.0 segfaults the object detector, and this seems to have been resolved in the post1 version).

**Top-left**: This is the status quo
**Right half**: Backwards and same-version compatible
**Bottom-left**: Forward incompatible (with respect to TC version). See note at the bottom.

The "graceful" failure in 4.0 actually says "Corrupted model. Cannot load a model with this version." for OD/AC, and for IC/IS it does not even check the version! This PR in an isolated commit also improves this and makes the message friendlier and tells the user to upgrade Turi Create. Unfortunately, whenever we upgrade the file format for IC/IS, it will fail very ungracefully on 4.0.

## Why not be forward compatible?

We could make newer models load in 4.0 as well. However, that is a commitment to write the backward migration to mxnet for all its future versions. For instance, in mxnet 5.0, we would still need to write json graphs that look like 0.11.0. It's better to break this compatibility now, since we would probably break it eventually. At least going forward, we have much better chances of being forward compatible (in mxnet version) for the AC, just like it turned out we are for IC/IS/OD.