### PR TITLE
Fix single-image classifier inference on multi-gpu

### DIFF
--- a/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
+++ b/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
@@ -65,6 +65,8 @@ class MXFeatureExtractor(ImageFeatureExtractor):
         if (label_layer is not None) and (label_layer not in arg_params):
             arg_params[label_layer] = _mx.nd.array([0])
 
+        # Make sure we do not use a number of contexts that could leave empty workloads
+        context = context[:batch_size]
         model = _mx.mod.Module(symbol=feature_layer_sym, label_names=None, context=context)
         model.bind(for_training=False, data_shapes=[(data_layer, (batch_size, ) + image_shape)])
         model.set_params(arg_params, aux_params)


### PR DESCRIPTION
MXNet fatally crashes when you give zero batches to a GPU (I really don't know why they chose to make this a fatal error!), so we have to
limit the contexts based on the batch size. I believe OD and AC already do this.

This bug is caught by the recent test `test_single_image` when gpus>=2.