### PR TITLE
Fix setup install_requires syntax

### DIFF
--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -166,7 +166,7 @@ if __name__ == '__main__':
             "decorator >= 4.0.9",
             "prettytable == 0.7.2",
             "requests >= 2.9.1",
-            "mxnet >= 0.11, mxnet < 1.0.0",
+            "mxnet >= 0.11, < 1.0.0",
             "coremltools == 0.6.3",
             "pillow >= 3.3.0",
             "pandas >= 0.19.0",


### PR DESCRIPTION
Building an egg produced the following error:
```
error in turicreate setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "', mxnet '"
```
With this PR I successfully built eggs on both Linux and macOS.