### PR TITLE
Fix validation set options for the sentence classifier

### DIFF
--- a/src/unity/python/turicreate/test/test_sentence_classifier.py
+++ b/src/unity/python/turicreate/test/test_sentence_classifier.py
@@ -158,15 +158,28 @@ class SentenceClassifierCreateTests(unittest.TestCase):
 
         # Test with a validation set
         model = tc.sentence_classifier.create(train, target='rating', validation_set=valid)
-        self.assertTrue(isinstance(model, tc.sentence_classifier.SentenceClassifier))
+        self.assertTrue('Validation-accuracy' in model.classifier.progress.column_names())
 
         # Test without a validation set
         model = tc.sentence_classifier.create(train, target='rating', validation_set=None)
-        self.assertTrue(isinstance(model, tc.sentence_classifier.SentenceClassifier))
+        self.assertTrue('Validation-accuracy' not in model.classifier.progress.column_names())
 
         # Test 'auto' validation set
-        model = tc.sentence_classifier.create(train, target='rating', validation_set='auto')
-        self.assertTrue(isinstance(model, tc.sentence_classifier.SentenceClassifier))
+        big_data = train.append(tc.SFrame({
+            'rating': [5] * 100,
+            'place': ['d'] * 100,
+            'text': ['large enough data for %5 percent validation split to activate'] * 100
+        }))
+        model = tc.sentence_classifier.create(big_data, target='rating', validation_set='auto')
+        self.assertTrue('Validation-accuracy' in model.classifier.progress.column_names())
+
+        # Test bad validation set string
+        with self.assertRaises(TypeError):
+            tc.sentence_classifier.create(train, target='rating', validation_set='wrong')
+
+        # Test bad validation set type
+        with self.assertRaises(TypeError):
+            tc.sentence_classifier.create(train, target='rating', validation_set=5)
 
     def test_sentiment_classifier(self):
         m = self.model

--- a/src/unity/python/turicreate/test/test_sentence_classifier.py
+++ b/src/unity/python/turicreate/test/test_sentence_classifier.py
@@ -164,6 +164,10 @@ class SentenceClassifierCreateTests(unittest.TestCase):
         model = tc.sentence_classifier.create(train, target='rating', validation_set=None)
         self.assertTrue(isinstance(model, tc.sentence_classifier.SentenceClassifier))
 
+        # Test 'auto' validation set
+        model = tc.sentence_classifier.create(train, target='rating', validation_set='auto')
+        self.assertTrue(isinstance(model, tc.sentence_classifier.SentenceClassifier))
+
     def test_sentiment_classifier(self):
         m = self.model
         self.assertEqual(m.classifier.classes, [1, 2, 3, 5])

--- a/src/unity/python/turicreate/toolkits/sentence_classifier/_sentence_classifier.py
+++ b/src/unity/python/turicreate/toolkits/sentence_classifier/_sentence_classifier.py
@@ -27,7 +27,7 @@ def _BOW_FEATURE_EXTRACTOR(sf):
         out[f] = _tc.text_analytics.count_words(out[f])
     return out
 
-def create(dataset, target, features=None, method='auto', validation_set=None):
+def create(dataset, target, features=None, method='auto', validation_set='auto'):
     """
     Create a model that trains a classifier to classify sentences from a
     collection of documents. The model is a
@@ -54,6 +54,13 @@ def create(dataset, target, features=None, method='auto', validation_set=None):
 
     validation_set : SFrame, optional
       A dataset for monitoring the model's generalization performance.
+      For each row of the progress table, the chosen metrics are computed
+      for both the provided training dataset and the validation_set. The
+      format of this SFrame must be the same as the training set.
+      By default this argument is set to 'auto' and a validation set is
+      automatically sampled and used for progress printing. If
+      validation_set is set to None, then no additional metrics
+      are computed. The default value is 'auto'.
 
     Returns
     -------
@@ -92,16 +99,14 @@ def create(dataset, target, features=None, method='auto', validation_set=None):
     train = feature_extractor(train)
 
     # Check for a validation set.
-    kwargs = {}
-    if validation_set is not None:
+    if isinstance(validation_set, _tc.SFrame):
         validation_set = feature_extractor(validation_set)
-        kwargs['validation_set'] = validation_set
 
     m = _tc.logistic_classifier.create(train,
                                        target=target,
                                        features=features,
                                        l2_penalty=.2,
-                                       **kwargs)
+                                       validation_set=validation_set)
     num_examples = len(dataset)
     model = SentenceClassifier()
     model.__proxy__.update(


### PR DESCRIPTION
Previously the sentence classifier would ignore ```validation_set=None``` and default to creating a validation set.
The behavior is now also more consistent with other toolkits.