### PR TITLE
Fix offset/length bug in NDArray-to-SArray

### DIFF
--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1455,7 +1455,10 @@ cdef inline bint _tr_buffer_to_flex_nd_vec(flex_nd_vec& retv, object v):
         #print "base and offset conversion"
         # compute offset
         offset = (np.byte_bounds(v)[0] - np.byte_bounds(v.base)[0]) // v.itemsize
-        if not _tr_buffer_to_flex_vec(f_elements, v.base.reshape(-1)[offset:]):
+        v_len = 1
+        for i in v.shape:
+            v_len *= i
+        if not _tr_buffer_to_flex_vec(f_elements, v.base.reshape(-1)[offset:offset+v_len]):
             #print "base and offset conversion fail"
             return False
 

--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1455,10 +1455,7 @@ cdef inline bint _tr_buffer_to_flex_nd_vec(flex_nd_vec& retv, object v):
         #print "base and offset conversion"
         # compute offset
         offset = (np.byte_bounds(v)[0] - np.byte_bounds(v.base)[0]) // v.itemsize
-        v_len = 1
-        for i in v.shape:
-            v_len *= i
-        if not _tr_buffer_to_flex_vec(f_elements, v.base.reshape(-1)[offset:offset+v_len]):
+        if not _tr_buffer_to_flex_vec(f_elements, v.base.reshape(-1)[offset:offset+v.size]):
             #print "base and offset conversion fail"
             return False
 


### PR DESCRIPTION
For np.ndarray input values which are slices of a base array, the conversion
procedure to flexible_type was using the entire buffer of the base array from
the offset onwards, instead of cropping to the length of the input slice. This
caused quadratic behavior, e.g., in the import of a value list(A), where A is
an np.ndarray of shape (N, 299, 299, 3).