### PR TITLE
Use binary mode to read README.rst

### DIFF
--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -123,8 +123,8 @@ if __name__ == '__main__':
         sys.stderr.write(msg)
         sys.exit(1)
 
-    with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
-        long_description = f.read()
+    with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'rb') as f:
+        long_description = f.read().decode('utf-8')
 
     setup(
         name="turicreate",


### PR DESCRIPTION
Then decode utf-8 explicitly. For some reason, otherwise we get:

```
+ VERSION_NUMBER=4.1.1
+ /builds/turi/turicreate-build/scripts/../deps/env/bin/python setup.py
bdist_wheel
Traceback (most recent call last):
  File "setup.py", line 127, in <module>
    long_description = f.read()
  File
"/builds/turi/turicreate-build/scripts/../deps/env/lib/python3.5/encodings/ascii.py",
line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position
106: ordinal not in range(128)
```