### PR TITLE
Fix SArray.show with undefined categorical

### DIFF
--- a/src/unity/lib/visualization/item_frequency.cpp
+++ b/src/unity/lib/visualization/item_frequency.cpp
@@ -70,7 +70,19 @@ std::string item_frequency_result::vega_column_data(bool sframe) const {
   }
 
   std::sort(items_list.begin(), items_list.end(), [](const std::pair<turi::flexible_type,flexible_type> &left, const std::pair<turi::flexible_type,flexible_type> &right) {
+    DASSERT_EQ(left.second.get_type(), flex_type_enum::INTEGER);
+    DASSERT_EQ(right.second.get_type(), flex_type_enum::INTEGER);
+
     if (left.second == right.second) {
+      // ignore undefined (always sort lower -- it'll get ignored later)
+      if (left.first.get_type() == flex_type_enum::UNDEFINED ||
+          right.first.get_type() == flex_type_enum::UNDEFINED) {
+        return false;
+      }
+
+      DASSERT_EQ(left.first.get_type(), flex_type_enum::STRING);
+      DASSERT_EQ(right.first.get_type(), flex_type_enum::STRING);
+
       // if count is equal, sort ascending by label
       return right.first > left.first;
     }


### PR DESCRIPTION
This would only repro on an SArray with categorical values with at least
one category that has the same count as the (hidden) "undefined" category.
Even though this doesn't repro on many real datasets, the minimal repro is:

```python
import turicreate as tc
sa = tc.SArray(['x', None])
sa.show()
```

Despite ignoring undefined values lower down in this function, the
item_frequency.cpp vega_column_data function attempts to sort all
keys/values for item frequency. If there is a null key with the same
count as another value, it sorts by key, and then throws when comparing
undefined with a string value.