### PR TITLE
Implemented SArray.value_counts()

### DIFF
--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -2730,6 +2730,43 @@ class SArray(object):
 
         return Sketch(self, background, sub_sketch_keys = sub_sketch_keys)
 
+    def value_counts(self):
+        """
+        Return an SFrame containing counts of unique values. The resulting
+        SFrame will be sorted in descending frequency.
+
+        Returns
+        -------
+        out : SFrame
+            An SFrame containing 2 columns : 'value', and 'count'. The SFrame will
+            be sorted in descending order by the column 'count'.
+
+        See Also
+        --------
+        SFrame.summary
+
+        Examples
+        --------
+        >>> sa = turicreate.SArray([1,1,2,2,2,2,3,3,3,3,3,3,3])
+        >>> sa.value_counts()
+            Columns:
+                    value	int
+                    count	int
+            Rows: 3
+            Data:
+            +-------+-------+
+            | value | count |
+            +-------+-------+
+            |   3   |   7   |
+            |   2   |   4   |
+            |   1   |   2   |
+            +-------+-------+
+            [3 rows x 2 columns]
+        """
+        from .sframe import SFrame as _SFrame
+        return _SFrame({'value':self}).groupby('value', {'count':_aggregate.COUNT}).sort('count', ascending=False)
+
+
     def append(self, other):
         """
         Append an SArray to the current SArray. Creates a new SArray with the

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -2978,3 +2978,13 @@ class SArrayTest(unittest.TestCase):
         assert sa is not sa_copy
 
         assert (sa == sa_copy).all()
+
+    def test_value_counts(self):
+        sa = SArray([1,1,2,2,2,2,3,3,3,3,3,3,3])
+        c = sa.value_counts()
+        self.assertEqual(c.column_names(), ['value','count'])
+        self.__test_equal(c['value'], [3,2,1], int)
+        self.__test_equal(c['count'], [7,4,2], int)
+        sa = SArray()
+        c = sa.value_counts()
+        self.assertEqual(len(c), 0)


### PR DESCRIPTION
SArray.value_counts() mimics pandas's Series.value_counts() method.
It returns an SFrame containing the counts of unique values in the
SArray.

Example:
```
  >>> sa = turicreate.SArray([1,1,2,2,2,2,3,3,3,3,3,3,3])
  >>> sa.value_counts()
      Columns:
              value	int
              count	int
      Rows: 3
      Data:
      +-------+-------+
      | value | count |
      +-------+-------+
      |   3   |   7   |
      |   2   |   4   |
      |   1   |   2   |
      +-------+-------+
      [3 rows x 2 columns]
```