### PR TITLE
Image Classifier & Image Similarity: take as input single image or SArray of images

### DIFF
--- a/src/unity/python/turicreate/test/test_image_similarity.py
+++ b/src/unity/python/turicreate/test/test_image_similarity.py
@@ -108,17 +108,17 @@ class ImageSimilarityTest(unittest.TestCase):
         for a, b in zip(list1, list2):
              self.assertAlmostEqual(a, b, delta = tol)
 
-    @pytest.mark.xfail(rases = _ToolkitError)
     def test_create_with_missing_feature(self):
-        tc.image_similarity.create(self.sf, feature='wrong_feature', label=self.label)
+        with self.assertRaises(_ToolkitError):
+            tc.image_similarity.create(self.sf, feature='wrong_feature', label=self.label)
 
-    @pytest.mark.xfail(rases = _ToolkitError)
     def test_create_with_missing_label(self):
-        tc.image_similarity.create(self.sf, feature=self.feature, label='wrong_label')
+        with self.assertRaises(_ToolkitError):
+            tc.image_similarity.create(self.sf, feature=self.feature, label='wrong_label')
 
-    @pytest.mark.xfail(rases = _ToolkitError)
     def test_create_with_empty_dataset(self):
-        tc.image_similarity.create(self.sf[:0])
+        with self.assertRaises(_ToolkitError):
+            tc.image_similarity.create(self.sf[:0])
 
     def test_invalid_num_gpus(self):
         num_gpus = tc.config.get_num_gpus()
@@ -155,6 +155,20 @@ class ImageSimilarityTest(unittest.TestCase):
             ans = model._get(field)
             self.assertTrue(self.get_ans[field](ans),
                     '''Get failed in field {}. Output was {}.'''.format(field, ans))
+
+    def test_query_input(self):
+        model = self.model
+
+        single_image = self.sf[self.feature][0]
+        sims = model.query(single_image)
+        self.assertIsNotNone(sims)
+
+        sarray = self.sf[self.feature]
+        sims = model.query(sarray)
+        self.assertIsNotNone(sims)
+
+        with self.assertRaises(TypeError):
+            model.query("this is a junk value")
 
     def test_summary(self):
         model = self.model

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -274,10 +274,11 @@ class ImageClassifier(_CustomModel):
 
         Parameters
         ----------
-        dataset : SFrame
-            Dataset of new observations. Must include columns with the same
-            names as the features used for model training, but does not require
-            a target column. Additional columns are ignored.
+        dataset : SFrame | SArray | turicreate.Image
+            The images to be classified.
+            If dataset is an SFrame, it must have a columns with the same names as
+            the features used for model training, but does not require a target
+            column. Additional columns are ignored.
 
         output_type : {'probability', 'margin', 'class', 'probability_vector'}, optional
             Form of the predictions which are one of:
@@ -307,6 +308,14 @@ class ImageClassifier(_CustomModel):
         >>> class_predictions = model.predict(data, output_type='class')
 
         """
+        if not isinstance(dataset, (_tc.SFrame, _tc.SArray, _tc.Image)):
+            raise TypeError('dataset must be either an SFrame, SArray or turicreate.Image')
+
+        if isinstance(dataset, _tc.SArray):
+            dataset = _tc.SFrame({self.feature: dataset})
+        elif isinstance(dataset, _tc.Image):
+            dataset = _tc.SFrame({self.feature: [dataset]})
+
         extracted_features = self._extract_features(dataset)
         return self.classifier.predict(extracted_features, output_type=output_type)
 
@@ -319,8 +328,9 @@ class ImageClassifier(_CustomModel):
 
         Parameters
         ----------
-        dataset : SFrame
-            Dataset of new observations. Must include columns with the same
+        dataset : SFrame | SArray | turicreate.Image
+            Images to be classified.
+            If dataset is an SFrame, it must include columns with the same
             names as the features used for model training, but does not require
             a target column. Additional columns are ignored.
 
@@ -338,6 +348,14 @@ class ImageClassifier(_CustomModel):
         >>> classes = model.classify(data)
 
         """
+        if not isinstance(dataset, (_tc.SFrame, _tc.SArray, _tc.Image)):
+            raise TypeError('dataset must be either an SFrame, SArray or turicreate.Image')
+
+        if isinstance(dataset, _tc.SArray):
+            dataset = _tc.SFrame({self.feature: dataset})
+        elif isinstance(dataset, _tc.Image):
+            dataset = _tc.SFrame({self.feature: [dataset]})
+
         extracted_features = self._extract_features(dataset)
         return self.classifier.classify(extracted_features)
 
@@ -350,10 +368,11 @@ class ImageClassifier(_CustomModel):
 
         Parameters
         ----------
-        dataset : SFrame
-            A dataset that has the same columns that were used during training.
-            If the target column exists in ``dataset`` it will be ignored
-            while making predictions.
+        dataset : SFrame | SArray | turicreate.Image
+            Images to be classified.
+            If dataset is an SFrame, it must include columns with the same
+            names as the features used for model training, but does not require
+            a target column. Additional columns are ignored.
 
         output_type : {'probability', 'rank', 'margin'}, optional
             Choose the return type of the prediction:
@@ -395,6 +414,14 @@ class ImageClassifier(_CustomModel):
         +--------+-------+-------------------+
         [35688 rows x 3 columns]
         """
+        if not isinstance(dataset, (_tc.SFrame, _tc.SArray, _tc.Image)):
+            raise TypeError('dataset must be either an SFrame, SArray or turicreate.Image')
+
+        if isinstance(dataset, _tc.SArray):
+            dataset = _tc.SFrame({self.feature: dataset})
+        elif isinstance(dataset, _tc.Image):
+            dataset = _tc.SFrame({self.feature: [dataset]})
+
         extracted_features = self._extract_features(dataset)
         return self.classifier.predict_topk(extracted_features, output_type = output_type, k = k)
 

--- a/src/unity/python/turicreate/toolkits/image_similarity/image_similarity.py
+++ b/src/unity/python/turicreate/toolkits/image_similarity/image_similarity.py
@@ -262,16 +262,17 @@ class ImageSimilarityModel(_CustomModel):
 
     def query(self, dataset, label=None, k=5, radius=None, verbose=True):
         """
-        For each row of the input 'dataset', retrieve the nearest neighbors
-        from the model's stored data. In general, the query dataset does not
-        need to be the same as the reference data stored in the model.
+        For each image, retrieve the nearest neighbors from the model's stored
+        data. In general, the query dataset does not need to be the same as
+        the reference data stored in the model.
 
         Parameters
         ----------
-        dataset : SFrame
-            Query data. Must contain columns with the same names and types as
-            the features used to train the model. Additional columns are
-            allowed, but ignored.
+        dataset : SFrame | SArray | turicreate.Image
+            Query data.
+            If dataset is an SFrame, it must contain columns with the same
+            names and types as the features used to train the model.
+            Additional columns are ignored.
 
         label : str, optional
             Name of the query SFrame column with row labels. If 'label' is not
@@ -328,6 +329,14 @@ class ImageSimilarityModel(_CustomModel):
         |      2      |        1        | 0.464004310325 |  2   |
         +-------------+-----------------+----------------+------+
         """
+        if not isinstance(dataset, (_tc.SFrame, _tc.SArray, _tc.Image)):
+            raise TypeError('dataset must be either an SFrame, SArray or turicreate.Image')
+
+        if isinstance(dataset, _tc.SArray):
+            dataset = _tc.SFrame({self.feature: dataset})
+        elif isinstance(dataset, _tc.Image):
+            dataset = _tc.SFrame({self.feature: [dataset]})
+
         extracted_features = self._extract_features(dataset)
         if label is not None:
             extracted_features[label] = dataset[label]

--- a/src/unity/toolkits/supervised_learning/logistic_regression.cpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression.cpp
@@ -207,8 +207,8 @@ void logistic_regression::train() {
   DenseVector init_point(this->num_coefficients);
   init_point.zeros();
   display_classifier_training_summary("Logistic regression");
-  logprogress_stream << "Number of coefficients    : " << this->num_coefficients
-                                                       << std::endl;
+  logprogress_stream << "Number of coefficients      : " << this->num_coefficients
+                     << std::endl;
 
 
   // Deal with regularizers


### PR DESCRIPTION
In addition:
* Raise `TypeError` for other input types
* Stop using `xfail` for testing error cases.
* Fix output alignment for logistic regression.