### PR TITLE
Add a setup.py for a source distribution

### DIFF
--- a/src/unsupported_python/setup.py
+++ b/src/unsupported_python/setup.py
@@ -38,7 +38,6 @@ class InstallEngine(install):
         sys.exit(1)
 
 if __name__ == '__main__':
-    from distutils.util import get_platform
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",

--- a/src/unsupported_python/setup.py
+++ b/src/unsupported_python/setup.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017 Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+import sys
+from setuptools import setup
+from setuptools.command.install import install
+
+PACKAGE_NAME="turicreate"
+VERSION='4.2'
+
+class InstallEngine(install):
+    def run(self):
+        msg = ("""
+
+        ==================================================================================
+        ERROR
+
+        If you see this message, pip install did not find an available binary package
+        for your system. Supported platforms are:
+
+        * Linux x86_64 (including WSL on Windows 10).
+        * macOS 10.12+ x86_64.
+        * Python 2.7, 3.5, or 3.6.
+
+        Other possible causes of this error are:
+
+        * Outdated pip version (try `pip install -U pip`).
+
+        ==================================================================================
+
+        """)
+        sys.stderr.write(msg)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    from distutils.util import get_platform
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Financial and Insurance Industry",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Other Audience",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: POSIX :: BSD",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+    ]
+
+    setup(
+        name="turicreate",
+        version=VERSION,
+        author='Apple Inc.',
+        author_email='turi-create@group.apple.com',
+        cmdclass=dict(install=InstallEngine),
+        url='https://github.com/apple/turicreate',
+        description='Turi Create simplifies the development of custom machine learning models.',
+        classifiers=classifiers,
+    )


### PR DESCRIPTION
We will use this one for erroring out on unsupported platforms, by
uploading it as an egg (source distribution). If a user's pip install
falls back to the egg (no compatible wheel) they will see this error
message.

* Fixes #27