### PR TITLE
Remove unnecessary Python linking

### DIFF
--- a/cmake/UseCython.cmake
+++ b/cmake/UseCython.cmake
@@ -270,8 +270,6 @@ function( cython_add_module _name )
   endif()
   if( APPLE )
     set_target_properties( ${_name} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup" )
-  else()
-    target_link_libraries( ${_name} ${PYTHON_LIBRARIES} )
   endif()
 endfunction()
 


### PR DESCRIPTION
This will help compatibility of our binary distribution
with Python packages that don't `--enable-shared`.

We shouldn't directly link to libpython2.7 anyway, as per
https://www.python.org/dev/peps/pep-0513/#libpythonx-y-so-1