### PR TITLE
Fix Python 3.x build

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -9,7 +9,8 @@ fi
 
 PIP=pip3
 # TODO - not sure why 'm' is necessary here (and not in 2.7)
-PYTHON_FULL_NAME=python${PYTHON_VERSION}m
+# note that PYTHON_VERSION includes the word "python", like "python2.7" or "python3.6"
+PYTHON_FULL_NAME=${PYTHON_VERSION}m
 if [[ "${PY_MAJOR_VERSION}" == "2.7" ]]; then
   PIP=pip
   PYTHON_FULL_NAME=python2.7


### PR DESCRIPTION
The word "python" got duplicated in the use of PYTHON_VERSION in
install_python_toolchain, only in the 3.x case. For Python 2.7, the
explicit assignment below makes it work.