### PR TITLE
Get rid of extra Materializing print statement

### DIFF
--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -2885,10 +2885,6 @@ std::shared_ptr<model_base> unity_sarray::plot(const std::string& path_to_client
   using namespace turi;
   using namespace turi::visualization;
 
-  logprogress_stream << "Materializing SArray..." << std::endl;
-  this->materialize();
-  logprogress_stream << "Done." << std::endl;
-
   if (this->size() == 0) {
     log_and_throw("Nothing to show; SArray is empty.");
   }


### PR DESCRIPTION
There are already Materializing print statements in the underlying plot
types (histogram and item_frequency), so this one is duplicated.

Fixes #517