### PR TITLE
Pre-screen all detection annotations for early error handling

### DIFF
--- a/src/unity/python/turicreate/test/test_object_detector.py
+++ b/src/unity/python/turicreate/test/test_object_detector.py
@@ -64,8 +64,8 @@ def _get_data(feature, annotations):
             x = (left + right) / 2
             y = (top + bottom) / 2
 
-            width = right - left
-            height = bottom - top
+            width = max(right - left, 1)
+            height = max(bottom - top, 1)
 
             label = {
                 'coordinates': {


### PR DESCRIPTION
This PR makes ill-formatted annotations cause an error up-front (before any training has happened) and shows the first five offenders. It adds check for negative width/height (#552).

Fixes #552 
Fixes #588