### PR TITLE
Add `set -e` to configure to make it fail early

### DIFF
--- a/configure
+++ b/configure
@@ -6,6 +6,7 @@ DEBUG_DIR=debug
 TURI_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 DEPS_PREFIX=$PWD/deps/local
 
+set -e
 
 function print_help {
   echo "Configures the build with the specified toolchain. "


### PR DESCRIPTION
It's quite a common situation that the python installation fails in `./configure` (often due to local experimental changes, but sometimes due to external issues). Right now, if this happens `./configure` returns 0 (no error) and the errors are not immediately visible since there is so much printed after them. As a result, I proceed with `make` and I discover that I have a broken python installation much later (usually around 97% build progress).

I keep adding this flag locally, so I think this will be useful for everyone.