### PR TITLE
Style transfer user guide polish

### DIFF
--- a/userguide/style_transfer/README.md
+++ b/userguide/style_transfer/README.md
@@ -4,8 +4,9 @@ Style Transfer is a task wherein the stylistic elements of a style image
 are imitated onto a new image while preserving the content of the new
 image. As an example, a style transfer model that uses these [style
 images](#style-images) when applied to this [content image](#content-image) 
-results in
-![stylized images](images/cat-stylized.png).
+results in:
+
+![Photo of cat in different styles](#style-images)](images/cat-stylized.png)
 
 The training procedure for style transfer requires the following data:
 - Content images: A set of representative images in your application
@@ -14,7 +15,7 @@ The training procedure for style transfer requires the following data:
 
 #### Introductory Example
 
-Here is a simple example end to end example of using style transfer.
+Here is a simple end-to-end example of using style transfer.
 
 ```python
 import turicreate as tc
@@ -96,32 +97,33 @@ For a model with 8 styles, the output looks like this:
 [8 rows x 3 columns]
 ```
 
-The resulting images look like 
-![stylized_sframe](images/stylized_sframe.png)
+We can visually explore these results using `stylized_images.explore()`:
 
-By default `stylize` will stylize a test image with all the styles used
-in the training.  You can also stylize on selected styles by passing
-`style` parameter into `stylize` method. Here are some examples:
+![View of SFrame with stylized images](images/stylized_sframe.png)
+
+By default `stylize` will apply all the styles of the model to each of the
+input images. You can also stylize using selected styles by setting the
+`style` parameter. Here are some examples:
 
 ```python
 # Only the first style
-stylized_image = model.stylize(test_images, style = 0)
+stylized_image = model.stylize(test_images, style=0)
 
 # A subset of styles
-stylized_images = model.stylize(test_images, style = [1, 2])
+stylized_images = model.stylize(test_images, style=[1, 2])
 ```
 
 By default, images with any one side larger than 800px are scaled down
 (preserving aspect ratio) so that the largest side of an image is less
-than 800px. You can adjust that using the `max_size` parameter:
+than 800px. You can adjust this using the `max_size` parameter:
 
 ```python
-stylized_images = model.stylize(test_images, max_size = 1024)
+stylized_images = model.stylize(test_images, max_size=1024)
 ```
 
 It is not always the case that stylizing your images at the highest
 possible resolution will produce the desired effect on your image so we
-recommend you chose this based on your styles and the desired effect
+recommend you choose this based on your styles and the desired effect
 you'd like it to have. The larger the size, the more computationally
 expensive it is to stylize (without resizing). Please refer to the [api
 docs](https://apple.github.io/turicreate/docs/api/generated/turicreate.style_transfer.StyleTransfer.stylize.html#turicreate.style_transfer.StyleTransfer.stylize)

--- a/userguide/style_transfer/how-it-works.md
+++ b/userguide/style_transfer/how-it-works.md
@@ -11,35 +11,22 @@ The technique used in Turi Create is based on [*"A Learned
 Representation For Artistic
 Style"*](https://arxiv.org/pdf/1610.07629.pdf). The model is compact and
 fast and hence can run on mobile devices like an iPhone. The model
-consists of 3 convolutional layers, 5 residual layers (2 convolutonal
+consists of 3 convolutional layers, 5 residual layers (2 convolutional
 layers in each) and 3 upsampling layers each followed by a convolutional
-layer.  There are totally 16 convolutional layers.
+layer.  There are a total of 16 convolutional layers.
 
-There are three aspects about this techinque that are worth noting:
-- It trades off training time (which can be larger) to make sure the
-  inference time is fast enough for use on a mobile device.
+There are three aspects about this technique that are worth noting:
+- It is designed to be incredibly fast at stylizing images, allowing deployment
+  on device. As a trade off, the model creation takes longer.
 - A single model can incorporate a large number of styles without any
   significant increase in the size of the model.
-- During inference, the model can take in any-sized input image and out
-  the stlyized image of the same size.
+- The model can take input of any size and output a stylized image of
+  the same size.
 
 During training, we employ [Transfer
 Learning](../image_classifier/how-it-works.md#transfer-learning). The 
-model uses  VGG-16 as a reference network to compute the losses. We 
-fine-tune only the instance norm parameters of the styles and not the 
-entire network.
-
-#### Advanced parameters
-
-We provide a few advanced training parameters that might be useful to
-you as you develop more intuition for the model. You may specifiy these
-parameters by specifying _advanced_parameters in
-[style_transfer.create()](https://apple.github.io/turicreate/docs/api/generated/turicreate.style_transfer.create.html#turicreate.style_transfer.create).
-Note that this may not result in a better model than the default
-parameters (which are chosen automatically based on your data):
-
-* `finetune_all_params`: Setting this to True will allow the fine-tune
-  all the parameters of resnet-16.
-* `print_loss_breakdown`: Setting this parameter to True will print the
-  content loss and style loss separately.Higher the style loss, lesser
-style elements will be captured in the content images.
+model uses the visual semantics of an already trained VGG-16 network to
+understand and mimic stylistic elements. It also updates only a small set of
+the parameters of the stylization network; the rest of the parameters were
+already trained and remain unchanged. This allows you to achieve great results
+with little data and shorter training time.


### PR DESCRIPTION
- Generally tries to avoid too technical terms, like "inference"
- Removes section on hidden parameters
- Typos and minor fixes