### PR TITLE
Generate Gain and Cover For xgboost models

### DIFF
--- a/src/unity/python/turicreate/test/test_boosted_trees.py
+++ b/src/unity/python/turicreate/test/test_boosted_trees.py
@@ -235,6 +235,11 @@ class BoostedTreesRegressionTest(unittest.TestCase):
         sf = self.model.get_feature_importance()
         self.assertEqual(sf.column_names(), ["name", "index", "count"])
 
+    def test_trees_json(self):
+        tree_0_vert_0 = eval(self.model.trees_json[0])['vertices'][0]
+        self.assertEquals(set(tree_0_vert_0.keys()),
+                          set(['name','value_hexadecimal','yes_child','cover','missing_child','no_child','type','id','value','gain']))
+
     def test_list_and_dict_type(self):
         rmse_threshold = 0.2
 

--- a/src/unity/toolkits/supervised_learning/xgboost.cpp
+++ b/src/unity/toolkits/supervised_learning/xgboost.cpp
@@ -1083,6 +1083,11 @@ void xgboost_model::train(void) {
   trim_boost_learner(booster_);
 }
 
+enum{
+    XGBOOST_WITH_STATS = 1, //output also gain and cover metrics per node
+    XGBOOST_JSON_FORMAT = 2 //use Json format for output
+};
+
 /**
  * Save the training state as model metadata
  */
@@ -1109,7 +1114,7 @@ void xgboost_model::_save_training_state(size_t iteration,
   // Store trees
   utils::FeatMap fmap;
   MakeFeatMap(fmap, this->ml_mdata);
-  std::vector<flexible_type> trees_json = convert_vec_string(booster_->DumpModel(fmap, 2 /** json **/));
+  std::vector<flexible_type> trees_json = convert_vec_string(booster_->DumpModel(fmap, XGBOOST_JSON_FORMAT | XGBOOST_WITH_STATS));
   info["trees_json"] = trees_json;
   info["num_trees"] = trees_json.size();
   add_or_update_state(flexmap_to_varmap(info));


### PR DESCRIPTION
This change will utilise already existing code in /src/external/xgboost/src/tree/model.h (e.g lines 509-512) and expose the Gain and Cover metrics in the model json.