### PR TITLE
Update get/set runtime config docs and errors

### DIFF
--- a/src/lambda/graph_pylambda_master.cpp
+++ b/src/lambda/graph_pylambda_master.cpp
@@ -39,7 +39,7 @@ graph_pylambda_master::graph_pylambda_master(size_t nworkers) {
   if (nworkers < thread::cpu_count()) {
     logprogress_stream << "Using default " << nworkers << " lambda workers.\n";
     logprogress_stream << "To maximize the degree of parallelism, add the following code to the beginning of the program:\n";
-    logprogress_stream << "\"turicreate.set_runtime_config(\'TURI_DEFAULT_NUM_GRAPH_LAMBDA_WORKERS\', " << thread::cpu_count() << ")\"\n";
+    logprogress_stream << "\"turicreate.config.set_runtime_config(\'TURI_DEFAULT_NUM_GRAPH_LAMBDA_WORKERS\', " << thread::cpu_count() << ")\"\n";
     logprogress_stream << "Note that increasing the degree of parallelism also increases the memory footprint." << std::endl;
   }
 }

--- a/src/lambda/lambda_master.cpp
+++ b/src/lambda/lambda_master.cpp
@@ -43,7 +43,7 @@ static lambda_master* instance_ptr = nullptr;
     if (nworkers < thread::cpu_count()) {
       logprogress_stream << "Using default " << nworkers << " lambda workers.\n";
       logprogress_stream << "To maximize the degree of parallelism, add the following code to the beginning of the program:\n";
-      logprogress_stream << "\"turicreate.set_runtime_config(\'TURI_DEFAULT_NUM_PYLAMBDA_WORKERS\', " << thread::cpu_count() << ")\"\n";
+      logprogress_stream << "\"turicreate.config.set_runtime_config(\'TURI_DEFAULT_NUM_PYLAMBDA_WORKERS\', " << thread::cpu_count() << ")\"\n";
       logprogress_stream << "Note that increasing the degree of parallelism also increases the memory footprint." << std::endl;
     }
 

--- a/src/unity/python/turicreate/config/__init__.py
+++ b/src/unity/python/turicreate/config/__init__.py
@@ -169,7 +169,7 @@ def set_log_level(level):
 def get_runtime_config():
     """
     Returns all the Turi Create configuration variables that can be set
-    at runtime. See :py:func:`turicreate.set_runtime_config()` to set these
+    at runtime. See :py:func:`turicreate.config.set_runtime_config()` to set these
     values and for documentation on the effect of each variable.
 
     Returns
@@ -188,7 +188,7 @@ def set_runtime_config(name, value):
     """
     Configures system behavior at runtime. These configuration values are also
     read from environment variables at program startup if available. See
-    :py:func:`turicreate.get_runtime_config()` to get the current values for
+    :py:func:`turicreate.config.get_runtime_config()` to get the current values for
     each variable.
 
     Note that defaults may change across versions and the names

--- a/src/unity/python/turicreate/util/__init__.py
+++ b/src/unity/python/turicreate/util/__init__.py
@@ -427,7 +427,7 @@ def _get_temp_file_location():
     Returns user specified temporary file location.
     The temporary location is specified through:
 
-    >>> turicreate.set_runtime_config('TURI_CACHE_FILE_LOCATIONS', ...)
+    >>> turicreate.config.set_runtime_config('TURI_CACHE_FILE_LOCATIONS', ...)
 
     '''
     from ..connect import main as _glconnect


### PR DESCRIPTION
This API moved in 4.0 to within turicreate.config and is no longer
top level. The doc strings and error messages needed to be updated.