### PR TITLE
Fix build break

### DIFF
--- a/src/unity/extensions/additional_sframe_utilities.hpp
+++ b/src/unity/extensions/additional_sframe_utilities.hpp
@@ -12,7 +12,7 @@ void sframe_load_to_numpy(turi::gl_sframe input, size_t outptr_addr,
                      std::vector<size_t> field_length,
                      size_t begin, size_t end);
 
-void image_load_to_numpy(const image_type& img, size_t outptr_addr,
+void image_load_to_numpy(const turi::image_type& img, size_t outptr_addr,
                          const std::vector<size_t>& outstrides);
 
 #endif


### PR DESCRIPTION
Not sure if this was broken for anyone else, but I was getting:

```
In file included from /Users/zach/turicreate/src/unity/extensions/additional_sframe_utilities.cpp:15:
/Users/zach/turicreate/src/unity/extensions/additional_sframe_utilities.hpp:15:32: error: unknown type name 'image_type'; did you mean 'turi::image_type'?
void image_load_to_numpy(const image_type& img, size_t outptr_addr,
                               ^~~~~~~~~~
                               turi::image_type
/Users/zach/turicreate/src/image/image_type.hpp:34:7: note: 'turi::image_type' declared here
class image_type {
      ^
1 error generated.
```