### PR TITLE
Fix C++ unit test build

### DIFF
--- a/src/unity/lib/visualization/CMakeLists.txt
+++ b/src/unity/lib/visualization/CMakeLists.txt
@@ -19,6 +19,7 @@ make_library(
     vega_data.cpp
     vega_spec.cpp
   REQUIRES
+    process
     EXTERNAL_VISIBILITY
 )
 


### PR DESCRIPTION
Include missing dependency `process` in the list of dependencies for the
visualization library.

Fixes test build break introduced in #179.