### PR TITLE
Add validation-set statistics to resulting model for linear/logistic regression

### DIFF
--- a/src/unity/toolkits/supervised_learning/linear_regression.cpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression.cpp
@@ -303,6 +303,16 @@ void linear_regression::train(){
   unity_progress->construct_from_sframe(stats.progress_table);
   state["progress"] = to_variant(unity_progress);
 
+  // Compute validation-set stats.
+  if (lr_interface->num_validation_examples() > 0) {
+    // Recycle lvalues from stats to use as out parameters here, now that we're
+    // otherwise done reading from stats.
+    lr_interface->compute_second_order_statistics(
+        stats.solution, stats.hessian, stats.gradient, stats.func_value);
+    state["validation_loss"] =  stats.func_value;
+    state["validation_rmse"] =  sqrt((stats.func_value)/examples);
+  }
+
   reg.reset();
   smooth_reg.reset();
 

--- a/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.cpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.cpp
@@ -113,6 +113,13 @@ size_t linear_regression_opt_interface::num_examples() const{
   return examples;
 }
 
+/**
+ * Get the number of validation-set examples in the model
+ */
+size_t linear_regression_opt_interface::num_validation_examples() const{
+  return valid_data.num_rows();
+}
+
 
 /**
  * Get strings needed to print the header for the progress table.

--- a/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.hpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.hpp
@@ -104,9 +104,16 @@ class linear_regression_opt_interface: public
   /**
    * Get the number of variables in the model
    *
-   * \returns Number of examples
+   * \returns Number of variables
    */
   size_t num_variables() const;
+
+  /**
+   * Get the number of validation-set examples in the model
+   *
+   * \returns Number of examples
+   */
+  size_t num_validation_examples() const;
 
   /**
    * Get strings needed to print the header for the progress table.

--- a/src/unity/toolkits/supervised_learning/logistic_regression.cpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression.cpp
@@ -343,6 +343,15 @@ void logistic_regression::train() {
   unity_progress->construct_from_sframe(stats.progress_table);
   state["progress"] = to_variant(unity_progress);
 
+  // Compute validation-set stats.
+  if (lr_interface->num_validation_examples() > 0) {
+    // Recycle lvalues from stats to use as out parameters here, now that we're
+    // otherwise done reading from stats.
+    lr_interface->compute_second_order_statistics(
+        stats.solution, stats.hessian, stats.gradient, stats.func_value);
+    state["validation_loss"] =  stats.func_value;
+  }
+
   reg.reset();
   smooth_reg.reset();
 }

--- a/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.cpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.cpp
@@ -161,6 +161,14 @@ size_t logistic_regression_opt_interface::num_examples() const{
 
 
 /**
+* Get the number of validation-set examples for the model
+*/
+size_t logistic_regression_opt_interface::num_validation_examples() const{
+  return valid_data.num_rows();
+}
+
+
+/**
 * Get the number of variables for the model
 */
 size_t logistic_regression_opt_interface::num_variables() const{

--- a/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.hpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.hpp
@@ -118,6 +118,13 @@ class logistic_regression_opt_interface: public
   size_t num_examples() const;
 
   /**
+  * Get the number of validation-set examples for the model
+  *
+  * \returns Number of examples
+  */
+  size_t num_validation_examples() const;
+
+  /**
   * Get the number of variables in the model
   *
   * \returns Number of variables


### PR DESCRIPTION
The models produced by linear regression included the training-set loss and RMSE, but not the validation-set metrics. Perform one more call to compute_second_order_statistics as the end of train() to populate these.