### PR TITLE
Append fixes

### DIFF
--- a/src/sframe/CMakeLists.txt
+++ b/src/sframe/CMakeLists.txt
@@ -31,6 +31,7 @@ project(sframe)
      testing_utils.cpp
      sframe_saving.cpp
      sframe_saving_impl.cpp
+     sframe_compact.cpp
      rolling_aggregate.cpp
    REQUIRES
      random flexible_type fileio parallel lz4 

--- a/src/sframe/sarray_file_format_interface.hpp
+++ b/src/sframe/sarray_file_format_interface.hpp
@@ -172,6 +172,13 @@ class sarray_group_format_writer {
                     size_t columns_to_create) = 0;
 
   /**
+   * Set write options.
+   * Available options are 
+   * "disable_padding" = true or false
+   */
+  virtual void set_options(const std::string& option, int64_t value) = 0;
+
+  /**
    * Gets a modifiable reference to the index file information which will 
    * be written to the index file. Can only be called after close()
    */

--- a/src/sframe/sarray_file_format_v2.hpp
+++ b/src/sframe/sarray_file_format_v2.hpp
@@ -600,6 +600,13 @@ class sarray_group_format_writer_v2: public sarray_group_format_writer<T> {
   }
 
   /**
+   * Sets write options. See \ref v2_block_impl::block_writer::set_options
+   */
+  void set_options(const std::string& option, int64_t value) {
+    m_writer.set_options(option, value);
+  }
+
+  /**
    * Gets a modifiable reference to the index file information which will 
    * be written to the index file. 
    */

--- a/src/sframe/sarray_v2_block_writer.cpp
+++ b/src/sframe/sarray_v2_block_writer.cpp
@@ -68,6 +68,11 @@ void block_writer::open_segment(size_t segmentid, std::string filename) {
 
 }
 
+void block_writer::set_options(const std::string& option, int64_t value) {
+  if (option == "disable_padding") {
+    m_disable_padding = value;
+  }
+}
 
 static char padding_bytes[4096] = {0};
 
@@ -104,6 +109,7 @@ size_t block_writer::write_block(size_t segment_id,
   }
 
   size_t padding = ((buffer_to_write_len + 4095) / 4096) * 4096 - buffer_to_write_len;
+  if (m_disable_padding) padding = 0;
   ASSERT_LT(padding, 4096);
   // write!
   m_output_file_locks[segment_id].lock();

--- a/src/sframe/sarray_v2_block_writer.hpp
+++ b/src/sframe/sarray_v2_block_writer.hpp
@@ -74,6 +74,12 @@ class block_writer {
                     std::string filename);
 
   /**
+   * Sets write options. The only option available now is
+   * "disable_padding". If set to non-zero, disables 4K padding of blocks.
+   */
+  void set_options(const std::string& option, int64_t value);
+
+  /**
    * Writes a block of data into a segment.
    *
    * \param segmentid The segment to write to
@@ -164,6 +170,9 @@ class block_writer {
 
   /// Writes the file footer
   void emit_footer(size_t segment_id);
+
+  /// Disables 4K padding if enabled
+  bool m_disable_padding = false;
 };
 
 } // namespace v2_block_impl

--- a/src/sframe/sframe.cpp
+++ b/src/sframe/sframe.cpp
@@ -15,6 +15,7 @@
 #include <sframe/sframe_constants.hpp>
 #include <sframe/sframe_config.hpp>
 #include <sframe/sframe_saving.hpp>
+#include <sframe/sframe_compact.hpp>
 #include <exceptions/error_types.hpp>
 namespace turi {
 
@@ -63,6 +64,7 @@ sframe::sframe(const dataframe_t& data) {
 
   // create the sframe
   open_for_write(column_names, column_types, "", 1);
+  group_writer->set_options("disable_padding", 1);
 
   auto output_iter = get_output_iterator(0);
   std::vector<flexible_type> buf(column_names.size());
@@ -326,7 +328,12 @@ sframe sframe::append(const sframe& other) const {
         (ret.columns[i]->append(*other.columns[i]));
   }
   ret.index_info.nrows += other.index_info.nrows;
+  ret.try_compact();
   return ret;
+}
+
+void sframe::try_compact() {
+  for (auto& col : columns) col->try_compact();
 }
 
 std::unique_ptr<sframe::reader_type> sframe::get_reader() const {

--- a/src/sframe/sframe.hpp
+++ b/src/sframe/sframe.hpp
@@ -668,6 +668,12 @@ class sframe : public swriter_base<sframe_output_iterator> {
   void save(oarchive& oarc) const;
 
    
+  /**
+   * Attempts to compact if the number of segments in the SArray 
+   * exceeds SFRAME_COMPACTION_THRESHOLD.
+   */
+  void try_compact();
+
   /** 
    * SFrame deserializer. iarc must be associated with a directory.
    * Loads from the next prefix inside the directory.

--- a/src/sframe/sframe_compact.cpp
+++ b/src/sframe/sframe_compact.cpp
@@ -1,0 +1,59 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#include <sframe/sframe.hpp>
+#include <sframe/sframe_compact.hpp>
+namespace turi {
+
+bool sframe_fast_compact(const sframe& sf) {
+  bool ret = false;
+  for (size_t i = 0;i < sf.num_columns(); ++i) {
+    auto cur_column = sf.select_column(i);
+    ret |= sarray_fast_compact(*cur_column);
+  }
+  return ret;
+}
+
+
+void sframe_compact(sframe& sf, size_t segment_threshold) {
+  sframe_fast_compact(sf);
+  size_t num_above_threshold = 0;
+  for (size_t i = 0;i < sf.num_columns(); ++i) {
+    auto cur_column = sf.select_column(i);
+    if (cur_column->get_index_info().segment_files.size() > segment_threshold) {
+      ++num_above_threshold;
+    }
+  }
+
+  if (num_above_threshold == sf.num_columns()) {
+    //rewrite the entire sframe
+    sframe ret;
+    size_t nsegments = std::min(segment_threshold, thread::cpu_count());
+    ret.open_for_write(sf.column_names(), sf.column_types(), "", nsegments);
+    auto reader = sf.get_reader(nsegments);
+    parallel_for(0, nsegments, [&](size_t segment_id) {
+                 auto iter = reader->begin(segment_id);
+                 auto end = reader->end(segment_id);
+                 auto out = ret.get_output_iterator(segment_id);
+                 while (iter != end) {
+                   *out = *iter;
+                   ++out;
+                   ++iter;
+                 }
+                 });
+    ret.close();
+    sf = ret;
+  } else {
+    // just rewrite some columns
+    for (size_t i = 0;i < sf.num_columns(); ++i) {
+      auto cur_column = sf.select_column(i);
+      if (cur_column->get_index_info().segment_files.size() > segment_threshold) {
+        sarray_compact(*cur_column, segment_threshold);
+      }
+    }
+  }
+}
+
+}

--- a/src/sframe/sframe_compact.hpp
+++ b/src/sframe/sframe_compact.hpp
@@ -1,0 +1,48 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_SFRAME_COMPACT_HPP
+#define TURI_SFRAME_COMPACT_HPP
+#include <vector>
+#include <memory>
+namespace turi {
+class sframe;
+
+template <typename T>
+class sarray;
+/**
+ * sframe_fast_compact looks for runs of small segments 
+ * (comprising of less than FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT block), and
+ * rebuilds them into bigger segments.
+ * Returns true if any compaction was performed.
+ */
+bool sframe_fast_compact(const sframe& sf);
+
+/**
+ * Inplace compacts an SFrame. Fast compact is tried first and if
+ * the number of segments do not fall below the target, a slow compaction
+ * is performed.
+ */
+void sframe_compact(sframe& sf, size_t segment_threshold);
+
+/**
+ * sarray_fast_compact looks for runs of small segments 
+ * (comprising of less than FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT block), and
+ * rebuilds them into bigger segments.
+ * Returns true if any compaction was performed.
+ */
+template <typename T>
+bool sarray_fast_compact(sarray<T>& column);
+
+/**
+ * Inplace compacts an SArray. Fast compact is tried first and if
+ * the number of segments do not fall below the target, a slow compaction
+ * is performed.
+ */
+template <typename T>
+void sarray_compact(sarray<T>& column, size_t segment_threshold);
+
+} // turi
+#endif

--- a/src/sframe/sframe_compact_impl.hpp
+++ b/src/sframe/sframe_compact_impl.hpp
@@ -1,0 +1,135 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_SFRAME_COMPACT_IMPL_HPP
+#define TURI_SFRAME_COMPACT_IMPL_HPP
+#include <vector>
+#include <memory>
+#include <sframe/sarray.hpp>
+namespace turi {
+namespace {
+/**
+ * Returns the number of blocks in a segment file
+ */
+inline size_t get_num_blocks_in_segment_file(const std::string& s) {
+  auto& manager = v2_block_impl::block_manager::get_instance();
+  auto columnaddr =  manager.open_column(s);
+  return manager.num_blocks_in_column(columnaddr);
+}
+
+template <typename T>
+inline std::shared_ptr<sarray<T>> 
+compact_rows(sarray<T>& arr, size_t row_start, size_t row_end) {
+  // returned sarray
+  auto ret = std::make_shared<sarray<T>>();
+  ret->open_for_write(1);
+  auto output = ret->get_output_iterator(0);
+
+    // read input array
+  auto reader = arr.get_reader();
+  sframe_rows rows;
+  while(row_start < row_end) {
+    size_t read_end = std::min(row_start + DEFAULT_SARRAY_READER_BUFFER_SIZE, row_end);
+    bool read_ok = reader->read_rows(row_start, read_end, rows);
+    ASSERT_TRUE(read_ok);
+
+    // write output array
+    (*output) = rows;
+    row_start = read_end;
+  }
+  ret->close();
+  return ret;
+}
+
+} // anonymous namespace
+
+template <typename T>
+bool sarray_fast_compact(sarray<T>& column) {
+
+  auto index = column.get_index_info();
+
+  // this is the resultant index
+  auto updated_index = index;
+  updated_index.segment_sizes.clear();
+  updated_index.segment_files.clear();
+
+  size_t row_counter = 0;
+  bool compaction_performed = false;
+
+  // we keep a buffer of the new sarrays constructed after compaction until we 
+  // actually piece them together. To avoid them going out of scope and
+  // and clearing the data.
+  std::vector<std::shared_ptr<sarray<T>>> new_sarrays;
+
+  for (size_t i = 0;i < index.segment_files.size(); ++i) {
+    size_t nblocks = get_num_blocks_in_segment_file(index.segment_files[i]);
+    if (nblocks < FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT) {
+      // find a run of block size 1
+      size_t runlength_in_segments = 1;
+      size_t runlength_in_rows = index.segment_sizes[i];
+      for (size_t j = i + 1; j < index.segment_files.size(); ++j) {
+        size_t nblocks = get_num_blocks_in_segment_file(index.segment_files[j]);
+        if (nblocks <= 1) {
+          runlength_in_rows += index.segment_sizes[j];
+          ++runlength_in_segments;
+        } else {
+          break;
+        }
+      }
+      // we only compact if there is more than one segment of block size 1
+      if (runlength_in_segments > 1) {
+        logstream(LOG_INFO) << "Compacting range of " 
+                            << runlength_in_segments << " blocks, " 
+                            << runlength_in_rows << " rows" << std::endl;
+
+        // we compact the segment range
+        auto new_sarray = compact_rows(column, row_counter, row_counter + runlength_in_rows);
+        // put it into the updated index
+        auto new_sarray_index = new_sarray->get_index_info();
+        ASSERT_EQ(new_sarray_index.segment_files.size(), 1);
+        ASSERT_EQ(new_sarray_index.segment_sizes[0], runlength_in_rows);
+        row_counter += runlength_in_rows;
+        updated_index.segment_sizes.push_back(new_sarray_index.segment_sizes[0]);
+        updated_index.segment_files.push_back(new_sarray_index.segment_files[0]);
+
+        //remember the new sarray so that it doesn't go out of scope
+        //until we actually construct the result.
+        compaction_performed = true;
+        new_sarrays.push_back(new_sarray);
+        // increment the index by the right amount so that we end up
+        // on the segment after the run
+        i += runlength_in_segments - 1;
+        continue;
+      }
+    }
+    row_counter += index.segment_sizes[i];
+    updated_index.segment_sizes.push_back(index.segment_sizes[i]);
+    updated_index.segment_files.push_back(index.segment_files[i]);
+  }
+
+  if (compaction_performed) {
+    sarray<T> final_array;
+    updated_index.nsegments = updated_index.segment_files.size();
+    final_array.open_for_read(updated_index);
+    ASSERT_EQ(final_array.size(), column.size());
+    column = final_array;
+  }
+  return compaction_performed;
+}
+
+
+template <typename T>
+void sarray_compact(sarray<T>& column, size_t segment_threshold) {
+  sarray_fast_compact(column);
+  if (column.get_index_info().segment_files.size() > segment_threshold) {
+    logstream(LOG_INFO) 
+        << "Slow compaction triggered because fast compact did not achieve target" 
+        << std::endl;
+    column = *(column.clone(std::min(segment_threshold, thread::cpu_count())));
+  }
+}
+
+} // turi
+#endif

--- a/src/sframe/sframe_constants.cpp
+++ b/src/sframe/sframe_constants.cpp
@@ -33,6 +33,8 @@ EXPORT size_t SFRAME_IO_READ_LOCK = false;
 EXPORT size_t SFRAME_SORT_PIVOT_ESTIMATION_SAMPLE_SIZE = 2000000;
 EXPORT size_t SFRAME_SORT_MAX_SEGMENTS = 128;
 EXPORT const size_t SFRAME_IO_LOCK_FILE_SIZE_THRESHOLD = 4 * 1024 * 1024;
+EXPORT size_t SFRAME_COMPACTION_THRESHOLD = 256;
+EXPORT size_t FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT = 8;
 
 
 REGISTER_GLOBAL_WITH_CHECKS(int64_t, 
@@ -104,4 +106,14 @@ REGISTER_GLOBAL_WITH_CHECKS(int64_t,
                             true,
                             +[](int64_t val){ return val > 1; });
 
+
+REGISTER_GLOBAL_WITH_CHECKS(int64_t, 
+                            FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT,
+                            true,
+                            +[](int64_t val){ return val >= 1; });
+
+
+REGISTER_GLOBAL(int64_t, 
+                SFRAME_COMPACTION_THRESHOLD,
+                true);
 } // namespace turi

--- a/src/sframe/sframe_constants.hpp
+++ b/src/sframe/sframe_constants.hpp
@@ -167,6 +167,17 @@ extern size_t SFRAME_SORT_PIVOT_ESTIMATION_SAMPLE_SIZE;
  */
 extern size_t SFRAME_SORT_MAX_SEGMENTS;
 
+/**
+ * The maximum number of segments an SFrame can have after which compaction
+ * will be attempted
+ */
+extern size_t SFRAME_COMPACTION_THRESHOLD;
+
+/**
+ * If a segment contains less than this number of blocks, it is 
+ * considered a small segment.
+ */
+extern size_t FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT;
 /// \} 
 } // namespace turi
 #endif

--- a/src/sframe/sframe_saving.cpp
+++ b/src/sframe/sframe_saving.cpp
@@ -3,6 +3,7 @@
  * Use of this source code is governed by a BSD-3-clause license that can
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
+#include <sframe/sframe_compact.hpp>
 #include <sframe/sframe.hpp>
 #include <sframe/sframe_index_file.hpp>
 #include <sframe/sarray_index_file.hpp>
@@ -213,6 +214,7 @@ void sframe_save(const sframe& sf_source,
   if (has_legacy_sframe) {
     sframe_save_naive(sf_source, index_file); 
   } else {
+    sframe_fast_compact(sf_source);
     sframe_save_blockwise(sf_source, index_file);
   }
 }

--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -96,7 +96,7 @@ void unity_sarray::construct_from_vector(const std::vector<flexible_type>& vec,
 
   auto sarray_ptr = std::make_shared<sarray<flexible_type>>();
 
-  sarray_ptr->open_for_write(1);
+  sarray_ptr->open_for_write(1, true /*disable padding*/);
   sarray_ptr->set_type(type);
 
   // ok. copy into the writer.

--- a/test/sframe/sframe_test.cxx
+++ b/test/sframe/sframe_test.cxx
@@ -1636,6 +1636,30 @@ struct sframe_test  {
        TS_ASSERT_EQUALS(result[i][2], std::to_string(i % 6));
      }
    }
+   void test_sarray_recursive_append(void) {
+     std::vector<flexible_type> int_col{0};
+     std::vector<flexible_type> float_col{0};
+     std::vector<flexible_type> str_col{"0"};
+     dataframe_t df;
+     df.set_column("int_col", int_col, flex_type_enum::INTEGER);
+     df.set_column("float_col", float_col, flex_type_enum::FLOAT);
+     df.set_column("str_col", str_col, flex_type_enum::STRING);
+     sframe sf(df);
+
+     for (size_t i = 0;i < 20; ++i) {
+       sf = sf.append(sf);
+     }
+     TS_ASSERT_EQUALS(sf.size(), 1048576);
+     auto reader = sf.get_reader();
+     sframe_rows rows;
+     reader->read_rows(0, 1048576, rows);
+     TS_ASSERT_EQUALS(rows.num_rows(), 1048576);
+     for (auto& row: rows) {
+       TS_ASSERT_EQUALS(row[0], int_col[0]);
+       TS_ASSERT_EQUALS(row[1], float_col[0]);
+       TS_ASSERT_EQUALS(row[2], str_col[0]);
+     }
+   }
 
    void test_sframe_rows() {
      std::vector<std::vector<flexible_type> > data{{1,2,3,4,5},


### PR DESCRIPTION
Implemented compaction heuristics for sframe/sarray append so that
recursive appends, or continuous appends of small sframe/sarrays do not
result in poorly organized SFrames.

The basic mechanism of the compaction process is two methods, a
sarray_fast_compact and a sarray_compact method. sarray_fast_compact
will look for contiguous segments with less than
FAST_COMPACT_BLOCKS_IN_SMALL_SEGMENT (8 by default) number of blocks,
and compact them into a single segment.

The sarray_compact method will try to perform a fast compaction, and if
unable to bring it below a threshold (SFRAME_COMPACTION_THRESHOLD =
256), will perform a full rewrite of the entire sarray.

SFrame compact is similar.

In addition, a block writing option ("disable_padding") is pushed
all the way through to sframe/sarray. This option is enabled when
small sframe/sarrays (things which fit in memory) are written.