### PR TITLE
Improve error message when an ndarray type cannot be converted.

### DIFF
--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1510,7 +1510,7 @@ cdef inline translate_ndarray(flexible_type& ret, object v, flex_type_enum* comm
     if _tr_buffer_to_flex_nd_vec(ft_nd_vec, v):
         ret.set_nd_vec(ft_nd_vec)
         return
-    raise TypeError("Could not convert python object with type " + str(type(v)) + " to flexible_type.")
+    raise TypeError("Could not convert python object with type " + type(v).__name__  + "('" + str(v.dtype) + "')" + " to flexible_type.")
 
 
 


### PR DESCRIPTION
Fixes #323

Instead of printing
``` 
Could not convert python object with type <type 'numpy.ndarray'> to flexible_type.
```

It now prints
```
Could not convert python object with type ndarray('datetime64') to flexible_type.
```