### PR TITLE
Fix some Unicode string cases in Python 2

### DIFF
--- a/src/unity/python/turicreate/cython/cy_dataframe.pyx
+++ b/src/unity/python/turicreate/cython/cy_dataframe.pyx
@@ -32,9 +32,9 @@ cdef gl_dataframe gl_dataframe_from_dict_of_arrays(dict df) except *:
     cdef flex_list fl
 
     for key, value in sorted(df.iteritems()):
-        ret.names.push_back(key.encode())
-        ret.values[key.encode()] = common_typed_flex_list_from_iterable(value, &ftype)
-        ret.types[key.encode()] = ftype
+        ret.names.push_back(key.encode('utf-8'))
+        ret.values[key.encode('utf-8')] = common_typed_flex_list_from_iterable(value, &ftype)
+        ret.types[key.encode('utf-8')] = ftype
 
     return ret
 

--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -32,6 +32,7 @@ import collections
 import datetime
 import warnings
 import numbers
+import six
 
 __all__ = ['SArray']
 
@@ -3089,6 +3090,8 @@ class SArray(object):
 
         if column_name_prefix is None:
             column_name_prefix = ""
+        if six.PY2 and type(column_name_prefix) == unicode:
+            column_name_prefix = column_name_prefix.encode('utf-8')
         if type(column_name_prefix) != str:
             raise TypeError("'column_name_prefix' must be a string")
 
@@ -3332,7 +3335,7 @@ class SArray(object):
 
         if column_name_prefix is None:
             column_name_prefix = ""
-        if type(column_name_prefix) != str:
+        if not(isinstance(column_name_prefix, six.string_types)):
             raise TypeError("'column_name_prefix' must be a string")
 
         # validate 'limit'
@@ -3394,9 +3397,9 @@ class SArray(object):
         with cython_context():
             if (self.dtype == dict and column_types is None):
                 limit = limit if limit is not None else []
-                return _SFrame(_proxy=self.__proxy__.unpack_dict(column_name_prefix.encode(), limit, na_value))
+                return _SFrame(_proxy=self.__proxy__.unpack_dict(column_name_prefix.encode('utf-8'), limit, na_value))
             else:
-                return _SFrame(_proxy=self.__proxy__.unpack(column_name_prefix.encode(), limit, column_types, na_value))
+                return _SFrame(_proxy=self.__proxy__.unpack(column_name_prefix.encode('utf-8'), limit, column_types, na_value))
 
     def sort(self, ascending=True):
         """

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -751,6 +751,8 @@ class SFrame(object):
         else:
             self.__proxy__ = UnitySFrameProxy()
             _format = None
+            if six.PY2 and isinstance(data, unicode):
+                data = data.encode('utf-8')
             if (format == 'auto'):
                 if (HAS_PANDAS and isinstance(data, pandas.DataFrame)):
                     _format = 'dataframe'
@@ -3080,16 +3082,11 @@ class SFrame(object):
         """
         if not _is_non_string_iterable(column_names):
             raise TypeError("column_names must be an iterable")
-        if not (all([isinstance(x, str) or isinstance(x, type) or isinstance(x, bytes)
+        if not (all([isinstance(x, six.string_types) or isinstance(x, type) or isinstance(x, bytes)
                      for x in column_names])):
-            raise TypeError("Invalid key type: must be str, bytes or type")
+            raise TypeError("Invalid key type: must be str, unicode, bytes or type")
 
-        column_names_set = set(self.column_names())
-        # quick validation to make sure all selected string columns exist
-        requested_str_columns = [s for s in column_names if isinstance(s, str)]
-        for i in requested_str_columns:
-            if i not in column_names_set:
-                raise RuntimeError("Column name " +  i + " does not exist")
+        requested_str_columns = [s for s in column_names if isinstance(s, six.string_types)]
 
         # Make sure there are no duplicates keys
         from collections import Counter
@@ -3520,7 +3517,9 @@ class SFrame(object):
         """
         if type(key) is SArray:
             return self._row_selector(key)
-        elif type(key) is str:
+        elif isinstance(key, six.string_types):
+            if six.PY2 and type(key) == unicode:
+                key = key.encode('utf-8')
             return self.select_column(key)
         elif type(key) is type:
             return self.select_columns([key])

--- a/src/unity/python/turicreate/test/test_unicode_strings.py
+++ b/src/unity/python/turicreate/test/test_unicode_strings.py
@@ -17,12 +17,10 @@ import turicreate as tc
 class UnicodeStringTest(unittest.TestCase):
 
     def test_unicode_column_accessor(self):
-        import turicreate as tc
         sf = tc.SFrame({'a': range(100)})
         self.assertEqual(sf[u'a'][0], sf['a'][0])
 
     def test_unicode_unpack_prefix(self):
-        import turicreate as tc
         sf = tc.SFrame({'a':[{'x':1}, {'x':2}, {'x':3}]})
         sf = sf.unpack('a', u'\u00aa')
         for col in sf.column_names():

--- a/src/unity/python/turicreate/test/test_unicode_strings.py
+++ b/src/unity/python/turicreate/test/test_unicode_strings.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+# This software may be modified and distributed under the terms
+# of the BSD license. See the LICENSE file for details.
+
+from __future__ import print_function as _
+from __future__ import division as _
+from __future__ import absolute_import as _
+
+import six
+import unittest
+import turicreate as tc
+
+class UnicodeStringTest(unittest.TestCase):
+
+    def test_unicode_column_accessor(self):
+        import turicreate as tc
+        sf = tc.SFrame({'a': range(100)})
+        self.assertEqual(sf[u'a'][0], sf['a'][0])
+
+    def test_unicode_unpack_prefix(self):
+        import turicreate as tc
+        sf = tc.SFrame({'a':[{'x':1}, {'x':2}, {'x':3}]})
+        sf = sf.unpack('a', u'\u00aa')
+        for col in sf.column_names():
+            if six.PY2:
+                # column names come out as str
+                self.assertTrue(col.startswith(u'\u00aa'.encode('utf-8')))
+            else:
+                # column names come out as unicode
+                self.assertTrue(col.startswith(u'\u00aa'))
+
+    def test_unicode_column_construction(self):
+        sf = tc.SFrame({u'\u00aa': [1, 2, 3]})
+        self.assertEqual(sf[u'\u00aa'][0], 1)
+
+    def test_access_nonexistent_column(self):
+        sf = tc.SFrame({u'\u00aa': [1,2,3], 'a': [4,5,6]})
+        with self.assertRaises(RuntimeError):
+            sf['b']
+        with self.assertRaises(RuntimeError):
+            sf[u'\u00ab']


### PR DESCRIPTION
* Assumes utf-8 everywhere (Python 3 already makes this assumption).
* Allow unicode column accessors in SFrame.
* Allow unicode column name in construction of SFrame.
* Allow unicode column_name_prefix in str_to_datetime and unpack.

Fixes #157