### PR TITLE
Fix Perplexity Bug

### DIFF
--- a/src/unity/python/turicreate/test/test_topic_model.py
+++ b/src/unity/python/turicreate/test/test_topic_model.py
@@ -464,8 +464,8 @@ class UtilitiesTest(unittest.TestCase):
 
     def setUp(self):
 
-        docs = turicreate.SArray([{'a': 3, 'b': 5},
-                                {'b': 5, 'c': 7},
+        docs = turicreate.SArray([{'b': 5, 'a': 3},
+                                {'c': 7, 'b': 5},
                                 {'a': 2, 'd': 3}])
 
         doc_topics = turicreate.SArray([[.9, .1],

--- a/src/unity/toolkits/text/perplexity.cpp
+++ b/src/unity/toolkits/text/perplexity.cpp
@@ -36,8 +36,7 @@ double perplexity(std::shared_ptr<sarray<flexible_type>> dataset,
   DASSERT_EQ(dataset->size(), doc_topic_prob->size());
   
   // Convert the SArray of vocabulary into std::vector 
-  std::vector<flexible_type> vocab = std::vector<flexible_type>();
-  vocab.reserve(vocabulary->size());
+  std::map<flexible_type, size_t> vocab;
   auto vocab_reader = vocabulary->get_reader();
   for (size_t seg = 0; seg < vocabulary->num_segments(); ++seg) {
     auto iter = vocab_reader->begin(seg);
@@ -45,25 +44,12 @@ double perplexity(std::shared_ptr<sarray<flexible_type>> dataset,
     while (iter != enditer) {
       DASSERT_EQ(flex_type_enum_to_name((*iter).get_type()), 
                  flex_type_enum_to_name(flex_type_enum::STRING));
-      
-      // Create a flex_dict element
-      std::pair<flexible_type, flexible_type> item = 
-          std::make_pair(*iter, 1.0);
-
-      vocab.push_back(flex_dict{item});
+      size_t idx = vocab.size();
+      vocab[(*iter)] = idx;
       ++iter;
     }
   }
 
-
-  // Construct an SFrame with one column (so that we may use ml_data)
-  std::vector<std::shared_ptr<sarray<flexible_type>>> columns = {dataset};
-  std::vector<std::string> column_names = {"data"};
-  sframe dataset_sf = sframe(columns, column_names);
-
-  // Create an ml_data object using the model's current metadata.
-  ml_data d;
-  d.fill(dataset_sf);
 
   // Load the topics SArray into a vector of vectors 
   std::vector<std::vector<double>> phi(word_topic_prob->size());
@@ -98,6 +84,7 @@ double perplexity(std::shared_ptr<sarray<flexible_type>> dataset,
   std::vector<double> llk_per_thread(num_segments);
   std::vector<size_t> num_words_per_thread(num_segments);
   auto theta_reader = doc_topic_prob->get_reader(num_segments);
+  auto doc_reader = dataset->get_reader(num_segments);
 
   // Start iterating through documents
   in_parallel([&](size_t thread_idx, size_t num_threads) {
@@ -106,39 +93,42 @@ double perplexity(std::shared_ptr<sarray<flexible_type>> dataset,
     auto theta_iter = theta_reader->begin(thread_idx);
     auto theta_enditer = theta_reader->end(thread_idx);   
 
+    auto doc_iter = doc_reader->begin(thread_idx);
+    auto doc_enditer = doc_reader->end(thread_idx);
     // Start iterating through documents
-    std::vector<ml_data_entry> x;
-    for(auto it = d.get_iterator(thread_idx, num_threads); !it.done(); ++it) {
+    while(doc_iter != doc_enditer && theta_iter != theta_enditer) {
+      if ((*theta_iter).get_type() == flex_type_enum::VECTOR &&
+          (*doc_iter).get_type() == flex_type_enum::DICT) {
+        // Get topic proportions
+        const flex_vec& theta_doc = *theta_iter;
+        const flex_dict& doc_dict = *doc_iter;
+        DASSERT_EQ(theta_doc.size(), num_topics);
+
+        for (size_t j = 0; j < doc_dict.size(); ++j) {
+          // Get word index and frequency
+          flexible_type word = doc_dict[j].first;
+          double freq = doc_dict[j].second.to<double>();
+          auto word_find_iter = vocab.find(word);
     
-      // Get topic proportions
-      const flex_vec& theta_doc = *theta_iter;
-      DASSERT_EQ(theta_doc.size(), num_topics);
+          if (word_find_iter != vocab.end()) {
+            size_t word_id = word_find_iter->second;
+            // Compute Pr(word | theta, phi)
+            double prob = 0;
+            for (size_t k = 0; k < num_topics; ++k) {
+              DASSERT_LT(0.0, theta_doc[k]);
+              DASSERT_LT(0.0, phi[word_id][k]);
+              prob += theta_doc[k] * phi[word_id][k];
+            }
 
-      // Get document data
-      it->fill(x); 
-      for (size_t j = 0; j < x.size(); ++j) {
-     
-        // Get word index and frequency
-        size_t word_id = x[j].index;
-        size_t freq = x[j].value;
-  
-        if (word_id < vocab.size()) {
-          // Compute Pr(word | theta, phi)
-          double prob = 0;
-          for (size_t k = 0; k < num_topics; ++k) {
-            DASSERT_LT(0.0, theta_doc[k]);
-            DASSERT_LT(0.0, phi[word_id][k]);
-            prob += theta_doc[k] * phi[word_id][k];
+            // Increment numerator and denominator of perplexity estimate
+            llk_per_thread[thread_idx] += freq * log(prob);
+            num_words_per_thread[thread_idx] += freq;
+
           }
-
-          // Increment numerator and denominator of perplexity estimate
-          llk_per_thread[thread_idx] += freq * log(prob);
-          num_words_per_thread[thread_idx] += freq;
-
         }
-
       }
       ++theta_iter;
+      ++doc_iter;
     }
   });
 


### PR DESCRIPTION
Topic Model perplexity computation may give different results depending
on the ordering of the input data. We fix it by enforcing the
vocabulary ordering.