### PR TITLE
Typographical errors in userguide

### DIFF
--- a/userguide/supervised-learning/linear-regression.md
+++ b/userguide/supervised-learning/linear-regression.md
@@ -146,7 +146,7 @@ coefficients estimated during model creation. Smaller standard errors implies
 more confidence in the value of the coefficients returned by th model.
 
 Standard errors on coefficients are only available when `solver=newton` or
-when the default `auto` solver option choses the newton method and if the
+when the default `auto` solver option chooses the newton method and if the
 number of examples in the training data is more than the number of
 coefficients. If standard errors cannot be estimated, a column of `None` values
 are returned.

--- a/userguide/supervised-learning/logistic-regression.md
+++ b/userguide/supervised-learning/logistic-regression.md
@@ -86,7 +86,7 @@ Refer to the chapter on linear regression for the following features:
 * [Sparse features](linear-regression.md#linregr-sparse-features)
 * [List features](linear-regression.md#linregr-list-features)
 * [Feature rescaling](linear-regression.md#linregr-feature-rescaling)
-* [Chosing the solver](linear-regression.md#linregr-solver)
+* [Choosing the solver](linear-regression.md#linregr-solver)
 * [Regularizing models](linear-regression.md#linregr-regularizer)
 
 We will now discuss some advanced features that are **specific to logistic


### PR DESCRIPTION
Corrected "chose" to "choose" in userguide.