### PR TITLE
Single-sample input gives single-sample results

### DIFF
--- a/src/unity/python/turicreate/test/test_image_classifier.py
+++ b/src/unity/python/turicreate/test/test_image_classifier.py
@@ -137,7 +137,7 @@ class ImageClassifierTest(unittest.TestCase):
         model = self.model
         single_image = self.sf[0][self.feature]
         prediction = model.predict(single_image)
-        self.assertTrue(isinstance(prediction, int))
+        self.assertTrue(isinstance(prediction, (int, str)))
         prediction = model.predict_topk(single_image)
         _raise_error_if_not_sframe(prediction)
         prediction = model.classify(single_image)
@@ -185,7 +185,7 @@ class ImageClassifierTest(unittest.TestCase):
 
             self.assertListAlmostEquals(
                coreml_values,
-               list(self.model.predict(img_fixed, output_type = 'probability_vector')[0]),
+               list(self.model.predict(img_fixed, output_type = 'probability_vector')),
                self.tolerance
             )
 

--- a/src/unity/python/turicreate/test/test_image_classifier.py
+++ b/src/unity/python/turicreate/test/test_image_classifier.py
@@ -133,12 +133,12 @@ class ImageClassifierTest(unittest.TestCase):
     def test_single_image(self):
         model = self.model
         single_image = self.sf[0][self.feature]
-        predictions = model.predict(single_image)
-        self.assertIsNotNone(predictions)
-        predictions = model.predict_topk(single_image)
-        self.assertIsNotNone(predictions)
-        predictions = model.classify(single_image)
-        self.assertIsNotNone(predictions)
+        prediction = model.predict(single_image)
+        self.assertTrue(isinstance(prediction, int))
+        prediction = model.predict_topk(single_image)
+        self.assertIsNotNone(prediction)
+        prediction = model.classify(single_image)
+        self.assertTrue(isinstance(prediction, dict) and 'class' in prediction and 'probability' in prediction)
 
     def test_sarray(self):
         model = self.model

--- a/src/unity/python/turicreate/test/test_image_classifier.py
+++ b/src/unity/python/turicreate/test/test_image_classifier.py
@@ -11,7 +11,9 @@ import sys
 import unittest
 import turicreate as tc
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
-from turicreate.toolkits._internal_utils import _mac_ver
+from turicreate.toolkits._internal_utils import (_mac_ver,
+                                                 _raise_error_if_not_sframe,
+                                                 _raise_error_if_not_sarray)
 import tempfile
 from . import util as test_util
 import pytest
@@ -128,6 +130,7 @@ class ImageClassifierTest(unittest.TestCase):
         model = self.model
         for output_type in ['class', 'probability_vector']:
             preds = model.predict(self.sf.head(), output_type=output_type)
+            _raise_error_if_not_sarray(preds)
             self.assertEqual(len(preds), len(self.sf.head()))
 
     def test_single_image(self):
@@ -136,7 +139,7 @@ class ImageClassifierTest(unittest.TestCase):
         prediction = model.predict(single_image)
         self.assertTrue(isinstance(prediction, int))
         prediction = model.predict_topk(single_image)
-        self.assertIsNotNone(prediction)
+        _raise_error_if_not_sframe(prediction)
         prediction = model.classify(single_image)
         self.assertTrue(isinstance(prediction, dict) and 'class' in prediction and 'probability' in prediction)
 
@@ -144,11 +147,11 @@ class ImageClassifierTest(unittest.TestCase):
         model = self.model
         data = self.sf[self.feature]
         predictions = model.predict(data)
-        self.assertIsNotNone(predictions)
+        _raise_error_if_not_sarray(predictions)
         predictions = model.predict_topk(data)
-        self.assertIsNotNone(predictions)
+        _raise_error_if_not_sframe(predictions)
         predictions = model.classify(data)
-        self.assertIsNotNone(predictions)
+        _raise_error_if_not_sframe(predictions)
 
     def test_junk_input(self):
         model = self.model

--- a/src/unity/python/turicreate/test/test_object_detector.py
+++ b/src/unity/python/turicreate/test/test_object_detector.py
@@ -210,6 +210,18 @@ class ObjectDetectorTest(unittest.TestCase):
         pred0 = self.model.predict(sf[:0])
         self.assertEqual(len(pred0), 0)
 
+    def test_single_image(self):
+        # Predict should work on a single image and product a list of dictionaries
+        # (we set confidene threshold to 0 to ensure predictions are returned)
+        pred = self.model.predict(self.sf[self.feature][0], confidence_threshold=0)
+        self.assertTrue(isinstance(pred, list))
+        self.assertTrue(isinstance(pred[0], dict))
+
+    def test_sarray(self):
+        sarray = self.sf.head()[self.feature]
+        pred = self.model.predict(sarray, confidence_threshold=0)
+        self.assertEqual(len(pred), len(sarray))
+
     def test_confidence_threshold(self):
         sf = self.sf.head()
         pred = self.model.predict(sf.head(), confidence_threshold=1.0)

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -300,6 +300,20 @@ class ImageClassifier(_CustomModel):
         section_titles = ['Schema', 'Training summary']
         return([model_fields, training_fields], section_titles)
 
+    def _canonize_input(self, dataset):
+        """
+        Takes input and returns tuple of the input in canonical form (SFrame)
+        along with an unpack callback function that can be applied to
+        prediction results to "undo" the canonization.
+        """
+        unpack = lambda x: x
+        if isinstance(dataset, _tc.SArray):
+            dataset = _tc.SFrame({self.feature: dataset})
+        elif isinstance(dataset, _tc.Image):
+            dataset = _tc.SFrame({self.feature: [dataset]})
+            unpack = lambda x: x[0]
+        return dataset, unpack
+
     def predict(self, dataset, output_type='class', batch_size=64):
         """
         Return predictions for ``dataset``, using the trained logistic
@@ -362,13 +376,10 @@ class ImageClassifier(_CustomModel):
         if(batch_size < 1):
             raise ValueError("'batch_size' must be greater than or equal to 1")
 
-        if isinstance(dataset, _tc.SArray):
-            dataset = _tc.SFrame({self.feature: dataset})
-        elif isinstance(dataset, _tc.Image):
-            dataset = _tc.SFrame({self.feature: [dataset]})
+        dataset, unpack = self._canonize_input(dataset)
 
         extracted_features = self._extract_features(dataset, batch_size=batch_size)
-        return self.classifier.predict(extracted_features, output_type=output_type)
+        return unpack(self.classifier.predict(extracted_features, output_type=output_type))
 
     def classify(self, dataset, batch_size=64):
         """
@@ -408,13 +419,10 @@ class ImageClassifier(_CustomModel):
         if(batch_size < 1):
             raise ValueError("'batch_size' must be greater than or equal to 1")
 
-        if isinstance(dataset, _tc.SArray):
-            dataset = _tc.SFrame({self.feature: dataset})
-        elif isinstance(dataset, _tc.Image):
-            dataset = _tc.SFrame({self.feature: [dataset]})
+        dataset, unpack = self._canonize_input(dataset)
 
         extracted_features = self._extract_features(dataset, batch_size=batch_size)
-        return self.classifier.classify(extracted_features)
+        return unpack(self.classifier.classify(extracted_features))
 
     def predict_topk(self, dataset, output_type="probability", k=3, batch_size=64):
         """
@@ -476,10 +484,7 @@ class ImageClassifier(_CustomModel):
         if(batch_size < 1):
             raise ValueError("'batch_size' must be greater than or equal to 1")
 
-        if isinstance(dataset, _tc.SArray):
-            dataset = _tc.SFrame({self.feature: dataset})
-        elif isinstance(dataset, _tc.Image):
-            dataset = _tc.SFrame({self.feature: [dataset]})
+        dataset, _ = self._canonize_input(dataset)
 
         extracted_features = self._extract_features(dataset)
         return self.classifier.predict_topk(extracted_features, output_type = output_type, k = k)

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -335,7 +335,7 @@ class ImageClassifier(_CustomModel):
         ----------
         dataset : SFrame | SArray | turicreate.Image
             The images to be classified.
-            If dataset is an SFrame, it must have a columns with the same names as
+            If dataset is an SFrame, it must have columns with the same names as
             the features used for model training, but does not require a target
             column. Additional columns are ignored.
 
@@ -358,7 +358,8 @@ class ImageClassifier(_CustomModel):
         Returns
         -------
         out : SArray
-            An SArray with model predictions.
+            An SArray with model predictions. If `dataset` is a single image, the
+            return value will be a single prediction.
 
         See Also
         ----------
@@ -403,7 +404,9 @@ class ImageClassifier(_CustomModel):
         Returns
         -------
         out : SFrame
-            An SFrame with model predictions i.e class labels and probabilities.
+            An SFrame with model predictions i.e class labels and
+            probabilities. If `dataset` is a single image, the return will be a
+            single row (dict).
 
         See Also
         ----------

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -925,10 +925,11 @@ class ObjectDetector(_CustomModel):
 
         Parameters
         ----------
-        dataset : SFrame
-            A dataset that has the same columns that were used during training.
-            If the annotations column exists in ``dataset`` it will be ignored
-            while making predictions.
+        dataset : SFrame | SArray | turicreate.Image
+            The images on which to perform object detection.
+            If dataset is an SFrame, it must have a column with the same name
+            as the feature column during training. Additional columns are
+            ignored.
 
         confidence_threshold : float
             Only return predictions above this level of confidence. The
@@ -942,7 +943,9 @@ class ObjectDetector(_CustomModel):
         out : SArray
             An SArray with model predictions. Each element corresponds to
             an image and contains a list of dictionaries. Each dictionary
-            describes an object instances that was found in the image.
+            describes an object instances that was found in the image. If
+            `dataset` is a single image, the return value will be a single
+            prediction.
 
         See Also
         --------


### PR DESCRIPTION
- Adds single-sample input to object detector
- Changes single-sample input for classification to unpack the return

Addresses #342.

Previous classifier behavior:
```python
>>> cc.predict(image)
dtype: str
Rows: 1
['bike']
```
New behavior:
```python
>>> cc.predict(image)
'bike'
```
Since this breaks current behavior, this should not be merged yet.