### PR TITLE
Fix TS_ASSERTS to be threadsafe

### DIFF
--- a/src/util/test_macros.hpp
+++ b/src/util/test_macros.hpp
@@ -5,16 +5,20 @@
  */
 #ifndef TEST_MACROS_HPP
 #define TEST_MACROS_HPP
+#include <mutex>
+static std::recursive_mutex __b_lock__;
+#define _TS_ADD_LOCK_GUARD std::lock_guard<std::recursive_mutex> __guard_b__(__b_lock__)
 
-#define TS_ASSERT(x)                     BOOST_CHECK(x);
-#define TS_ASSERT_EQUALS(x,y)            BOOST_TEST((x) == (y));
-#define TS_ASSERT_DIFFERS(x,y)           BOOST_TEST((x) != (y));
-#define TS_ASSERT_LESS_THAN_EQUALS(x,y)  BOOST_TEST((x) <= (y));
-#define TS_ASSERT_LESS_THAN(x,y)         BOOST_TEST((x) < (y));
-#define TS_ASSERT_DELTA(x,y,e)           BOOST_CHECK_SMALL(double((x)-(y)),double(e));
-#define TS_ASSERT_THROWS_NOTHING(expr)   BOOST_CHECK_NO_THROW(expr);
+#define TS_ASSERT(x)                     do { _TS_ADD_LOCK_GUARD; BOOST_CHECK(x); } while(0)
+#define TS_ASSERT_EQUALS(x,y)            do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) == (y)); } while(0)
+#define TS_ASSERT_DIFFERS(x,y)           do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) != (y)); } while(0)
+#define TS_ASSERT_LESS_THAN_EQUALS(x,y)  do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) <= (y)); } while(0)
+#define TS_ASSERT_LESS_THAN(x,y)         do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) < (y)); } while(0)
+#define TS_ASSERT_DELTA(x,y,e)           do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_SMALL(double((x)-(y)),double(e)); } while(0)
+#define TS_ASSERT_THROWS_NOTHING(expr)   do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_NO_THROW(expr); } while(0)
 #define TS_ASSERT_THROWS_ANYTHING(expr)  \
-{ \
+do { \
+  _TS_ADD_LOCK_GUARD; \
   bool threw=false; \
   try { \
     expr; \
@@ -22,10 +26,10 @@
     threw=true;\
   } \
   BOOST_TEST(threw==true);\
-}
-#define TS_ASSERT_THROWS(expr,type)      BOOST_CHECK_THROW(expr,type);
-#define TS_FAIL(msg)                     BOOST_FAIL(msg);
-#define TS_WARN(msg)                     BOOST_TEST_MESSAGE(msg);
-#define TS_ASSERT_SAME_DATA(x,y,size)    BOOST_CHECK_EQUAL_COLLECTIONS(x, x+size, y, y+size)
+} while(0)
+#define TS_ASSERT_THROWS(expr,type)      do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_THROW(expr,type); } while(0)
+#define TS_FAIL(msg)                     do { _TS_ADD_LOCK_GUARD; BOOST_FAIL(msg); } while(0)
+#define TS_WARN(msg)                     do { _TS_ADD_LOCK_GUARD; BOOST_TEST_MESSAGE(msg); } while(0)
+#define TS_ASSERT_SAME_DATA(x,y,size)    do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_EQUAL_COLLECTIONS(x, x+size, y, y+size); } while(0)
 
 #endif

--- a/test/flexible_type/flexible_datatype.cxx
+++ b/test/flexible_type/flexible_datatype.cxx
@@ -409,13 +409,13 @@ struct flexible_datatype_test  {
     TS_ASSERT_THROWS_ANYTHING(dt.set_microsecond(-1));
     TS_ASSERT_THROWS_ANYTHING(dt.set_microsecond(1000001));
 
-    TS_ASSERT(flex_date_time(441964800) < flex_date_time(441964801)) 
-    TS_ASSERT(flex_date_time(441964801) > flex_date_time(441964800)) 
-    TS_ASSERT(flex_date_time(441964800) == flex_date_time(441964800)) 
-    TS_ASSERT(flex_date_time(441964800) < flex_date_time(441964800, 0, 1)) 
-    TS_ASSERT(flex_date_time(441964800, 0, 1) > flex_date_time(441964800)) 
-    TS_ASSERT(flex_date_time(441964800, 0, 1) == flex_date_time(441964800, 0, 1)) 
-    TS_ASSERT(flex_date_time(441964800, 0, 1) == flex_date_time(441964800, 10, 1)) 
+    TS_ASSERT(flex_date_time(441964800) < flex_date_time(441964801));
+    TS_ASSERT(flex_date_time(441964801) > flex_date_time(441964800));
+    TS_ASSERT(flex_date_time(441964800) == flex_date_time(441964800));
+    TS_ASSERT(flex_date_time(441964800) < flex_date_time(441964800, 0, 1));
+    TS_ASSERT(flex_date_time(441964800, 0, 1) > flex_date_time(441964800));
+    TS_ASSERT(flex_date_time(441964800, 0, 1) == flex_date_time(441964800, 0, 1));
+    TS_ASSERT(flex_date_time(441964800, 0, 1) == flex_date_time(441964800, 10, 1));
 
     dt.set_microsecond_res_timestamp(441964800.5);
     TS_ASSERT_DELTA(dt.microsecond_res_timestamp(), 441964800.5,

--- a/test/nanosockets/reqreptest.cxx
+++ b/test/nanosockets/reqreptest.cxx
@@ -60,7 +60,8 @@ void test_client(async_request_socket& sock, size_t id = 0) {
     set_value(req, i);
     int rc = sock.request_master(req, response);
     TS_ASSERT_EQUALS(rc, 0);
-    TS_ASSERT_EQUALS(get_value(response), i + 1);
+    auto get_value_ret = get_value(response);
+    TS_ASSERT_EQUALS(get_value_ret, i + 1);
   }
   std::cout << "Finished " << id << std::endl;
 }

--- a/test/unity/toolkits/feature_engineering/random_projection_test.cxx
+++ b/test/unity/toolkits/feature_engineering/random_projection_test.cxx
@@ -318,7 +318,7 @@ struct random_projection_test  {
     sf_embed5 = sf_embed5.unpack("data_out");
 
     TS_ASSERT_DIFFERS(sf_embed_unpacked.select_column("X.0")[0],
-                      sf_embed5.select_column("X.0")[0])
+                      sf_embed5.select_column("X.0")[0]);
   }
 
 

--- a/test/unity/unity_sframe.cxx
+++ b/test/unity/unity_sframe.cxx
@@ -478,7 +478,7 @@ struct unity_sframe_test {
 
     std::cout << "done appending two sframes " << std::endl;
 
-    TS_ASSERT_EQUALS(sf3->size(), sf1->size() + sf2->size())
+    TS_ASSERT_EQUALS(sf3->size(), sf1->size() + sf2->size());
     for (size_t i = 0; i < num_items; i++) {
       TS_ASSERT_EQUALS(sf3_values[i], test_data1[i]);
       TS_ASSERT_EQUALS(sf3_values[i + num_items], test_data2[i]);

--- a/test/unity/unity_sgraph.cxx
+++ b/test/unity/unity_sgraph.cxx
@@ -236,7 +236,7 @@ struct unity_graph_test {
     TS_ASSERT_EQUALS(vf.size(), 3);
     TS_ASSERT_EQUALS(vf.count("__id"), 1);
     TS_ASSERT_EQUALS(vf.count("d"), 1);
-    TS_ASSERT_EQUALS(vf.count("e"), 1)
+    TS_ASSERT_EQUALS(vf.count("e"), 1);
 
     std::vector<std::string> efields = graph6->get_edge_fields(groupa, groupb);
     std::set<std::string> ef(efields.begin(), efields.end());
@@ -245,7 +245,7 @@ struct unity_graph_test {
     TS_ASSERT_EQUALS(ef.count("__dst_id"), 1);
     TS_ASSERT_EQUALS(ef.count("c"), 1);
     TS_ASSERT_EQUALS(ef.count("d"), 1);
-    TS_ASSERT_EQUALS(ef.count("e"), 1)
+    TS_ASSERT_EQUALS(ef.count("e"), 1);
 
     sgraph::options_map_t empty_constraint;
     dataframe_t vt = graph6->get_vertices({}, empty_constraint, group)->_head(size_t(-1));


### PR DESCRIPTION
An annoying side effect is that TS_ASSERTS are now *really* slow.
In particular for some tests that loop TS_ASSERTS millions of times,
this will degrade test performance significantly. Those tests may have
to change from:

  TS_ASSERT(something);

to

  if (something) {
    TS_ASSERT(something);
  }

It will also be problematic if TS_ASSERT blocks, in particular, in
tests of threading primitives. For instance this is not a good idea.

  TS_ASSERT(wait_for_thread());

instead:

  int ret = wait_for_thread();
  TS_ASSERT(ret);