### PR TITLE
Fix JSON export of array dtype

### DIFF
--- a/src/sframe/csv_writer.cpp
+++ b/src/sframe/csv_writer.cpp
@@ -25,8 +25,15 @@ void csv_writer::csv_print_internal(std::string& out, const flexible_type& val) 
       out += std::string(val);
       break;
     case flex_type_enum::DATETIME:
-    case flex_type_enum::VECTOR:
       out += std::string(val);
+      break;
+    case flex_type_enum::VECTOR:
+      out += '[';
+      for(size_t i = 0;i < val.get<flex_vec>().size(); ++i) {
+        csv_print_internal(out, val.get<flex_vec>()[i]);
+        if (i + 1 < val.get<flex_vec>().size()) out += ',';
+      }
+      out += ']';
       break;
     case flex_type_enum::STRING:
       // do not print double quotes

--- a/src/unity/python/turicreate/test/test_json.py
+++ b/src/unity/python/turicreate/test/test_json.py
@@ -5,6 +5,12 @@
 # be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 # This software may be modified and distributed under the terms
 # of the BSD license. See the LICENSE file for details.
+
+# This file tests invertibility (serializing to/from) the "serializable" format
+# of variant_type (produced by extensions.json). This extension results in a
+# naively-JSON-serializable flexible_type that should retain all necessary
+# information to be rehydrated into the original variant_type.
+
 from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _

--- a/src/unity/python/turicreate/test/test_json_export.py
+++ b/src/unity/python/turicreate/test/test_json_export.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+# This software may be modified and distributed under the terms
+# of the BSD license. See the LICENSE file for details.
+
+# This file tests validity of the JSON export produced by SFrame/SArray.
+# NOTE: Complex types like datetime and Image are likely broken.
+# TODO: When https://github.com/apple/turicreate/issues/89 is fixed,
+# also check inverse (exported JSON, when loaded, should produce original
+# SFrame.)
+
+from __future__ import print_function as _
+from __future__ import division as _
+from __future__ import absolute_import as _
+
+import json
+import numpy as np
+import struct
+import sys
+import tempfile
+import unittest
+
+import turicreate as tc
+
+_TEST_CASE_SIZE = 1000
+
+class JSONExporterTest(unittest.TestCase):
+
+    # tests int/float/str
+    def test_simple_types(self):
+        np.random.seed(42)
+        sf = tc.SFrame()
+        sf['idx'] = range(_TEST_CASE_SIZE)
+        sf['ints'] = np.random.randint(-sys.maxint - 1, sys.maxint, _TEST_CASE_SIZE)
+        sf['strings'] = sf['ints'].astype(str)
+        sf['floats'] = np.random.random(_TEST_CASE_SIZE)
+
+        # TODO: nans and infs will break JSON - what should we do about this?
+        #sf['nans_and_infs'] = sf['idx'].apply(lambda x: float('nan') if x > 0 else float('inf'))
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix = '.json') as json_file:
+            sf.save(json_file.name, format='json')
+            with open(json_file.name) as json_data:
+                # will throw if JSON export doesn't work
+                loaded = json.load(json_data)
+
+    def test_array_dtype(self):
+        np.random.seed(42)
+        sf = tc.SFrame()
+        sf['arr'] = np.random.rand(100,3)
+        with tempfile.NamedTemporaryFile(mode='w', suffix = '.json') as json_file:
+            sf.save(json_file.name, format='json')
+            with open(json_file.name) as json_data:
+                # will throw if JSON export doesn't work
+                loaded = json.load(json_data)


### PR DESCRIPTION
This fixes the formatting of the `flex_vec` (array) dtype in CSV export
from SFrame.

Still quite a few bugs lurking in the JSON export -- I also tested
inf/nan handling and it's broken. Leaving that commented out in the test
for now. I suspect other things are broken too (namely datetime or Image
types - not sure how to reasonably JSON export those).

We might want to consider extensions._json for JSON export.