### PR TITLE
Allow SArray of URL -> SArray of Image conversion via astype

### DIFF
--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -1276,8 +1276,13 @@ std::shared_ptr<unity_sarray_base> unity_sarray::lazy_astype(flex_type_enum dtyp
   // Special path for converting strings to image
   if (current_type == flex_type_enum::STRING &&
       dtype == flex_type_enum::IMAGE) {
-    return transform_lambda([](const flexible_type& f)->flexible_type {
-                                  return image_util::load_image(f.to<flex_string>(), "");
+    return transform_lambda([=](const flexible_type& f)->flexible_type {
+                                  try {
+                                    return image_util::load_image(f.to<flex_string>(), "");
+                                  } catch (...) {
+                                    if (undefined_on_failure) return FLEX_UNDEFINED;
+                                    else throw;
+                                  }
                                 },
                                 dtype,
                                 true /*skip undefined*/,

--- a/src/unity/python/turicreate/test/test_image_type.py
+++ b/src/unity/python/turicreate/test/test_image_type.py
@@ -171,13 +171,20 @@ class ImageClassTest(unittest.TestCase):
     def test_astype_image(self):
         import glob
         imagelist = glob.glob(current_file_dir + '/images/*/**')
-        imageurls = tc.SArray(imagelist)
-        images = images.astype(image.Image)
+        imageurls = SArray(imagelist)
+        images = imageurls.astype(image.Image)
         self.assertEqual(images.dtype, image.Image)
         # check that we actually loaded something.
         for i in images:
             self.assertGreater(i.height, 0)
             self.assertGreater(i.width, 0)
+
+        # try a bad image
+        imageurls = SArray(["no_image_here", "go_away"])
+        self.assertRaises(Exception, lambda: imageurls.astype(image.Image))
+        ret = imageurls.astype(image.Image, undefined_on_failure=True)
+        self.assertEqual(ret[0], None)
+        self.assertEqual(ret[1], None)
 
     def test_casting(self):
         image_url_dir = current_file_dir + '/images/nested'

--- a/src/unity/python/turicreate/test/test_image_type.py
+++ b/src/unity/python/turicreate/test/test_image_type.py
@@ -168,6 +168,17 @@ class ImageClassTest(unittest.TestCase):
         image_analysis.load_images(image_url_dir, 'JPG', ignore_failure=True)
         image_analysis.load_images(image_url_dir, 'PNG', ignore_failure=True)
 
+    def test_astype_image(self):
+        import glob
+        imagelist = glob.glob(current_file_dir + '/images/*/**')
+        imageurls = tc.SArray(imagelist)
+        images = images.astype(image.Image)
+        self.assertEqual(images.dtype, image.Image)
+        # check that we actually loaded something.
+        for i in images:
+            self.assertGreater(i.height, 0)
+            self.assertGreater(i.width, 0)
+
     def test_casting(self):
         image_url_dir = current_file_dir + '/images/nested'
         sf = image_analysis.load_images(image_url_dir, "auto", True, True)


### PR DESCRIPTION
This patch allows for

    urls = tc.SArray(["a.png","b.jpg","file:///somewhere/a.png",
                      "https://someotherplace.com/image.png"])
    images = urls.astype(tc.Image)