### PR TITLE
Build + test fixes to prepare for 4.1 release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,7 @@ function build_python_egg {
   rm -rf ${target_dir}/python
   mkdir -p ${target_dir}/python
 
-  bash scripts/make_egg.sh --skip_test --skip_cpp_test --build_number="$build_number" --num_procs=${jobs} --${build_mode} --target-dir="${install_dir}"
+  bash scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number="$build_number" --num_procs=${jobs} --${build_mode} --target-dir="${install_dir}"
   pushd ${build_mode}/src
 
   if [[ $apple -eq 1 ]]; then

--- a/configure
+++ b/configure
@@ -32,8 +32,9 @@ function print_help {
   echo "  --with-visualization (default)    Build Turi Create visualization client."
   echo "  --no-visualization"
   echo
-  echo "  --python3                         Use Python 3.4, default is Python 2.7."
+  echo "  --python2.7                       Use Python 2.7 (default)."
   echo "  --python3.5                       Use Python 3.5, default is Python 2.7."
+  echo "  --python3.6                       Use Python 3.6, default is Python 2.7."
   echo 
   echo "  --yes                             Defaults to yes on a prompt"
   echo
@@ -101,8 +102,9 @@ with_ccache=1
 with_ccache=1
 with_visualization=1
 
-python3=0
+python27=0
 python35=0
+python36=0
 
 ###############################################################################
 #
@@ -128,8 +130,9 @@ while [ $# -gt 0 ]
 
     --yes)                  default_yes=1;;
 
-    --python3)              python3=1;;
+    --python2.7)            python27=1;;
     --python3.5)            python35=1;;
+    --python3.6)            python36=1;;
     
     --help)                 print_help ;;
 
@@ -145,18 +148,18 @@ if [[ $cleanup_option == 1 ]]; then
 fi
 
 
-if [[ $python35 == 1 && $python3 ]]; then
-  echo "Two version of Python specified. Pick one."
+if [[ $(($python27 + $python35 + $python36)) -gt 1 ]]; then
+  echo "Two or more versions of Python specified. Pick one."
   exit 1
 fi
 
 
-if [[ $python3 == 1 ]]; then
-  CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DPYTHON_VERSION=\"python3.4m\""
-  PYTHON_VERSION="python3.4m"
-elif [[ $python35 == 1 ]]; then
-  CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DPYTHON_VERSION=\"python3.5m\""
-  PYTHON_VERSION="python3.5m"
+if [[ $python35 == 1 ]]; then
+  CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DPYTHON_VERSION=\"python3.5\""
+  PYTHON_VERSION="python3.5"
+elif [[ $python36 == 1 ]]; then
+  CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DPYTHON_VERSION=\"python3.6\""
+  PYTHON_VERSION="python3.6"
 else
   CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DPYTHON_VERSION=\"python2.7\""
   PYTHON_VERSION="python2.7"

--- a/gitlab_scripts/test_python.sh
+++ b/gitlab_scripts/test_python.sh
@@ -2,8 +2,6 @@
 set -x
 set -e
 
-export TURICREATE_USERNAME=''
-
 # command line arguments
 if [[ -z $1 ]]; then
   echo "build type must be specified. "
@@ -11,22 +9,13 @@ if [[ -z $1 ]]; then
   exit 1
 fi
 
-# platform specific logic
-if [[ $OSTYPE == darwin* ]]; then
-  ARCHIVE_FILE_EXT=whl
-else
-  ARCHIVE_FILE_EXT=tar.gz
-fi
-
 BUILD_TYPE=$1
 date
-git lfs pull
-date
-(test -d $BUILD_TYPE) || ./configure
+(test -d $BUILD_TYPE) || ./configure --$2
 date
 source deps/env/bin/activate
 date
-pip install target/turicreate-*.$ARCHIVE_FILE_EXT
+pip install target/turicreate-*.whl
 date
 
 # create a variable for project root dir
@@ -36,8 +25,8 @@ export LFS_ROOT=$PWD/lfs
 cd $BUILD_TYPE/src/unity/python
 make python_source
 cd ../../../..
-cp -a $BUILD_TYPE/src/unity/python/turicreate/test deps/env/lib/python2.7/site-packages/turicreate/
-cd deps/env/lib/python2.7/site-packages/turicreate/test
+cp -a $BUILD_TYPE/src/unity/python/turicreate/test deps/env/lib/$2/site-packages/turicreate/
+cd deps/env/lib/$2/site-packages/turicreate/test
 
 # run tests
 pytest -v --junit-xml=../../../../../../../pytest.xml

--- a/scenario-tests/additional_requirements.txt
+++ b/scenario-tests/additional_requirements.txt
@@ -5,6 +5,5 @@ nltk==3.2
 pyscreenshot==0.4
 python-swiftclient
 python-keystoneclient
-spacy==0.100.7
 testfixtures==4.10.0
 h5py==2.7.1

--- a/scenario-tests/common/base.py
+++ b/scenario-tests/common/base.py
@@ -1,5 +1,5 @@
 import unittest
-
+import six
 
 class TestCase(unittest.TestCase):
     def __init__(self, methodName='runTest'):
@@ -11,13 +11,13 @@ class TestCase(unittest.TestCase):
     # since they are not type safe in Python.
     # non type-safe comparisons pass when they should fail, a lot.
     def assertEqual(self, a, b):
-        both_int_types = type(a) in [int, long] and type(b) in [int, long]
+        both_int_types = isinstance(a, six.integer_types) and isinstance(b, six.integer_types)
         if not both_int_types:
             super(TestCase, self).assertEqual(type(a), type(b))
         super(TestCase, self).assertEqual(a, b)
 
     def assertNotEqual(self, a, b):
-        both_int_types = type(a) in [int, long] and type(b) in [int, long]
+        both_int_types = isinstance(a, six.integer_types) and isinstance(b, six.integer_types)
         if not both_int_types:
             super(TestCase, self).assertEqual(type(a), type(b))
         super(TestCase, self).assertNotEqual(a, b)
@@ -25,7 +25,7 @@ class TestCase(unittest.TestCase):
     # useful methods for our own purposes
     def assertWithinRange(self, value, target, allowed_range):
         # asserts that value is within allowed_range of target
-        self.assertEquals(max(abs(value - target), allowed_range), allowed_range)
+        self.assertEqual(max(abs(value - target), allowed_range), allowed_range)
 
     def assertBetween(self, value, lower, upper):
         # asserts that a value is between two bounds, including the bounds

--- a/scenario-tests/common/mirror_retrieve.py
+++ b/scenario-tests/common/mirror_retrieve.py
@@ -1,7 +1,7 @@
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 def _raw_urlretrieve(url, target_file, context=None):
-    handle = urllib.urlopen(url)#, context=context)
+    handle = urllib.request.urlopen(url)#, context=context)
     if handle.getcode() >= 300:
         raise IOError("HTTP Error " + str(handle.getcode()))
     with open(target_file, 'wb') as output:
@@ -14,5 +14,5 @@ def _raw_urlretrieve(url, target_file, context=None):
 
 
 def urlretrieve(url, target_file):
-    print "Downloading " + url + " to " + target_file
+    print("Downloading " + url + " to " + target_file)
     _raw_urlretrieve(url, target_file)

--- a/scenario-tests/driver.py
+++ b/scenario-tests/driver.py
@@ -53,19 +53,19 @@ for test in os.listdir(test_path):
         # if file does not exist, stat will raise an exception. which is kind of
         # annoying. one might expect S_ISDIR to just return False. But no.....
         continue
-    print "============================================================================"
-    print test
-    print "============================================================================"
+    print("============================================================================")
+    print(test)
+    print("============================================================================")
     cmd = 'python single_test_driver.py "{}" "{}"'.format(test, test)
-    print cmd
+    print(cmd)
     # trigger test in subdirectory
     subprocess_exit_code = os.system(cmd)
 
     # error handling -- fail parent process if a test subprocess fails
     if subprocess_exit_code != 0:
-        print "****************************************************************************"
-        print "Non-zero process return: %s" % test
-        print "****************************************************************************"
+        print("****************************************************************************")
+        print("Non-zero process return: %s" % test)
+        print("****************************************************************************")
 
         exit_code = 1
 

--- a/scenario-tests/run_scenario_tests.sh
+++ b/scenario-tests/run_scenario_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -e
+set -x
+
 function print_help {
   echo "Executes all scenario tests using a given egg location"
 
@@ -66,8 +68,11 @@ fi
 set -x
 
 # Set up virtual environment
+if [[ "$VIRTUALENV" == "" ]]; then
+  VIRTUALENV=virtualenv
+fi
 if [[ ! -e venv ]]; then
-    virtualenv venv
+    $VIRTUALENV venv
 fi
 source venv/bin/activate
 pip install -r ../scripts/requirements.txt

--- a/scenario-tests/tests/engine/test_lambda.py
+++ b/scenario-tests/tests/engine/test_lambda.py
@@ -66,7 +66,7 @@ class LambdaTests(unittest.TestCase):
     @unittest.skip("Disabling crash recovery test")
     def test_crash_recovery(self):
         import time, sys
-        ls = range(1000)
+        ls = list(range(1000))
 
         def good_fun(x):
             return x

--- a/scenario-tests/tests/setup_reporter.py
+++ b/scenario-tests/tests/setup_reporter.py
@@ -38,7 +38,7 @@ def try_execfile(test_path, filename):
         if os.path.exists(report_filename):
             os.remove(report_filename)
         try:
-            execfile(test_file, globals())
+            exec(compile(open(test_file).read(), test_file, 'exec'), globals())
         except:
             with open(report_filename, 'w') as f:
                 report_failure(f, test_path, filename, sys.exc_info())

--- a/scenario-tests/tests/single_test_driver.py
+++ b/scenario-tests/tests/single_test_driver.py
@@ -7,7 +7,7 @@ import sys
 from setup_reporter import try_execfile
 
 def print_help():
-    print("""\
+    print(("""\
 %s [sub_directory] [Optional output xunit xml path prefix]
 
 This test runs the scenario test located in the sub directory.
@@ -20,7 +20,7 @@ tests.
 
 For instance, if the PATH variable is changed in setup.py a different python
 environment may be used to run pytest
-""" % sys.argv[0])
+""" % sys.argv[0]))
 
 # set PYTHONPATH to include `common` so that test files can include shared code.
 common_dir = os.path.join(os.getcwd(), '..', 'common')

--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -3,7 +3,19 @@
 set -x
 set -e
 
-virtualenv ${PWD}/deps/env
+if [[ -z $VIRTUALENV ]]; then
+  VIRTUALENV=virtualenv
+fi
+
+PIP=pip3
+# TODO - not sure why 'm' is necessary here (and not in 2.7)
+PYTHON_FULL_NAME=${PYTHON_VERSION}m
+if [[ "${PYTHON_VERSION}" == "python2.7" ]]; then
+  PIP=pip
+  PYTHON_FULL_NAME=${PYTHON_VERSION}
+fi
+
+$VIRTUALENV ${PWD}/deps/env
 source ${PWD}/deps/env/bin/activate
 
 python_scripts=deps/env/bin
@@ -38,46 +50,14 @@ function download_file {
   fi
 } # end of download file
 
-haspython=0
-if [ -e deps/env/bin/python ]; then
-        haspython=1
-fi
-
-if [[ $haspython == 0 ]]; then
-        if [[ $OSTYPE == darwin* ]]; then
-                if [[ ${PYTHON_VERSION} == "python3.4m" ]]; then
-                        echo "Not supported yet"
-                        exit 1
-                elif [[ ${PYTHON_VERSION} == "python3.5m" ]]; then
-                        echo "Not supported yet"
-                        exit 1
-                else
-                        virtualenv deps/env
-                        source deps/env/bin/activate
-                        echo "skip conda"
-                fi
-        else
-                if [[ ${PYTHON_VERSION} == "python3.4m" ]]; then
-                        echo "Not supported yet"
-                        exit 1
-                elif [[ ${PYTHON_VERSION} == "python3.5m" ]]; then
-                        echo "Not supported yet"
-                        exit 1
-                else
-                        virtualenv deps/env
-                        source deps/env/bin/activate
-                        echo "skip conda"
-                fi
-        fi
-fi
-$python_scripts/pip install --upgrade "pip>=8.1"
-$python_scripts/pip install -r scripts/requirements.txt
+$python_scripts/$PIP install --upgrade "pip>=8.1"
+$python_scripts/$PIP install -r scripts/requirements.txt
 
 mkdir -p deps/local/lib
 mkdir -p deps/local/include
 
 pushd deps/local/include
-for f in `ls ../../env/include/python2.7/*`; do  
+for f in `ls ../../env/include/$PYTHON_FULL_NAME/*`; do  
   ln -Ffs $f
 done
 popd

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-scipy==0.17.0
+scipy==0.19.1
 numpy==1.11.1
 cython==0.24
 Jinja2==2.8
@@ -6,8 +6,8 @@ argparse==1.2.1
 decorator==4.1.2
 mock==2.0.0
 pytest==3.2.5
-pandas==0.19.0
-pillow==3.3.0
+pandas==0.22.0
+pillow==5.0.0
 prettytable==0.7.2
 pytz==2016.3
 requests>=2.9.1
@@ -16,4 +16,3 @@ six==1.10.0
 statsmodels==0.8.0
 wheel==0.29.0
 mxnet==0.11
-coremltools==0.6.3

--- a/src/unity/lib/version_number.hpp
+++ b/src/unity/lib/version_number.hpp
@@ -3,4 +3,4 @@
  * Use of this source code is governed by a BSD-3-clause license that can
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
-#define __UNITY_VERSION__ "4.0"//#{{VERSION_STRING}}
+#define __UNITY_VERSION__ "4.1a1"//#{{VERSION_STRING}}

--- a/src/unity/python/dummy.c
+++ b/src/unity/python/dummy.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main()
+{
+      return 0;
+}
+
+void initdummy() {}

--- a/src/unity/python/dummy.c
+++ b/src/unity/python/dummy.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 int main()
 {
       return 0;

--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -10,12 +10,12 @@ import os
 import sys
 import glob
 import subprocess
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
 from setuptools.dist import Distribution
 from setuptools.command.install import install
 
 PACKAGE_NAME="turicreate"
-VERSION='4.0'#{{VERSION_STRING}}
+VERSION='4.1a1'#{{VERSION_STRING}}
 
 # Prevent distutils from thinking we are a pure python package
 class BinaryDistribution(Distribution):
@@ -124,6 +124,12 @@ if __name__ == '__main__':
     setup(
         name="turicreate",
         version=VERSION,
+
+        # This distribution contains platform-specific C++ libraries, but they are not
+        # built with distutils. So we must create a dummy Extension object so when we
+        # create a binary file it knows to make it platform-specific.
+        ext_modules=[Extension('turicreate.__dummy', sources = ['dummy.c'])],
+
         author='Apple Inc.',
         author_email='turi-create@group.apple.com',
         cmdclass=dict(install=InstallEngine),
@@ -167,7 +173,7 @@ if __name__ == '__main__':
             "prettytable == 0.7.2",
             "requests >= 2.9.1",
             "mxnet >= 0.11, < 1.0.0",
-            "coremltools == 0.6.3",
+            "coremltools == 0.8",
             "pillow >= 3.3.0",
             "pandas >= 0.19.0",
         ],

--- a/src/unity/python/turicreate/test/test_topic_model.py
+++ b/src/unity/python/turicreate/test/test_topic_model.py
@@ -504,4 +504,4 @@ class UtilitiesTest(unittest.TestCase):
                                    self.word_topics,
                                    self.vocabulary)
 
-        self.assertTrue(abs(perp - observed_perp) < .0001)
+        self.assertAlmostEqual(perp, observed_perp, delta=0.0001)

--- a/src/unity/python/turicreate/version_info.py
+++ b/src/unity/python/turicreate/version_info.py
@@ -11,7 +11,7 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 
 # python egg version
-__version__ = '4.0'#{{VERSION_STRING}}
+__version__ = '4.1a1'#{{VERSION_STRING}}
 version = __version__
 build_number = '0'#{{BUILD_NUMBER}}
 git_sha = 'NA'#{{GIT_SHA}}


### PR DESCRIPTION
* Remove unused spacy dependency in scenario tests
* Bump coremltools dependency to 0.8
* Use assertAlmostEqual to get better failure msg in test_perplexity
* Get scenario tests ready for Python 3 execution
* Expect wheels on Linux for scenario and unit tests
* Make wheels on Linux
* Rename make_egg -> make_wheel
* Bump version number to 4.1a1
* Use VIRTUALENV env variable in run_scenario_tests