### PR TITLE
Remove set_credentials from API docs

### DIFF
--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -291,10 +291,7 @@ class SFrame(object):
 
     Construct an SFrame from a csv file on Amazon S3. This requires the
     environment variables: *AWS_ACCESS_KEY_ID* and *AWS_SECRET_ACCESS_KEY* to be
-    set before the python session started. Alternatively, you can use
-    :py:func:`turicreate.aws.set_credentials()` to set the credentials after
-    python is started and :py:func:`turicreate.aws.get_credentials()` to verify
-    these environment variables.
+    set before the python session started.
 
     >>> sf = SFrame(data='s3://mybucket/foo.csv')
 

--- a/src/unity/python/turicreate/util/__init__.py
+++ b/src/unity/python/turicreate/util/__init__.py
@@ -64,10 +64,6 @@ def _get_aws_credentials():
         environment variable. The second string of the tuple is the value of the
         AWS_SECRET_ACCESS_KEY environment variable.
 
-    See Also
-    --------
-    set_credentials
-
     Examples
     --------
     >>> turicreate.aws.get_credentials()
@@ -75,9 +71,9 @@ def _get_aws_credentials():
     """
 
     if (not 'AWS_ACCESS_KEY_ID' in _os.environ):
-        raise KeyError('No access key found. Please set the environment variable AWS_ACCESS_KEY_ID, or using turicreate.aws.set_credentials()')
+        raise KeyError('No access key found. Please set the environment variable AWS_ACCESS_KEY_ID.')
     if (not 'AWS_SECRET_ACCESS_KEY' in _os.environ):
-        raise KeyError('No secret key found. Please set the environment variable AWS_SECRET_ACCESS_KEY, or using turicreate.aws.set_credentials()')
+        raise KeyError('No secret key found. Please set the environment variable AWS_SECRET_ACCESS_KEY.')
     return (_os.environ['AWS_ACCESS_KEY_ID'], _os.environ['AWS_SECRET_ACCESS_KEY'])
 
 


### PR DESCRIPTION
It's gone from the API; looks like setting env variables is the only way
to set AWS credentials.