### PR TITLE
Fix loose flex type casting in histogram

### DIFF
--- a/src/unity/lib/visualization/histogram.cpp
+++ b/src/unity/lib/visualization/histogram.cpp
@@ -223,15 +223,15 @@ void histogram::init(const gl_sarray& source) {
   if (input_size >= 2 &&
       m_source[0].get_type() != flex_type_enum::UNDEFINED &&
       m_source[1].get_type() != flex_type_enum::UNDEFINED &&
-      std::isfinite(m_source[0].get<flex_float>()) &&
-      std::isfinite(m_source[1].get<flex_float>())) {
+      std::isfinite(m_source[0].to<flex_float>()) &&
+      std::isfinite(m_source[1].to<flex_float>())) {
     // start with a sane range for the bins (somewhere near the data)
     // (it can be exceptionally small, since the doubling used in resize()
     // will make it converge to the real range quickly)
     m_transformer->init(dtype, m_source[0], m_source[1]);
   } else if (input_size == 1 &&
              m_source[0].get_type() != flex_type_enum::UNDEFINED &&
-             std::isfinite(m_source[0].get<flex_float>())) {
+             std::isfinite(m_source[0].to<flex_float>())) {
     // one value, not so interesting
     m_transformer->init(dtype, m_source[0], m_source[0]);
   } else {


### PR DESCRIPTION
Now that flex_int can't implicitly cast to flex_float, we need to use
the `to` method instead of `get`.