### PR TITLE
add missing step to fix type error in userguide/text/analysis.md

### DIFF
--- a/userguide/text/analysis.md
+++ b/userguide/text/analysis.md
@@ -38,6 +38,8 @@ Note: Only the head of the SFrame is printed.
 
 ##### Text cleaning
 
+First, we must convert our SFrame of `str` into an SFrame of type `dict` using [turicreate.text_analytics.count_words](https://apple.github.io/turicreate/docs/api/generated/turicreate.text_analytics.count_words). This operations converts the array of strings into an array of dictionaries. The keys are each word in the document and the values are the number of times the word occurs.
+
 We can easily remove all words do not occur at least twice in each
 document using
 [SArray.dict_trim_by_values](https://apple.github.io/turicreate/docs/api/generated/turicreate.SArray.dict_trim_by_values.html).


### PR DESCRIPTION
Within this section, following the sample code produces an error because `SArray.dict_trim_by_values` expects the `dtype` to be `dict`, not `str`.

This change adds a step to first call `turicreate.text_analytics.count_words` to convert the `SFrame dtype=str` into a ` dtype=dict` before proceeding with the `trim_by_keys` and `stopwords` example.