### PR TITLE
Allow log level setting from Python

### DIFF
--- a/src/unity/lib/api/unity_global_interface.hpp
+++ b/src/unity/lib/api/unity_global_interface.hpp
@@ -65,6 +65,7 @@ typedef std::map<std::string, flexible_type> global_configuration_type;
       (bool, __chmod__, (const std::string&)(short))
       (size_t, __get_heap_size__, )
       (size_t, __get_allocated_size__, )
+      (void, set_log_level, (size_t))
       (global_configuration_type, list_globals, (bool))
       (std::string, set_global, (std::string)(flexible_type))
       (std::shared_ptr<unity_sarray_base>, create_sequential_sarray, (ssize_t)(ssize_t)(bool))

--- a/src/unity/lib/unity_global.cpp
+++ b/src/unity/lib/unity_global.cpp
@@ -507,6 +507,10 @@ namespace turi {
     return memory_info::allocated_bytes();
   }
 
+  void unity_global::set_log_level(size_t level) {
+    if (level <= 8) global_logger().set_log_level(level);
+  }
+
   std::map<std::string, flexible_type> unity_global::list_globals(bool runtime_modifiable) {
     auto ret = globals::list_globals(runtime_modifiable);
     return std::map<std::string, flexible_type>(ret.begin(), ret.end());

--- a/src/unity/lib/unity_global.hpp
+++ b/src/unity/lib/unity_global.hpp
@@ -231,6 +231,11 @@ class unity_global: public unity_global_base {
    */
   size_t __get_allocated_size__();
 
+  /**
+   * \internal
+   * Sets the logging level
+   */
+  void set_log_level(size_t);
 
   /**
    * \internal

--- a/src/unity/python/turicreate/config/__init__.py
+++ b/src/unity/python/turicreate/config/__init__.py
@@ -156,6 +156,17 @@ def get_environment_config():
     unity = _glconnect.get_unity()
     return unity.list_globals(False)
 
+def set_log_level(level):
+    """
+    Sets the log level.
+    Lower log levels log more.
+    if level is 8, nothing is logged. If level is 0, everything is logged.
+    """
+    from ..connect import main as _glconnect
+    unity = _glconnect.get_unity()
+    return unity.set_log_level(level)
+
+
 def get_runtime_config():
     """
     Returns all the Turi Create configuration variables that can be set

--- a/src/unity/python/turicreate/cython/cy_unity.pxd
+++ b/src/unity/python/turicreate/cython/cy_unity.pxd
@@ -68,6 +68,8 @@ cdef extern from "<unity/lib/unity_global.hpp>" namespace "turi":
 
         size_t __get_allocated_size__() except +
 
+        void set_log_level(size_t) except +
+
         gl_options_map list_globals(bint) except +
 
         string set_global(string, flexible_type) except +
@@ -134,6 +136,8 @@ cdef class UnityGlobalProxy:
     cpdef __get_heap_size__(self)
 
     cpdef __get_allocated_size__(self)
+
+    cpdef set_log_level(self, size_t level)
 
     cpdef list_globals(self, bint runtime_modifiable)
 

--- a/src/unity/python/turicreate/cython/cy_unity.pyx
+++ b/src/unity/python/turicreate/cython/cy_unity.pyx
@@ -172,6 +172,9 @@ cdef class UnityGlobalProxy:
     cpdef __get_allocated_size__(self):
         return self.thisptr.__get_allocated_size__()
 
+    cpdef set_log_level(self, size_t level):
+        return self.thisptr.set_log_level(level)
+
     cpdef list_globals(self, bint runtime_modifiable):
         return pydict_from_gl_options_map(self.thisptr.list_globals(runtime_modifiable))
 


### PR DESCRIPTION
This makes debugging easier. i.e. We can suggest the following for bug
reports:

```
  import turicreate as tc
  print tc.config.get_server_log_location() + ".0"
  tc.config.set_log_level(1)
  # Do something which fails unexpectedly
```
Then send us the filename printed.