### PR TITLE
Do not use PIL for decoding images for pixel_data

### DIFF
--- a/src/unity/extensions/additional_sframe_utilities.cpp
+++ b/src/unity/extensions/additional_sframe_utilities.cpp
@@ -16,6 +16,55 @@
 using namespace turi;
 
 
+template <typename T>
+void copy_image_to_memory(const image_type& img, T *outptr,
+                          const std::vector<size_t>& outstrides,
+                          bool channel_last) {
+  ASSERT_EQ(outstrides.size(), 3);
+  size_t index_h, index_w, index_c;
+  if (channel_last) {
+    // Format: HWC
+    index_h = 0;
+    index_w = 1;
+    index_c = 2;
+  } else {
+    // Format: CHW
+    index_c = 0;
+    index_h = 1;
+    index_w = 2;
+  }
+
+  // Decode if needed
+  if (!img.is_decoded()) {
+    char* buf = NULL;
+    size_t length = 0;
+    if (img.m_format == Format::JPG) {
+      decode_jpeg((const char*)img.get_image_data(), img.m_image_data_size, &buf, length);
+    } else if (img.m_format == Format::PNG) {
+      decode_png((const char*)img.get_image_data(), img.m_image_data_size, &buf, length);
+    }
+    size_t cnt = 0;
+    for (size_t i = 0; i < img.m_height; ++i) {
+      for (size_t j = 0; j < img.m_width; ++j) {
+        for (size_t k = 0; k < img.m_channels; ++k) {
+          outptr[i * outstrides[index_h] + j * outstrides[index_w] + k * outstrides[index_c]] = static_cast<unsigned char>(buf[cnt++]);
+        }
+      }
+    }
+    delete[] buf;
+  } else {
+    size_t cnt = 0;
+    const unsigned char* raw_data = img.get_image_data();
+    for (size_t i = 0; i < img.m_height; ++i) {
+      for (size_t j = 0; j < img.m_width; ++j) {
+        for (size_t k = 0; k < img.m_channels; ++k) {
+          outptr[i * outstrides[index_h] + j * outstrides[index_w] + k * outstrides[index_c]] = static_cast<unsigned char>(raw_data[cnt++]);
+        }
+      }
+    }
+  }
+}
+
 void copy_to_memory(const sframe_rows::row& data,
                     float* outptr, 
                     const std::vector<size_t>& outstrides,
@@ -31,37 +80,7 @@ void copy_to_memory(const sframe_rows::row& data,
   if (type == flex_type_enum::IMAGE) {
     ASSERT_MSG(data.size() == 1, "Image data only support one input field");
     const image_type& img = data[0].get<flex_image>();
-    ASSERT_EQ(outstrides.size(), 3);
-
-    // Decode if needed
-    if (!img.is_decoded()) {
-      char* buf = NULL;
-      size_t length = 0;
-      if (img.m_format == Format::JPG) {
-        decode_jpeg((const char*)img.get_image_data(), img.m_image_data_size, &buf, length);
-      } else if (img.m_format == Format::PNG) {
-        decode_png((const char*)img.get_image_data(), img.m_image_data_size, &buf, length);
-      }
-      size_t cnt = 0;
-      for (size_t i = 0; i < img.m_height; ++i) {
-        for (size_t j = 0; j < img.m_width; ++j) {
-          for (size_t k = 0; k < img.m_channels; ++k) {
-            outptr[k * outstrides[0] + i * outstrides[1] + j * outstrides[2]] = static_cast<unsigned char>(buf[cnt++]);
-          }
-        }
-      }
-      delete[] buf;
-    } else {
-      size_t cnt = 0;
-      const unsigned char* raw_data = img.get_image_data();
-      for (size_t i = 0; i < img.m_height; ++i) {
-        for (size_t j = 0; j < img.m_width; ++j) {
-          for (size_t k = 0; k < img.m_channels; ++k) {
-            outptr[k * outstrides[0] + i * outstrides[1] + j * outstrides[2]] = static_cast<unsigned char>(raw_data[cnt++]);
-          }
-        }
-      }
-    }
+    copy_image_to_memory<float>(img, outptr, outstrides, false);
     return;
   } else if (data.size() == 1 && (type == flex_type_enum::FLOAT || type == flex_type_enum::INTEGER)) {
     // Case 2: Single value type (should really get rid of this special case) 
@@ -145,6 +164,15 @@ void sframe_load_to_numpy(turi::gl_sframe input, size_t outptr_addr,
   }
 }
 
+// Loads image into row-major array with shape HWC (height, width, channel)
+void image_load_to_numpy(const image_type& img, size_t outptr_addr,
+                          const std::vector<size_t>& outstrides) {
+  unsigned char *outptr = reinterpret_cast<unsigned char *>(outptr_addr);
+  copy_image_to_memory(img, outptr, outstrides, true);
+}
+
+
 BEGIN_FUNCTION_REGISTRATION
 REGISTER_FUNCTION(sframe_load_to_numpy, "input", "outptr_addr", "outstrides", "field_length", "begin", "end");
+REGISTER_FUNCTION(image_load_to_numpy, "img", "outptr_addr", "outstrides");
 END_FUNCTION_REGISTRATION

--- a/src/unity/extensions/additional_sframe_utilities.cpp
+++ b/src/unity/extensions/additional_sframe_utilities.cpp
@@ -42,6 +42,8 @@ void copy_image_to_memory(const image_type& img, T *outptr,
       decode_jpeg((const char*)img.get_image_data(), img.m_image_data_size, &buf, length);
     } else if (img.m_format == Format::PNG) {
       decode_png((const char*)img.get_image_data(), img.m_image_data_size, &buf, length);
+    } else {
+      ASSERT_MSG(false, "Unsupported image format");
     }
     size_t cnt = 0;
     for (size_t i = 0; i < img.m_height; ++i) {
@@ -166,7 +168,7 @@ void sframe_load_to_numpy(turi::gl_sframe input, size_t outptr_addr,
 
 // Loads image into row-major array with shape HWC (height, width, channel)
 void image_load_to_numpy(const image_type& img, size_t outptr_addr,
-                          const std::vector<size_t>& outstrides) {
+                         const std::vector<size_t>& outstrides) {
   unsigned char *outptr = reinterpret_cast<unsigned char *>(outptr_addr);
   copy_image_to_memory(img, outptr, outstrides, true);
 }

--- a/src/unity/extensions/additional_sframe_utilities.hpp
+++ b/src/unity/extensions/additional_sframe_utilities.hpp
@@ -12,4 +12,7 @@ void sframe_load_to_numpy(turi::gl_sframe input, size_t outptr_addr,
                      std::vector<size_t> field_length,
                      size_t begin, size_t end);
 
+void image_load_to_numpy(const image_type& img, size_t outptr_addr,
+                         const std::vector<size_t>& outstrides);
+
 #endif

--- a/src/unity/python/turicreate/data_structures/image.py
+++ b/src/unity/python/turicreate/data_structures/image.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from StringIO import StringIO as _StringIO
 
-from ..deps import numpy as _np, HAS_NUMPY as _HAS_NUMPY
+from ..deps import numpy as _np
 import array as _array
 
 _JPG = "JPG"
@@ -153,16 +153,10 @@ class Image(object):
 
         Returns
         -------
-        out : {array.array | numpy.array}
-            The pixel data of the Image object. If user has numpy, it
-            is returned as a multi-dimensional numpy array, where the shape of the
-            array represents the shape of the image.  Otherwise, it is
-            returned as a flat array.array with interleaved pixel values
-            ie. it is stored as RGBRGBRGB, where each sequence of three values
-            represents the Red, Green, and Blue. If the image is grayscale,
-            there is only one value per pixel. If the image is RGBA, there are
-            four values per pixel. The pixels are stored in row-major order.
-
+        out : numpy.array
+            The pixel data of the Image object. It returns a multi-dimensional
+            numpy array, where the shape of the array represents the shape of
+            the image (height, weight, channels).
 
         See Also
         --------
@@ -175,19 +169,10 @@ class Image(object):
         >>> image_array = img.pixel_data
         """
 
-        try:
-            pil_img = self._to_pil_image()
-            if _HAS_NUMPY:
-                return _np.asarray(pil_img)
-            else:
-                ret = _array.array('B')
-                if self._channels == 1:
-                    ret.fromlist([z for z in pil_img.getdata()])
-                else:
-                    ret.fromlist([z for i in pil_img.getdata() for z in i])
-                return ret
-        except ImportError:
-            print("Install pillow to get the pixel_data property")
+        from .. import extensions as _extensions
+        data = _np.zeros((self.height, self.width, self.channels), dtype=_np.uint8)
+        _extensions.image_load_to_numpy(self, data.ctypes.data, data.strides)
+        return data
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -208,19 +193,8 @@ class Image(object):
         return ret
 
     def _to_pil_image(self):
-        from PIL import Image as _PIL_image
-        if self._format_enum == _format[_RAW]:
-            if self.channels == 1:
-                img = _PIL_image.frombytes('L', (self._width, self._height), bytes(self._image_data))
-            elif self.channels == 3:
-                img = _PIL_image.frombytes('RGB', (self._width, self._height), bytes(self._image_data))
-            elif self.channels == 4:
-                img = _PIL_image.frombytes('RGBA', (self._width, self._height), bytes(self._image_data))
-            else:
-                raise ValueError('Unsupported channel size: ' + str(self.channels))
-        else:
-            img = _PIL_image.open(_StringIO(self._image_data))
-        return img
+        from PIL import Image as _PIL_Image
+        return _PIL_Image.fromarray(self.pixel_data)
 
     def show(self):
         """

--- a/src/unity/python/turicreate/data_structures/image.py
+++ b/src/unity/python/turicreate/data_structures/image.py
@@ -172,6 +172,8 @@ class Image(object):
         from .. import extensions as _extensions
         data = _np.zeros((self.height, self.width, self.channels), dtype=_np.uint8)
         _extensions.image_load_to_numpy(self, data.ctypes.data, data.strides)
+        if self.channels == 1:
+            data = data.squeeze(2)
         return data
 
     def __eq__(self, other):

--- a/src/unity/python/turicreate/test/test_image_type.py
+++ b/src/unity/python/turicreate/test/test_image_type.py
@@ -242,3 +242,9 @@ class ImageClassTest(unittest.TestCase):
             self.assertEqual(pixel_data[p], 50)
 
 
+        # Load images and make sure shape is right
+        img_color = image.Image(os.path.join(current_file_dir, 'images', 'sample.png'))
+        self.assertEqual(img_color.pixel_data.shape, (444, 800, 3))
+
+        img_gray = image.Image(os.path.join(current_file_dir, 'images', 'nested', 'sample_grey.png'))
+        self.assertEqual(img_gray.pixel_data.shape, (444, 800))


### PR DESCRIPTION
This partly addresses #380. It does not remove pillow as a dependency (that can be considered separately), but does remove PIL as a means to decode images.

Images are exported into numpy arrays in two flavors:

- In format CHW in floats (for feeding to mxnet)
- in format HWC in unsigned chars (for `pixel_data`)

I have consolidated both these extraction needs in `copy_image_to_memory`.

### API Break
Also, this is technically a breaking API change. The `pixel_data` used to be able to fall back to returning `array.array` in the case numpy is not installed. I removed this since numpy is a hard dependency of turicreate, so this is only breaking API if used in a non-standard way (by delibrately uninstalling numpy). @znation What do you think? Should I mark this PR as api-breaking? Or, should I extend the implementation to also support `array.array`?