### PR TITLE
Note nodejs/npm as a build dependency on macOS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -21,7 +21,13 @@ overwritten on the next build. Make changes in the `src/` directory, and run bui
 Build Dependencies
 ------------------
 
-Turi Create automatically satisfies most dependencies in the `deps/` directory,
+You will need:
+
+* On macOS, [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) with command line tools (tested with Xcode 9)
+* On Linux, a C++ compiler toolchain with C++11 support
+* [Node.js](https://nodejs.org) 6.x or later with `node` and `npm` in `$PATH`
+
+Turi Create automatically satisfies other dependencies in the `deps/` directory,
 which includes compiler support and dependent libraries.
 
 Compiling

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -3,6 +3,11 @@ project(Turi)
 if(APPLE)
   if(${TC_BUILD_VISUALIZATION_CLIENT})
 
+    find_program(NPM npm)
+    if(NOT NPM)
+      message(FATAL_ERROR "npm not found. Node.js 6.x or later with npm is required to build Turi Create.")
+    endif()
+
     add_custom_target(visualization_client
       COMMAND xcodebuild -project "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization.xcodeproj/" -configuration ${CMAKE_BUILD_TYPE} SYMROOT=${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Building visualization client via xcodebuild"


### PR DESCRIPTION
* Update BUILD.md to accurately describe pre-existing dependencies vs.
  supplied dependencies.
* Error out in CMakeLists.txt if npm is missing, and
  TC_BUILD_VISUALIZATION_CLIENT is enabled.