### PR TITLE
Fix validation-set statistics saved to linear/logistic regression models

### DIFF
--- a/src/unity/toolkits/supervised_learning/linear_regression.cpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression.cpp
@@ -307,7 +307,7 @@ void linear_regression::train(){
   if (lr_interface->num_validation_examples() > 0) {
     // Recycle lvalues from stats to use as out parameters here, now that we're
     // otherwise done reading from stats.
-    lr_interface->compute_second_order_statistics(
+    lr_interface->compute_validation_second_order_statistics(
         stats.solution, stats.hessian, stats.gradient, stats.func_value);
     state["validation_loss"] =  stats.func_value;
     state["validation_rmse"] =  sqrt((stats.func_value)/examples);

--- a/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.cpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.cpp
@@ -236,10 +236,10 @@ void linear_regression_opt_interface::compute_first_order_statistics(const
 /**
  * Compute the second order statistics
 */
-void linear_regression_opt_interface::compute_second_order_statistics(const
-    DenseVector& point, DenseMatrix& hessian, DenseVector& gradient, double&
-    function_value) {
-  
+void linear_regression_opt_interface::compute_second_order_statistics(
+    const ml_data& data, const DenseVector& point, DenseMatrix& hessian,
+    DenseVector& gradient, double& function_value) {
+
   std::vector<DenseMatrix> H(n_threads, 
                         arma::zeros(variables,variables));
   std::vector<DenseVector> G(n_threads, 
@@ -330,6 +330,20 @@ void linear_regression_opt_interface::compute_second_order_statistics(const
 
 }
 
+void linear_regression_opt_interface::compute_second_order_statistics(
+    const DenseVector& point, DenseMatrix& hessian, DenseVector& gradient,
+    double& function_value) {
+  compute_second_order_statistics(
+      data, point, hessian, gradient, function_value);
+}
+
+void
+linear_regression_opt_interface::compute_validation_second_order_statistics(
+    const DenseVector& point, DenseMatrix& hessian, DenseVector& gradient,
+    double& function_value) {
+  compute_second_order_statistics(
+      valid_data, point, hessian, gradient, function_value);
+}
 
 } // supervised
 } // turicreate

--- a/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.hpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression_opt_interface.hpp
@@ -36,8 +36,7 @@ namespace supervised {
  */
 class linear_regression_opt_interface: public
                                        optimization::second_order_opt_interface
-  {
-
+{
   protected:
 
   ml_data data;
@@ -145,6 +144,7 @@ class linear_regression_opt_interface: public
   void compute_first_order_statistics(const DenseVector &point, DenseVector&
       gradient, double & function_value, const size_t mbStart = 0, const size_t
       mbSize = -1);
+
   /**
    * Compute second order statistics at the given point. (Gradient & Function value)
    *
@@ -157,7 +157,25 @@ class linear_regression_opt_interface: public
   void compute_second_order_statistics(const DenseVector &point, DenseMatrix&
       hessian, DenseVector& gradient, double & function_value);
 
+  /**
+   * Compute second order statistics at the given point with respect to the
+   * validation data. (Gradient & Function value)
+   *
+   * \param[in]  point           Point at which we are computing the stats.
+   * \param[out] hessian         Hessian (Dense)
+   * \param[out] gradient        Dense gradient
+   * \param[out] function_value  Function value
+   *
+   */
+  void compute_validation_second_order_statistics(
+      const DenseVector& point, DenseMatrix& hessian, DenseVector& gradient,
+      double &function_value);
 
+  private:
+
+  void compute_second_order_statistics(
+      const ml_data& data, const DenseVector &point, DenseMatrix& hessian,
+      DenseVector& gradient, double & function_value);
 };
 
 

--- a/src/unity/toolkits/supervised_learning/logistic_regression.cpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression.cpp
@@ -347,7 +347,7 @@ void logistic_regression::train() {
   if (lr_interface->num_validation_examples() > 0) {
     // Recycle lvalues from stats to use as out parameters here, now that we're
     // otherwise done reading from stats.
-    lr_interface->compute_second_order_statistics(
+    lr_interface->compute_validation_second_order_statistics(
         stats.solution, stats.hessian, stats.gradient, stats.func_value);
     state["validation_loss"] =  stats.func_value;
   }

--- a/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.cpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.cpp
@@ -331,9 +331,9 @@ void logistic_regression_opt_interface::compute_first_order_statistics(const
 /**
  * Compute the second order statistics
 */
-void logistic_regression_opt_interface::compute_second_order_statistics( const
-    DenseVector& point, DenseMatrix& hessian, DenseVector& gradient, double&
-    function_value) {
+void logistic_regression_opt_interface::compute_second_order_statistics(
+    const ml_data& data, const DenseVector& point, DenseMatrix& hessian,
+    DenseVector& gradient, double& function_value) {
     
   timer t;
   double start_time = t.current_time();
@@ -482,6 +482,21 @@ void logistic_regression_opt_interface::compute_second_order_statistics( const
                       << (t.current_time() - start_time) << "s" << std::endl; 
 #endif
 
+}
+
+void logistic_regression_opt_interface::compute_second_order_statistics(
+    const DenseVector& point, DenseMatrix& hessian, DenseVector& gradient,
+    double& function_value) {
+  compute_second_order_statistics(
+      data, point, hessian, gradient, function_value);
+}
+
+void
+logistic_regression_opt_interface::compute_validation_second_order_statistics(
+    const DenseVector& point, DenseMatrix& hessian, DenseVector& gradient,
+    double& function_value) {
+  compute_second_order_statistics(
+      valid_data, point, hessian, gradient, function_value);
 }
 
 

--- a/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.hpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.hpp
@@ -169,6 +169,7 @@ class logistic_regression_opt_interface: public
   void compute_first_order_statistics(const DenseVector &point, DenseVector&
       gradient, double & function_value, const size_t mbStart = 0, const size_t
       mbSize = -1);
+
   /**
    * Compute second order statistics at the given point. (Gradient & Function value)
    *
@@ -181,6 +182,25 @@ class logistic_regression_opt_interface: public
   void compute_second_order_statistics(const DenseVector &point, DenseMatrix&
       hessian, DenseVector& gradient, double & function_value);
 
+  /**
+   * Compute second order statistics at the given point with respect to the
+   * validation data. (Gradient & Function value)
+   *
+   * \param[in]  point           Point at which we are computing the stats.
+   * \param[out] hessian         Hessian (Dense)
+   * \param[out] gradient        Dense gradient
+   * \param[out] function_value  Function value
+   *
+   */
+  void compute_validation_second_order_statistics(
+      const DenseVector& point, DenseMatrix& hessian, DenseVector& gradient,
+      double &function_value);
+
+  private:
+
+  void compute_second_order_statistics(
+      const ml_data& data,const DenseVector& point, DenseMatrix& hessian,
+      DenseVector& gradient, double &function_value);
 };
 
 


### PR DESCRIPTION
The changes for https://github.com/apple/turicreate/pull/274 were incomplete. They added validation-set fields, but populated them with recomputed training-set stats. The optimizer interface must explicitly support computing validation-set stats.