### PR TITLE
Fix C++ unit test failure

### DIFF
--- a/src/sframe/parallel_csv_parser.cpp
+++ b/src/sframe/parallel_csv_parser.cpp
@@ -32,16 +32,31 @@ using fileio::file_status;
  * Escape BOMs
  */
 void skip_BOM(general_ifstream& fin) {
-   char fChar, sChar, tChar;
-   fChar = fin.get();
-   sChar = fin.get();
-   tChar = fin.get();
-   bool isBOM = ((fChar == (char)0xEF) && (sChar == (char)0xBB) && (tChar == (char)0xBF));
-   if (!isBOM) {
-     fin.putback(tChar);
-     fin.putback(sChar);
-     fin.putback(fChar);
-   }
+  const size_t BOM_SIZE = 3;
+  char bom[BOM_SIZE];
+  if (!fin.good()) {
+    return;
+  }
+  // use readsome to avoid setting failbit on eof
+  // (.get sets failbit!)
+  auto size = fin.readsome(bom, sizeof(bom));
+  if (size != BOM_SIZE) {
+    DASSERT_LT(size, BOM_SIZE);
+    if (size == 2) {
+      fin.putback(bom[1]);
+    }
+    if (size >= 1) {
+      fin.putback(bom[0]);
+    }
+    return;
+  }
+
+  bool isBOM = ((bom[0] == (char)0xEF) && (bom[1] == (char)0xBB) && (bom[2] == (char)0xBF));
+  if (!isBOM) {
+    fin.putback(bom[2]);
+    fin.putback(bom[1]);
+    fin.putback(bom[0]);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes two issues in the skip_BOM function:

* Should not set failbit on the fstream.
* If it reads 1 or 2 chars (not 3), it should only put back 1 or 2.