### PR TITLE
Fix #518

### DIFF
--- a/src/unity/python/turicreate/visualization/_plot.py
+++ b/src/unity/python/turicreate/visualization/_plot.py
@@ -199,7 +199,7 @@ class Plot(object):
     def _repr_javascript_(self):
         from IPython.core.display import display, HTML
 
-        vega_spec = self._get_vega(True)["vega_spec"]
+        vega_spec = self._get_vega(True)
 
         vega_html = '<html lang="en"> \
                         <head> \


### PR DESCRIPTION
Remove extra ["vega_spec"] - we already return only the vega spec.