### PR TITLE
Remove redundant line (that has typo in it)

### DIFF
--- a/src/unity/python/README.rst
+++ b/src/unity/python/README.rst
@@ -19,7 +19,6 @@ System Requirements
 
 -  Python 2.7 (Python 3.5+ support coming soon)
 -  x86_64 architecture
--  macOS 10.11+, Linux with glibc 2.12+ (including WSL on Windows 10)
 
 Installation
 ------------


### PR DESCRIPTION
The platforms are already mentioned and as the typo (10.11+ should be 10.12+) proves this is just
a more stuff to keep synchronized. This copies what the main README does, which is to not repeat the platforms since they were just listed above.