### PR TITLE
Add -Werror with most existing warnings whitelisted via -Wno-error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,10 @@ message(WARNING "OpenMP Libraries were not found")
 #**************************************************************************/
 if (CLANG)
 set(CPP11_FLAGS "-std=c++11 -stdlib=libc++ -Wno-deprecated-register -Wno-enum-compare -Wno-conversion-null -Wno-constant-logical-operand -Wno-parentheses-equality -ftemplate-depth=900" CACHE STRING "C++11 enabling flags")
+set(WERROR_FLAGS "-Werror -Wno-error=tautological-undefined-compare -Wno-error=reorder -Wno-error=exceptions -Wno-error=switch -Wno-error=sometimes-uninitialized -Wno-error=unused-lambda-capture -Wno-error=missing-braces -Wno-error=absolute-value -Wno-error=potentially-evaluated-expression -Wno-error=null-arithmetic -Wno-error=format -Wno-error=pessimizing-move -Wno-error=comment -Wno-error=main -Wno-error=constant-conversion -Wno-error=deprecated-declarations -Wno-error=return-type -Wno-error=inconsistent-missing-override -Wno-error=overloaded-virtual -Wno-error=unused-private-field -Wno-error=unused-variable -Wno-error=unused-local-typedef")
 else()
 set(CPP11_FLAGS "-std=c++11 -Wno-enum-compare -Wno-conversion-null -ftemplate-depth=900" CACHE STRING "C++11 enabling flags")
+set(WERROR_FLAGS "")
 endif()
 # Shared compiler flags used by all builds (debug, profile, release)
 # Allow COMPILER_FLAGS to be used as options from the ./configure without
@@ -285,11 +287,17 @@ endif()
 #endif()
 
 # Set the debug flags
-set(CMAKE_C_FLAGS_DEBUG
+set(EXTERNAL_CMAKE_C_FLAGS_DEBUG
   "${DEBUG_OPTIMIZATION_LEVEL} ${PLATFORM_FLAGS} -Wno-attributes -march=${MARCH} -Winit-self ${PROFILING_FLAGS} ${C_REAL_COMPILER_FLAGS} -fno-inline ${ALTERNATE_LINKER} -DHAVE_PTHREAD=1"
   CACHE STRING "compiler options" FORCE)
-set(CMAKE_CXX_FLAGS_DEBUG
+set(CMAKE_C_FLAGS_DEBUG
+  "${EXTERNAL_CMAKE_C_FLAGS_DEBUG} ${WERROR_FLAGS}"
+  CACHE STRING "compiler options" FORCE)
+set(EXTERNAL_CMAKE_CXX_FLAGS_DEBUG
   "${DEBUG_OPTIMIZATION_LEVEL} ${PLATFORM_FLAGS} ${DISABLE_WARNING_FLAGS} -Wno-attributes -march=${MARCH} -Winit-self ${PROFILING_FLAGS} ${CPP_REAL_COMPILER_FLAGS} ${INT128_FLAGS} ${ALTERNATE_LINKER} -fno-inline -DHAVE_PTHREAD=1"
+  CACHE STRING "compiler options" FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG
+  "${EXTERNAL_CMAKE_CXX_FLAGS_DEBUG} ${WERROR_FLAGS}"
   CACHE STRING "compiler options" FORCE)
 
 set(CMAKE_C_FLAGS_RELEASE
@@ -788,9 +796,9 @@ include(SharedLibraryFromStatic)
 include(MergeStaticLibraries)
 
 
-include_directories(SYSTEM src)
+include_directories(src)
 include_directories(SYSTEM src/external)
-include_directories(SYSTEM src/platform)
+include_directories(src/platform)
 
 # for build-time generated source code
 include_directories(SYSTEM ${CMAKE_BINARY_DIR}/src)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1,5 +1,11 @@
 project(TuriExternalDependencies)
 
+set(CMAKE_C_FLAGS_DEBUG
+  "${EXTERNAL_CMAKE_C_FLAGS_DEBUG}")
+
+set(CMAKE_CXX_FLAGS_DEBUG
+  "${EXTERNAL_CMAKE_CXX_FLAGS_DEBUG}")
+
 #3rd party source 
 subdirs(
   libjson

--- a/src/external/aws-sdk-cpp/CMakeLists.txt
+++ b/src/external/aws-sdk-cpp/CMakeLists.txt
@@ -250,7 +250,7 @@ make_library(aws-sdk-cpp
     curl openssl uuid
   )
 
-target_include_directories(aws-sdk-cpp 
+target_include_directories(aws-sdk-cpp SYSTEM
   PUBLIC aws-cpp-sdk-core/include
   PUBLIC aws-cpp-sdk-s3/include
   )

--- a/src/flexible_type/flexible_type.hpp
+++ b/src/flexible_type/flexible_type.hpp
@@ -1814,26 +1814,30 @@ inline FLEX_ALWAYS_INLINE_FLATTEN void flexible_type::swap(flexible_type& b) {
 
 template <typename T>
 inline FLEX_ALWAYS_INLINE T& flexible_type::mutable_get() {
-  typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
+  __attribute__((unused))
+  typedef flexible_type_impl::invalid_type_instantiation_assert<false> unused;
   __builtin_unreachable();
 }
 
 template <typename T>
 inline FLEX_ALWAYS_INLINE const T& flexible_type::get() const {
-  typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
+  __attribute__((unused))
+  typedef flexible_type_impl::invalid_type_instantiation_assert<false> unused;
   __builtin_unreachable();
 }
 
 
 template <typename T>
 inline FLEX_ALWAYS_INLINE T& flexible_type::reinterpret_mutable_get() {
-  typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
+  __attribute__((unused))
+  typedef flexible_type_impl::invalid_type_instantiation_assert<false> unused;
   __builtin_unreachable();
 }
 
 template <typename T>
 inline FLEX_ALWAYS_INLINE const T& flexible_type::reinterpret_get() const {
-  typedef flexible_type_impl::invalid_type_instantiation_assert<true> unused;
+  __attribute__((unused))
+  typedef flexible_type_impl::invalid_type_instantiation_assert<false> unused;
   __builtin_unreachable();
 }
 

--- a/src/flexible_type/type_traits.hpp
+++ b/src/flexible_type/type_traits.hpp
@@ -113,7 +113,7 @@ template<typename... A> struct is_string {
 // Is tuple?
 
 template<class T> struct is_tuple : public std::false_type {};
-template <> template<typename... A> struct is_tuple<std::tuple<A...> > : public std::true_type {};
+template<typename... A> struct is_tuple<std::tuple<A...> > : public std::true_type {};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -128,13 +128,11 @@ template<class T> struct first_nested_type {
   typedef invalid_type type;
 };
 
-template<>
 template<class T, typename... A, template <typename...> class C>
 struct first_nested_type<C<T, A...> > {
   typedef T type;
 };
 
-template<>
 template<class T, template <typename> class C>
 struct first_nested_type<C<T> > {
   typedef T type;
@@ -152,13 +150,11 @@ template<class T> struct second_nested_type {
   typedef invalid_type type;
 };
 
-template<>
 template<class T, class U, typename... A, template <typename...> class C>
 struct second_nested_type<C<T, U, A...> > {
   typedef U type;
 };
 
-template<>
 template<class T, class U, template <typename...> class C>
 struct second_nested_type<C<T, U> > {
   typedef U type;

--- a/src/lambda/pylambda_function.hpp
+++ b/src/lambda/pylambda_function.hpp
@@ -15,7 +15,7 @@ namespace turi {
 class sframe_rows;
 
 namespace fileio {
-class file_ownership_handle;
+struct file_ownership_handle;
 }
 
 namespace lambda {

--- a/src/sframe_query_engine/algorithm/ec_sort.hpp
+++ b/src/sframe_query_engine/algorithm/ec_sort.hpp
@@ -14,7 +14,7 @@ class sframe;
 
 namespace query_eval {
 
-class planner_node;
+struct planner_node;
 
 /**
  * \ingroup sframe_query_engine

--- a/src/sframe_query_engine/algorithm/groupby_aggregate.hpp
+++ b/src/sframe_query_engine/algorithm/groupby_aggregate.hpp
@@ -14,7 +14,7 @@
 namespace turi {
 class sframe;
 namespace query_eval {
-class planner_node;
+struct planner_node;
 
 /**
  * \ingroup sframe_query_engine

--- a/src/sframe_query_engine/algorithm/sort.hpp
+++ b/src/sframe_query_engine/algorithm/sort.hpp
@@ -15,7 +15,8 @@ class sframe;
 
 namespace query_eval {
 
-class planner_node;
+struct planner_node;
+
 /**
  * \ingroup sframe_query_engine
  * \addtogroup Algorithms Algorithms

--- a/src/sframe_query_engine/planning/optimizations/optimization_transforms.hpp
+++ b/src/sframe_query_engine/planning/optimizations/optimization_transforms.hpp
@@ -12,8 +12,8 @@
 namespace turi {
 namespace query_eval {
 
-class optimization_transform_registry;
-class materialize_options;
+struct optimization_transform_registry;
+struct materialize_options;
 
 /**
  *  Optimization transforms are successively applied until no more

--- a/src/unity/lib/unity_sarray.hpp
+++ b/src/unity/lib/unity_sarray.hpp
@@ -23,7 +23,7 @@ template <typename T>
 class sarray_iterator;
 
 namespace query_eval {
-class planner_node;
+struct planner_node;
 } // query_eval
 
 /**

--- a/src/unity/lib/unity_sframe.hpp
+++ b/src/unity/lib/unity_sframe.hpp
@@ -24,7 +24,7 @@ class sframe_reader;
 class sframe_iterator;
 
 namespace query_eval {
-class planner_node;
+struct planner_node;
 } // query_eval
 
 

--- a/src/unity/python/turicreate/cython/CMakeLists.txt
+++ b/src/unity/python/turicreate/cython/CMakeLists.txt
@@ -1,5 +1,11 @@
 project(unity_cython)
 
+set(CMAKE_C_FLAGS_DEBUG
+  "${EXTERNAL_CMAKE_C_FLAGS_DEBUG}")
+
+set(CMAKE_CXX_FLAGS_DEBUG
+  "${EXTERNAL_CMAKE_CXX_FLAGS_DEBUG}")
+
 include_directories(${NUMPY_INCLUDE_DIRS})
 
 function(cython_add_turicreate_module _module_name _sources)

--- a/src/unity/toolkits/factorization/factorization_model_impl.hpp
+++ b/src/unity/toolkits/factorization/factorization_model_impl.hpp
@@ -50,7 +50,7 @@ public:
   static constexpr bool num_factors_known = (_num_factors_if_known != DYNAMIC);
 
   typedef typename std::conditional<num_factors_known, 
-            arma::Row<float>::fixed<_num_factors_if_known>, 
+            arma::Row<float>::fixed<static_cast<arma::uword>(_num_factors_if_known)>,
             arma::Row<float> >::type factor_type;
 
   typedef row_major_matrix<float> factor_matrix_type;

--- a/src/unity/toolkits/nearest_neighbors/distance_functions.hpp
+++ b/src/unity/toolkits/nearest_neighbors/distance_functions.hpp
@@ -241,6 +241,7 @@ struct transformed_dot_product final : public distance_metric {
 /* jaccard distance 
  */
 struct jaccard final : public distance_metric {
+  using distance_metric::distance;
   
   double distance(const DenseVector& a, const DenseVector& b) const {
     DASSERT_EQ(a.size(), b.size());

--- a/src/unity/toolkits/supervised_learning/xgboost.hpp
+++ b/src/unity/toolkits/supervised_learning/xgboost.hpp
@@ -26,7 +26,7 @@
 namespace xgboost {
 namespace learner {
 class BoostLearner;
-class DMatrix;
+struct DMatrix;
 }
 }
 

--- a/test/unity/toolkits/recsys/itemcf.cxx
+++ b/test/unity/toolkits/recsys/itemcf.cxx
@@ -392,10 +392,10 @@ struct recsys_itemcf_test  {
     b_d = 0.0;
     c_d = 1.0 / std::sqrt(3.) / std::sqrt(2.);
 
-    ans << 1.,  a_b, a_c, a_d,
-        0.0, 1.,  b_c, b_d,
-        0.0, 0.0, 1.,  c_d,
-        0.0, 0.0, 0.0, 1.;
+    ans = { {1.,  a_b, a_c, a_d, },
+            {0.0, 1.,  b_c, b_d, },
+            {0.0, 0.0, 1.,  c_d, },
+            {0.0, 0.0, 0.0, 1.   } };
 
     // test getting item neighbors
     {


### PR DESCRIPTION
Add -Werror for clang debug builds. Whitelists existing warnings, with the idea being that we can gradually remove warning types from the whitelist until we get down to no warnings. Then we can investigate using -Werror in other contexts (non-clang?)