### PR TITLE
Fix Linux C++ test build

### DIFF
--- a/test/capi/boost_utils.hpp
+++ b/test/capi/boost_utils.hpp
@@ -1,0 +1,19 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef CAPI_BOOST_TEST_UTILS
+#define CAPI_BOOST_TEST_UTILS
+
+// TODO - not sure why this is necessary, but we get symbol undefined errors
+// unless we define this explicitly. The errors are of the form:
+//
+// print_helper.hpp:216: undefined reference to `boost::test_tools::tt_detail::print_log_value<decltype(nullptr)>::operator()(std::ostream&, decltype(nullptr))'
+//
+void boost::test_tools::tt_detail::print_log_value<decltype(nullptr)>::operator()(std::ostream& os, decltype(nullptr)) {
+  os << "nullptr";
+}
+
+#endif

--- a/test/capi/boost_utils.hpp
+++ b/test/capi/boost_utils.hpp
@@ -8,12 +8,14 @@
 #define CAPI_BOOST_TEST_UTILS
 
 // TODO - not sure why this is necessary, but we get symbol undefined errors
-// unless we define this explicitly. The errors are of the form:
+// on gcc unless we define this explicitly. The errors are of the form:
 //
 // print_helper.hpp:216: undefined reference to `boost::test_tools::tt_detail::print_log_value<decltype(nullptr)>::operator()(std::ostream&, decltype(nullptr))'
 //
+#ifndef __clang__
 void boost::test_tools::tt_detail::print_log_value<decltype(nullptr)>::operator()(std::ostream& os, decltype(nullptr)) {
   os << "nullptr";
 }
+#endif
 
 #endif

--- a/test/capi/capi_datetime.cxx
+++ b/test/capi/capi_datetime.cxx
@@ -11,6 +11,7 @@
 #include <capi/impl/capi_wrapper_structs.hpp>
 #include <flexible_type/flexible_type.hpp>
 #include <util/test_macros.hpp>
+#include "boost_utils.hpp"
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_create_empty) {
   tc_error* error = nullptr;

--- a/test/capi/capi_ndarray.cxx
+++ b/test/capi/capi_ndarray.cxx
@@ -22,6 +22,7 @@
 
 #include <capi/TuriCreate.h>
 #include <capi/impl/capi_wrapper_structs.hpp>
+#include "boost_utils.hpp"
 
 using namespace turi;
 using namespace flexible_type_impl;

--- a/test/capi/capi_sframe.cxx
+++ b/test/capi/capi_sframe.cxx
@@ -17,6 +17,7 @@
 #include <unity/toolkits/util/random_sframe_generation.hpp>
 #include <fileio/fileio_constants.hpp>
 #include "capi_utils.hpp"
+#include "boost_utils.hpp"
 
 BOOST_AUTO_TEST_CASE(test_sframe_allocation) {
     tc_error* error = NULL;


### PR DESCRIPTION
For some reason, boost::test leaves something undefined when compiled on
Linux, if you try to print `std::nullptr`. We can fix that by defining
it ourselves.