### PR TITLE
Avoiding default atof behavior for integers and floats

### DIFF
--- a/src/flexible_type/flexible_type_detail.hpp
+++ b/src/flexible_type/flexible_type_detail.hpp
@@ -540,7 +540,7 @@ struct get_int_visitor {
     long long int converted = std::strtoll(t.c_str(), &end, 10); 
     if (*end != '\0') {
       // was not at end of element so throw error
-      throw std::runtime_error("Invalid conversion: " + t + "cannot be interpreted as an integer");
+      throw std::runtime_error("Invalid conversion: " + t + " cannot be interpreted as an integer");
     } else {
       return converted; 
     }
@@ -566,7 +566,7 @@ struct get_float_visitor {
     double converted = std::strtod(t.c_str(), &end); 
     if (*end != '\0') {
       // was not at end of element so throw error
-      throw std::runtime_error("Invalid conversion: " + t + "cannot be interpreted as a float");
+      throw std::runtime_error("Invalid conversion: " + t + " cannot be interpreted as a float");
     } else {
       return (float)converted; 
     }

--- a/src/flexible_type/flexible_type_detail.hpp
+++ b/src/flexible_type/flexible_type_detail.hpp
@@ -535,7 +535,16 @@ struct get_int_visitor {
     return dt.posix_timestamp();
   }
   inline FLEX_ALWAYS_INLINE_FLATTEN flex_int operator()(flex_float i) const {return i; }
-  inline FLEX_ALWAYS_INLINE_FLATTEN flex_int operator()(const flex_string& t) const { return std::atoll(t.c_str()); }
+  inline FLEX_ALWAYS_INLINE_FLATTEN flex_int operator()(const flex_string& t) const { 
+    char *end;
+    long long int converted = std::strtoll(t.c_str(), &end, 10); 
+    if (**end != '\0') {
+      // was not at end of element so throw error
+      throw std::runtime_error("Invalid conversion: String contains more characters than just float");
+    } else {
+      return converted; 
+    }
+  }
 };
 
 /**
@@ -552,7 +561,16 @@ struct get_float_visitor {
   }
   inline FLEX_ALWAYS_INLINE_FLATTEN flex_float operator()(flex_int i) const {return i; }
   inline FLEX_ALWAYS_INLINE_FLATTEN flex_float operator()(flex_float i) const {return i; }
-  inline FLEX_ALWAYS_INLINE_FLATTEN flex_float operator()(const flex_string& t) const { return std::atof(t.c_str()); }
+  inline FLEX_ALWAYS_INLINE_FLATTEN flex_float operator()(const flex_string& t) const { 
+    char *end;
+    double converted = std::strtod(t.c_str(), &end); 
+    if (**end != '\0') {
+      // was not at end of element so throw error
+      throw std::runtime_error("Invalid conversion: String contains more characters than just float");
+    } else {
+      return (float)converted; 
+    }
+  }
 };
 
 

--- a/src/flexible_type/flexible_type_detail.hpp
+++ b/src/flexible_type/flexible_type_detail.hpp
@@ -540,7 +540,7 @@ struct get_int_visitor {
     long long int converted = std::strtoll(t.c_str(), &end, 10); 
     if (*end != '\0') {
       // was not at end of element so throw error
-      throw std::runtime_error("Invalid conversion: String contains more characters than just integer");
+      throw std::runtime_error("Invalid conversion: " + t + "cannot be interpreted as an integer");
     } else {
       return converted; 
     }
@@ -566,7 +566,7 @@ struct get_float_visitor {
     double converted = std::strtod(t.c_str(), &end); 
     if (*end != '\0') {
       // was not at end of element so throw error
-      throw std::runtime_error("Invalid conversion: String contains more characters than just float");
+      throw std::runtime_error("Invalid conversion: " + t + "cannot be interpreted as a float");
     } else {
       return (float)converted; 
     }

--- a/src/flexible_type/flexible_type_detail.hpp
+++ b/src/flexible_type/flexible_type_detail.hpp
@@ -538,7 +538,7 @@ struct get_int_visitor {
   inline FLEX_ALWAYS_INLINE_FLATTEN flex_int operator()(const flex_string& t) const { 
     char *end;
     long long int converted = std::strtoll(t.c_str(), &end, 10); 
-    if (**end != '\0') {
+    if (*end != '\0') {
       // was not at end of element so throw error
       throw std::runtime_error("Invalid conversion: String contains more characters than just float");
     } else {
@@ -564,7 +564,7 @@ struct get_float_visitor {
   inline FLEX_ALWAYS_INLINE_FLATTEN flex_float operator()(const flex_string& t) const { 
     char *end;
     double converted = std::strtod(t.c_str(), &end); 
-    if (**end != '\0') {
+    if (*end != '\0') {
       // was not at end of element so throw error
       throw std::runtime_error("Invalid conversion: String contains more characters than just float");
     } else {

--- a/src/flexible_type/flexible_type_detail.hpp
+++ b/src/flexible_type/flexible_type_detail.hpp
@@ -540,7 +540,7 @@ struct get_int_visitor {
     long long int converted = std::strtoll(t.c_str(), &end, 10); 
     if (*end != '\0') {
       // was not at end of element so throw error
-      throw std::runtime_error("Invalid conversion: String contains more characters than just float");
+      throw std::runtime_error("Invalid conversion: String contains more characters than just integer");
     } else {
       return converted; 
     }

--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -1296,9 +1296,11 @@ std::shared_ptr<unity_sarray_base> unity_sarray::lazy_astype(flex_type_enum dtyp
       flexible_type ret;
       try {
         if (dtype == flex_type_enum::INTEGER) {
-          ret = std::stoll(f.get<flex_string>());
+          f.to<flex_int>();
+          // ret = std::stoll(f.get<flex_string>());
         } else if (dtype == flex_type_enum::FLOAT) {
-          ret = std::stod(f.get<flex_string>());
+          f.to<flex_float>();
+          // ret = std::stod(f.get<flex_string>());
         } else if (dtype == flex_type_enum::VECTOR) {
           bool success;
           const std::string& val = f.get<flex_string>();

--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -1301,10 +1301,8 @@ std::shared_ptr<unity_sarray_base> unity_sarray::lazy_astype(flex_type_enum dtyp
       try {
         if (dtype == flex_type_enum::INTEGER) {
           f.to<flex_int>();
-          // ret = std::stoll(f.get<flex_string>());
         } else if (dtype == flex_type_enum::FLOAT) {
           f.to<flex_float>();
-          // ret = std::stod(f.get<flex_string>());
         } else if (dtype == flex_type_enum::VECTOR) {
           bool success;
           const std::string& val = f.get<flex_string>();

--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -2484,7 +2484,6 @@ class SArray(object):
         [{1: 2, 3: 4}, {'a': 'b', 'c': 'd'}]
         """
 
-
         if (dtype == _Image) and (self.dtype == array.array):
             raise TypeError("Cannot cast from image type to array with sarray.astype(). Please use sarray.pixel_array_to_img() instead.")
 

--- a/src/unity/python/turicreate/test/test_flexible_type.py
+++ b/src/unity/python/turicreate/test/test_flexible_type.py
@@ -60,7 +60,7 @@ StringValue = ([str('bork'), unicode('bork'), b'bork', b'']
                + [_dt('') for _dt in
                   [np.unicode, np.unicode_, str, unicode, np.str,
                    np.str_, np.string_]])
-                   
+
 special_types.add(id(StringValue))
 
 DictValue = [{'a' : 12}, dict()]
@@ -209,6 +209,7 @@ def verify_inference(values, expected_type):
                     "\nOutput value = %s"
                     "\nReconverted  = %s")
                    % (str(v_list), str(result), reconverted_result))
+
 
 
 
@@ -544,4 +545,21 @@ class FlexibleTypeTest(unittest.TestCase):
         self.assertEqual(pytype_from_type_name("undefined"), type(None))
 
         self.assertRaises(ValueError, lambda: pytype_from_type_name("happiness"))
+
+    def test_type_conversions(self):
+        # testing valid sarray of inf's (inf is a float)
+        sa_all_inf = SArray(["inf", "Inf", "iNf", "inF", "INF"])
+        sa_all_inf.astype(float) # should not raise error so we good
+        # testing invalid sarray of float words
+        sa_float_words = SArray(["inf", "infiltrate", "nanana", "2.0version"])
+        with self.assertRaises(RuntimeError):
+            sa_float_words.astype(float)
+        # testing invalid sarray of int words
+        sa_int_words = SArray(["1world", "2dreams", "3000apples"])
+        with self.assertRaises(RuntimeError):
+            sa_int_words.astype(int)
+
+
+
+
         

--- a/userguide/clustering/kmeans.md
+++ b/userguide/clustering/kmeans.md
@@ -99,7 +99,7 @@ centers, one per row, in terms of the same features used to create the
 model.
 
 ```python
-kmeans_model['cluster_info'].print_rows(num_columns=5, max_row_width=80,
+kmeans_model.cluster_info.print_rows(num_columns=5, max_row_width=80,
                                         max_column_width=10)
 ```
 ```no-highlight
@@ -121,7 +121,7 @@ corresponding cluster: ID number, number of points in the cluster, and the
 within-cluster sum of squared distances to the center.
 
 ```python
-kmeans_model['cluster_info'][['cluster_id', 'size', 'sum_squared_distance']]
+kmeans_model.cluster_info[['cluster_id', 'size', 'sum_squared_distance']]
 ```
 ```no-highlight
 +------------+------+----------------------+
@@ -142,7 +142,7 @@ data point, along with the Euclidean distance from the point to its assigned
 cluster's center.
 
 ```python
-kmeans_model['cluster_id'].head()
+kmeans_model.cluster_id.head()
 ```
 ```no-highlight
 +--------+------------+---------------+
@@ -213,7 +213,7 @@ K-means model.
 kmeans_sample = tc.kmeans.create(sf.sample(0.2), num_clusters=K,
                                  max_iterations=0)
 
-my_centers = kmeans_sample['cluster_info']
+my_centers = kmeans_sample.cluster_info
 my_centers = my_centers.remove_columns(['cluster_id', 'size',
                                         'sum_squared_distance'])
 


### PR DESCRIPTION
Redirected from unity_sarray to go to flex_int and flex_float and added logic in flexible_type_detail to deal with invalid strings like "2hello", "INFiltrate", etc. Built and tested locally.