### PR TITLE
Never Use Validation Set for Image Classification

### DIFF
--- a/src/unity/python/turicreate/toolkits/classifier/logistic_classifier.py
+++ b/src/unity/python/turicreate/toolkits/classifier/logistic_classifier.py
@@ -382,7 +382,7 @@ class LogisticClassifier(_Classifier):
 
     """
     def __init__(self, model_proxy):
-        '''__init__(self)'''
+
         self.__proxy__ = model_proxy
         self.__name__ = self.__class__._native_name()
 

--- a/src/unity/python/turicreate/toolkits/clustering/kmeans.py
+++ b/src/unity/python/turicreate/toolkits/clustering/kmeans.py
@@ -200,7 +200,6 @@ class KmeansModel(_Model):
     documentation for the create function.
     """
     def __init__(self, model):
-        '''__init__(self)'''
         self.__proxy__ = model
         self.__name__ = self.__class__._native_name()
 

--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -129,6 +129,7 @@ def create(dataset, target, feature = None, model = 'resnet-50',
                                               target=target,
                                               max_iterations=max_iterations,
                                               seed=seed,
+                                              validation_set=None,
                                               verbose=verbose)
 
     # Save the model

--- a/src/unity/python/turicreate/util/__init__.py
+++ b/src/unity/python/turicreate/util/__init__.py
@@ -110,7 +110,7 @@ def _make_internal_url(url):
     For hdfs urls:
       Error if hadoop classpath is not set
     For local file urls:
-      conver slashes for windows sanity
+      convert slashes for windows sanity
 
     Parameters
     ----------


### PR DESCRIPTION
Fix for #519 and #419.

If the total number of images in the training set is at least 100, then by default logistic regression will create a validation set. Having a validation set causes second order statistics to be calculated at the end of training. This calculate is very costly when there are a large number of features. The fix is easy, just don't use a validation set.