### PR TITLE
Add NDArray Type

### DIFF
--- a/src/flexible_type/flexible_type.cpp
+++ b/src/flexible_type/flexible_type.cpp
@@ -7,6 +7,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <flexible_type/flexible_type.hpp>
 #include <logger/assertions.hpp>
+#include <image/image_util_impl.hpp>
 
 // contains some of the bigger functions I do not want to inline
 namespace turi {
@@ -80,6 +81,12 @@ flex_string get_string_visitor::operator()(const flex_vec& vec) const {
   return strm.str();
 }
 
+flex_string get_string_visitor::operator()(const flex_nd_vec& vec) const {
+  std::stringstream strm;
+  strm << vec;
+  return strm.str();
+}
+
 flex_string get_string_visitor::operator()(const flex_date_time& i) const {
   return date_time_to_string(i);
 }
@@ -120,22 +127,239 @@ flex_string get_string_visitor::operator()(const flex_dict& vec) const {
   return strm.str();
 }
 
- flex_string get_string_visitor::operator() (const flex_image& img) const {
+flex_string get_string_visitor::operator() (const flex_image& img) const {
   std::stringstream strm;
   strm << "Height: " << img.m_height;
   strm << " Width: " << img.m_width;
 
   return strm.str();
- }
+}
 
- flex_vec get_vec_visitor::operator() (const flex_image& img) const {
+flex_vec get_vec_visitor::operator() (const flex_image& img) const {
   flex_vec vec;
-  ASSERT_MSG(img.m_format == Format::RAW_ARRAY, "Cannot convert encoded image to array");
-  for (size_t i = 0 ; i < img.m_image_data_size; ++i){
-    vec.push_back(static_cast<double>(static_cast<unsigned char>(img.m_image_data[i])));
+  if(img.m_format == Format::RAW_ARRAY) {
+    for (size_t i = 0 ; i < img.m_image_data_size; ++i){
+      vec.push_back(static_cast<double>(static_cast<unsigned char>(img.m_image_data[i])));
+    }
+  } else {
+    // pay the price to decode
+    flex_image newimg = img;
+    decode_image_inplace(newimg);
+    ASSERT_TRUE(newimg.m_format == Format::RAW_ARRAY);
+    for (size_t i = 0 ; i < newimg.m_image_data_size; ++i){
+      vec.push_back(static_cast<double>(static_cast<unsigned char>(newimg.m_image_data[i])));
+    }
   }
   return vec;
- }
+}
+
+/**
+ * Flatten a potentially recursive flexible_type to nd_vec.
+ *
+ * Recursively breaks down the flexible_type flattening it into the ret array
+ * with the canonical ordering.
+ *
+ * Returns true on success, false on any shape error.
+ *
+ * \param f The flexible_type (and a few overloads of it) to flatten
+ * \param shape The target output shape.
+ * \param shape_index The current shape index of the recursive decomposition.
+ */
+static bool flexible_type_flatten_to_nd_vec(const flexible_type& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret);
+static bool flexible_type_flatten_to_nd_vec(const flex_vec& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret);
+static bool flexible_type_flatten_to_nd_vec(const flex_list& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret);
+static bool flexible_type_flatten_to_nd_vec(const flex_nd_vec& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret);
+
+static bool flexible_type_flatten_to_nd_vec(const flexible_type& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret) {
+  if (f.get_type() == flex_type_enum::VECTOR) {
+    return flexible_type_flatten_to_nd_vec(f.get<flex_vec>(), shape, shape_index, ret);
+  } else if (f.get_type() == flex_type_enum::ND_VECTOR) {
+    return flexible_type_flatten_to_nd_vec(f.get<flex_nd_vec>(), shape, shape_index, ret);
+  } else if (f.get_type() == flex_type_enum::LIST) {
+    return flexible_type_flatten_to_nd_vec(f.get<flex_list>(), shape, shape_index, ret);
+  } else {
+    return false;
+  }
+}
+
+static bool flexible_type_flatten_to_nd_vec(const flex_vec& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret) {
+  // check shape.
+  if (shape_index == shape.size() - 1 && f.size() == shape[shape_index]) {
+    // shape is good
+    std::copy(f.begin(), f.end(), std::inserter(ret, ret.end()));
+    return true;
+  }
+  return false;
+}
+
+static bool flexible_type_flatten_to_nd_vec(const flex_list& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret) {
+  // check shape
+  if (shape_index < shape.size() && f.size() == shape[shape_index]) {
+    // shape is good
+    if (shape_index == shape.size() - 1) {
+      // fast path for last entry is numeric
+      for (size_t i = 0;i < f.size(); ++i) {
+        if (flex_type_is_convertible(f[i].get_type(), flex_type_enum::FLOAT)) {
+          ret.push_back(f[i].to<double>());
+        } else {
+          return false;
+        }
+      }
+    } else {
+      for (size_t i = 0;i < f.size(); ++i) {
+        if (!flexible_type_flatten_to_nd_vec(f[i], shape, shape_index+1, ret)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  } 
+  return false;
+}
+
+
+static bool flexible_type_flatten_to_nd_vec(const flex_nd_vec& f, 
+                                            const std::vector<size_t>& shape,
+                                            size_t shape_index,
+                                            std::vector<double>& ret) {
+  // check shape
+  if (shape.size() - shape_index == f.shape().size()) {
+    bool shape_good = true;
+    for (size_t i = shape_index; i < shape.size(); ++i) {
+      shape_good &= (shape[i] == f.shape()[i-shape_index]);
+    }
+    if (shape_good == false) return false;
+    // shape is good
+
+    if (f.num_elem() == 0) return true;
+    std::vector<size_t> idx(f.shape().size(), 0);
+    do {
+      ret.push_back(f[f.fast_index(idx)]);
+    } while(f.increment_index(idx));
+    return true;
+  }
+  return false;
+}
+
+
+flex_nd_vec get_ndvec_visitor::operator()(flex_list u) const {
+  // find dimensionality.
+  std::vector<size_t> shape;
+
+  // we try to derive from u[0]. But it could be recursive hierarchies of stuff.
+  const flex_list* l = &u;
+  while(1) {
+    shape.push_back(l->size());
+    if (l->size() == 0) {
+      break;
+    }
+    const flexible_type& f = (*l)[0];
+    if (f.get_type() == flex_type_enum::VECTOR) {
+      // list contains a vector.
+      // this is the last shape dimension.
+      shape.push_back(f.size());
+      break;
+    } else if (f.get_type() == flex_type_enum::ND_VECTOR) {
+      // list contains a nd vector.
+      // this is the last shape dimension.
+      const flex_nd_vec& v = f.get<flex_nd_vec>();
+      for (size_t j = 0; j < v.shape().size(); ++j) shape.push_back(v.shape()[j]);
+      break;
+    } else if (f.get_type() == flex_type_enum::LIST) {
+      // we have another list to break down
+      l  = &(f.get<flex_list>());
+      continue;
+    } else if (flex_type_is_convertible(f.get_type(), flex_type_enum::FLOAT)) {
+      // list contains a scalar, we are now at the deepest recursive level
+      break;
+    } else {
+      log_and_throw("list contains non-numeric type. Cannot convert to ndarray");
+    }
+  }
+
+  // we have a shape
+  // empty shape
+  if (shape.size() == 0) {
+    return flex_nd_vec();
+  }
+  // 0 element shape
+  size_t numel = 1;
+  for (size_t i = 0; i < shape.size(); ++i) numel *= shape[i];
+  if (numel == 0) {
+    return flex_nd_vec(flex_nd_vec::container_type(), shape);
+  }
+
+  // n element shape
+  auto elems = std::make_shared<flex_nd_vec::container_type>() ;
+  elems->reserve(numel);
+  if (flexible_type_flatten_to_nd_vec(u, shape, 0, *elems) == false) {
+    log_and_throw("list shape invalid");
+  } 
+  return flex_nd_vec(elems, shape);
+}
+
+flex_nd_vec get_ndvec_visitor::operator()(const flex_image& img) const {
+  flex_vec flattened = get_vec_visitor()(img);
+  auto elem = std::make_shared<flex_nd_vec::container_type>();
+  (*elem) = std::move(flattened);
+  if (img.m_channels == 1) {
+    return flex_nd_vec(elem, {img.m_height, img.m_width});
+  } else {
+    return flex_nd_vec(elem, {img.m_height, img.m_width, img.m_channels});
+  }
+}
+
+flex_image get_img_visitor::operator()(const flex_nd_vec& v) const {
+  ASSERT_MSG(v.shape().size() == 2 || v.shape().size() == 3, "Cannot convert nd array to image");
+  size_t channels = 1, height = 0, width = 0;
+  if (v.shape().size() == 2) {
+    height = v.shape()[0];
+    width = v.shape()[1];
+  } else if (v.shape().size() == 3) {
+    height = v.shape()[0];
+    width = v.shape()[1];
+    channels = v.shape()[2];
+  }
+  ASSERT_MSG(channels == 1 || channels == 3 || channels == 4, "Channels must be 1,3 or 4");
+
+  size_t npixels = channels * height * width;
+  if (npixels == 0) {
+    return flex_image(nullptr, height, width, channels, 0,
+                      IMAGE_TYPE_CURRENT_VERSION, int(Format::RAW_ARRAY));
+  }
+  std::vector<unsigned char> pixels(npixels, 0);
+
+  // loop through v converting it to pixels
+  std::vector<size_t> idx(v.shape().size(), 0);
+  size_t ctr = 0;
+  do {
+    pixels[ctr] = v[v.fast_index(idx)];
+    ++ctr;
+  } while(v.increment_index(idx));
+  return flex_image((const char*)(pixels.data()), height, width, channels, pixels.size(),
+                    IMAGE_TYPE_CURRENT_VERSION, int(Format::RAW_ARRAY));
+}
 
 void soft_assignment_visitor::operator()(flex_vec& t, const flex_list& u) const {
   t.resize(u.size());
@@ -146,6 +370,7 @@ void soft_assignment_visitor::operator()(flex_vec& t, const flex_list& u) const 
     t[i] = ft.get<flex_float>();
   }
 }
+
 
 bool approx_equality_operator::operator()(const flex_dict& t, const flex_dict& u) const {
     if (t.size() != u.size()) return false;

--- a/src/flexible_type/flexible_type_base_types.hpp
+++ b/src/flexible_type/flexible_type_base_types.hpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <iostream>
 #include <serialization/serialization_includes.hpp>
+#include <flexible_type/ndarray.hpp>
 #include <image/image_type.hpp>
 
 namespace turi {
@@ -40,6 +41,7 @@ typedef std::string flex_string;
 /**
  * A vector<double> that can be stored in a flexible_type.
  * Corresponds to the type enum \ref flex_type_enum::VECTOR.
+ * \deprecated
  */
 typedef std::vector<double> flex_vec;
 /**
@@ -58,6 +60,10 @@ typedef std::vector<std::pair<flexible_type, flexible_type>> flex_dict;
  */
 typedef image_type flex_image;
 
+/**
+ * A ND-array double type that can be stored in a flexible_type.
+ * This is the successor to flex_vec.  */
+typedef flexible_type_impl::ndarray<double> flex_nd_vec;
 /**
  * A date_time object that can be stored in a flexible_type.
  * Corresponds to the type enum \ref flex_type_enum::DATETIME
@@ -327,13 +333,17 @@ enum class flex_type_enum: char {
   INTEGER = 0,  /**< Integer type. Stored type is the \ref flex_int */
   FLOAT = 1,    /**< 64-bit floating point type. Stored type is the \ref flex_float */
   STRING = 2,   /**< String type. Stored type is the \ref flex_string */
-  VECTOR = 3,   /**< Numeric vector type. Stored type is the \ref flex_vec */
+  VECTOR = 3,   /**< Numeric vector type. Stored type is the \ref flex_vec. This is deprecated. */
   LIST = 4,     /**< Recursive List type. Stored type is the \ref flex_list */
   DICT = 5,     /**< Recursive Dictionary type. Stored type is the \ref flex_dict */
   DATETIME = 6, /**< Date-Time type. Stored type is the \ref flex_date_time */
   UNDEFINED = 7,/**< Undefined / Missing Value type. Stored type is the \ref flex_undefined */
-  IMAGE= 8      /**< Image type. Stored type is the \ref flex_image */
-  // types above 127 are reserved
+  IMAGE = 8,    /**< Image type. Stored type is the \ref flex_image */
+  ND_VECTOR = 9,   /**< Numeric vector type. Stored type is the \ref flex_nd_vec */
+  // types >= 128 are reserved. 
+  // (Or rather more accurately, they should not be used without a lot of
+  //  thought and care.)
+  // See flexible_type::save / load for the reason why.
 };
 
 /**
@@ -341,19 +351,18 @@ enum class flex_type_enum: char {
  * Check if one flexible type is convertable to the other.
  */
 inline bool flex_type_is_convertible(flex_type_enum from, flex_type_enum to) {
-  static constexpr bool castable[9][9] =
-        // int flt str vec rec dic dtime undef img
-/*int*/  {{1,  1,  1,  0,  0,  0,  1,  0,  0},  // integer casts to self, float and string
-/*flt*/   {1,  1,  1,  0,  0,  0,  1,  0,  0},  // float casts to integer, self, string
-/*str*/   {0,  0,  1,  0,  0,  0,  0,  0,  0},  // string casts to string only
-/*vec*/   {0,  0,  1,  1,  1,  0,  0,  0,  0},  // vector casts to string and self and recursive
-/*rec*/   {0,  0,  1,  0,  1,  0,  0,  0,  0},  // recursive casts to string and self.
-                                                // technically a cast from rec to vec exists, but it could fail
-                                                // and so is not a reliable test for castability
-/*dic*/   {0,  0,  1,  0,  0,  1,  0,  0,  0},  // dict casts to self
-/*dtime*/ {1,  1,  1,  0,  0,  0,  1,  0,  0},  // dtime casts to string and self
-/*undef*/ {0,  0,  1,  0,  0,  0,  0,  1,  0},  //UNDEFINED casts to string and UNDEFINED
-/*img*/   {0,  0,  1,  1,  0,  0,  0,  0,  1}}; // img casts to string, vec, and self.
+  static constexpr bool castable[10][10] =
+        // int flt str vec rec dic dtime undef img ndvec
+/*int*/  {{1,  1,  1,  0,  0,  0,  1,  0,  0, 0},  // integer casts to self, float and string
+/*flt*/   {1,  1,  1,  0,  0,  0,  1,  0,  0, 0},  // float casts to integer, self, string
+/*str*/   {0,  0,  1,  0,  0,  0,  0,  0,  0, 0},  // string casts to string only
+/*vec*/   {0,  0,  1,  1,  1,  0,  0,  0,  0, 1},  // vector casts to string and self and recursive, ndvec
+/*rec*/   {0,  0,  1,  0,  1,  0,  0,  0,  0, 0},  // recursive casts to string vec, rec, ndvec, and self.
+/*dic*/   {0,  0,  1,  0,  0,  1,  0,  0,  0, 0},  // dict casts to self
+/*dtime*/ {1,  1,  1,  0,  0,  0,  1,  0,  0, 0},  // dtime casts to string and self
+/*undef*/ {0,  0,  1,  0,  0,  0,  0,  1,  0, 0},  //UNDEFINED casts to string and UNDEFINED
+/*img*/   {0,  0,  1,  1,  0,  0,  0,  0,  1, 1},  // img casts to string, ndvec, vec, and self.
+/*ndvec*/ {0,  0,  1,  1,  0,  0,  0,  0,  1, 1}}; // ndvec casts to str and flattens to vec, img, self
   return castable[static_cast<int>(from)][static_cast<int>(to)];
 }
 
@@ -384,65 +393,70 @@ inline bool flex_type_is_convertible(flex_type_enum from, flex_type_enum to) {
 inline bool flex_type_has_binary_op(flex_type_enum left,
                                     flex_type_enum right,
                                     char op) {
-  static constexpr bool plus_operator[9][9] =     // '+' operator
-        // int flt str vec rec cel dtime undef img
-/*int*/  {{1,  1,  0,  0,  0,  0,  0,  0,  0},
-/*flt*/   {1,  1,  0,  0,  0,  0,  0,  0,  0},
+  static constexpr bool plus_operator[10][10] =     // '+' operator
+        // int flt str vec rec cel dtime undef img ndvec
+/*int*/  {{1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*flt*/   {1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*str*/   {0,  0,  1,  0,  0,  0,  0,  0,  0,  0},
+/*vec*/   {1,  1,  0,  1,  0,  0,  0,  0,  0,  0},
+/*rec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*cel*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*dtime*/ {1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*undef*/ {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*ndvec*/ {1,  1,  0,  0,  0,  0,  0,  0,  0,  1}};
+
+  static constexpr bool minus_operator[10][10] =  // '-' operator
+        // int flt str vec rec cel dtime undef img ndvec
+/*int*/  {{1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*flt*/   {1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*str*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*vec*/   {1,  1,  0,  1,  0,  0,  0,  0,  0,  0},
+/*rec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*cel*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*dtime*/ {1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*undef*/ {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*ndvec*/ {1,  1,  0,  0,  0,  0,  0,  0,  0,  1}};
+
+  static constexpr bool other_numeric_operators[10][10] =  // '*','/','%' operator
+        // int flt str vec rec cel dtime undef img ndvec
+/*int*/  {{1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*flt*/   {1,  1,  0,  0,  0,  0,  0,  0,  0,  0},
+/*str*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*vec*/   {1,  1,  0,  1,  0,  0,  0,  0,  0,  0},
+/*rec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*cel*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*dtime*/ {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*undef*/ {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*ndvec*/ {1,  1,  0,  0,  0,  0,  0,  0,  0,  1}};
+
+  static constexpr bool comparison_operators[10][10] =  // < or > operator
+        // int flt str vec rec cel dtime undef img ndvec
+/*int*/  {{1,  1,  0,  0,  0,  0,  1,  0,  0},
+/*flt*/   {1,  1,  0,  0,  0,  0,  1,  0,  0},
 /*str*/   {0,  0,  1,  0,  0,  0,  0,  0,  0},
-/*vec*/   {1,  1,  0,  1,  0,  0,  0,  0,  0},
+/*vec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
 /*rec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
 /*cel*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*dtime*/ {1,  1,  0,  0,  0,  0,  0,  0,  0},
+/*dtime*/ {1,  1,  0,  0,  0,  0,  1,  0,  0},
 /*undef*/ {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0}};
+/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
+/*ndvec*/ {0,  0,  0,  0,  0,  0,  0,  0,  0}};
 
-  static constexpr bool minus_operator[9][9] =  // '*','/','%' operator
-        // int flt str vec rec cel dtime undef img
-/*int*/  {{1,  1,  0,  0,  0,  0,  0,  0,  0},
-/*flt*/   {1,  1,  0,  0,  0,  0,  0,  0,  0},
-/*str*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*vec*/   {1,  1,  0,  1,  0,  0,  0,  0,  0},
-/*rec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*cel*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*dtime*/ {1,  1,  0,  0,  0,  0,  0,  0,  0},
-/*undef*/ {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0}};
-
-  static constexpr bool other_numeric_operators[9][9] =  // '-','*','/','%' operator
-        // int flt str vec rec cel dtime undef img
-/*int*/  {{1,  1,  0,  0,  0,  0,  0,  0,  0},
-/*flt*/   {1,  1,  0,  0,  0,  0,  0,  0,  0},
-/*str*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*vec*/   {1,  1,  0,  1,  0,  0,  0,  0,  0},
-/*rec*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*cel*/   {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*dtime*/ {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*undef*/ {0,  0,  0,  0,  0,  0,  0,  0,  0},
-/*img*/   {0,  0,  0,  0,  0,  0,  0,  0,  0}};
-
-  static constexpr bool comparison_operators[9][9] =  // < or > operator
-        // int flt str vec rec cel dtime undef img
-/*int*/  {{1,  1,  0,  0,  0,  0,  1,  0},
-/*flt*/   {1,  1,  0,  0,  0,  0,  1,  0},
-/*str*/   {0,  0,  1,  0,  0,  0,  0,  0},
-/*vec*/   {0,  0,  0,  0,  0,  0,  0,  0},
-/*rec*/   {0,  0,  0,  0,  0,  0,  0,  0},
-/*cel*/   {0,  0,  0,  0,  0,  0,  0,  0},
-/*dtime*/ {1,  1,  0,  0,  0,  0,  1,  0},
-/*undef*/ {0,  0,  0,  0,  0,  0,  0,  0},
-/*img*/   {0,  0,  0,  0,  0,  0,  0,  0}};
-
-  static constexpr bool equality_operators[9][9] =  // = operator
-        // int flt str vec rec cel dtime undef img
-/*int*/  {{1,  1,  0,  0,  0,  0,  1,  1, 0},
-/*flt*/   {1,  1,  0,  0,  0,  0,  1,  1, 0},
-/*str*/   {0,  0,  1,  0,  0,  0,  0,  1, 0},
-/*vec*/   {0,  0,  0,  1,  0,  0,  0,  1, 0},
-/*rec*/   {0,  0,  0,  0,  0,  0,  0,  1, 0},
-/*cel*/   {0,  0,  0,  0,  0,  0,  0,  1, 0},
-/*dtime*/ {1,  1,  0,  0,  0,  0,  1,  1, 0},
-/*undef*/ {1,  1,  1,  1,  1,  1,  1,  1, 1},
-/*img*/   {0,  0,  0,  0,  0,  0,  0,  1, 0}};
+  static constexpr bool equality_operators[10][10] =  // = operator
+        // int flt str vec rec cel dtime undef img ndvec
+/*int*/  {{1,  1,  0,  0,  0,  0,  1,  1,  0,  0},
+/*flt*/   {1,  1,  0,  0,  0,  0,  1,  1,  0,  0},
+/*str*/   {0,  0,  1,  0,  0,  0,  0,  1,  0,  0},
+/*vec*/   {0,  0,  0,  1,  0,  0,  0,  1,  0,  0},
+/*rec*/   {0,  0,  0,  0,  0,  0,  0,  1,  0,  0},
+/*cel*/   {0,  0,  0,  0,  0,  0,  0,  1,  0,  0},
+/*dtime*/ {1,  1,  0,  0,  0,  0,  1,  1,  0,  0},
+/*undef*/ {1,  1,  1,  1,  1,  1,  1,  1,  1,  0},
+/*img*/   {0,  0,  0,  0,  0,  0,  0,  1,  0,  0},
+/*ndvec*/ {0,  0,  0,  0,  0,  0,  0,  0,  0,  1}};
   switch(op) {
    case '+':
     return plus_operator[static_cast<int>(left)][static_cast<int>(right)];
@@ -513,6 +527,12 @@ struct type_to_enum<flex_string> {
 template <>
 struct type_to_enum<flex_vec> {
   static constexpr flex_type_enum value = flex_type_enum::VECTOR;
+  constexpr operator flex_type_enum() const { return value; }
+};
+
+template <>
+struct type_to_enum<flex_nd_vec> {
+  static constexpr flex_type_enum value = flex_type_enum::ND_VECTOR;
   constexpr operator flex_type_enum() const { return value; }
 };
 
@@ -596,6 +616,12 @@ struct is_valid_flex_type<flex_vec> {
 };
 
 template <>
+struct is_valid_flex_type<flex_nd_vec> {
+  static constexpr bool value = true;
+  constexpr operator bool() const { return value; }
+};
+
+template <>
 struct is_valid_flex_type<flex_dict> {
   static constexpr bool value = true;
   constexpr operator bool() const { return value; }
@@ -659,6 +685,10 @@ struct enum_to_type<flex_type_enum::VECTOR>{
   typedef flex_vec type;
 };
 
+template <>
+struct enum_to_type<flex_type_enum::ND_VECTOR>{
+  typedef flex_nd_vec type;
+};
 
 template <>
 struct enum_to_type<flex_type_enum::LIST>{
@@ -698,6 +728,8 @@ inline const char* flex_type_enum_to_name(flex_type_enum en) {
      return "string";
    case flex_type_enum::VECTOR:
      return "array";
+   case flex_type_enum::ND_VECTOR:
+     return "ndarray";
    case flex_type_enum::LIST:
      return "list";
    case flex_type_enum::DICT:
@@ -722,6 +754,7 @@ inline flex_type_enum flex_type_enum_from_name(const std::string& name) {
     {"float", flex_type_enum::FLOAT},
     {"string", flex_type_enum::STRING},
     {"array", flex_type_enum::VECTOR},
+    {"ndarray", flex_type_enum::ND_VECTOR},
     {"list", flex_type_enum::LIST},
     {"dictionary", flex_type_enum::DICT},
     {"image", flex_type_enum::IMAGE},
@@ -752,6 +785,7 @@ struct has_direct_conversion_to_flexible_type {
       std::is_convertible<T, flex_string>::value ||
       std::is_convertible<T, flex_list>::value ||
       std::is_convertible<T, flex_vec>::value ||
+      std::is_convertible<T, flex_nd_vec>::value ||
       std::is_convertible<T, flex_dict>::value ||
       std::is_convertible<T, flex_date_time>::value ||
       std::is_convertible<T, flex_image>::value ||
@@ -763,6 +797,7 @@ struct has_direct_conversion_to_flexible_type {
       std::is_convertible<T, flex_string>::value ? flex_type_enum::STRING :
       std::is_convertible<T, flex_list>::value ? flex_type_enum::LIST :
       std::is_convertible<T, flex_vec>::value ? flex_type_enum::VECTOR :
+      std::is_convertible<T, flex_nd_vec>::value ? flex_type_enum::ND_VECTOR :
       std::is_convertible<T, flex_dict>::value ? flex_type_enum::DICT :
       std::is_convertible<T, flex_date_time>::value ? flex_type_enum::DATETIME :
       std::is_convertible<T, flex_image>::value ? flex_type_enum::IMAGE :

--- a/src/flexible_type/ndarray.hpp
+++ b/src/flexible_type/ndarray.hpp
@@ -1,0 +1,721 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_FLEXIBLE_TYPE_NDARRAY
+#define TURI_FLEXIBLE_TYPE_NDARRAY
+#include <tuple>
+#include <iostream>
+#include <logger/assertions.hpp>
+#include <serialization/serialization_includes.hpp>
+namespace turi {
+namespace flexible_type_impl {
+
+
+template <typename T>
+static void mod_helper(T& a, const T& b, 
+                       typename std::enable_if<std::is_floating_point<T>::value>::type* = 0) {
+  a = fmod(a,b);
+}
+template <typename T>
+static void mod_helper(T& a, const T& b,
+                       typename std::enable_if<!std::is_floating_point<T>::value>::type* = 0) {
+  a %= b;
+}
+/**
+ * A generic dense multidimensional array.
+ *
+ * This class implements a very minimal generic dense multidimensional 
+ * array type.
+ * 
+ * The basic layout is simple.
+ *  - elems: is a flattened array of all the elements
+ *  - start: The offset of the 0th element in elems.
+ *  - shape: is the dimensions of the ndarray. The product of all the values in
+ *    shape should equal elems.length()
+ *  - stride: is used to convert between ND-indices and element indices.
+ *
+ *
+ *
+ * Array indexing is computed as follows:
+ *
+ *   ndarray[i,j,k] = elements[start + i * stride[0] + j * stride[1] + k * stride[2]]
+ *
+ * Note the stride are not based on the element size. i.e. if we have a simple 
+ * 1-D array, stride[0] is always 1. (as opposed to sizeof(T)).
+ *
+ * The NDArray's default construction layout is "C" ordering: the stride
+ * array is non-increasing. That is, for a simple 3D ndarray[i,j,k], elements
+ * ndarray[i,j,k], ndarray[i,j,k+1] are adjacent.
+ *
+ * However, due to to explicit representation of offset, shape and stride, almost
+ * arbitrary layouts and slices can be represented by the ndarray.
+ *
+ * The current implementation of the ndarray enforces that all mutation
+ * operations require elems to be unique (elems.use_count() == 1). Hence views
+ * are not modifiable; modifying a view automtacally incurs a data copy. This
+ * might be relaxed in the future (perhaps with a inherited view<T> type) but
+ * this assumption allows for simpler memory management right now.
+ *
+ * Note
+ * ----
+ * The performance of the ndarray operators is probably not particularly 
+ * optimized. Really, the \ref increment_index() system should be replaced
+ * with an iterator.
+ **/
+template <typename T>
+class ndarray {
+ public:
+  typedef size_t index_type;
+  typedef T value_type;
+  typedef std::vector<index_type> index_range_type;
+  typedef std::vector<T> container_type;
+
+ private:
+  std::shared_ptr<container_type> m_elem;
+  index_range_type m_shape;
+  index_range_type m_stride;
+  index_type m_start = 0;
+
+ public:
+
+  /// construct with custom stride ordering
+  ndarray(const container_type& elements = container_type(), 
+          const index_range_type& shape = index_range_type(),
+          const index_range_type& stride = index_range_type(),
+          const index_type start = 0):
+              ndarray(std::make_shared<container_type>(elements), shape, stride, start) {}
+
+  /// construct with custom stride ordering
+  ndarray(const std::shared_ptr<container_type>& elements, 
+          const index_range_type& shape = index_range_type(),
+          const index_range_type& stride = index_range_type(),
+          const index_type start = 0): 
+              m_elem(elements), m_shape(shape), m_stride(stride), m_start(start) { 
+    // construct m_shape if not given
+    if (m_shape.size() == 0 && elements->size() - m_start > 0) {
+      m_shape.push_back(elements->size() - m_start);
+    }
+    // construct m_stide if not given
+    if (m_stride.size() == 0 && m_shape.size() > 0) {
+      m_stride.resize(m_shape.size());
+      int i = m_shape.size() - 1;
+      m_stride[i] = 1;
+      --i;
+      for (;i >= 0; --i) {
+        m_stride[i] = m_stride[i + 1] * m_shape[i + 1];
+      }
+    }
+
+    // if any shape axis is empty
+    bool empty = m_shape.size() == 0;
+    for (size_t i = 0;i < m_shape.size(); ++i) {
+      if (m_shape[i] == 0) {
+        empty = true;
+      }
+    }
+    if (empty) {
+      m_elem->clear();
+      m_shape.clear();
+      m_stride.clear();
+      m_start = 0;
+    }
+
+    ASSERT_TRUE(is_valid());
+    for (size_t i = 0;i < m_shape.size(); ++i) {
+      ASSERT_TRUE(m_shape[i] > 0);
+    }
+  }
+
+  ndarray(const ndarray<T>&) = default;
+  ndarray(ndarray<T>&&) = default;
+  ndarray& operator=(const ndarray<T>&) = default;
+  ndarray& operator=(ndarray<T>&&) = default;
+
+  /**
+   * Ensures that m_elem is a unique copy.
+   */
+  void ensure_unique() {
+    if (m_elem.use_count() > 1) {
+      m_elem = std::make_shared<container_type>(*m_elem);
+    }
+  }
+
+  /**
+   * Returns true if the ndarray is empty / has no elements.
+   */
+  bool empty() const {
+    if (m_elem->empty()) {
+      return true;
+    } else {
+      return num_elem() == 0;
+    }
+  }
+
+  /**
+   * Returns the linear index given an N-d index
+   * performing bounds checking on the index ranges.
+   * 
+   * \code
+   * std::vector<size_t> indices = {1,5,2};
+   * arr.at(arr.index(indices)) = 10 // also bounds check the linear index
+   * arr[arr.index(indices)] = 10    // does not bounds check the linear index
+   * \endcode
+   */
+  template <typename U>
+  index_type index(const std::vector<U>& index) const {
+    ASSERT_EQ(m_stride.size(), index.size());
+
+    size_t idx = 0;
+    for (size_t i = 0; i < index.size(); ++i) {
+      index_type v = index[i];
+      ASSERT_LT(v, m_shape[i]);
+      idx += v * m_stride[i];
+    }
+    return idx;
+  }
+
+  /**
+   * Returns the linear index given an N-d index
+   * without performing bounds checking on the index ranges.
+   *
+   * \code
+   * std::vector<size_t> indices = {1,5,2};
+   * arr[arr.fast_index(indices)] = 10 // does not bounds check the linear index
+   * arr.at(arr.fast_index(indices)) = 10 // bounds check the linear index
+   * \endcode
+   */
+  template <typename U>
+  index_type fast_index(const std::vector<U>& index) const {
+    size_t idx = 0;
+    for (size_t i = 0; i < index.size(); ++i) {
+      index_type v = index[i];
+      idx += v * m_stride[i];
+    }
+    return idx;
+  }
+
+  /**
+   * Returns a reference to an element given the linear index, no bounds
+   * checking is performed.
+   *
+   * Note that if the memory used by this array is shared, this may have
+   * unintentional side effects (changing other arrays).
+   */
+  value_type& operator[](size_t elem_index) {
+    ensure_unique();
+    return (*m_elem)[m_start + elem_index];
+  }
+
+  /**
+   * Returns a const reference to an element given the linear index, no bounds
+   * checking is performed.
+   */
+  const value_type& operator[](size_t elem_index) const {
+    return (*m_elem)[m_start + elem_index];
+  }
+
+  /**
+   * Returns a reference to an element given the linear index, performing bounds
+   * checking on the index range.
+   *
+   * Note that if the memory used by this array is shared, this may have
+   * unintentional side effects (changing other arrays).
+   */
+  value_type& at(size_t elem_index) {
+    ensure_unique();
+    ASSERT_LT(m_start + elem_index, m_elem->size());
+    return (*m_elem)[m_start + elem_index];
+  }
+
+  /**
+   * Returns a const reference to an element given the linear index, performing
+   * checking on the index range.
+   */
+  const value_type& at(size_t elem_index) const {
+    ASSERT_LT(m_start + elem_index, m_elem->size());
+    return (*m_elem)[m_start + elem_index];
+  }
+
+  /**
+   * Returns a reference to all the elements in a linear layout; if is_full()
+   * is false, this will include unindexable elements.
+   *
+   * Note that if the memory used by this array is shared, this may have
+   * unintentional side effects (changing other arrays).
+   */
+  container_type& raw_elements() {
+    return *m_elem;
+  }
+
+  /**
+   * Returns a reference to all the elements in a linear layout; if is_full()
+   * is false, this will include unindexable elements.
+   */
+  const container_type& raw_elements() const {
+    return *m_elem;
+  }
+
+  /**
+   * Returns a reference to all the elements in a linear layout, is_full()
+   * must be true.
+   *
+   * Note that if the memory used by this array is shared, this may have
+   * unintentional side effects (changing other arrays).
+   */
+  container_type& elements() {
+    ensure_unique();
+    ASSERT_TRUE(is_full());
+    return *m_elem;
+  }
+  /**
+   * Returns a const reference to all the elements in a linear layout, is_full()
+   * must be true.
+   */
+  const container_type& elements() const {
+    ASSERT_TRUE(is_full());
+    return *m_elem;
+  }
+
+  /**
+   * Returns a const reference to the shape.
+   */
+  const index_range_type& shape() const {
+    return m_shape;
+  }
+
+  /**
+   * Returns a const reference to the stride.
+   */
+  const index_range_type& stride() const {
+    return m_stride;
+  }
+
+  /**
+   * Returns a const reference to the stride.
+   */
+  index_type start() const {
+    return m_start;
+  }
+
+  /**
+   * Returns the number of elements in the array.
+   *
+   * This is equivalent to the product of the values in the shape array.
+   * Note that this may not be the same as elements().size().
+   */
+  size_t num_elem() const {
+    if (m_shape.size() == 0) return 0;
+    if (m_elem == nullptr) return 0;
+    size_t p = 1;
+    for (size_t s: m_shape) {
+      p = p * s;
+    }
+    return p;
+  }
+
+  /**
+   * Returns true if every element in elements() is reachable by an
+   * N-d index.
+   */
+  bool is_full() const {
+    return m_start == 0 && 
+        num_elem() == m_elem->size() && 
+        last_index() == m_elem->size();
+  }
+
+  /**
+   * Returns true if the shape and stride of the array is laid out 
+   * correctly such at all array indices are within elements().size().
+   * 
+   * An ndarray can be invalid for instance, if the stride is too large,
+   * or if the shape is larger than the total number of elements.
+   */
+  bool is_valid() const {
+    return m_shape.size() == m_stride.size() &&   // shape and stride line up
+          num_elem() + m_start <= m_elem->size() &&  // num_elements (as computed by shape) is in m_elem
+          last_index() + m_start <= m_elem->size();  // max index (as computed by stride( is in m_elem
+  }
+
+  /** 
+   * Returns true if the stride is ordered canonically.
+   * The strides must be non-increasing and non-zero.
+  */
+  bool has_canonical_stride() const {
+    if (m_stride.size() == 0) return true;
+    if (m_stride[0] == 0) return false;
+    for (size_t i = 1; i < m_stride.size(); ++i) {
+      if (m_stride[i] == 0 || m_stride[i - 1] < m_stride[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Returns true if the nd-array is in canonical ordering
+  bool is_canonical() const {
+    return is_full() && has_canonical_stride();
+  }
+
+  /**
+   * Increments a vector representing an N-D index.
+   *
+   * Assumes that the index is valid to begin with.
+   * Returns 1 + [the index position we incremented] while we have not reached
+   * the end of the array. Returns 0 once we increment past the end of the
+   * array.
+   */
+  template <typename U>
+  size_t inline increment_index(std::vector<U>& idx) const {
+    DASSERT_TRUE(idx.size() == m_shape.size());
+    int i = idx.size() - 1;
+    for (;i >= 0 ; --i) {
+      ++idx[i];
+      if (idx[i] < m_shape[i]) break;
+      // we hit counter limit we need to advance the next counter;
+      idx[i] = 0;
+    }
+    if (i < 0) return 0;
+    else return i + 1;
+  }
+
+  /**
+   * Returns an ndarray ordered canonically.
+   *
+   * The canonical ordering is full (\ref is_full()) and the stride array
+   * is non-descending.
+   *
+   * Raises an exception if the array is not valid.
+   *
+   * \note The performance of this algorithm can probably be improved.
+   */
+  ndarray<T> canonicalize() const {
+    if (is_canonical()) return (*this);
+    ASSERT_TRUE(is_valid());
+
+    ndarray<T> ret;
+    ret.m_start = 0;
+    ret.m_shape = m_shape;
+    ret.m_elem->resize(num_elem());
+    ret.m_stride.resize(m_shape.size());
+
+    // empty array
+    if (ret.m_shape.size() == 0 || ret.m_elem->size() == 0) {
+      return ret;
+    }
+
+    // compute the stride
+    int i = ret.m_shape.size() - 1;
+    ret.m_stride[i] = 1;
+    --i;
+    for (;i >= 0; --i) {
+      ret.m_stride[i] = ret.m_stride[i + 1] * ret.m_shape[i + 1];
+    }
+
+    std::vector<size_t> idx(m_shape.size(), 0);
+    size_t ctr = 0;
+    do {
+      // directly referencing ret.m_elem is ok here because ret.m_start is 0
+      (*ret.m_elem)[ctr] = (*this)[fast_index(idx)];
+      ++ctr;
+    } while(increment_index(idx));
+
+    return ret;
+  }
+
+  /**
+   * Forces this ndarray to be full by compacting if necessary.
+   */
+  void ensure_full() {
+    if (!is_full()) {
+      (*this) = compact();
+    }
+  }
+
+  /**
+   * Returns a compacted ndarray.
+   * 
+   * A compacted NDArray has the same stride ordering as the original array,
+   * but enforces that the array is full. This essentially means that the
+   * elements array has the same order of elements, but skipped elements are
+   * removed.
+   *
+   * Raises an exception if the array is not valid.
+   *
+   * \note The performance of this algorithm can probably be improved.
+   */
+  ndarray<T> compact() const {
+    ASSERT_TRUE(is_valid());
+    if (is_full()) return (*this);
+
+    ndarray<T> ret;
+    ret.m_start = 0;
+    ret.m_shape = m_shape;
+    ret.m_elem->resize(num_elem());
+    ret.m_stride.resize(m_shape.size());
+
+    // empty array
+    if (ret.m_shape.size() == 0 || ret.m_elem->size() == 0) {
+      return ret;
+    }
+
+    std::vector<std::pair<size_t, size_t>> stride_ordering(m_stride.size());
+    for (size_t i = 0;i < m_stride.size(); ++i) stride_ordering[i] = {m_stride[i], i};
+    std::sort(stride_ordering.rbegin(), stride_ordering.rend());
+
+    // compute the stride
+    ret.m_stride[stride_ordering[0].second] = 1;
+    for (size_t i = 1;i < m_stride.size(); ++i) {
+      ret.m_stride[stride_ordering[i].second] = 
+          ret.m_stride[stride_ordering[i - 1].second] * ret.m_shape[stride_ordering[i - 1].second];
+    }
+
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      // directly referencing ret.m_elem is ok here because ret.m_start is 0
+      (*ret.m_elem)[ret.fast_index(idx)] = (*this)[fast_index(idx)];
+    } while(increment_index(idx));
+
+    return ret;
+  }
+
+  /// serializer
+  void save(oarchive& oarc) const {
+    ASSERT_TRUE(is_valid());
+    oarc << char(0);
+    if (is_full()) {
+      oarc << m_shape;
+      oarc << m_stride;
+      oarc << *m_elem;
+    } else {
+      ndarray<T> c = compact();
+      ASSERT_TRUE(c.is_full());
+      oarc << c.m_shape;
+      oarc << c.m_stride;
+      oarc << *(c.m_elem);
+    }
+  }
+
+  /// deserializer
+  void load(iarchive& iarc) {
+    char c;
+    iarc >> c;
+    ASSERT_TRUE(c == 0);
+    m_start = 0;
+    iarc >> m_shape;
+    iarc >> m_stride;
+    m_elem = std::make_shared<container_type>();
+    iarc >> *m_elem;
+  }
+
+  /**
+   * Return true if this ndarray has the same shape as another ndarray.
+   */
+  bool same_shape(const ndarray<T>& other) const {
+    if (m_shape.size() != other.m_shape.size()) return false;
+    for (size_t i = 0;i < m_shape.size(); ++i) {
+      if (m_shape[i] != other.m_shape[i]) return false;
+    }
+    return true;
+  }
+
+  /// element-wise addition. The other array must have the same shape.
+  ndarray<T>& operator+=(const ndarray<T>& other) {
+    ASSERT_TRUE(same_shape(other));
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] += other[other.fast_index(idx)];
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// scalar addition. 
+  ndarray<T>& operator+=(T other) {
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] += other;
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// element-wise subtraction. The other array must have the same shape.
+  ndarray<T>& operator-=(const ndarray<T>& other) {
+    ASSERT_TRUE(same_shape(other));
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] -= other[other.fast_index(idx)];
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// scalar subtraction. 
+  ndarray<T>& operator-=(T other) {
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] -= other;
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// element-wise multiplication. The other array must have the same shape.
+  ndarray<T>& operator*=(const ndarray<T>& other) {
+    ASSERT_TRUE(same_shape(other));
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] *= other[other.fast_index(idx)];
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// scalar multiplication 
+  ndarray<T>& operator*=(T other) {
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] *= other;
+    } while(increment_index(idx));
+    return *this;
+  }
+
+
+  /// element-wise division. The other array must have the same shape.
+  ndarray<T>& operator/=(const ndarray<T>& other) {
+    ASSERT_TRUE(same_shape(other));
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] /= other[other.fast_index(idx)];
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// scalar division
+  ndarray<T>& operator/=(T other) {
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      (*this)[fast_index(idx)] /= other;
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// element-wise modulo. The other array must have the same shape.
+  ndarray<T>& operator%=(const ndarray<T>& other) {
+    ASSERT_TRUE(same_shape(other));
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      T& left = (*this)[fast_index(idx)];
+      mod_helper(left, other[other.fast_index(idx)]);
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// scalar modulo. 
+  ndarray<T>& operator%=(T other) {
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      T& left = (*this)[fast_index(idx)];
+      mod_helper(left, other);
+    } while(increment_index(idx));
+    return *this;
+  }
+
+  /// negation
+  ndarray<T>& negate() {
+    if (num_elem() == 0) return *this;
+    ensure_unique();
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      T& v = (*this)[fast_index(idx)];
+      v = -v;
+    } while(increment_index(idx));
+    return *this;
+  }
+
+
+  /// element-wise equality. The other array must have the same shape.
+  bool operator==(const ndarray<T>& other) const {
+    if (&other == this) return true;
+    if (!same_shape(other)) return false;
+    if (num_elem() == 0) return true;
+    std::vector<size_t> idx(m_shape.size(), 0);
+    do {
+      if ((*this)[fast_index(idx)] != other[other.fast_index(idx)]) return false;
+    } while(increment_index(idx));
+    return true;
+  }
+
+  /// inverse of ==
+  bool operator!=(const ndarray<T>& other) const {
+    return !((*this) == other);
+  }
+
+  void print(std::ostream& os) const {
+    std::vector<size_t> idx(m_shape.size(), 0);
+    if (num_elem() == 0) os << "[]";
+
+    // print all the open square brackets
+    for (size_t i = 0;i < idx.size(); ++i) os << "[";
+    size_t next_bracket_depth;
+    bool is_first_element = true;
+    do {
+      if (is_first_element == false) os << ",";
+      os << (*m_elem)[fast_index(idx)];
+      is_first_element = false;
+      next_bracket_depth = increment_index(idx);
+      if (next_bracket_depth == 0) break;
+      for (size_t i = next_bracket_depth ;i < idx.size(); ++i) os << "]";
+      if (next_bracket_depth < idx.size()) os << ",";
+      for (size_t i = next_bracket_depth;i < idx.size(); ++i) os << "[";
+      if (next_bracket_depth < idx.size()) is_first_element = true;
+    }while(1);
+    for (size_t i = 0;i < idx.size(); ++i) os << "]";
+  }
+  
+ private:
+  /**
+   * Returns one past the last valid linear index of the array according to the
+   * shape and stride information.
+   */
+  size_t last_index() const {
+    if (m_shape.size() == 0) return 0;
+    size_t last_idx = 0;
+    for (size_t i = 0; i < m_shape.size(); ++i) {
+      last_idx += (m_shape[i]-1) * m_stride[i];
+    }
+    return last_idx + 1;
+  }
+
+};
+
+// pointer to ndarray is constrained to pointer size
+// to enforce that it will always fit in a flexible_type.
+static_assert(sizeof(ndarray<int>*) == sizeof(size_t));
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const ndarray<T>& n) {
+  n.print(os);
+  return os;
+}
+
+} // flexible_type_impl
+} // namespace turi
+#endif

--- a/src/image/CMakeLists.txt
+++ b/src/image/CMakeLists.txt
@@ -9,8 +9,10 @@ project(image)
 make_library(image_type
   SOURCES
     image_type.cpp
+    image_util_impl.cpp
   REQUIRES
     logger
+    image_io
     EXTERNAL_VISIBILITY
 )
 

--- a/src/image/image_util_impl.cpp
+++ b/src/image/image_util_impl.cpp
@@ -3,9 +3,6 @@
  * Use of this source code is governed by a BSD-3-clause license that can
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
-#ifndef IMAGE_UTIL_DETAIL_HPP
-#define IMAGE_UTIL_DETAIL_HPP
-
 #include <image/io.hpp>
 #ifndef png_infopp_NULL
 #define png_infopp_NULL (png_infopp)NULL
@@ -139,5 +136,15 @@ void encode_image_impl(image_type& image) {
 }
 
 } // end of image_util_detail
+
+
+void decode_image_inplace(image_type& image) {
+  image_util_detail::decode_image_impl(image); 
+}
+
+void encode_image_inplace(image_type& image) {
+  image_util_detail::encode_image_impl(image); 
+}
+
+
 } // end of turicreate
-#endif

--- a/src/image/image_util_impl.hpp
+++ b/src/image/image_util_impl.hpp
@@ -1,0 +1,38 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef IMAGE_UTIL_IMPL_HPP
+#define IMAGE_UTIL_IMPL_HPP
+
+#include <image/io.hpp>
+namespace turi {
+
+
+namespace image_util_detail {
+
+void resize_image_impl(const char* data, size_t width, size_t height, 
+                       size_t channels, size_t resized_width, size_t resized_height, 
+                       size_t resized_channels, char** resized_data);
+
+void decode_image_impl(image_type& image);
+
+void encode_image_impl(image_type& image);
+
+} // end of image_util_detail
+
+
+/**
+ * Makes an image raw.
+ */
+void decode_image_inplace(image_type& image);
+
+
+/**
+ * Makes an image png if raw.
+ */
+void encode_image_inplace(image_type& image);
+
+} // end of turicreate
+#endif

--- a/src/sframe/groupby_aggregate_operators.hpp
+++ b/src/sframe/groupby_aggregate_operators.hpp
@@ -81,11 +81,12 @@ class vector_sum : public group_aggregate_value {
 
   /// The types supported by the sum
   bool support_type(flex_type_enum type) const {
-    return type == flex_type_enum::VECTOR;
+    return type == flex_type_enum::VECTOR || type == flex_type_enum::ND_VECTOR;
   }
 
   /// The input type to be summed
   flex_type_enum set_input_type(flex_type_enum type) {
+    value.reset(type);
     return type;
   }
 
@@ -697,11 +698,12 @@ class vector_average: public group_aggregate_value {
 
   /// The types supported by the count. (everything)
   bool support_type(flex_type_enum type) const {
-    return type == flex_type_enum::VECTOR;
+    return type == flex_type_enum::VECTOR || type == flex_type_enum::ND_VECTOR;
   }
 
   /// The input type
   flex_type_enum set_input_type(flex_type_enum type) {
+    value.reset(type);
     return type;
     
   }

--- a/src/sframe/sarray_v2_type_encoding.hpp
+++ b/src/sframe/sarray_v2_type_encoding.hpp
@@ -309,6 +309,75 @@ static void decode_vector_stream(size_t num_elements,
   }
 }
 
+/**
+ * Decodes num_elements of nd_vectors, calling the callback for each string.
+ */
+template <typename Fn> // Fn is a function like void(flexible_type)
+static void decode_nd_vector_stream(size_t num_elements,
+                                    iarchive& iarc,
+                                    Fn callback,
+                                    bool new_format) {
+  // new_format is ignored. it should always be true.
+  // one character is reserved so we can add new encoders as needed in the future
+  char reserved = 0;
+  iarc.read(&(reserved), sizeof(reserved));
+
+  std::vector<flexible_type> shape_lengths(num_elements);
+  std::vector<flexible_type> numel(num_elements);
+  std::vector<flexible_type> shapes;
+  std::vector<flexible_type> strides;
+  std::vector<flexible_type> values;
+
+  // decode shape lengths and numel
+  decode_number(iarc, shape_lengths, 0);
+  decode_number(iarc, numel, 0);
+
+  // compute the length of shapes and strides
+  size_t sum_shape_len = 0;
+  for (auto i : shape_lengths) sum_shape_len += i.get<flex_int>();
+  // decode shape and strides
+  shapes.resize(sum_shape_len);
+  strides.resize(sum_shape_len);
+  decode_number(iarc, shapes, 0);
+  decode_number(iarc, strides, 0);
+
+  // compute the length of values
+  size_t sum_values_len = 0;
+  for (auto i : numel) sum_values_len += i.get<flex_int>();
+  values.resize(sum_values_len);
+  decode_double(iarc, values, 0);
+
+  // emit
+  size_t shape_stride_ctr = 0;
+  size_t value_ctr = 0;
+
+  std::vector<size_t> ret_shape;
+  std::vector<size_t> ret_stride;
+
+  for (size_t i = 0 ;i < num_elements; ++i) {
+    // construct the shape and stride
+    ret_shape.resize(shape_lengths[i]);
+    ret_stride.resize(shape_lengths[i]);
+    for (size_t j = 0;j < shape_lengths[i]; ++j) {
+      ret_shape[j] = shapes[shape_stride_ctr].get<flex_int>();
+      ret_stride[j] = strides[shape_stride_ctr].get<flex_int>();
+      ++shape_stride_ctr;
+    }
+
+    // construct the values
+    size_t ret_numel = numel[i].get<flex_int>();
+    auto ret_values = std::make_shared<flex_nd_vec::container_type>(ret_numel);
+    for (size_t i = 0;i < ret_numel; ++i) {
+      (*ret_values)[i] = values[i + value_ctr].reinterpret_get<flex_float>();
+    }
+    value_ctr += ret_numel;
+    flexible_type ret(flex_nd_vec(ret_values, ret_shape, ret_stride));
+    callback(ret);
+  }
+}
+
+
+
 
 
 /**
@@ -407,6 +476,9 @@ static bool typed_decode_stream_callback(const block_info& info,
       decode_string_stream(elements_to_decode, iarc, stream_callback); 
     } else if (column_type == flex_type_enum::VECTOR) {
       decode_vector_stream(elements_to_decode, iarc, stream_callback, 
+                           info.flags & BLOCK_ENCODING_EXTENSION); 
+    } else if (column_type == flex_type_enum::ND_VECTOR) {
+      decode_nd_vector_stream(elements_to_decode, iarc, stream_callback, 
                            info.flags & BLOCK_ENCODING_EXTENSION); 
     } else {
       flexible_type_impl::deserializer s{iarc};

--- a/src/sframe/sframe_reader.cpp
+++ b/src/sframe/sframe_reader.cpp
@@ -25,13 +25,13 @@ void sframe_reader::init(const sframe& frame, size_t num_segments) {
     m_num_segments = frame.columns[0]->get_index_info().nsegments;
     std::vector<size_t> segment_sizes = frame.columns[0]->get_index_info().segment_sizes;
     for (size_t i = 0;i < index_info.column_names.size(); ++i) {
-      column_data.emplace_back(std::move(frame.columns[i]->get_reader(segment_sizes)));
+      column_data.emplace_back(frame.columns[i]->get_reader(segment_sizes));
     }
   } else {
     // create num_segments worth of segments
     m_num_segments = num_segments;
     for (size_t i = 0;i < index_info.column_names.size(); ++i) {
-      column_data.emplace_back(std::move(frame.columns[i]->get_reader(m_num_segments)));
+      column_data.emplace_back(frame.columns[i]->get_reader(m_num_segments));
     }
   }
 }
@@ -48,7 +48,7 @@ void sframe_reader::init(const sframe& frame, const std::vector<size_t>& segment
 
   m_num_segments = segment_lengths.size();
   for (size_t i = 0;i < index_info.column_names.size(); ++i) {
-    column_data.emplace_back(std::move(frame.columns[i]->get_reader(segment_lengths)));
+    column_data.emplace_back(frame.columns[i]->get_reader(segment_lengths));
   }
 }
 

--- a/src/unity/lib/image_util.cpp
+++ b/src/unity/lib/image_util.cpp
@@ -4,7 +4,7 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 #include <unity/lib/image_util.hpp>
-#include <unity/lib/image_util_impl.hpp>
+#include <image/image_util_impl.hpp>
 #include <sframe/sframe_iterators.hpp>
 #include <sframe/sframe.hpp>
 #include <unity/lib/unity_sframe.hpp>
@@ -292,11 +292,6 @@ std::shared_ptr<unity_sframe> load_images(std::string url, std::string format, b
     return image_unity_sframe;
 }
 
-
-void decode_image_inplace(image_type& image) {
-  image_util_detail::decode_image_impl(image); 
-}
-
 /**
  * Decode the image into raw pixels
  */
@@ -306,7 +301,7 @@ flexible_type decode_image(const flexible_type& image) {
   }
   flexible_type ret = image;
   flex_image& img = ret.mutable_get<flex_image>();
-  image_util_detail::decode_image_impl(img);
+  turi::decode_image_inplace(img);
   return ret;
 };
 
@@ -319,7 +314,7 @@ flexible_type encode_image(const flexible_type& image) {
   }
   flexible_type ret = image;
   flex_image& img = ret.mutable_get<flex_image>();
-  image_util_detail::encode_image_impl(img);
+  turi::encode_image_inplace(img);
   return ret;
 };
 

--- a/src/unity/lib/image_util.hpp
+++ b/src/unity/lib/image_util.hpp
@@ -53,10 +53,6 @@ flexible_type load_image(const std::string& url, const std::string format);
 /*                                                                        */
 /**************************************************************************/
 
-/**
- * Decode the image data inplace
- */
-void decode_image_inplace(image_type& data);
 
 /**
  * Decode the image into raw pixels

--- a/src/unity/lib/unity_sarray_binary_operations.cpp
+++ b/src/unity/lib/unity_sarray_binary_operations.cpp
@@ -26,7 +26,13 @@ void check_operation_feasibility(flex_type_enum left,
                              || left == flex_type_enum::VECTOR)
                              && (right == flex_type_enum::FLOAT
                                  || right == flex_type_enum::INTEGER
-                                 || right == flex_type_enum::VECTOR));
+                                 || right == flex_type_enum::VECTOR)) ||
+                            ((left == flex_type_enum::FLOAT
+                             || left == flex_type_enum::INTEGER
+                             || left == flex_type_enum::ND_VECTOR)
+                             && (right == flex_type_enum::FLOAT
+                                 || right == flex_type_enum::INTEGER
+                                 || right == flex_type_enum::ND_VECTOR));
     }
   } else if (op == "%") {
     operation_is_feasible = left == flex_type_enum::INTEGER &&
@@ -84,6 +90,9 @@ flex_type_enum get_output_type(flex_type_enum left,
       return flex_type_enum::FLOAT;
     } else if (left == flex_type_enum::DATETIME && right == flex_type_enum::DATETIME && op == "-") {
       return flex_type_enum::FLOAT;
+    } else if (left == flex_type_enum::ND_VECTOR || right == flex_type_enum::ND_VECTOR) {
+      // vector operations always return vector
+      return flex_type_enum::ND_VECTOR;
     } else if (left == flex_type_enum::VECTOR || right == flex_type_enum::VECTOR) {
       // vector operations always return vector
       return flex_type_enum::VECTOR;
@@ -108,9 +117,15 @@ flex_type_enum get_output_type(flex_type_enum left,
       return flex_type_enum::INTEGER;
     }
   } else if (op == "%") {
+    if (left == flex_type_enum::VECTOR || left == flex_type_enum::ND_VECTOR) {
+      return left;
+    }
     return flex_type_enum::INTEGER;
   } else if (op == "/") {
-    if (left == flex_type_enum::VECTOR || right == flex_type_enum::VECTOR) {
+    if (left == flex_type_enum::ND_VECTOR || right == flex_type_enum::ND_VECTOR) {
+      // vector operations always return vector
+      return flex_type_enum::ND_VECTOR;
+    } else if (left == flex_type_enum::VECTOR || right == flex_type_enum::VECTOR) {
       // vector operations always return vector
       return flex_type_enum::VECTOR;
     } else {
@@ -151,9 +166,9 @@ get_binary_operator(flex_type_enum left, flex_type_enum right, std::string op) {
        if (l.size() != r.size()) return FLEX_UNDEFINED;
        return l + r;
      };
-    } else if (left == flex_type_enum::VECTOR) {
+    } else if (left == flex_type_enum::VECTOR || left == flex_type_enum::ND_VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return l + r; };
-    } else if (right == flex_type_enum::VECTOR) {
+    } else if (right == flex_type_enum::VECTOR || right == flex_type_enum::ND_VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return r + l; };
     } else {
       // everything else, left hand side is good
@@ -184,9 +199,9 @@ get_binary_operator(flex_type_enum left, flex_type_enum right, std::string op) {
        if (l.size() != r.size()) return FLEX_UNDEFINED;
        return l - r;
      };
-    } else if (left == flex_type_enum::VECTOR) {
+    } else if (left == flex_type_enum::VECTOR || left == flex_type_enum::ND_VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return l - r; };
-    } else if (right == flex_type_enum::VECTOR) {
+    } else if (right == flex_type_enum::VECTOR || right == flex_type_enum::ND_VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return -r + l; };
     } else {
       // everything else, left hand side is good
@@ -211,9 +226,15 @@ get_binary_operator(flex_type_enum left, flex_type_enum right, std::string op) {
        if (l.size() != r.size()) return FLEX_UNDEFINED;
        return l * r;
      };
+    } else if (left == flex_type_enum::ND_VECTOR && right == flex_type_enum::ND_VECTOR) {
+     return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return l * r; };
     } else if (left == flex_type_enum::VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return l * r; };
     } else if (right == flex_type_enum::VECTOR) {
+     return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return r * l; };
+    } else if (left == flex_type_enum::ND_VECTOR) {
+     return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return l * r; };
+    } else if (right == flex_type_enum::ND_VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return r * l; };
     } else {
       // everything else, left hand side is good
@@ -240,6 +261,19 @@ get_binary_operator(flex_type_enum left, flex_type_enum right, std::string op) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{
        flexible_type ret = r;
        for (size_t i = 0;i < ret.size(); ++i) ret[i] = l / ret[i];
+       return ret;
+     };
+    } else if (left == flex_type_enum::ND_VECTOR) {
+     return [](const flexible_type& l, const flexible_type& r)->flexible_type{ return l / r; };
+    } else if (right == flex_type_enum::ND_VECTOR) {
+     return [](const flexible_type& l, const flexible_type& r)->flexible_type{ 
+       flexible_type ret = r;
+       flex_nd_vec& v = ret.mutable_get<flex_nd_vec>();
+       v.ensure_unique();
+       double dl = l.to<double>();
+       for (auto & i: v.elements()) {
+         i = dl / i;
+       }
        return ret;
      };
     } else {

--- a/src/unity/lib/unity_sketch.cpp
+++ b/src/unity/lib/unity_sketch.cpp
@@ -25,7 +25,7 @@ void unity_sketch::construct_from_sarray(
     std::shared_ptr<unity_sarray_base> uarray, bool background, const std::vector<flexible_type>& keys) {
   auto array = std::static_pointer_cast<unity_sarray>(uarray)->get_underlying_sarray();
   std::shared_ptr<sarray<flexible_type>::reader_type>
-      reader(std::move(array->get_reader()));
+      reader(array->get_reader());
 
   std::unordered_set<flexible_type> key_set = std::unordered_set<flexible_type>(keys.begin(), keys.end());
   init(NULL, array->get_type(), key_set, reader);

--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -170,5 +170,6 @@ if __name__ == '__main__':
             "coremltools == 0.6.3",
             "pillow >= 3.3.0",
             "pandas >= 0.19.0",
+            "numpy"
         ],
     )

--- a/src/unity/python/turicreate/cython/cy_flexible_type.pxd
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pxd
@@ -49,6 +49,7 @@ cdef extern from "<flexible_type/flexible_type.hpp>" namespace "turi":
         DATETIME        "turi::flex_type_enum::DATETIME" = 6
         UNDEFINED       "turi::flex_type_enum::UNDEFINED"= 7
         IMAGE           "turi::flex_type_enum::IMAGE"    = 8
+        ND_VECTOR       "turi::flex_type_enum::ND_VECTOR"   = 9
 
     cdef cppclass flexible_type:
         flexible_type()
@@ -66,6 +67,8 @@ cdef extern from "<flexible_type/flexible_type.hpp>" namespace "turi":
         const flex_string& get_string "get<turi::flex_string>"()
         const flex_vec& get_vec "get<turi::flex_vec>"()
         flex_vec& get_vec_m "mutable_get<turi::flex_vec>"()
+        const flex_nd_vec& get_nd_vec "get<turi::flex_nd_vec>"()
+        flex_nd_vec& get_nd_vec_m "mutable_get<turi::flex_nd_vec>"()
         const flex_list& get_list "get<turi::flex_list>"()
         flex_list& get_list_m "mutable_get<turi::flex_list>"()
         const flex_dict& get_dict "get<turi::flex_dict>"()
@@ -81,6 +84,7 @@ cdef extern from "<flexible_type/flexible_type.hpp>" namespace "turi":
         flexible_type& set_double "operator=<double>"(const flex_float& other)
         flexible_type& set_string "operator=<std::string>"(const flex_string& other)
         flexible_type& set_vec "operator=<std::vector<double> >"(const flex_vec& other)
+        flexible_type& set_nd_vec "operator=<turi::flex_nd_vec>"(const flex_nd_vec& other)
         flexible_type& set_list "operator=<turi::flex_list>"(const flex_list& other)
         flexible_type& set_dict "operator=<turi::flex_dict>"(const flex_dict& other)
         flexible_type& set_img "operator=<turi::flex_image>"(const flex_image& other)
@@ -95,6 +99,21 @@ cdef extern from "<flexible_type/flexible_type.hpp>" namespace "turi":
     cdef int EMPTY_TIMEZONE "turi::flex_date_time::EMPTY_TIMEZONE"
     cdef string flex_type_enum_to_name(flex_type_enum)
     cdef bint flex_type_is_convertible(flex_type_enum, flex_type_enum)
+
+    cdef cppclass flex_nd_vec:
+        flex_nd_vec()
+        flex_nd_vec(vector[double])
+        flex_nd_vec(vector[double], vector[size_t])
+        flex_nd_vec(vector[double], vector[size_t], vector[size_t])
+        const vector[double]& elements()
+        const vector[size_t]& shape()
+        const vector[size_t]& stride()
+        const size_t start()
+        const size_t num_elem()
+        bint is_full()
+        bint is_valid()
+
+
 
 ### Other unity types ###
 ctypedef map[string, flexible_type] gl_options_map

--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -170,8 +170,8 @@ cdef extern from "Python.h":
 cdef extern from "math.h":
     double NAN
 
+DEF _NUM_FLEX_TYPES = 10
 ###### Date time stuff
-DEF _NUM_FLEX_TYPES = 9
 
 from datetime import tzinfo
 from datetime import timedelta
@@ -198,6 +198,52 @@ class GMT(tzinfo):
     def  __repr__(self):
         return self.tzname(self.offset)
 
+################################################################################
+# NDArray wrapper that exposes the buffer protocol
+
+from cpython cimport Py_buffer
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+from cpython.buffer cimport PyBUF_ND, PyBUF_WRITABLE
+cdef class NDArrayWrapper:
+    cdef flex_nd_vec* vec
+    cdef Py_ssize_t* shape
+    cdef Py_ssize_t* strides
+
+    def __cinit__(self):
+        vec = NULL
+        shape = NULL
+        strides = NULL
+
+    cdef initialize(self, const flex_nd_vec* vec):
+        self.vec = new flex_nd_vec()
+        self.vec[0] = vec[0]
+        self.shape = <Py_ssize_t*>PyMem_Malloc(vec.shape().size() * sizeof(Py_ssize_t))
+        self.strides = <Py_ssize_t*>PyMem_Malloc(vec.stride().size() * sizeof(Py_ssize_t))
+        for i in range(vec.shape().size()):
+            self.shape[i] = vec.shape()[i]
+
+        for i in range(vec.stride().size()):
+            self.strides[i] = vec.stride()[i] * 8
+
+    def __dealloc__(self):
+        if self.vec != NULL:
+            del self.vec
+            PyMem_Free(self.shape)
+            PyMem_Free(self.strides)
+
+    def __getbuffer__(self, Py_buffer *buffer, int flags):
+        cdef Py_ssize_t itemsize = 8
+        buffer.buf = <char *>&(self.vec.elements()[self.vec.start()])
+        buffer.format = 'd'                     # double
+        buffer.internal = NULL                  # see References
+        buffer.itemsize = itemsize
+        buffer.len = self.vec.num_elem() * itemsize
+        buffer.ndim = self.vec.shape().size()
+        buffer.obj = self
+        buffer.readonly = 0
+        buffer.shape = self.shape
+        buffer.strides = self.strides
+        buffer.suboffsets = NULL                # for pointer arrays only
 
 ################################################################################
 # Some specific types require specific handling between python 2 and
@@ -229,6 +275,25 @@ timedelta_type = datetime.timedelta
 cdef object _image_type
 cdef bint have_imagetype
 
+cdef bint HAS_NUMPY = False
+cdef bint HAS_PANDAS = False
+
+try:
+    import numpy as np
+    HAS_NUMPY = True
+except ImportError:
+    HAS_NUMPY = False
+
+try:
+    import pandas as pd
+    HAS_PANDAS = True
+except ImportError:
+    HAS_PANDAS = False
+
+cdef type np_ndarray
+assert(HAS_NUMPY)
+np_ndarray = np.ndarray
+
 class __bad_image(object):
     def __init__(*args, **kwargs):
         raise TypeError("Image type not supported outside of full sframe/turicreate package.")
@@ -256,11 +321,12 @@ DEF FT_ARRAY_TYPE     = 8
 DEF FT_NONE_TYPE      = 9
 DEF FT_DATETIME_TYPE  = 10
 DEF FT_IMAGE_TYPE     = 11
+DEF FT_NDARRAY_TYPE   = 12
 
 # The robust versions of the previous ones, which perform extra checks
 # and possible casting.  The robust versions of the above are FT_SAFE
 # plus the previous value.
-DEF FT_SAFE = 12
+DEF FT_SAFE = 13
 DEF FT_LARGEST = 2*FT_SAFE
 DEF FT_FAILURE = 2*FT_LARGEST + 1
 
@@ -282,6 +348,7 @@ _code_by_type_lookup[<object_ptr>(array_type)]          = FT_ARRAY_TYPE
 _code_by_type_lookup[<object_ptr>(xrange_type)]         = FT_LIST_TYPE + FT_SAFE
 _code_by_type_lookup[<object_ptr>(datetime_type)]       = FT_DATETIME_TYPE
 _code_by_type_lookup[<object_ptr>(_image_type)]         = FT_IMAGE_TYPE
+_code_by_type_lookup[<object_ptr>(np_ndarray)]          = FT_NDARRAY_TYPE
 
 cdef map[object_ptr, int] _code_by_map_force = map[object_ptr, int]()
 
@@ -295,6 +362,7 @@ _code_by_map_force[<object_ptr>(dict)]          = FT_DICT_TYPE      + FT_SAFE
 _code_by_map_force[<object_ptr>(datetime_type)] = FT_DATETIME_TYPE  + FT_SAFE
 _code_by_map_force[<object_ptr>(none_type)]     = FT_NONE_TYPE
 _code_by_map_force[<object_ptr>(_image_type)]   = FT_IMAGE_TYPE     + FT_SAFE
+_code_by_map_force[<object_ptr>(np_ndarray)]    = FT_NDARRAY_TYPE
 
 cdef dict _code_by_name_lookup = {
     'str'      : FT_STR_TYPE     + FT_SAFE,
@@ -405,6 +473,7 @@ _code_by_forced_type[<object_ptr>(none_type)]      = FT_NONE_TYPE     + FT_SAFE
 _code_by_forced_type[<object_ptr>(datetime_type)]  = FT_DATETIME_TYPE + FT_SAFE
 _code_by_forced_type[<object_ptr>(array_type)]     = FT_BUFFER_TYPE
 _code_by_forced_type[<object_ptr>(str)]            = FT_STR_TYPE      + FT_SAFE
+_code_by_forced_type[<object_ptr>(np_ndarray)]     = FT_NDARRAY_TYPE
 
 ################################################################################
 # Enum type only.
@@ -419,6 +488,7 @@ _type_lookup_by_type_enum[<int>DICT]      = dict
 _type_lookup_by_type_enum[<int>DATETIME]  = datetime_type
 _type_lookup_by_type_enum[<int>UNDEFINED] = none_type
 _type_lookup_by_type_enum[<int>IMAGE]     = _image_type
+_type_lookup_by_type_enum[<int>ND_VECTOR] = np_ndarray
 
 cdef type pytype_from_flex_type_enum(flex_type_enum e):
     return _type_lookup_by_type_enum[<int> e]
@@ -465,6 +535,7 @@ _enum_tr_codes[FT_TUPLE_TYPE]              = LIST
 _enum_tr_codes[FT_DICT_TYPE]               = DICT
 _enum_tr_codes[FT_BUFFER_TYPE]             = VECTOR
 _enum_tr_codes[FT_ARRAY_TYPE]              = VECTOR
+_enum_tr_codes[FT_NDARRAY_TYPE]            = ND_VECTOR
 _enum_tr_codes[FT_NONE_TYPE]               = UNDEFINED
 _enum_tr_codes[FT_DATETIME_TYPE]           = DATETIME
 _enum_tr_codes[FT_IMAGE_TYPE]              = IMAGE
@@ -480,6 +551,7 @@ _enum_tr_codes[FT_SAFE + FT_ARRAY_TYPE]    = VECTOR
 _enum_tr_codes[FT_SAFE + FT_NONE_TYPE]     = UNDEFINED
 _enum_tr_codes[FT_SAFE + FT_DATETIME_TYPE] = DATETIME
 _enum_tr_codes[FT_SAFE + FT_IMAGE_TYPE]    = IMAGE
+_enum_tr_codes[FT_SAFE + FT_NDARRAY_TYPE]            = ND_VECTOR
 _enum_tr_codes[FT_FAILURE]                 = UNDEFINED
 
 cdef inline flex_type_enum flex_type_from_tr_code(int tr_code):
@@ -507,22 +579,9 @@ cdef inline bint flex_type_is_vector_implicit_castable(flex_type_enum ft_type):
 
 ################################################################################
 
-cdef bint HAS_NUMPY = False
-cdef bint HAS_PANDAS = False
-
-try:
-    import numpy as np
-    HAS_NUMPY = True
-except ImportError:
-    HAS_NUMPY = False
-
-try:
-    import pandas as pd
-    HAS_PANDAS = True
-except ImportError:
-    HAS_PANDAS = False
 
 cdef vector[flex_type_enum] _dtype_to_flex_enum_lookup = vector[flex_type_enum](128, UNDEFINED)
+__fill_numpy_info()
 
 cdef __fill_numpy_info():
     cdef dict __typecodes = np.typecodes
@@ -534,10 +593,6 @@ cdef __fill_numpy_info():
     for c in <str>(__typecodes.get("Character", "") + "SU"):
         _dtype_to_flex_enum_lookup[<int>(ord(c))] = STRING
 
-cdef type np_ndarray
-if HAS_NUMPY:
-    np_ndarray = np.ndarray
-    __fill_numpy_info()
 
 cdef flex_type_enum flex_type_from_dtype(object dt):
     cdef flex_type_enum ft_type
@@ -698,10 +753,11 @@ DEF FTI_DICT           = 32
 DEF FTI_DATETIME       = 64
 DEF FTI_NONE           = 128
 DEF FTI_IMAGE          = 256
+DEF FTI_NDARRAY        = 512
 
 # additional things that are handled specially
-DEF FTI_NUMERIC_LIST   = 512
-DEF FTI_EMPTY_LIST     = 1024
+DEF FTI_NUMERIC_LIST   = 1024
+DEF FTI_EMPTY_LIST     = 2048
 
 cdef map[size_t, flex_type_enum] _common_type_inference_rules = map[size_t, flex_type_enum]()
 
@@ -720,6 +776,7 @@ _common_type_inference_rules[FTI_NONE]         = INTEGER
 _common_type_inference_rules[FTI_IMAGE]        = IMAGE
 _common_type_inference_rules[FTI_NUMERIC_LIST] = VECTOR
 _common_type_inference_rules[FTI_EMPTY_LIST]   = LIST
+_common_type_inference_rules[FTI_NDARRAY]      = ND_VECTOR
 
 # Upgrade rules:
 
@@ -753,6 +810,11 @@ while _it != _common_type_inference_rules.end():
         _common_type_inference_rules[_k | FTI_LIST] = LIST
     inc(_it)
 
+# ndarray and array makes nd vector
+_common_type_inference_rules[FTI_NDARRAY] = ND_VECTOR
+_common_type_inference_rules[FTI_NDARRAY | FTI_VECTOR] = ND_VECTOR
+_common_type_inference_rules[FTI_NDARRAY | FTI_VECTOR | FTI_NONE] = ND_VECTOR
+
 
 ################################################################################
 #
@@ -775,6 +837,7 @@ _inference_code_from_tr_code[FT_ARRAY_TYPE]              = FTI_VECTOR
 _inference_code_from_tr_code[FT_NONE_TYPE]               = FTI_NONE
 _inference_code_from_tr_code[FT_DATETIME_TYPE]           = FTI_DATETIME
 _inference_code_from_tr_code[FT_IMAGE_TYPE]              = FTI_IMAGE
+_inference_code_from_tr_code[FT_NDARRAY_TYPE]            = FTI_NDARRAY
 _inference_code_from_tr_code[FT_SAFE + FT_INT_TYPE]      = 0
 _inference_code_from_tr_code[FT_SAFE + FT_FLOAT_TYPE]    = FTI_FLOAT
 _inference_code_from_tr_code[FT_SAFE + FT_STR_TYPE]      = FTI_STRING
@@ -787,6 +850,7 @@ _inference_code_from_tr_code[FT_SAFE + FT_ARRAY_TYPE]    = FTI_VECTOR
 _inference_code_from_tr_code[FT_SAFE + FT_NONE_TYPE]     = FTI_NONE
 _inference_code_from_tr_code[FT_SAFE + FT_DATETIME_TYPE] = FTI_DATETIME
 _inference_code_from_tr_code[FT_SAFE + FT_IMAGE_TYPE]    = FTI_IMAGE
+_inference_code_from_tr_code[FT_SAFE + FT_NDARRAY_TYPE]  = FTI_NDARRAY
 _inference_code_from_tr_code[FT_FAILURE]                 = <size_t>(-1)
 
 # Choosing it from the flexible type code
@@ -801,6 +865,7 @@ _inference_code_from_flex_type_enum[<int>DICT]      = FTI_DICT
 _inference_code_from_flex_type_enum[<int>IMAGE]     = FTI_IMAGE
 _inference_code_from_flex_type_enum[<int>DATETIME]  = FTI_DATETIME
 _inference_code_from_flex_type_enum[<int>UNDEFINED] = FTI_NONE
+_inference_code_from_flex_type_enum[<int>ND_VECTOR] = FTI_NDARRAY
 
 cdef size_t _choose_inference_code(int tr_code, object v) except -2:
 
@@ -844,6 +909,8 @@ cdef size_t _choose_inference_code(int tr_code, object v) except -2:
             return FTI_NUMERIC_LIST
         else:
             return FTI_LIST
+    elif tr_code == FT_NDARRAY_TYPE or tr_code == FT_NDARRAY_TYPE + FT_SAFE:
+        return FTI_NDARRAY
     elif tr_code == FT_BUFFER_TYPE or (tr_code == FT_BUFFER_TYPE + FT_SAFE):
         ft_type = _infer_buffer_element_type(v, False, False, &is_object_buffer)
         if is_object_buffer:
@@ -903,6 +970,9 @@ cdef inline flex_type_enum infer_common_type(size_t present_types, bint undefine
             if (present_types & FTI_VECTOR) != 0:
                 types.append(flex_type_enum_to_name(VECTOR))
                 present_types -= FTI_VECTOR
+            if (present_types & FTI_NDARRAY) != 0:
+                types.append(flex_type_enum_to_name(ND_VECTOR))
+                present_types -=FTI_NDARRAY 
             if (present_types & FTI_DICT) != 0:
                 types.append(flex_type_enum_to_name(DICT))
                 present_types -= FTI_DICT
@@ -952,8 +1022,8 @@ cdef flex_type_enum _infer_common_type_of_listlike(_listlike vl, bint undefined_
 
         if tr_code_buffer != NULL:
             tr_code_buffer[0][i] = tr_code
-
-    return infer_common_type(seen_types, undefined_on_error)
+    cdef flex_type_enum f = infer_common_type(seen_types, undefined_on_error)
+    return f
 
 cdef flex_type_enum infer_common_type_of_flex_list(const flex_list& fl, bint undefined_on_error = False):
     """
@@ -1061,6 +1131,12 @@ cdef flex_type_enum infer_flex_type_of_sequence(object l, bint undefined_on_erro
         return _infer_buffer_element_type(l, True, undefined_on_error)
     elif tr_code == FT_ARRAY_TYPE:
         return flex_type_from_array_typecode( (<array.array>l).typecode)
+    elif tr_code == FT_NDARRAY_TYPE or tr_code == FT_NDARRAY_TYPE + FT_SAFE:
+        try:
+            return flex_type_from_array_typecode(l.dtype.char)
+        except:
+            return _infer_common_type_of_listlike(list(l), undefined_on_error)
+
     elif tr_code == FT_LIST_TYPE + FT_SAFE:
         if type(l) is list:
             return _infer_common_type_of_listlike(<list>l, undefined_on_error)
@@ -1107,7 +1183,6 @@ cdef inline fill_list(flex_list& retl, _listlike v,
     for the list is expected, and the result is stored in common_type[0].
     If tr_code_buffer is not null, then the translation codes are taken from that.
     """
-
     cdef size_t i
     cdef int tr_code = -1
     cdef size_t seen_types = 0
@@ -1305,7 +1380,9 @@ cdef inline bint __try_buffer_type_vec(flex_vec& retv, object v, _numeric t):
 
     try:
         buf = v
-    except:
+    except Exception as e:
+        #print "buf conversion failed for ", type(v), v
+        #print type(e), e
         return False
 
     cdef size_t i
@@ -1343,6 +1420,56 @@ cdef inline bint _tr_buffer_to_flex_vec(flex_vec& retv, object v):
 
     return False
 
+
+@cython.boundscheck(False)
+cdef inline bint _tr_buffer_to_flex_nd_vec(flex_nd_vec& retv, object v):
+    if type(v) is not np_ndarray:
+        return False
+
+    # translate the elements
+    cdef flex_vec f_elements
+    cdef vector[size_t] f_shape
+    cdef vector[size_t] f_stride
+
+    # there are certain bases which we don't understand
+    # and will cause problems. Copy it if necessary.
+    if v.base is not None and type(v.base) is not np_ndarray:
+        v = np.copy(v, 'C')
+
+    # if not writeable, we get conversion issues
+    # https://github.com/cython/cython/issues/1605
+    if v.flags['WRITEABLE'] == False:
+        v = np.copy(v, 'C')
+
+    if v.flags['C_CONTIGUOUS'] == False and v.flags['F_CONTIGUOUS'] == False:
+        # we need to make contiguous
+        #print "converting to contiguous"
+        v = np.ascontiguousarray(v)
+
+    if v.base is None:
+        #print "baseless conversion"
+        if not _tr_buffer_to_flex_vec(f_elements, v.reshape(-1)):
+            #print "baseless conversion fail"
+            return False
+    else:
+        #print "base and offset conversion"
+        # compute offset
+        offset = (np.byte_bounds(v)[0] - np.byte_bounds(v.base)[0]) / v.itemsize
+        if not _tr_buffer_to_flex_vec(f_elements, v.base.reshape(-1)[offset:]):
+            #print "base and offset conversion fail"
+            return False
+
+    stride = [i / v.itemsize for i in v.strides]
+    for i in stride:
+        f_stride.push_back(<size_t>i)
+    for i in v.shape:
+        f_shape.push_back(<size_t>i)
+
+    # Argh. Assignment to reference bug.
+    # https://github.com/cython/cython/issues/1863
+    (&retv)[0] = flex_nd_vec(f_elements, f_shape, f_stride)
+    return True
+
 ################################################################################
 
 cdef inline tr_buffer_to_ft(flexible_type& ret, object v, flex_type_enum* common_type = NULL):
@@ -1377,6 +1504,15 @@ cdef inline tr_buffer_to_ft(flexible_type& ret, object v, flex_type_enum* common
 
     # Error if there are no more options.
     raise TypeError("Could not convert python object with type " + str(type(v)) + " to flexible_type.")
+
+cdef inline translate_ndarray(flexible_type& ret, object v, flex_type_enum* common_type = NULL):
+    cdef flex_nd_vec ft_nd_vec
+    if _tr_buffer_to_flex_nd_vec(ft_nd_vec, v):
+        ret.set_nd_vec(ft_nd_vec)
+        return
+    raise TypeError("Could not convert python object with type " + str(type(v)) + " to flexible_type.")
+
+
 
 
 ################################################################################
@@ -1415,6 +1551,9 @@ cdef flexible_type _ft_translate(object v, int tr_code) except *:
         return ret
     elif tr_code == FT_IMAGE_TYPE:
         translate_image(ret, v)
+        return ret
+    elif tr_code == FT_NDARRAY_TYPE:
+        translate_ndarray(ret, v)
         return ret
     elif tr_code == FT_BUFFER_TYPE or tr_code == FT_ARRAY_TYPE:
         tr_buffer_to_ft(ret, v)
@@ -1467,6 +1606,9 @@ cdef flexible_type _ft_translate(object v, int tr_code) except *:
         return ret
     elif tr_code == (FT_BUFFER_TYPE + FT_SAFE) or tr_code == (FT_ARRAY_TYPE + FT_SAFE):
         tr_buffer_to_ft(ret, v)
+        return ret
+    elif tr_code == (FT_NDARRAY_TYPE + FT_SAFE):
+        translate_ndarray(ret, v)
         return ret
     elif tr_code == (FT_NONE_TYPE + FT_SAFE):
         # Here for forced type conversion semantics
@@ -1554,6 +1696,23 @@ cdef inline array.array pyvec_from_flex_vec(const flex_vec& fv):
     return ret
 
 @cython.boundscheck(False)
+cdef inline object pyndarray_from_flex_nd_vec(const flex_nd_vec& fv):
+    wrapper = NDArrayWrapper()
+    wrapper.initialize(&fv)
+    return np.asarray(wrapper)
+    # old unused code path
+    # cdef vector[size_t] shape  = fv.shape()
+    # cdef vector[size_t] stride = fv.stride()
+    # cdef const vector[double]* elements = &(fv.elements())
+    # cdef size_t start = fv.start()
+
+    # array_buf = pyvec_from_flex_vec(deref(elements))
+    # for i in range(stride.size()):
+    #     stride[i] *= 8
+
+    # return np_ndarray(shape, np.float64, array_buf, start, stride)
+
+@cython.boundscheck(False)
 cdef list pylist_from_flex_list(const flex_list& vec):
     """
     Converting vector[flexible_type] to list
@@ -1630,6 +1789,8 @@ cdef pyobject_from_flexible_type(const flexible_type& v):
         return pylist_from_flex_list(v.get_list())
     elif f_type == VECTOR:
         return pyvec_from_flex_vec(v.get_vec())
+    elif f_type == ND_VECTOR:
+        return pyndarray_from_flex_nd_vec(v.get_nd_vec())
     elif f_type == DICT:
         return pydict_from_flex_dict(v.get_dict())
     elif f_type == IMAGE:
@@ -1882,7 +2043,6 @@ cdef flex_list flex_list_from_typed_iterable(object v, flex_type_enum common_typ
     """
     Converting any iterable into a list of a certain type.
     """
-
     cdef int tr_code = get_translation_code(type(v), v)
     cdef flex_list ret
 
@@ -1893,7 +2053,7 @@ cdef flex_list flex_list_from_typed_iterable(object v, flex_type_enum common_typ
     elif tr_code == FT_TUPLE_TYPE:
         fill_typed_list(ret, <tuple>v, common_type, ignore_cast_failure)
         return ret
-    elif tr_code == FT_BUFFER_TYPE or tr_code == FT_ARRAY_TYPE:
+    elif tr_code == FT_BUFFER_TYPE or tr_code == FT_ARRAY_TYPE or tr_code == FT_NDARRAY_TYPE:
         tr_buffer_to_flex_list(ret, v, common_type, ignore_cast_failure)
         return ret
     elif tr_code == (FT_LIST_TYPE + FT_SAFE):
@@ -1908,11 +2068,11 @@ cdef flex_list flex_list_from_typed_iterable(object v, flex_type_enum common_typ
         else:
             fill_typed_list(ret, tuple(v), common_type, ignore_cast_failure)
         return ret
-    elif tr_code == (FT_BUFFER_TYPE + FT_SAFE) or tr_code == (FT_ARRAY_TYPE + FT_SAFE):
+    elif tr_code == (FT_BUFFER_TYPE + FT_SAFE) or tr_code == (FT_ARRAY_TYPE + FT_SAFE) or tr_code == (FT_NDARRAY_TYPE + FT_SAFE):
         tr_buffer_to_flex_list(ret, v, common_type, ignore_cast_failure)
         return ret
     else:
-        raise TypeError("Cannot convert type '" + type(v).__name__ + "' into flexible list.")
+        raise TypeError("Cannot convert type '" + type(v).__name__ + "' into flexible list. (" + str(tr_code) + ")")
 
 ################################################################################
 # Testing utilities

--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -1220,6 +1220,8 @@ class SArray(object):
 
             # Not in cache, need to grab it
             block_size = 1024 * (32 if self.dtype in [int, long, float] else 4)
+            if self.dtype in [numpy.ndarray, _Image, dict, list]:
+                block_size = 16
 
             block_num = int(other // block_size)
 

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -23,7 +23,7 @@ from ..util import get_module_from_object, pytype_to_printf
 from .sarray import SArray, _create_sequential_sarray
 from .. import aggregate
 from .image import Image as _Image
-from ..deps import pandas, HAS_PANDAS, HAS_NUMPY
+from ..deps import pandas, numpy, HAS_PANDAS, HAS_NUMPY
 from .grouped_sframe import GroupedSFrame
 
 import array
@@ -2012,6 +2012,8 @@ class SFrame(object):
         def _value_to_str(value):
             if (type(value) is array.array):
                 return str(list(value))
+            elif (type(value) is numpy.ndarray):
+                return str(value).replace('\n',' ')
             elif (type(value) is list):
                 return '[' + ", ".join(_value_to_str(x) for x in value) + ']'
             else:
@@ -4084,10 +4086,10 @@ class SFrame(object):
                   val = operation[key]
                   if type(val) is tuple:
                     (op, column) = val
-                    if (op == '__builtin__avg__' and self[column[0]].dtype is array.array):
+                    if (op == '__builtin__avg__' and self[column[0]].dtype in [array.array, numpy.ndarray]):
                         op = '__builtin__vector__avg__'
 
-                    if (op == '__builtin__sum__' and self[column[0]].dtype is array.array):
+                    if (op == '__builtin__sum__' and self[column[0]].dtype in [array.array, numpy.ndarray]):
                         op = '__builtin__vector__sum__'
 
                     if (op == '__builtin__argmax__' or op == '__builtin__argmin__') and ((type(column[0]) is tuple) != (type(key) is tuple)):
@@ -4122,10 +4124,10 @@ class SFrame(object):
               for val in operation:
                   if type(val) is tuple:
                     (op, column) = val
-                    if (op == '__builtin__avg__' and self[column[0]].dtype is array.array):
+                    if (op == '__builtin__avg__' and self[column[0]].dtype in [array.array, numpy.ndarray]):
                         op = '__builtin__vector__avg__'
 
-                    if (op == '__builtin__sum__' and self[column[0]].dtype is array.array):
+                    if (op == '__builtin__sum__' and self[column[0]].dtype in [array.array, numpy.ndarray]):
                         op = '__builtin__vector__sum__'
 
                     if (op == '__builtin__argmax__' or op == '__builtin__argmin__') and type(column[0]) is tuple:

--- a/src/unity/python/turicreate/test/test_coreml_export.py
+++ b/src/unity/python/turicreate/test/test_coreml_export.py
@@ -21,6 +21,7 @@ import numpy as np
 import coremltools
 import sys
 import platform
+import array
 
 class CoreMLExportTest(unittest.TestCase):
 
@@ -32,7 +33,7 @@ class CoreMLExportTest(unittest.TestCase):
         n, d = 100, 10
         self.sf = tc.SFrame()
         for i in range(d):
-            self.sf.add_column(tc.SArray(rs.randn(n)), inplace=True)
+            self.sf.add_column(tc.SArray(array.array('d',rs.randn(n))), inplace=True)
 
         # Add a categorical column
         categories = np.array(['cat', 'dog', 'foosa'])
@@ -91,6 +92,8 @@ class CoreMLExportTest(unittest.TestCase):
             def array_to_numpy(row):
                 import array
                 import numpy
+                import copy
+                row = copy.copy(row)
                 for r in row:
                     if type(row[r]) == array.array:
                         row[r] = numpy.array(row[r])

--- a/src/unity/python/turicreate/test/test_recommender.py
+++ b/src/unity/python/turicreate/test/test_recommender.py
@@ -1749,14 +1749,14 @@ class SideDataTests(unittest.TestCase):
         self.user_side = tc.SFrame({'userID': ["0", "1", "20"],
                                     'blahID': ["a", "b", "b"],
                                     'blahREAL': [0.1, 12, 22],
-                                    'blahVECTOR': [np.array([0,1]), np.array([0,2]), np.array([2,3])],
+                                    'blahVECTOR': [array.array('d',[0,1]), array.array('d',[0,2]), array.array('d',[2,3])],
                                     'blahDICT': [{'a' : 23}, {'a' : 13}, {'a' : 23, 'b' : 32}],
                                     })
 
         self.item_side = tc.SFrame({'placeID': ["a", "b", "f"],
                                     'blahID2': ["e", "e", "3"],
                                     'blahREAL2': [0.4, 12, 22],
-                                    'blahVECTOR2': [np.array([0,1,2]), np.array([0,2,3]), np.array([2,3,3])],
+                                    'blahVECTOR2': [array.array('d', [0,1,2]), array.array('d',[0,2,3]), array.array('d', [2,3,3])],
                                     'blahDICT2': [{'a' : 23}, {'b' : 13}, {'a' : 23, 'c' : 32}]})
 
         self.user_id = 'userID'
@@ -1892,14 +1892,14 @@ class FactorizationTests(unittest.TestCase):
         self.user_side = tc.SFrame({'userID': ["0", "1", "2"],
                                     'blahID': ["a", "b", "b"],
                                     'blahREAL': [0.1, 12, 22],
-                                    'blahVECTOR': [np.array([0,1]), np.array([0,2]), np.array([2,3])],
+                                    'blahVECTOR': [array.array('d',[0,1]), array.array('d',[0,2]), array.array('d',[2,3])],
                                     'blahDICT': [{'a' : 23}, {'a' : 13}, {'a' : 23, 'b' : 32}],
                                     })
 
         self.item_side = tc.SFrame({'placeID': ["a", "b", "d"],
                                     'blahID2': ["e", "e", "3"],
                                     'blahREAL2': [0.4, 12, 22],
-                                    'blahVECTOR2': [np.array([0,1,2]), np.array([0,2,3]), np.array([2,3,3])],
+                                    'blahVECTOR2': [array.array('d',[0,1,2]), array.array('d',[0,2,3]), array.array('d',[2,3,3])],
                                     'blahDICT2': [{'a' : 23}, {'b' : 13}, {'a' : 23, 'c' : 32, None : 12}]})
 
         self.user_id = 'userID'

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -1073,10 +1073,13 @@ class SFrameTest(unittest.TestCase):
             values = range(m)
             vector_values = [[random.randint(1,100) for num in range(10)] \
                                                           for y in range(m)]
+            nd_values = [np.array([float(random.randint(1,100)) for num in range(10)]).reshape(2,5) \
+                                                          for y in range(m)]
             sf = SFrame()
             sf['key'] = [1] * m
             sf['value'] = values
             sf['vector_values'] = vector_values
+            sf['nd_values'] = nd_values 
             sf.__materialize__()
             built_ins = [aggregate.COUNT(), aggregate.SUM('value'),
                     aggregate.AVG('value'), aggregate.MIN('value'),
@@ -1085,7 +1088,9 @@ class SFrameTest(unittest.TestCase):
                     aggregate.MEAN('vector_values'),
                     aggregate.COUNT_DISTINCT('value'),
                     aggregate.DISTINCT('value'),
-                    aggregate.FREQ_COUNT('value')]
+                    aggregate.FREQ_COUNT('value'),
+                    aggregate.SUM('nd_values'),
+                    aggregate.MEAN('nd_values')]
             sf2 = sf.groupby('key', built_ins)
             self.assertEqual(len(sf2), 1)
             self.assertEqual(sf2['Count'][0], m)
@@ -1099,6 +1104,10 @@ class SFrameTest(unittest.TestCase):
                     list(np.sum(vector_values, axis=0)))
             np.testing.assert_almost_equal(list(sf2['Vector Avg of vector_values'][0]),
                     list(np.mean(vector_values, axis=0)))
+            np.testing.assert_almost_equal(list(sf2['Vector Sum of nd_values'][0]),
+                    list(np.sum(nd_values, axis=0)))
+            np.testing.assert_almost_equal(list(sf2['Vector Avg of nd_values'][0]),
+                    list(np.mean(nd_values, axis=0)))
             self.assertEqual(sf2['Count Distinct of value'][0],
                     len(np.unique(values)))
             self.assertEqual(sorted(sf2['Distinct of value'][0]),

--- a/src/unity/python/turicreate/test/test_sframe_sequence_iterator.py
+++ b/src/unity/python/turicreate/test/test_sframe_sequence_iterator.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import as _
 import unittest
 import turicreate as tc
 import numpy as np
+import array
 from turicreate.toolkits.activity_classifier import _sframe_sequence_iterator as sframe_sequence_iterator
 
 
@@ -144,7 +145,7 @@ class SFrameActivityIteratorTest(unittest.TestCase):
 
     def _prepare_expected_chunked_dataset(self):
         # Expcted result of prep_data with p_w = 3, predictions_in_chunk = 2
-        builder = tc.SFrameBuilder([np.ndarray , int , str , np.ndarray , np.ndarray] , ['features' , 'chunk_len' , 'session_id' , 'target' , 'weights'])
+        builder = tc.SFrameBuilder([array.array , int , str , array.array , array.array] , ['features' , 'chunk_len' , 'session_id' , 'target' , 'weights'])
         builder.append([[0, 0, 1, 10, 2, 20, 3, 30] + [0] * 4 , 4 , 's1' , [1 , 2] , [1 , 1] ])
         builder.append([[4, 40, 5, 50, 6, 60, 7, 70, 8, 80, 9, 90] , 6 , 's2' , [1 , 3], [1 , 1] ])
         builder.append([[10, 100, 11, 110, 12, 120, 13, 130, 14, 140, 15, 150] , 6 , 's3' , [1 , 3], [1 , 1] ])
@@ -152,7 +153,7 @@ class SFrameActivityIteratorTest(unittest.TestCase):
         self.expected_chunked_3_2 = builder.close()
 
         # Expcted result of prep_data with p_w = 2, predictions_in_chunk = 3
-        builder = tc.SFrameBuilder([np.ndarray , int , str , np.ndarray , np.ndarray] , ['features' , 'chunk_len' , 'session_id' , 'target' , 'weights'])
+        builder = tc.SFrameBuilder([array.array , int , str , array.array , array.array] , ['features' , 'chunk_len' , 'session_id' , 'target' , 'weights'])
         builder.append([[0, 0, 1, 10, 2, 20, 3, 30] + [0] * 4 , 4 , 's1' , [1 , 2 , 0] , [1 , 1 , 0] ])
         builder.append([[4, 40, 5, 50, 6, 60, 7, 70, 8, 80, 9, 90] , 6 , 's2' , [1 , 1 , 3], [1 , 1 , 1] ])
         builder.append([[10, 100, 11, 110, 12, 120, 13, 130, 14, 140, 15, 150] , 6 , 's3' , [1 ,2, 3], [1 , 1, 1] ])
@@ -160,7 +161,7 @@ class SFrameActivityIteratorTest(unittest.TestCase):
         self.expected_chunked_2_3 = builder.close()
 
         # Expcted result of prep_data with p_w = 4, predictions_in_chunk = 2
-        builder = tc.SFrameBuilder([np.ndarray , int , str , np.ndarray , np.ndarray] , ['features' , 'chunk_len' , 'session_id' , 'target' , 'weights'])
+        builder = tc.SFrameBuilder([array.array , int , str , array.array , array.array] , ['features' , 'chunk_len' , 'session_id' , 'target' , 'weights'])
         builder.append([[0, 0, 1, 10, 2, 20, 3, 30] + [0] * 8 , 4 , 's1' , [1 , 0] , [1 , 0] ])
         builder.append([[4, 40, 5, 50, 6, 60, 7, 70, 8, 80, 9, 90] + [0] * 4, 6 , 's2' , [1 , 3], [1 , 1] ])
         builder.append([[10, 100, 11, 110, 12, 120, 13, 130, 14, 140, 15, 150, 16, 160, 17, 170] , 8 , 's3' , [1 , 2], [1 , 1] ])

--- a/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
+++ b/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
@@ -109,7 +109,7 @@ class MXFeatureExtractor(ImageFeatureExtractor):
                 raise RuntimeError("Expected image of size %s. Got %s instead." % (
                                                self.image_shape, dataIter.data_shape[1:]))
             model.forward(next(dataIter))
-            mx_out = model.get_outputs()[0].asnumpy()
+            mx_out = [array.array('d',m) for m in model.get_outputs()[0].asnumpy()]
             if dataIter.getpad() != 0:
                 # If batch size is not evenly divisible by the length, it will loop back around.
                 # We don't want that.

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -581,7 +581,7 @@ class ActivityClassifier(_CustomModel):
             # remove predictions for padded data
             unpadded_len = chunked_data['chunk_len'].apply(
                 lambda l: _ceil_dev(l, prediction_window)).to_numpy()
-            preds = [p[:unpadded_len[i]] for i, p in enumerate(preds)]
+            preds = [list(p[:unpadded_len[i]]) for i, p in enumerate(preds)]
 
             out = _SFrame({
                 self.session_id: chunked_data['session_id'],

--- a/src/unity/python/turicreate/toolkits/evaluation.py
+++ b/src/unity/python/turicreate/toolkits/evaluation.py
@@ -27,6 +27,7 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 import turicreate as _turicreate
+from ..deps import numpy
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sarray,\
                                               _check_categorical_option_type
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
@@ -37,7 +38,7 @@ def _check_prob_and_prob_vector(predictions):
     """
     ptype = predictions.dtype
     import array
-    if ptype not in [float, array.array, int]:
+    if ptype not in [float, numpy.ndarray, array.array, int]:
         err_msg  = "Input `predictions` must be of numeric type (for binary "
         err_msg += "classification) or array (of probability vectors) for "
         err_msg += "multiclass classification."

--- a/src/unity/toolkits/coreml_export/xgboost_exporter.cpp
+++ b/src/unity/toolkits/coreml_export/xgboost_exporter.cpp
@@ -197,7 +197,7 @@ void export_xgboost_model(const std::string& filename,
       std::map<flex_string, flexible_type> node_dict(node_dict_raw.begin(), node_dict_raw.end());
       flex_int node_id = node_dict.at("id").get<flex_int>();
       flex_string type = node_dict.at("type").get<flex_string>();
-      flex_float value = node_dict.at("value").get<flex_float>();
+      flex_float value = node_dict.at("value").to<flex_float>();
 
       // Get the exact non-lossy double value and use that.  But it's stored as an
       flex_float exact_value = hexadecimal_to_float(node_dict.at("value_hexadecimal").get<flex_string>());

--- a/test/flexible_type/CMakeLists.txt
+++ b/test/flexible_type/CMakeLists.txt
@@ -3,6 +3,7 @@ project(flexible_type_test)
 make_boost_test(flexible_datatype.cxx REQUIRES flexible_type)
 make_boost_test(new_flexible_type_test.cxx REQUIRES flexible_type)
 make_boost_test(flexible_type_hashing.cxx REQUIRES flexible_type)
+make_boost_test(ndarray_test.cxx REQUIRES flexible_type)
 make_executable(flexible_datatype_bench SOURCES flexible_datatype_bench.cpp REQUIRES flexible_type)
 make_executable(flexible_type_spirit SOURCES flexible_type_spirit REQUIRES flexible_type)
 

--- a/test/flexible_type/flexible_datatype.cxx
+++ b/test/flexible_type/flexible_datatype.cxx
@@ -1,25 +1,8 @@
-/*
- * Copyright (c) 2013 Turi Inc.
- *     All rights reserved.
+/* Copyright © 2017 Apple Inc. All rights reserved.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an "AS
- *  IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *  express or implied.  See the License for the specific language
- *  governing permissions and limitations under the License.
- *
- * For more about this software visit:
- *
- *      http://turicreate.com
- *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
-
 #define BOOST_TEST_MODULE
 #include <boost/test/unit_test.hpp>
 #include <util/test_macros.hpp>

--- a/test/flexible_type/flexible_type_hashing.cxx
+++ b/test/flexible_type/flexible_type_hashing.cxx
@@ -177,6 +177,12 @@ struct flexible_type_hash_test  {
     stress_test_flex_type<uint128_t>([](flexible_type f) {return f.hash128(); });
   }
 
+  void test_nd_vec_hashability() {
+    flex_nd_vec vec({0,5,1,6,2,7,3,8,4,9},
+                    {2,5},
+                    {1,2});
+    uint64_t h1 = flexible_type(vec).hash();
+  }
 };
 
 BOOST_FIXTURE_TEST_SUITE(_flexible_type_hash_test, flexible_type_hash_test)

--- a/test/flexible_type/ndarray_test.cxx
+++ b/test/flexible_type/ndarray_test.cxx
@@ -1,0 +1,577 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#define BOOST_TEST_MODULE
+#include <boost/test/unit_test.hpp>
+#include <util/test_macros.hpp>
+#include <vector>
+#include <iostream>
+#include <typeinfo>       // operator typeid
+
+
+#include <flexible_type/flexible_type.hpp>
+#include <flexible_type/ndarray.hpp>
+
+using namespace turi;
+using namespace flexible_type_impl;
+namespace tt = boost::test_tools;
+
+template <typename T>
+void nd_assert_equal(const ndarray<T>& a, const ndarray<T>& b) {
+  BOOST_CHECK(a.is_valid());
+  BOOST_CHECK(b.is_valid());
+
+  BOOST_TEST(a.num_elem() == b.num_elem());
+  BOOST_TEST(a.shape() == b.shape());
+  if (a.shape().size() > 0) {
+    std::vector<size_t> idx(a.shape().size(), 0);
+    do {
+      double aval = a.at(a.index(idx));
+      double bval = b.at(b.index(idx));
+      BOOST_TEST(aval == bval);
+    } while(a.increment_index(idx));
+  }
+}
+
+template <typename T>
+void test_save_load(const ndarray<T>& a) {
+  oarchive oarc;
+  oarc << a;
+  iarchive iarc(oarc.buf, oarc.off);
+  ndarray<T> b;
+  iarc >> b;
+  nd_assert_equal(a, b);
+  BOOST_TEST(b.is_valid() == true);
+  BOOST_TEST(b.is_full() == true);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_empty) {
+ ndarray<int> i;
+ BOOST_TEST(i.is_valid());
+ BOOST_TEST(i.is_full());
+ test_save_load(i);
+
+ ndarray<int> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ BOOST_TEST(array1.empty() == false);
+ ndarray<int> array2;
+ BOOST_TEST(array2.empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(test_canonical) {
+ ndarray<int> fortran({0,5,1,6,2,7,3,8,4,9},
+                      {2,5},
+                      {1,2});
+ std::cout << fortran << "\n";
+ BOOST_TEST(fortran.is_valid());
+ BOOST_TEST(fortran.is_full());
+ ndarray<int> c = fortran.canonicalize();
+
+ std::vector<size_t> desired_stride{5,1};
+ std::vector<size_t> desired_shape{2,5};
+ std::vector<int> desired_elements{0,1,2,3,4,5,6,7,8,9};
+ BOOST_TEST(c.stride() == desired_stride, tt::per_element());
+ BOOST_TEST(c.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(c.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(c.is_valid() == true);
+ BOOST_TEST(c.is_full() == true);
+ BOOST_TEST(c.is_canonical() == true);
+ nd_assert_equal(c, fortran);
+
+ test_save_load(fortran);
+ test_save_load(c);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_subarray) {
+ ndarray<int> subarray({0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16},
+                      {2,2},
+                      {1,4}); // top left corner of array
+ std::cout << subarray << "\n";
+ BOOST_TEST(subarray.is_valid());
+ BOOST_TEST(subarray.is_full() == false);
+ BOOST_TEST(subarray.is_canonical() == false);
+ ndarray<int> c = subarray.canonicalize();
+
+ std::vector<int> desired_elements{0,4,1,5};
+ std::vector<size_t> desired_shape{2,2};
+ std::vector<size_t> desired_stride{2,1};
+ BOOST_TEST(c.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(c.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(c.stride() == desired_stride, tt::per_element());
+ BOOST_TEST(c.is_valid() == true);
+ BOOST_TEST(c.is_full() == true);
+ BOOST_TEST(c.is_canonical() == true);
+ nd_assert_equal(c, subarray);
+
+ test_save_load(subarray);
+ test_save_load(c);
+}
+
+BOOST_AUTO_TEST_CASE(test_print) {
+ ndarray<int> array({0,1,2,3,4,5},
+                      {2,3},
+                      {3,1}); // top left corner of array
+ std::cout << "print test " << array << "\n";
+}
+
+
+BOOST_AUTO_TEST_CASE(test_subarray2) {
+ ndarray<int> subarray({0,1,2,3,
+                        4,5,6,7,
+                        8,9,10,11,
+                        12,13,14,15,16},
+                      {2,2},
+                      {1,4},
+                      2); // top right corner of array
+ BOOST_TEST(subarray.is_valid());
+ BOOST_TEST(subarray.is_full() == false);
+ BOOST_TEST(subarray.is_canonical() == false);
+ ndarray<int> c = subarray.canonicalize();
+
+ std::vector<int> desired_elements{2,6,3,7};
+ std::vector<size_t> desired_shape{2,2};
+ std::vector<size_t> desired_stride{2,1};
+ BOOST_TEST(c.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(c.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(c.stride() == desired_stride, tt::per_element());
+ BOOST_TEST(c.is_valid() == true);
+ BOOST_TEST(c.is_full() == true);
+ BOOST_TEST(c.is_canonical() == true);
+ nd_assert_equal(c, subarray);
+
+ test_save_load(subarray);
+ test_save_load(c);
+}
+
+BOOST_AUTO_TEST_CASE(test_invalid) {
+ TS_ASSERT_THROWS(ndarray<int>({0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16},
+                               {2,3},
+                               {2,8}), std::string);
+
+ TS_ASSERT_THROWS(ndarray<int>({0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16},
+                               {3,8},
+                               {1,1}), std::string);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_bad_shapes) {
+ ndarray<int> a({0,1,2,3,4,5,6,7,8,9},
+                {0,0},
+                {1,5});
+ BOOST_TEST(a.elements().size() == 0);
+ ndarray<int> b({0,1,2,3,4,5,6,7,8,9},
+                {1,0},
+                {1,5});
+ BOOST_TEST(b.elements().size() == 0);
+}
+BOOST_AUTO_TEST_CASE(test_odd_stride) {
+ // a stride of 0 is technically valid
+ // though a little odd
+ {
+   ndarray<int> zero_stride({0,1,2,3,4,5,6,7,8,9},
+                           {2,5},
+                           {1,0});
+   BOOST_TEST(zero_stride.is_valid() == true);
+   BOOST_TEST(zero_stride.is_full() == false);
+   BOOST_TEST(zero_stride.is_canonical() == false);
+   ndarray<int> zero_stride_c = zero_stride.canonicalize();
+   std::vector<int> desired_elements{0,0,0,0,0,1,1,1,1,1};
+   std::vector<size_t> desired_shape{2,5};
+   std::vector<size_t> desired_stride{5,1};
+   BOOST_TEST(zero_stride_c.elements() == desired_elements, tt::per_element());
+   BOOST_TEST(zero_stride_c.shape() == desired_shape, tt::per_element());
+   BOOST_TEST(zero_stride_c.stride() == desired_stride, tt::per_element());
+   test_save_load(zero_stride);
+ }
+
+ // test dim 1
+ {
+   ndarray<int> dim1(std::vector<int>{0,1,2},
+                     {1,1,3},
+                     {0,0,1}); 
+   BOOST_TEST(dim1.is_valid() == true);
+   BOOST_TEST(dim1.is_full() == true);
+   BOOST_TEST(dim1.is_canonical() == false);
+   ndarray<int> dim1_c = dim1.canonicalize();
+   std::vector<int> desired_elements{0,1,2};
+   std::vector<size_t> desired_shape{1,1,3};
+   std::vector<size_t> desired_stride{3,3,1};
+   BOOST_TEST(dim1_c.elements() == desired_elements, tt::per_element());
+   BOOST_TEST(dim1_c.shape() == desired_shape, tt::per_element());
+   BOOST_TEST(dim1_c.stride() == desired_stride, tt::per_element());
+   test_save_load(dim1);
+ }
+ // another test dim 1
+ {
+   ndarray<int> dim1({0,2,4,1,3,5},
+                     {3,1,1,2},
+                     {1,0,0,3}); 
+   std::cout << dim1 << "\n";
+   BOOST_TEST(dim1.is_valid() == true);
+   BOOST_TEST(dim1.is_full() == true);
+   BOOST_TEST(dim1.is_canonical() == false);
+   ndarray<int> dim1_c = dim1.canonicalize();
+   std::vector<int> desired_elements{0,1,2,3,4,5};
+   std::vector<size_t> desired_shape{3,1,1,2};
+   std::vector<size_t> desired_stride{2,2,2,1};
+   BOOST_TEST(dim1_c.elements() == desired_elements, tt::per_element());
+   BOOST_TEST(dim1_c.shape() == desired_shape, tt::per_element());
+   BOOST_TEST(dim1_c.stride() == desired_stride, tt::per_element());
+   test_save_load(dim1);
+   test_save_load(dim1_c);
+ }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_add) {
+ ndarray<int> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ ndarray<int> array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,4},
+                      {1,2});
+ std::cout << array1 << "\n";
+ std::cout << array2 << "\n";
+ array1 += array2;
+ std::vector<int> desired_elements{1+1,1+1,2+2,3+3,4+4,5+5,6+6,7+7};
+ std::vector<size_t> desired_shape{2,4};
+ std::vector<size_t> desired_stride{4,1};
+ BOOST_TEST(array1.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(array1.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(array1.stride() == desired_stride, tt::per_element());
+
+ array2 += 5;
+ std::vector<int> desired_elements2{1+5,4+5, 1+5,5+5, 2+5,6+5,3+5,7+5} ;
+ BOOST_TEST(array2.elements() == desired_elements2, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(test_sub) {
+ ndarray<int> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ ndarray<int> array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,4},
+                      {1,2});
+ std::cout << array1 << "\n";
+ std::cout << array2 << "\n";
+ array1 -= array2;
+ std::vector<int> desired_elements{1-1,1-1,2-2,3-3,4-4,5-5,6-6,7-7};
+ std::vector<size_t> desired_shape{2,4};
+ std::vector<size_t> desired_stride{4,1};
+ BOOST_TEST(array1.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(array1.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(array1.stride() == desired_stride, tt::per_element());
+
+ array2 -= 5;
+ std::vector<int> desired_elements2{1-5,4-5, 1-5,5-5, 2-5,6-5,3-5,7-5} ;
+ BOOST_TEST(array2.elements() == desired_elements2, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(test_multiply) {
+ ndarray<int> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ ndarray<int> array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,4},
+                      {1,2});
+ array1 *= array2;
+ std::vector<int> desired_elements{1*1,1*1,2*2,3*3,4*4,5*5,6*6,7*7};
+ std::vector<size_t> desired_shape{2,4};
+ std::vector<size_t> desired_stride{4,1};
+ BOOST_TEST(array1.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(array1.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(array1.stride() == desired_stride, tt::per_element());
+
+ array2 *= 5;
+ std::vector<int> desired_elements2{1*5,4*5, 1*5,5*5, 2*5,6*5,3*5,7*5} ;
+ BOOST_TEST(array2.elements() == desired_elements2, tt::per_element());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_divide) {
+ ndarray<int> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ ndarray<int> array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,4},
+                      {1,2});
+ array1 /= array2;
+ std::vector<int> desired_elements{1/1,1/1,2/2,3/3,4/4,5/5,6/6,7/7};
+ std::vector<size_t> desired_shape{2,4};
+ std::vector<size_t> desired_stride{4,1};
+ BOOST_TEST(array1.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(array1.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(array1.stride() == desired_stride, tt::per_element());
+
+ array2 /= 5;
+ std::vector<int> desired_elements2{1/5,4/5, 1/5,5/5, 2/5,6/5,3/5,7/5} ;
+ BOOST_TEST(array2.elements() == desired_elements2, tt::per_element());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_mod) {
+ ndarray<int> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ ndarray<int> array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,4},
+                      {1,2});
+ array1 %= array2;
+ std::vector<int> desired_elements{1%1,1%1,2%2,3%3,4%4,5%5,6%6,7%7};
+ std::vector<size_t> desired_shape{2,4};
+ std::vector<size_t> desired_stride{4,1};
+ BOOST_TEST(array1.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(array1.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(array1.stride() == desired_stride, tt::per_element());
+
+ array2 %= 5;
+ std::vector<int> desired_elements2{1%5,4%5, 1%5,5%5, 2%5,6%5,3%5,7%5} ;
+ BOOST_TEST(array2.elements() == desired_elements2, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(test_mod_float) {
+ ndarray<double> array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ double c = 0.6;
+ array1 %= c;
+ std::vector<double> desired_elements{fmod(1,c),fmod(1,c),fmod(2,c),fmod(3,c),
+                                      fmod(4,c),fmod(5,c),fmod(6,c),fmod(7,c)};
+ std::vector<size_t> desired_shape{2,4};
+ std::vector<size_t> desired_stride{4,1};
+ BOOST_TEST(array1.elements() == desired_elements, tt::per_element());
+ BOOST_TEST(array1.shape() == desired_shape, tt::per_element());
+ BOOST_TEST(array1.stride() == desired_stride, tt::per_element());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_flexible_type_conversions1) {
+ flex_list array1{flexible_type(flex_vec{1,1,1,1}),
+                  flexible_type(flex_vec{2,2,2,2}),
+                  flexible_type(flex_vec{3,3,3,3}),
+                  flexible_type(flex_vec{4,4,4,4})};
+ flexible_type f1(array1);
+ flex_nd_vec target1({1,1,1,1,
+                      2,2,2,2,
+                      3,3,3,3,
+                      4,4,4,4},
+                      {4,4});
+ flex_nd_vec fconv1 = f1.to<flex_nd_vec>();
+
+ BOOST_TEST(fconv1.elements() == target1.elements(), tt::per_element());
+ BOOST_TEST(fconv1.shape() == target1.shape(), tt::per_element());
+ BOOST_TEST(fconv1.stride() == target1.stride(), tt::per_element());
+ test_save_load(fconv1);
+}
+
+BOOST_AUTO_TEST_CASE(test_flexible_type_conversions2) {
+ flexible_type two(2.0);
+ flexible_type four(4);
+ flex_list array1{flexible_type(flex_vec{1,1,1,1}),
+                  flexible_type(flex_list{two,two,two,two}),
+                  flexible_type(flex_nd_vec({3,3,3,3})),
+                  flexible_type(flex_list{four,four,four,four})};
+ flexible_type f1(array1);
+ flex_nd_vec target1({1,1,1,1,
+                      2,2,2,2,
+                      3,3,3,3,
+                      4,4,4,4},
+                      {4,4});
+ flex_nd_vec fconv1 = f1.to<flex_nd_vec>();
+
+ BOOST_TEST(fconv1.elements() == target1.elements(), tt::per_element());
+ BOOST_TEST(fconv1.shape() == target1.shape(), tt::per_element());
+ BOOST_TEST(fconv1.stride() == target1.stride(), tt::per_element());
+ test_save_load(fconv1);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_flexible_type_conversions_3d) {
+ flex_nd_vec nd1({1,1,1,1,
+                  2,2,2,2,
+                  3,3,3,3},
+                  {3,4});
+ flex_list array1{flexible_type(nd1),
+                  flexible_type(nd1),
+                  flexible_type(nd1),
+                  flexible_type(nd1)};
+ flexible_type f1(array1);
+
+ flex_nd_vec target1({1,1,1,1,
+                      2,2,2,2,
+                      3,3,3,3,
+                      1,1,1,1,
+                      2,2,2,2,
+                      3,3,3,3,
+                      1,1,1,1,
+                      2,2,2,2,
+                      3,3,3,3,
+                      1,1,1,1,
+                      2,2,2,2,
+                      3,3,3,3},
+                      {4,3,4});
+ flex_nd_vec fconv1 = f1.to<flex_nd_vec>();
+
+ BOOST_TEST(fconv1.elements() == target1.elements(), tt::per_element());
+ BOOST_TEST(fconv1.shape() == target1.shape(), tt::per_element());
+ BOOST_TEST(fconv1.stride() == target1.stride(), tt::per_element());
+ test_save_load(fconv1);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_flexible_type_conversions_fail1) {
+ flexible_type two(2.0);
+ flexible_type four(4);
+ flex_list array1{flexible_type(flex_vec{1,1,1,1}),
+                  flexible_type(flex_list{two,two,two,two}),
+                  flexible_type(flex_vec{3,3,3}),
+                  flexible_type(flex_list{four,four,four,four})};
+ flexible_type f1(array1);
+ TS_ASSERT_THROWS(f1.to<flex_nd_vec>(), std::string);
+
+ flex_list array2{flexible_type(flex_vec{1,1,1,1}),
+                  flexible_type(flex_list{two,two,two,two, two})};
+ flexible_type f2(array2);
+ TS_ASSERT_THROWS(f2.to<flex_nd_vec>(), std::string);
+
+ flex_list array3{flexible_type(flex_list{two,two,two,two, two}),
+                  flexible_type(flex_vec{1,1,1,1})};
+ flexible_type f3(array3);
+ TS_ASSERT_THROWS(f3.to<flex_nd_vec>(), std::string);
+
+ flex_list array4{flexible_type(flex_list{two,two,two,two, two}),
+                  flexible_type(1)};
+ flexible_type f4(array4);
+ TS_ASSERT_THROWS(f4.to<flex_nd_vec>(), std::string);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_image_conversion) {
+ flex_nd_vec nd1({1,1,1,1,
+                 2,2,2,2,
+                 3,3,3,3,
+                 1,1,1,1,
+                 2,2,2,2,
+                 3,3,3,3,
+                 1,1,1,1,
+                 2,2,2,2,
+                 3,3,3,3,
+                 1,1,1,1,
+                 2,2,2,2,
+                 3,3,3,3},
+                 {4,3,4});
+ auto rt1 = flexible_type(flexible_type(nd1).to<flex_image>()).to<flex_nd_vec>();
+ BOOST_TEST(nd1.elements() == rt1.elements(), tt::per_element());
+ BOOST_TEST(nd1.shape() == rt1.shape(), tt::per_element());
+ BOOST_TEST(nd1.stride() == rt1.stride(), tt::per_element());
+
+ flex_nd_vec nd2({1,1,1,
+                 2,2,2,
+                 3,3,3,
+                 1,1,1,
+                 2,2,2,
+                 3,3,3,
+                 1,1,1,
+                 2,2,2,
+                 3,3,3,
+                 1,1,1,
+                 2,2,2,
+                 3,3,3,},
+                 {4,3,3});
+ auto rt2 = flexible_type(flexible_type(nd2).to<flex_image>()).to<flex_nd_vec>();
+ BOOST_TEST(nd2.elements() == rt2.elements(), tt::per_element());
+ BOOST_TEST(nd2.shape() == rt2.shape(), tt::per_element());
+ BOOST_TEST(nd2.stride() == rt2.stride(), tt::per_element());
+
+ flex_nd_vec nd3({1, 2, 3, 
+                 1, 2, 3,
+                 1, 2, 3,
+                 1, 2, 3,},
+                 {4,3});
+ auto rt3 = flexible_type(flexible_type(nd3).to<flex_image>()).to<flex_nd_vec>();
+ BOOST_TEST(nd3.elements() == rt3.elements(), tt::per_element());
+ BOOST_TEST(nd3.shape() == rt3.shape(), tt::per_element());
+ BOOST_TEST(nd3.stride() == rt3.stride(), tt::per_element());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_equality) {
+ flex_nd_vec array1({1,1,2,3,
+                      4,5,6,7},
+                      {2,4},
+                      {4,1});
+ flex_nd_vec array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,4},
+                      {1,2});
+ flexible_type f1(array1);
+ flexible_type f2(array2);
+ BOOST_TEST(array1 == array2);
+ BOOST_TEST(f1 == f2);
+}
+
+BOOST_AUTO_TEST_CASE(test_equality_subarray) {
+ flex_nd_vec array1({1,1,2,3,
+                      4,5,6,7},
+                      {1,2},
+                      {4,1});
+ flex_nd_vec array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {1,2},
+                      {1,2});
+ flexible_type f1(array1);
+ flexible_type f2(array2);
+ BOOST_TEST(array1 == array2);
+ BOOST_TEST(f1 == f2);
+}
+
+BOOST_AUTO_TEST_CASE(test_equality_fail) {
+ flex_nd_vec array1({1,1,2,3,
+                      4,5,6,7},
+                      {1,2},
+                      {4,1});
+ flex_nd_vec array2({1,4,
+                      1,5,
+                      2,6,
+                      3,7},
+                      {2,1},
+                      {2,1});
+ flexible_type f1(array1);
+ flexible_type f2(array2);
+ BOOST_TEST(array1 != array2);
+ BOOST_TEST(f1 != f2);
+ // check both == and != 
+ bool t = f1 == f2;
+ BOOST_TEST(t == false);
+}

--- a/test/flexible_type/new_flexible_type_test.cxx
+++ b/test/flexible_type/new_flexible_type_test.cxx
@@ -1,3 +1,8 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
 #define BOOST_TEST_MODULE
 #include <boost/test/unit_test.hpp>
 #include <util/test_macros.hpp>


### PR DESCRIPTION
This somewhat large commit adds an NDArray type to SFrame.

ndarray<T> type
---------------
In src/flexible_type/ndarray.hpp

ndarray<T> implements a standard ndarray layout comprising of
 - a vector of elements (really a shared_ptr over elements)
 - a vector of shape
 - a vector of strides
 - an 'start' offset integer

Array indexing is computed as follows:

  ndarray[i,j,k] = elements[start + i * stride[0] + j * stride[1] + k * stride[2]]

Note the stride are not based on the element size. i.e. if we have a simple
1-D array, stride[0] is always 1. (as opposed to sizeof(T)).

The NDArray's default construction layout is "C" ordering: the stride
array is non-increasing. That is, for a simple 3D ndarray[i,j,k], elements
ndarray[i,j,k], ndarray[i,j,k+1] are adjacent.

However, due to to explicit representation of offset, shape and stride, almost
arbitrary layouts and slices can be represented by the ndarray.

The current implementation of the ndarray enforces that all mutation
operations require elems to be unique (elems.use_count() == 1). Hence views
are not modifiable; modifying a view automtacally incurs a data copy. This
might be relaxed in the future (perhaps with a inherited view<T> type) but
this assumption allows for simpler memory management right now.

NDArray operations are right now not particularly efficient. There are no
fast paths that avoid recomputing the array indexing for every element.
For instance, an operator+= on two NDArrays of the same 2D shape, the code is
roughly as efficient as:

    for (i = 0; i < shape[0]; ++i) {
      for (j = 0; j < shape[1]; ++j) {
        left_index = i * left.stride[0] + j * left.stride[1]
        right_index = i * right.stride[0] + j * right.stride[1]
        left.elements[left_index] += right.elements[right_index]
      }
    }

When really if both arrays have the same stride and shape, we could:

    for (i = 0;i < shape[0] * shape[1]; ++i) {
      left.elements[i] += right.elements[i]
    }

flexible_type
-------------

ndarray<double> is typedefed to flex_nd_vec (flex_type_enum::ND_VECTOR) which
is a new addition to the flexible_type union. The following conversion paths
are currently implemented.
 - image <--> ndarray
 - array <--> ndarray
 - list --> ndarray
 - ndarray --> str

To support some of these better, some image operations
(encode_image, decode_image) have been moved around a bit.

Operators +,-,*,/ are implemented only against nd_vector, int, and float.

SFrame
------
Once the ndarray is supported in the flexible_type supporting it in SFrame
requires a surprisingly little amount of work. Encoders and Decoders for the
new type have been implemented such that an image represented as an ndarray
will generally not require more storage than the raw image equivalent.

The VECTOR SUM and AVG groupby aggregators have been expanded to support
ND_VECTOR which allows groupby() and sum() operators to automatically take
advantage of them.

Four unnecessary std::moves were also removed to remove clang warnings.

Python SFrame
-------------
The ndarray is exposed to Python as the type "np.ndarray". This forces
numpy to be a *required* dependency. Only *exactly* np.ndarray types will be
converted to ndarray. No other cast paths are permitted.

Conversion from np.ndarray to flexible_type[containing an ndarray] always
requires a copy.

Conversions from flexible_type[containing an ndarray] to np.ndarray does not
require a copy relying on Python's buffer protocol to expose the ndarray<double>
memory layout to Python.

What works on ndarray columns:
 - Most numeric ops
 - sum()
 - SFrame groupby sum/avg on ndarray columns

Also SArray / SFrame indexing cache size had to be tweaked and reduced to
better support large ndarrays.

Backward Compatibility
----------------------
Since this new datatype allows all np.ndarray to be maintained as np.ndarray,
this breaks backwards compatibility for operations of the form:

    a = [np.array([1,2,3]),np.array([2,3,4])]
    tc.SArray(a)
    a.dtype == array.array # previous
    a.dtype == np.ndarray  # now

There were a number of tests which assume the previous behavior. All have been
fixed.

Previously, due to implicit np.ndarray --> array.array casting, it might have
been possible to call model prediction using ndarrays. Now, since ndarray
are not (yet) supported by any toolkit, this will likely result in an error.

Known Issues
------------
 - The ndarray type is not supported by any of the toolkits. All toolkits
 need to be upgraded to be aware of this type.
 - show() does not support ndarray.
 - explore() works, but how it is displayed may not be ideal.