### PR TITLE
Fix link to the GPU support section in the user guide

### DIFF
--- a/userguide/image_classifier/advanced-usage.md
+++ b/userguide/image_classifier/advanced-usage.md
@@ -30,7 +30,7 @@ model = tc.image_classifier.create(
 GPUs can be extremely fast for creating an image classifier model. If
 your machine has an NVIDIA GPU, you can setup a GPU version of Turi
 Create using the [instructions
-here](https://github.com/apple/turicreate). Depending on your setup,
+here](https://github.com/apple/turicreate#gpu-support). Depending on your setup,
 things can be up to 20x faster using GPUs.
 
 ```python


### PR DESCRIPTION
The link for the GPU support in the main readme was not pointing to the relevant section.