### PR TITLE
Make sure distributions contain README.rst

### DIFF
--- a/src/unity/python/MANIFEST.in
+++ b/src/unity/python/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.txt
+include README.rst
 recursive-include turicreate *.so *.so.1 *.dylib *.pyd *.dll pylambda_worker  *.exe
 recursive-include *.pyd *.so
 recursive-include turicreate/canvas *.html *.css *.js *.ico *.otf *.eot *.svg *.ttf *.woff *LICENSE* *.png

--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
                      "*.demo", "*.demo.*", "demo.*", "demo", "*.demo", "*.demo.*", "demo.*", "demo"]),
         url='https://github.com/apple/turicreate',
         license='LICENSE.txt',
-        description='Turi Create enables developers and data scientists to apply machine learning to build state of the art data products.',
+        description='Turi Create simplifies the development of custom machine learning models.',
         long_description=long_description,
         classifiers=classifiers,
         install_requires=[

--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -123,6 +123,9 @@ if __name__ == '__main__':
         sys.stderr.write(msg)
         sys.exit(1)
 
+    with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
+        long_description = f.read()
+
     setup(
         name="turicreate",
         version=VERSION,
@@ -169,6 +172,7 @@ if __name__ == '__main__':
         url='https://github.com/apple/turicreate',
         license='LICENSE.txt',
         description='Turi Create enables developers and data scientists to apply machine learning to build state of the art data products.',
+        long_description=long_description,
         classifiers=classifiers,
         install_requires=[
             "decorator >= 4.0.9",


### PR DESCRIPTION
Right now, the README.rst does not show up on PyPI. This is addressed in
two ways (not sure if both are necessary, but it seems to be common
practice to do both):

- Add to manifest file
- Add to `long_description` in setup.py