### PR TITLE
Added translation macros of google namespace.

### DIFF
--- a/src/external/protobuf/CMakeLists.txt
+++ b/src/external/protobuf/CMakeLists.txt
@@ -77,3 +77,8 @@ make_library(protobuf
     wire_format_lite.cc
     wrappers.pb.cc
   )
+
+# Add this in so that the protobuf namespace is globally redefined to __tc_google.
+# This avoids symbol conflicts with other version of protobuf.  
+target_compile_definitions(protobuf PUBLIC google=__tc_google)
+

--- a/src/external/sparsehash/CMakeLists.txt
+++ b/src/external/sparsehash/CMakeLists.txt
@@ -3,7 +3,6 @@ project(TuriExternalDependencies)
 
 
 add_library(sparsehash INTERFACE )
-target_compile_definitions(sparsehash INTERFACE HAS_SPARSEHASH)
+target_compile_definitions(sparsehash INTERFACE HAS_SPARSEHASH google=__tc_google)
 set(HAS_SPARSEHASH TRUE CACHE BOOL "")
-
 


### PR DESCRIPTION
It turned out that when Turi Create tried to link against a library that
included another version of one of the external libraries, the symbols
would get clobbered in some of the C++ tests, causing failures.  This
change isolates the local libraries in question.