### PR TITLE
Fix Linux build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -147,12 +147,12 @@ function build_python_egg {
   pushd ${build_mode}/src
 
   if [[ $apple -eq 1 ]]; then
-    find . -type f -name '*.dylib' -o -name '*.so' | xargs strip -x -
+    find . \(-type f -name '*.dylib' -o -name '*.so'\) -print0 | xargs -0 strip -x -
   else
     find . -type f -name '*.so' -print0 | xargs -0 strip -s
   fi
 
-  find . -type f -name '*.dylib' -o -name '*.so' | xargs tar cvzf ${install_dir}/shared_objects.tar.gz
+  find . \(-type f -name '*.dylib' -o -name '*.so'\) -print0 | xargs -0 tar cvzf ${install_dir}/shared_objects.tar.gz
 }
 
 

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -71,6 +71,9 @@ if(${TC_BUILD_VISUALIZATION_CLIENT})
 
     add_executable(visualization_client "${TCVIZ_SRCS}")
 
+    set_target_properties(visualization_client
+      PROPERTIES LINK_FLAGS "-Wl,--unresolved-symbols=ignore-in-shared-libs")
+
     target_link_libraries(visualization_client
       ${LIB_CEF_DLL_WRAPPER}
       ${LIB_CEF}


### PR DESCRIPTION
* Make sure `find | xargs` in build.sh can handle spaces
* Don't error out on missing dependencies of libcef.so (these don't need
  to be satisfied at build time, only at runtime).