### PR TITLE
Fixes model loading in Python 3

### DIFF
--- a/src/unity/python/turicreate/cython/cy_unity.pyx
+++ b/src/unity/python/turicreate/cython/cy_unity.pyx
@@ -42,7 +42,7 @@ cdef read_archive_version(variant_map_type& d):
     Reads only the 'archive_version' from a model state.
     """
     cdef variant_map_type_iterator it = d.begin()
-    ret = 0
+    ret = -1
     while (it != d.end()):
         if cpp_to_str(deref(it).first) == 'archive_version':
             ret = variant_to_value(deref(it).second)
@@ -116,7 +116,7 @@ cdef class UnityGlobalProxy:
             response = self.thisptr.load_model(url)
 
         version = read_archive_version(response)
-        if version == 0:
+        if version <= 0:
             # Legacy model, read all strings as bytes
             try:
                 disable_cpp_str_decode()

--- a/src/unity/python/turicreate/cython/cy_unity.pyx
+++ b/src/unity/python/turicreate/cython/cy_unity.pyx
@@ -4,10 +4,11 @@
 # Use of this source code is governed by a BSD-3-clause license that can
 # be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 from .cy_variant cimport variant_type
+from .cy_variant cimport variant_map_type_iterator
 from .cy_variant cimport from_dict as variant_map_from_dict
 from .cy_variant cimport to_dict as variant_map_to_dict
-from .cy_variant cimport read_archive_version
 from .cy_variant cimport from_value as variant_from_value
+from .cy_variant cimport to_value as variant_to_value
 from .cy_variant cimport make_shared_variant
 
 from .cy_flexible_type cimport pylist_from_flex_list
@@ -30,9 +31,24 @@ from libcpp.map cimport map
 from .cy_cpp_utils cimport str_to_cpp, cpp_to_str, from_vector_of_strings, disable_cpp_str_decode, enable_cpp_str_decode
 
 from cython.operator cimport dereference as deref
+from cython.operator cimport preincrement as inc
 import inspect
 from ..util import cloudpickle
 import pickle
+
+
+cdef read_archive_version(variant_map_type& d):
+    """
+    Reads only the 'archive_version' from a model state.
+    """
+    cdef variant_map_type_iterator it = d.begin()
+    ret = 0
+    while (it != d.end()):
+        if cpp_to_str(deref(it).first) == 'archive_version':
+            ret = variant_to_value(deref(it).second)
+            break
+        inc(it)
+    return ret
 
 
 cdef class UnityGlobalProxy:

--- a/src/unity/python/turicreate/cython/cy_variant.pxd
+++ b/src/unity/python/turicreate/cython/cy_variant.pxd
@@ -60,7 +60,6 @@ ctypedef map[string, variant_type].iterator variant_map_type_iterator
 ctypedef vector[variant_type] variant_vector_type
 ctypedef vector[variant_type].iterator variant_vector_type_iterator
 
-cdef read_archive_version(variant_map_type& d)
 cdef dict to_dict(variant_map_type& d)
 cdef list to_vector(variant_vector_type& d)
 

--- a/src/unity/python/turicreate/cython/cy_variant.pxd
+++ b/src/unity/python/turicreate/cython/cy_variant.pxd
@@ -60,6 +60,7 @@ ctypedef map[string, variant_type].iterator variant_map_type_iterator
 ctypedef vector[variant_type] variant_vector_type
 ctypedef vector[variant_type].iterator variant_vector_type_iterator
 
+cdef read_archive_version(variant_map_type& d)
 cdef dict to_dict(variant_map_type& d)
 cdef list to_vector(variant_vector_type& d)
 

--- a/src/unity/python/turicreate/cython/cy_variant.pyx
+++ b/src/unity/python/turicreate/cython/cy_variant.pyx
@@ -694,19 +694,6 @@ cdef variant_type from_value(object v) except *:
 
 ################################################################################
 
-cdef read_archive_version(variant_map_type& d):
-    """
-    Reads only the 'archive_version' from a model state.
-    """
-    cdef variant_map_type_iterator it = d.begin()
-    ret = 0
-    while (it != d.end()):
-        if cpp_to_str(deref(it).first) == 'archive_version':
-            ret = to_value(deref(it).second)
-            break
-        inc(it)
-    return ret
-
 
 cdef dict to_dict(variant_map_type& d):
     """

--- a/src/unity/python/turicreate/cython/cy_variant.pyx
+++ b/src/unity/python/turicreate/cython/cy_variant.pyx
@@ -694,6 +694,20 @@ cdef variant_type from_value(object v) except *:
 
 ################################################################################
 
+cdef read_archive_version(variant_map_type& d):
+    """
+    Reads only the 'archive_version' from a model state.
+    """
+    cdef variant_map_type_iterator it = d.begin()
+    ret = 0
+    while (it != d.end()):
+        if cpp_to_str(deref(it).first) == 'archive_version':
+            ret = to_value(deref(it).second)
+            break
+        inc(it)
+    return ret
+
+
 cdef dict to_dict(variant_map_type& d):
     """
     Converts a variant map type to a python dictionary.

--- a/src/unity/python/turicreate/toolkits/_model.py
+++ b/src/unity/python/turicreate/toolkits/_model.py
@@ -72,7 +72,9 @@ def load_model(location):
     # The archive version could be both bytes/unicode
     key = u'archive_version'
     archive_version = saved_state[key] if key in saved_state else saved_state[key.encode()]
-    if archive_version > 1:
+    if archive_version < 0:
+        raise ToolkitError("File does not appear to be a Turi Create model.")
+    elif archive_version > 1:
         raise ToolkitError("Unable to load model.\n\n"
                            "This model looks to have been saved with a future version of Turi Create.\n"
                            "Please upgrade Turi Create before attempting to load this model file.")


### PR DESCRIPTION
This is an alternative to #110. This PR decodes the model state to unicode strings in Python 3 in the Cython bridge instead of as an afterthought from Python.

However, legacy models need to be decoded and unpickled using the old method, so this PR first peeks at the `archive_version` and then uses old behavior if it's 0 and new behavior if it's 1. Note, `disable_cpp_str_decode()` doesn't change anything in Python 2, however it is important in Python 3 so that we don't get a decode error when reading legacy models. This PR doesn't actually offer support of loading legacy models in Python 3 (this is hard since it involves unpickling Python 2), but it does offer a more user-friendly error message. This is why it's important to avoid the decoding error happening. An alternative to peeking at the archive version would be to simply catch the decoding errors and re-throw a friendly message, but I think assuming decoding errors are always caused by legacy models could mask unrelated future errors.

All 4.0 models are of course loadable in both Python 2 and 3 with this PR.

As a bonus, I also added a nicer error for `archive_version > 1` to be more future proof. Right now, it actually tries to do the legacy loading for newer version numbers.