### PR TITLE
Added patch to gracefully handle pyfpe not being present.

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -89,5 +89,6 @@ for f in `ls ../../env/bin`; do
 done
 popd
 
-linux_patch_sigfpe_handler
+# This is not always present and so it may fail.
+linux_patch_sigfpe_handler || echo "WARNING: Error patching pyfpe.h file."
 


### PR DESCRIPTION
On ubuntu 16.04, the default environment does not create a pyfpe.h file in the installation process.  Thus we should simply warn out if it's not present. 