### PR TITLE
Fix user facing deprecation warning for panda's to_datetime usage

### DIFF
--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1619,7 +1619,7 @@ cdef flexible_type _ft_translate(object v, int tr_code) except *:
         if HAS_NUMPY and isinstance(v, np.datetime64):
           tr_datetime64_to_ft(ret, v)
         elif HAS_PANDAS and isinstance(v, pd.Timestamp):
-          tr_datetime_to_ft(ret, v.to_datetime())
+          tr_datetime_to_ft(ret, v.to_pydatetime())
         elif isinstance(v, datetime.datetime):
           tr_datetime_to_ft(ret, v)
         else:

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -12,7 +12,6 @@ from ..data_structures.sarray import SArray
 from ..util.timezone import GMT
 from . import util
 
-import binascii
 import pandas as pd
 import numpy as np
 import unittest
@@ -24,7 +23,6 @@ import math
 import shutil
 import array
 import time
-import itertools
 import warnings
 import functools
 import tempfile
@@ -2866,7 +2864,7 @@ class SArrayTest(unittest.TestCase):
         sa = SArray(iso_str_list)
         self.__test_equal(sa,self.datetime_data,dt.datetime)
 
-        iso_str_list[2] = pd.tslib.NaT
+        iso_str_list[2] = pd.NaT
         sa = SArray(iso_str_list)
         self.__test_equal(sa,self.datetime_data,dt.datetime)
 


### PR DESCRIPTION
fixed another deprecation warning in the unit tests too.