### PR TITLE
Fix for not thread safe TS_ASSERT in parallel block.

### DIFF
--- a/test/unity/toolkits/sparse_similarity/test_brute_force_all_pairs.cxx
+++ b/test/unity/toolkits/sparse_similarity/test_brute_force_all_pairs.cxx
@@ -134,7 +134,7 @@ void run_test(const std::vector<std::vector<std::pair<size_t, T> > >& data_1,
 
     size_t idx = ref_idx * m + query_idx;
 
-    TS_ASSERT(hit[idx] == false);
+    ASSERT_FALSE(hit[idx]);
 
     hit[idx] = true;
 


### PR DESCRIPTION
Turns out that the the TS_ASSERT_* macros are not threadsafe on linux (due to the underlying boost calls not being threadsafe).  This causes sporadic failures in some C++ tests.  The immediate workaround is to replace all these statements by builtin ASSERT statements, which raise an exception. 