### PR TITLE
Fix some unit tests in Python 3

### DIFF
--- a/src/unity/python/turicreate/test/test_json_export.py
+++ b/src/unity/python/turicreate/test/test_json_export.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import as _
 import json
 import numpy as np
 import struct
-import sys
 import tempfile
 import unittest
 
@@ -34,7 +33,7 @@ class JSONExporterTest(unittest.TestCase):
         np.random.seed(42)
         sf = tc.SFrame()
         sf['idx'] = range(_TEST_CASE_SIZE)
-        sf['ints'] = np.random.randint(-sys.maxint - 1, sys.maxint, _TEST_CASE_SIZE)
+        sf['ints'] = np.random.randint(-100000, 100000, _TEST_CASE_SIZE)
         sf['strings'] = sf['ints'].astype(str)
         sf['floats'] = np.random.random(_TEST_CASE_SIZE)
 

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -496,18 +496,18 @@ class ImageClassifier(_CustomModel):
 
         probOutput = spec.description.output[0]
         classLabel = spec.description.output[1]
-        probOutput.type.dictionaryType.MergeFromString('')
+        probOutput.type.dictionaryType.MergeFromString(b'')
         if type(class_labels[0]) == int:
             nn_spec.ClearField('int64ClassLabels')
-            probOutput.type.dictionaryType.int64KeyType.MergeFromString('')
-            classLabel.type.int64Type.MergeFromString('')
+            probOutput.type.dictionaryType.int64KeyType.MergeFromString(b'')
+            classLabel.type.int64Type.MergeFromString(b'')
             del nn_spec.int64ClassLabels.vector[:]
             for c in class_labels:
                 nn_spec.int64ClassLabels.vector.append(c)
         else:
             nn_spec.ClearField('stringClassLabels')
-            probOutput.type.dictionaryType.stringKeyType.MergeFromString('')
-            classLabel.type.stringType.MergeFromString('')
+            probOutput.type.dictionaryType.stringKeyType.MergeFromString(b'')
+            classLabel.type.stringType.MergeFromString(b'')
             del nn_spec.stringClassLabels.vector[:]
             for c in class_labels:
                 nn_spec.stringClassLabels.vector.append(c)


### PR DESCRIPTION
* `sys.maxint` appears to be gone; we really just need a range of ints
  here, so hardcoding a range in test_json_export.
* MergeFromString() from protobuf always takes bytes. Adding `b` prefix
  to string literals in a few uses that were passing `''`.