### PR TITLE
Fix slicing issue for NDArray inside SArray (Python 3)

### DIFF
--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1454,12 +1454,12 @@ cdef inline bint _tr_buffer_to_flex_nd_vec(flex_nd_vec& retv, object v):
     else:
         #print "base and offset conversion"
         # compute offset
-        offset = (np.byte_bounds(v)[0] - np.byte_bounds(v.base)[0]) / v.itemsize
+        offset = (np.byte_bounds(v)[0] - np.byte_bounds(v.base)[0]) // v.itemsize
         if not _tr_buffer_to_flex_vec(f_elements, v.base.reshape(-1)[offset:]):
             #print "base and offset conversion fail"
             return False
 
-    stride = [i / v.itemsize for i in v.strides]
+    stride = [i // v.itemsize for i in v.strides]
     for i in stride:
         f_stride.push_back(<size_t>i)
     for i in v.shape:


### PR DESCRIPTION
This causes `test_sarray.py::SArrayTest::test_ndarray_shape` to fail.
That test also fails for another reason that will be addressed separately.

Fixes #355.