### PR TITLE
Update supported and recommended MXNet versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ CUDA-enabled `mxnet-cu80` package:
 
 ```
 (venv) pip uninstall -y mxnet
-(venv) pip install mxnet-cu80==0.12.1
+(venv) pip install mxnet-cu80==1.1.0
 ```
 
 Make sure you install the same version of MXNet as the one `turicreate` recommends
-(currently `0.12.1`). If you have trouble setting up the GPU, the [MXNet
+(currently `1.1.0`). If you have trouble setting up the GPU, the [MXNet
 installation instructions](https://mxnet.incubator.apache.org/get_started/install.html) may
 offer additional help.
 

--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
             "decorator >= 4.0.9",
             "prettytable == 0.7.2",
             "requests >= 2.9.1",
-            "mxnet >= 0.11, < 1.0.0",
+            "mxnet >= 0.11, < 1.2.0",
             "coremltools == 0.8",
             "pillow >= 3.3.0",
             "pandas >= 0.19.0",

--- a/src/unity/python/turicreate/__init__.py
+++ b/src/unity/python/turicreate/__init__.py
@@ -120,8 +120,8 @@ def _mxnet_check():
         import mxnet as _mx
         version_tuple = tuple(int(x) for x in _mx.__version__.split('.') if x.isdigit())
         lowest_version = (0, 11, 0)
-        not_yet_supported_version = (1, 0, 0)
-        recommended_version_str = '0.12.1'
+        not_yet_supported_version = (1, 2, 0)
+        recommended_version_str = '1.1.0'
         if not (lowest_version <= version_tuple < not_yet_supported_version):
             print('WARNING: You are using MXNet', _mx.__version__, 'which may result in breaking behavior.')
             print('         To fix this, please install the currently recommended version:')


### PR DESCRIPTION
After extensive testing (on both macOS and Linux / with and without GPU), I have found no issues with MXNet 1.1.0, so this extends official support.

Note: This does not update the testing version in `scripts/requirements.txt`, which is still at our lowest supported version 0.11.