### PR TITLE
Fix compilation issue on c++ versions less than 17

### DIFF
--- a/src/flexible_type/ndarray.hpp
+++ b/src/flexible_type/ndarray.hpp
@@ -708,7 +708,7 @@ class ndarray {
 
 // pointer to ndarray is constrained to pointer size
 // to enforce that it will always fit in a flexible_type.
-static_assert(sizeof(ndarray<int>*) == sizeof(size_t));
+static_assert(sizeof(ndarray<int>*) == sizeof(size_t), "Pointer to ndarray must be the same size as size_t");
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const ndarray<T>& n) {


### PR DESCRIPTION
According to http://en.cppreference.com/w/cpp/language/static_assert the message can only be omitted starting from c++17,  so the master branch not compile for me on gcc 5.4 and c++11.