### PR TITLE
Fix S3 Certificate Issues on Linux

### DIFF
--- a/src/fileio/dmlcio/s3_filesys.cc
+++ b/src/fileio/dmlcio/s3_filesys.cc
@@ -817,7 +817,8 @@ void ListObjects(const URI &path,
   ASSERT_TRUE(curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result) == CURLE_OK);
   set_curl_options(curl);
   ASSERT_TRUE(curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1) == CURLE_OK);
-  ASSERT_TRUE(curl_easy_perform(curl) == CURLE_OK);
+  CURLcode performret = curl_easy_perform(curl);
+  ASSERT_EQ(performret, CURLE_OK);
   curl_slist_free_all(slist);
   curl_easy_cleanup(curl);
   // parse xml

--- a/src/fileio/set_curl_options.cpp
+++ b/src/fileio/set_curl_options.cpp
@@ -5,6 +5,7 @@
  */
 #include <fileio/fileio_constants.hpp>
 #include <logger/assertions.hpp>
+#include <fileio/fs_utils.hpp>
 extern "C" {
 #include <curl/curl.h>
 }
@@ -17,10 +18,14 @@ void set_curl_options(void* ecurl) {
   using turi::fileio::get_alternative_ssl_cert_file;
   using turi::fileio::insecure_ssl_cert_checks;
   if (!get_alternative_ssl_cert_dir().empty()) {
-    ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAPATH, get_alternative_ssl_cert_dir().c_str()), CURLE_OK);
+    if (get_file_status(get_alternative_ssl_cert_file()) == file_status::DIRECTORY) {
+      ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAPATH, get_alternative_ssl_cert_dir().c_str()), CURLE_OK);
+    }
   }
   if (!get_alternative_ssl_cert_file().empty()) {
-    ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAINFO, get_alternative_ssl_cert_file().c_str()), CURLE_OK);
+    if (get_file_status(get_alternative_ssl_cert_file()) == file_status::REGULAR_FILE) {
+      ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAINFO, get_alternative_ssl_cert_file().c_str()), CURLE_OK);
+    }
   }
   if (insecure_ssl_cert_checks()) {
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYPEER, 0l), CURLE_OK);

--- a/test/fileio/fs.cpp
+++ b/test/fileio/fs.cpp
@@ -8,6 +8,7 @@
 #include <boost/program_options.hpp>
 #include <regex>
 #include <boost/algorithm/string.hpp>
+#include <globals/globals.hpp>
 #include <fileio/fs_utils.hpp>
 #include <fileio/sanitize_url.hpp>
 #include <fileio/general_fstream.hpp>
@@ -181,7 +182,7 @@ int main(int argc, char** argv) {
     print_help(argv);
     return 0;
   }
-  
+  turi::globals::initialize_globals_from_environment(argv[0]);  
   std::string command = argv[1];
   if (command == "cp" && argc == 4) {
     std::string srcpath = argv[2];


### PR DESCRIPTION
Under some conditions S3 access on Linux does not work. This turns out to be caused by incorrect curl options resulting in CURLE_SSL_CACERT_BADFILE. Added checks to mitigate this.