### PR TITLE
Fix Mac version check on Linux running Python 3

### DIFF
--- a/src/unity/python/turicreate/toolkits/_internal_utils.py
+++ b/src/unity/python/turicreate/toolkits/_internal_utils.py
@@ -545,7 +545,7 @@ def _model_version_check(file_version, code_version):
 def _mac_ver():
     """
     Returns Mac version as a tuple of integers, making it easy to do proper
-    version comparisons. On non-Macs, it returns None.
+    version comparisons. On non-Macs, it returns an empty tuple.
     """
     import platform
     import sys
@@ -553,4 +553,4 @@ def _mac_ver():
         ver_str = platform.mac_ver()[0]
         return tuple([int(v) for v in ver_str.split('.')])
     else:
-        return None
+        return ()


### PR DESCRIPTION
Python 2 allows comparisons like `None >= (10, 13)`, which will occur for instance here:

https://github.com/apple/turicreate/blob/80e4094da5d044b0904114825869ef672f6aeb25/src/unity/python/turicreate/test/test_object_detector.py#L261

This kind of comparison is not allowed in Python 3, so the `None` is replaced with an empty tuple `()`.