### PR TITLE
Make explicit unsafe use of flexible_type

### DIFF
--- a/src/flexible_type/flexible_type.hpp
+++ b/src/flexible_type/flexible_type.hpp
@@ -463,6 +463,33 @@ class flexible_type {
   template <typename T>
   const T& get() const;
 
+
+  /**
+   * Gets a modifiable type unchecked modifiable reference to the value stored 
+   * inside the flexible_type.
+   *
+   * This is generally unsafe to use unless you *really* know what 
+   * you are doing. Use \ref get() instead.
+   * 
+   * Note that this is only defined for flex_int and flex_float type. It really
+   * does not make sense to use this anywhere else.
+   */
+  template <typename T>
+  T& reinterpret_mutable_get();
+
+  /**
+   * Gets a type unchecked modifiable reference to the value stored 
+   * inside the flexible_type.
+   *
+   * This is generally unsafe to use unless you *really* know what 
+   * you are doing. Use \ref get() instead.
+   *
+   * Note that this is only defined for flex_int and flex_float type. It really
+   * does not make sense to use this anywhere else.
+   */
+  template <typename T>
+  const T& reinterpret_get() const;
+
   /**
    * \{
    * Converts the flexible_type to a particular type.
@@ -1441,6 +1468,16 @@ inline FLEX_ALWAYS_INLINE const flex_int& flexible_type::get<flex_int>() const {
   return val.intval;
 }
 
+template <>
+inline FLEX_ALWAYS_INLINE flex_int& flexible_type::reinterpret_mutable_get<flex_int>() {
+  return val.intval;
+}
+
+template <>
+inline FLEX_ALWAYS_INLINE const flex_int& flexible_type::reinterpret_get<flex_int>() const {
+  return val.intval;
+}
+
 // flex_float
 template <>
 inline FLEX_ALWAYS_INLINE flex_float& flexible_type::mutable_get<flex_float>() {
@@ -1452,6 +1489,16 @@ inline FLEX_ALWAYS_INLINE flex_float& flexible_type::mutable_get<flex_float>() {
 template <>
 inline FLEX_ALWAYS_INLINE const flex_float& flexible_type::get<flex_float>() const {
   DFLEX_TYPE_ASSERT(get_type() == flex_type_enum::FLOAT);
+  return val.dblval;
+}
+
+template <>
+inline FLEX_ALWAYS_INLINE flex_float& flexible_type::reinterpret_mutable_get<flex_float>() {
+  return val.dblval;
+}
+
+template <>
+inline FLEX_ALWAYS_INLINE const flex_float& flexible_type::reinterpret_get<flex_float>() const {
   return val.dblval;
 }
 
@@ -1470,6 +1517,7 @@ inline FLEX_ALWAYS_INLINE const flex_string& flexible_type::get<flex_string>() c
   return val.strval->second;
 }
 
+
 // VECTOR
 template <>
 inline FLEX_ALWAYS_INLINE flex_vec& flexible_type::mutable_get<flex_vec>() {
@@ -1484,6 +1532,7 @@ inline FLEX_ALWAYS_INLINE const flex_vec& flexible_type::get<flex_vec>() const {
   DFLEX_TYPE_ASSERT(get_type() == flex_type_enum::VECTOR);
   return val.vecval->second;
 }
+
 
 // LIST
 template <>
@@ -1515,6 +1564,7 @@ inline FLEX_ALWAYS_INLINE const flex_dict& flexible_type::get<flex_dict>() const
   DFLEX_TYPE_ASSERT(get_type() == flex_type_enum::DICT);
   return val.dictval->second;
 }
+
 
 // IMAGE
 template <>
@@ -1725,6 +1775,19 @@ inline FLEX_ALWAYS_INLINE T& flexible_type::mutable_get() {
 
 template <typename T>
 inline FLEX_ALWAYS_INLINE const T& flexible_type::get() const {
+  typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
+  __builtin_unreachable();
+}
+
+
+template <typename T>
+inline FLEX_ALWAYS_INLINE T& flexible_type::reinterpret_mutable_get() {
+  typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
+  __builtin_unreachable();
+}
+
+template <typename T>
+inline FLEX_ALWAYS_INLINE const T& flexible_type::reinterpret_get() const {
   typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
   __builtin_unreachable();
 }

--- a/src/platform/user_pagefault/type_heuristic_encode.cpp
+++ b/src/platform/user_pagefault/type_heuristic_encode.cpp
@@ -119,7 +119,7 @@ void compress(char* start, size_t length,
   for (size_t i = 0;i < numel; ++i) {
     // we store the raw value whether or not it is an integer.
     // without trying to interpret it
-    column_buffer[cur_column][cur_row].mutable_get<flex_int>() = input[i];
+    column_buffer[cur_column][cur_row].reinterpret_mutable_get<flex_int>() = input[i];
     ++cur_column;
     if (cur_column >= ncols) {
       cur_column = 0;
@@ -177,7 +177,7 @@ void decompress(char* start, size_t length, char* output) {
     // scatter
     size_t ctr = 0;
     for (size_t j = i; j < numel; j += ncols) {
-      output_values[j] = f[ctr].get<flex_int>();
+      output_values[j] = f[ctr].reinterpret_get<flex_int>();
       ++ctr;
     }
   }

--- a/src/sframe/sarray_v2_type_encoding.cpp
+++ b/src/sframe/sarray_v2_type_encoding.cpp
@@ -50,7 +50,7 @@ void decode_number(iarchive& iarc,
   for (size_t i = 0;i < ret.size(); ++i) {
     if (ret[i].get_type() != flex_type_enum::UNDEFINED) {
       if (bufstart < buflen) {
-        ret[i].mutable_get<flex_int>() = buf[bufstart];
+        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
         ++bufstart;
         --num_values_to_read;
       } else {
@@ -63,7 +63,7 @@ void decode_number(iarchive& iarc,
 //         }
 //         logstream(LOG_INFO) << std::endl;
         bufstart = 0;
-        ret[i].mutable_get<flex_int>() = buf[bufstart];
+        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
         ++bufstart;
         --num_values_to_read;
       }
@@ -90,7 +90,7 @@ void encode_double_legacy(block_info& info,
     // collect a block of 128 integers
     while(i < data.size() && encode_buflen < MAX_INTEGERS_PER_BLOCK) {
       if (data[i].get_type() != flex_type_enum::UNDEFINED) {
-        encode_buf[encode_buflen] = data[i].get<flex_int>();
+        encode_buf[encode_buflen] = data[i].reinterpret_get<flex_int>();
         ++encode_buflen;
       }
       ++i;
@@ -157,7 +157,7 @@ void decode_double_legacy(iarchive& iarc,
   for (size_t i = 0;i < ret.size(); ++i) {
     if (ret[i].get_type() != flex_type_enum::UNDEFINED) {
       if (bufstart < buflen) {
-        ret[i].mutable_get<flex_int>() = buf[bufstart];
+        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
         ++bufstart;
         --num_values_to_read;
       } else {
@@ -169,7 +169,7 @@ void decode_double_legacy(iarchive& iarc,
           buf[j] = (buf[j] >> 1) | (buf[j] << 63);
         }
         bufstart = 0;
-        ret[i].mutable_get<flex_int>() = buf[bufstart];
+        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
         ++bufstart;
         --num_values_to_read;
       }

--- a/src/sframe/sarray_v2_type_encoding.hpp
+++ b/src/sframe/sarray_v2_type_encoding.hpp
@@ -187,7 +187,7 @@ static void decode_double_stream_legacy(size_t num_elements,
       size_t intval = (buf[i] >> 1) | (buf[i] << 63);
       // make a double flexible_type
       flexible_type ret(0.0);
-      ret.mutable_get<flex_int>() = intval;
+      ret.reinterpret_mutable_get<flex_int>() = intval;
       callback(ret);
     }
     num_elements -= buflen;
@@ -302,7 +302,7 @@ static void decode_vector_stream(size_t num_elements,
     ++length_ctr;
     // fill in the value
     for(size_t j = 0; j < output_vec.size(); ++j) {
-      output_vec[j] = values[value_ctr].get<flex_float>();
+      output_vec[j] = values[value_ctr].reinterpret_get<flex_float>();
       ++value_ctr;
     }
     callback(ret);


### PR DESCRIPTION
Adds 2 new methods to flexible_type

  reinterpret_get<T>
  reinterpret_mutable_get<T>

These two functions behave identically to get<T> and mutable_get<T> but
bypasses type checking. They are used in limited situations where it is
useful to reinterpret between integer and floating points types and to
make it clear when this is happening.

This also fixes the test failures introduced in #177