### PR TITLE
SArray Construction from list perf fix

### DIFF
--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -96,7 +96,7 @@ void unity_sarray::construct_from_vector(const std::vector<flexible_type>& vec,
 
   auto sarray_ptr = std::make_shared<sarray<flexible_type>>();
 
-  sarray_ptr->open_for_write();
+  sarray_ptr->open_for_write(1);
   sarray_ptr->set_type(type);
 
   // ok. copy into the writer.


### PR DESCRIPTION
SArray Construction from list can create excessively large SFrame files
when the number of CPUs is very large compared to the size of the
SFrame. (For instance, 3000 rows, 64 threads).
This also affects SFrame construction from pandas.

This is because the SFrame is created with ncpu segments resulting in
highly inefficient compression. The fix is to simply construct the
SArray with 1 segment.