### PR TITLE
Update instructions to reflect currently recommended mxnet version

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ CUDA-enabled `mxnet-cu80` package:
 
 ```
 (venv) pip uninstall -y mxnet
-(venv) pip install mxnet-cu80==0.11.0
+(venv) pip install mxnet-cu80==0.12.1
 ```
 
-Make sure you install the same version of MXNet as the one `turicreate` depends
-on (currently `0.11.0`). If you have trouble setting up the GPU, the [MXNet
+Make sure you install the same version of MXNet as the one `turicreate` recommends
+(currently `0.12.1`). If you have trouble setting up the GPU, the [MXNet
 installation instructions](https://mxnet.incubator.apache.org/get_started/install.html) may
 offer additional help.
 


### PR DESCRIPTION
... instead of minimum supported. As defined by:

https://github.com/apple/turicreate/blob/7f379e2c74b94429dd578581ef3aee353d7b9e84/src/unity/python/turicreate/__init__.py#L133-L135