### PR TITLE
Single dictionary support for OD.

### DIFF
--- a/src/unity/python/turicreate/test/test_object_detector.py
+++ b/src/unity/python/turicreate/test/test_object_detector.py
@@ -185,7 +185,6 @@ class ObjectDetectorTest(unittest.TestCase):
         annotated_img = tc.object_detector.util.draw_bounding_boxes(sf_copy[self.feature],
                 sf_copy[self.annotations])
 
-
     def test_invalid_num_gpus(self):
         num_gpus = tc.config.get_num_gpus()
         tc.config.set_num_gpus(-2)

--- a/src/unity/python/turicreate/test/test_object_detector.py
+++ b/src/unity/python/turicreate/test/test_object_detector.py
@@ -171,6 +171,21 @@ class ObjectDetectorTest(unittest.TestCase):
     def test_create_with_empty_dataset(self):
         tc.object_detector.create(self.sf[:0])
 
+    def test_dict_annotations(self):
+        sf_copy = self.sf[:]
+        sf_copy[self.annotations] = sf_copy[self.annotations].apply(lambda x: x[0] if len(x) > 0 else None)
+        dict_model = tc.object_detector.create(sf_copy,
+                          feature=self.feature,
+                          annotations=self.annotations,
+                          max_iterations=1,
+                          model=self.pre_trained_model)
+
+        pred = dict_model.predict(sf_copy)
+        metrics = dict_model.evaluate(sf_copy)
+        annotated_img = tc.object_detector.util.draw_bounding_boxes(sf_copy[self.feature],
+                sf_copy[self.annotations])
+
+
     def test_invalid_num_gpus(self):
         num_gpus = tc.config.get_num_gpus()
         tc.config.set_num_gpus(-2)

--- a/src/unity/python/turicreate/toolkits/_internal_utils.py
+++ b/src/unity/python/turicreate/toolkits/_internal_utils.py
@@ -91,8 +91,10 @@ def _find_only_column_of_type(sframe, target_type, type_name, col_name):
     strings for the purpose of error feedback.
     """
     image_column_name = None
+    if type(target_type) != list:
+        target_type = [target_type]
     for name, ctype in zip(sframe.column_names(), sframe.column_types()):
-        if ctype is target_type:
+        if ctype in target_type:
             if image_column_name is not None:
                 raise ToolkitError('No "{col_name}" column specified and more than one {type_name} column in "dataset". Can not infer correct {col_name} column.'.format(col_name=col_name, type_name=type_name))
             image_column_name = name

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -151,7 +151,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
                 label = row[self.annotations_column]
                 if label == None:
                     label = []
-                if type(label) == dict:
+                elif type(label) == dict:
                     label = [label]
 
                 def is_valid(ann):
@@ -170,9 +170,6 @@ class SFrameDetectionIter(_mx.io.DataIter):
                     return ok_optional
 
                 # Unchanged boxes, for evaluation
-                if not hasattr(label, '__iter__'):
-                    import pdb; pdb.set_trace()
-
                 raw_bbox = _np.array([[
                         ann['coordinates']['x'],
                         ann['coordinates']['y'],

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -149,6 +149,10 @@ class SFrameDetectionIter(_mx.io.DataIter):
             oshape = orig_image.shape
             if self.load_labels:
                 label = row[self.annotations_column]
+                if label == None:
+                    label = []
+                if type(label) == dict:
+                    label = [label]
 
                 def is_valid(ann):
                     is_rect = ('type' not in ann or ann['type'] == 'rectangle')
@@ -166,6 +170,9 @@ class SFrameDetectionIter(_mx.io.DataIter):
                     return ok_optional
 
                 # Unchanged boxes, for evaluation
+                if not hasattr(label, '__iter__'):
+                    import pdb; pdb.set_trace()
+
                 raw_bbox = _np.array([[
                         ann['coordinates']['x'],
                         ann['coordinates']['y'],

--- a/src/unity/python/turicreate/toolkits/object_detector/util/_visualization.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/util/_visualization.py
@@ -122,7 +122,7 @@ def draw_bounding_boxes(images, annotations, confidence_threshold=0):
         anns = row['annotations']
         if anns == None:
             anns = []
-        if type(anns) == dict:
+        elif type(anns) == dict:
             anns = [anns]
         pil_img = Image.fromarray(image.pixel_data)
         _annotate_image(pil_img, anns, confidence_threshold=confidence_threshold)

--- a/src/unity/python/turicreate/toolkits/object_detector/util/_visualization.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/util/_visualization.py
@@ -120,6 +120,10 @@ def draw_bounding_boxes(images, annotations, confidence_threshold=0):
     def draw_single_image(row):
         image = row['image']
         anns = row['annotations']
+        if anns == None:
+            anns = []
+        if type(anns) == dict:
+            anns = [anns]
         pil_img = Image.fromarray(image.pixel_data)
         _annotate_image(pil_img, anns, confidence_threshold=confidence_threshold)
         image = _np.array(pil_img)


### PR DESCRIPTION
Fixes #87. Object detectors can now take in an annotation column that's just a single dictionary (if its all just 1 objects)