### PR TITLE
Fix .explore on string escaping with double quotes

### DIFF
--- a/src/unity/lib/visualization/vega_spec.cpp
+++ b/src/unity/lib/visualization/vega_spec.cpp
@@ -27,7 +27,7 @@ namespace visualization {
 std::string escape_string(const std::string& str) {
   std::string ret;
   size_t ret_len;
-  ::turi::escape_string(str, '\\', true /* use_escape_char */, '\"', true /* use_quote_char */, true /* double_quote */, ret, ret_len);
+  ::turi::escape_string(str, '\\', true /* use_escape_char */, '\"', true /* use_quote_char */, false /* double_quote */, ret, ret_len);
 
   // ::turi::escape_string may yield an std::string padded with null terminators, and ret_len represents the true length.
   // truncate to the ret_len length.


### PR DESCRIPTION
The "double quote" parameter to escape_string doesn't behave like I
expected it to originally - it actually inserts two quotemarks (rather
than simply using double quotes to surround the string), which
terminates the string and produces invalid JSON. Seems this is intended
to be used for CSV escaping instead.