### PR TITLE
Add official support for MXNet 0.12 and unofficial support for MXNet 1.X

### DIFF
--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -166,7 +166,7 @@ if __name__ == '__main__':
             "decorator >= 4.0.9",
             "prettytable == 0.7.2",
             "requests >= 2.9.1",
-            "mxnet == 0.11",
+            "mxnet >= 0.11, mxnet < 1.0.0",
             "coremltools == 0.6.3",
             "pillow >= 3.3.0",
             "pandas >= 0.19.0",

--- a/src/unity/python/turicreate/__init__.py
+++ b/src/unity/python/turicreate/__init__.py
@@ -125,17 +125,26 @@ _sys.modules["turicreate.extensions"] = _extensions_wrapper(_sys.modules["turicr
 # rewrite the import
 extensions = _sys.modules["turicreate.extensions"]
 
-try:
-    import mxnet as _mx
-    if _mx.__version__ != '0.11.0':
-        print('WARNING: Currently only mxnet version 0.11.0 is officially supported.')
-        print('         You are using version', _mx.__version__, 'which may result in breaking behavior,')
-        print('         especially during saving and loading models. To fix this, please run:')
-        print()
-        print('             pip uninstall -y mxnet && pip install mxnet==0.11.0')
-        print()
-except (ImportError, OSError):
-    pass
+
+def _mxnet_check():
+    try:
+        import mxnet as _mx
+        version_tuple = tuple(int(x) for x in _mx.__version__.split('.') if x.isdigit())
+        lowest_version = (0, 11, 0)
+        not_yet_supported_version = (1, 0, 0)
+        recommended_version_str = '0.12.1'
+        if not (lowest_version <= version_tuple < not_yet_supported_version):
+            print('WARNING: You are using MXNet', _mx.__version__, 'which may result in breaking behavior.')
+            print('         To fix this, please install the currently recommended version:')
+            print()
+            print('             pip uninstall -y mxnet && pip install mxnet==%s' % recommended_version_str)
+            print()
+            print("         If you want to use a CUDA GPU, then change 'mxnet' to 'mxnet-cu90' (adjust 'cu90' depending on your CUDA version):")
+            print()
+    except (ImportError, OSError):
+        pass
+
+_mxnet_check()
 
 from .visualization import show
 

--- a/src/unity/python/turicreate/toolkits/_mxnet_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mxnet_utils.py
@@ -63,11 +63,12 @@ def get_mxnet_context(max_devices=None):
             # extra attention to this message
             print()
             print('ERROR: Incomplete installation for leveraging GPUs for computations.')
-            print('Please make sure you have CUDA 8.0 installed and run the following line in')
+            print('Please make sure you have CUDA installed and run the following line in')
             print('your terminal and try again:')
             print()
-            print('    pip uninstall -y mxnet && pip install mxnet_cu80=={}'.format(_mx.__version__))
+            print('    pip uninstall -y mxnet && pip install mxnet-cu90=={}'.format(_mx.__version__))
             print()
+            print("Adjust 'cu90' depending on your CUDA version ('cu75' and 'cu80' are also available).")
             print('You can also disable GPU usage altogether by invoking turicreate.config.set_num_gpus(0)')
             _sys.exit(1)
         return ctx


### PR DESCRIPTION
With this PR, we have support for pretty much all versions of MXNet from 0.11.

I updated the support in `setup.py` to `mxnet >= 0.11, mxnet < 1.0.0`. This PR makes 1.0.0 theoretically work, but that version causes a segfault in the object detector. This segfault seems to be fixed in every subsequent nightly release, so hopefully it will not be an issue in 1.0.1. When that version is released, we can extend official support for 1.X and remove or update the `mxnet < 1.0.0`.