### PR TITLE
Remove "Done" from visualization materialization

### DIFF
--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -2887,9 +2887,8 @@ std::shared_ptr<model_base> unity_sarray::plot(const std::string& path_to_client
   using namespace turi;
   using namespace turi::visualization;
 
-  logprogress_stream << "Materializing SArray..." << std::endl;
+  logprogress_stream << "Materializing SArray" << std::endl;
   this->materialize();
-  logprogress_stream << "Done." << std::endl;
 
   if (this->size() == 0) {
     log_and_throw("Nothing to show; SArray is empty.");

--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -1614,9 +1614,8 @@ void unity_sframe::explore(const std::string& path_to_client, const std::string&
 
   std::shared_ptr<unity_sframe_base> self = this->select_columns(this->column_names());
 
-  logprogress_stream << "Materializing SFrame..." << std::endl;
+  logprogress_stream << "Materializing SFrame" << std::endl;
   this->materialize();
-  logprogress_stream << "Done." << std::endl;
 
   if(self->size() == 0){
     log_and_throw("Nothing to explore; SFrame is empty.");

--- a/src/unity/lib/visualization/columnwise_summary.cpp
+++ b/src/unity/lib/visualization/columnwise_summary.cpp
@@ -6,9 +6,8 @@ namespace turi {
     std::shared_ptr<Plot> plot_columnwise_summary(
       const std::string& path_to_client, std::shared_ptr<unity_sframe_base> sf) {
 
-      logprogress_stream << "Materializing SFrame..." << std::endl;
+      logprogress_stream << "Materializing SFrame" << std::endl;
       sf->materialize();
-      logprogress_stream << "Done." << std::endl;
 
       if (sf->size() == 0) {
         log_and_throw("Nothing to show; SFrame is empty.");

--- a/src/unity/lib/visualization/histogram.cpp
+++ b/src/unity/lib/visualization/histogram.cpp
@@ -340,9 +340,8 @@ std::shared_ptr<Plot> plot_histogram(const std::string& path_to_client,
     using namespace turi;
     using namespace turi::visualization;
 
-    logprogress_stream << "Materializing SArray..." << std::endl;
+    logprogress_stream << "Materializing SArray" << std::endl;
     sa.materialize();
-    logprogress_stream << "Done." << std::endl;
 
     if (sa.size() == 0) {
       log_and_throw("Nothing to show; SArray is empty.");

--- a/src/unity/lib/visualization/item_frequency.cpp
+++ b/src/unity/lib/visualization/item_frequency.cpp
@@ -139,9 +139,8 @@ namespace turi {
         using namespace turi;
         using namespace turi::visualization;
 
-        logprogress_stream << "Materializing SArray..." << std::endl;
+        logprogress_stream << "Materializing SArray" << std::endl;
         sa.materialize();
-        logprogress_stream << "Done." << std::endl;
 
         if (sa.size() == 0) {
           log_and_throw("Nothing to show; SArray is empty.");

--- a/src/unity/lib/visualization/show.cpp
+++ b/src/unity/lib/visualization/show.cpp
@@ -32,11 +32,10 @@ namespace turi {
               const std::string& ylabel,
               const std::string& title) {
 
-        logprogress_stream << "Materializing X axis SArray..." << std::endl;
+        logprogress_stream << "Materializing X axis SArray" << std::endl;
         x.materialize();
-        logprogress_stream << "Materializing Y axis SArray..." << std::endl;
+        logprogress_stream << "Materializing Y axis SArray" << std::endl;
         y.materialize();
-        logprogress_stream << "Done." << std::endl;
 
         const size_t size = x.size();
 


### PR DESCRIPTION
Just print out that we are materializing, then allow the display of the
visualization to indicate to the user that it's done.