### PR TITLE
Object detector optimization

### DIFF
--- a/src/unity/python/turicreate/_sys_util.py
+++ b/src/unity/python/turicreate/_sys_util.py
@@ -64,7 +64,12 @@ def make_unity_server_env():
     # Set mxnet envvars
     if 'MXNET_CPU_WORKER_NTHREADS' not in env:
         from multiprocessing import cpu_count
-        num_workers = min(2, int(env.get('OMP_NUM_THREADS', cpu_count())))
+        num_cpus = int(env.get('OMP_NUM_THREADS', cpu_count()))
+        if sys.platform == 'darwin':
+            num_workers = num_cpus
+        else:
+            # On Linux, BLAS doesn't seem to tolerate larger numbers of workers.
+            num_workers = min(2, num_cpus)
         env['MXNET_CPU_WORKER_NTHREADS'] = str(num_workers)
 
     ## set local to be c standard so that unity_server will run ##

--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -299,7 +299,8 @@ class MpsGraphAPI(object):
             assert x.shape == self._ishape
         else:
             assert x.shape == self._oshape
-        x = x.astype(_np.float32)
+        if x.dtype != _np.float32:
+            x = x.astype(_np.float32)
         if not x.flags.c_contiguous:
             x = x.copy()
         assert x.flags.c_contiguous, "Input image must be row-major"
@@ -313,7 +314,8 @@ class MpsGraphAPI(object):
     def prepare_label(self, t):
         assert t.shape == self._oshape
         assert self._is_train, "Pure inference graph does not expect label input"
-        t = t.astype(_np.float32)
+        if t.dtype != _np.float32:
+            t = t.astype(_np.float32)
         if not t.flags.c_contiguous:
             t = t.copy()
         assert t.flags.c_contiguous, "Input label must be row-major"

--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -250,8 +250,6 @@ class MpsGraphAPI(object):
         self.network_id = network_id
         # current state, for reloading weights
         self._cur_config = {}
-        self._cur_inputs = {}
-        self._cur_label = None
         self._cur_learning_rate = None
 
     def __del__(self):
@@ -296,7 +294,7 @@ class MpsGraphAPI(object):
         self._ishape = (n, h_in, w_in, c_in)
         self._oshape = (n, h_out, w_out, c_out)
 
-    def set_input(self, x, flag=0):
+    def prepare_input(self, x, flag=0):
         if flag == 0:
             assert x.shape == self._ishape
         else:
@@ -305,44 +303,65 @@ class MpsGraphAPI(object):
         if not x.flags.c_contiguous:
             x = x.copy()
         assert x.flags.c_contiguous, "Input image must be row-major"
-        self._cur_inputs[flag] = x.copy()
         ptr = x.ctypes.data_as(_ctypes.POINTER(_ctypes.c_void_p))
         sz = _ctypes.c_int64(x.size)
         s = _np.array(x.shape).astype(_np.int64)
         shape = s.ctypes.data_as(_ctypes.POINTER(_ctypes.c_int64))
         dim = _ctypes.c_int32(x.ndim)
-        self._LIB.SetInputGraph(self.handle, ptr, sz, shape,
-                          dim, flag)
+        return {'_input' : x, '_shape' : s, 'args' : [ptr, sz, shape, dim]}
 
-    def set_label(self, t):
+    def prepare_label(self, t):
         assert t.shape == self._oshape
         assert self._is_train, "Pure inference graph does not expect label input"
         t = t.astype(_np.float32)
         if not t.flags.c_contiguous:
             t = t.copy()
         assert t.flags.c_contiguous, "Input label must be row-major"
-        self._cur_label = t.copy()
         ptr = t.ctypes.data_as(_ctypes.POINTER(_ctypes.c_void_p))
-        self._LIB.SetLossStateGraph(self.handle, ptr)
+        return {'_label' : t, 'args' : [ptr]}
 
-    def run_graph(self):
+    # Submits an input batch to the model. The model will process the input
+    # asynchronously. This call must be matched with a corresponding call to
+    # wait_for_batch. Label data is required for models initialized with
+    # MpsGraphMode.Train; grad data is required for models initialized with
+    # MpsGraphMode.TrainReturnGrad.
+    def start_batch(self, input, label=None, grad=None):
         if self._mode == MpsGraphMode.Train:
-            self._LIB.RunGraph(self.handle, 0, _ctypes.byref(self._buf_loss))
+            input_args = self.prepare_input(input, 0)
+            label_args = self.prepare_label(label)
+            args = input_args['args'] + label_args['args']
+            self._LIB.StartTrainingBatchGraph(self.handle, *args)
+        elif self._mode == MpsGraphMode.TrainReturnGrad:
+            input_args = self.prepare_input(input, 0)
+            grad_args = self.prepare_input(grad, 1)
+            args = input_args['args'] + grad_args['args']
+            self._LIB.StartTrainReturnGradBatchGraph(self.handle, *args)
+        else:
+            input_args = self.prepare_input(input, 0)
+            args = input_args['args']
+            self._LIB.StartInferenceBatchGraph(self.handle, *args)
+
+    # Waits for a previously submitted batch to complete and returns the output.
+    # For models initialized with MpsGraphMode.Train, the return value is the
+    # loss. For models initialized with MpsGraphMode.Inference, the return value
+    # is the model predictions. For models initialized with
+    # MpsGraphMode.TrainReturnGrad, the return value is the gradient for the
+    # input layer.
+    def wait_for_batch(self):
+        if self._mode == MpsGraphMode.Train:
+            self._LIB.WaitForTrainingBatchGraph(self.handle, _ctypes.byref(self._buf_loss))
             loss = _np.frombuffer(self._buf_loss, dtype=_np.float32).copy()
             return loss
         elif self._mode == MpsGraphMode.TrainReturnGrad:
-            self._LIB.RunGraph(self.handle, _ctypes.byref(self._buf_out_fp16), 0)
+            self._LIB.WaitForTrainReturnGradBatchGraph(self.handle, _ctypes.byref(self._buf_out_fp16))
             raw_out = _np.frombuffer(self._buf_out_fp16, dtype=_np.float16)
             out = raw_out.reshape(self._ishape).astype(_np.float32).copy()
             return out
         else:
-            self._LIB.RunGraph(self.handle, _ctypes.byref(self._buf_out_fp16), 0)
+            self._LIB.WaitForInferenceBatchGraph(self.handle, _ctypes.byref(self._buf_out_fp16))
             raw_out = _np.frombuffer(self._buf_out_fp16, dtype=_np.float16)
             out = raw_out.reshape(self._oshape).astype(_np.float32).copy()
             return out
-
-    def wait_until_completed(self):
-        self._LIB.WaitUntilCompletedGraph(self.handle)
 
     def set_learning_rate(self, new_lr):
         self._cur_learning_rate = new_lr
@@ -358,10 +377,6 @@ class MpsGraphAPI(object):
         self.init(n, c_in, h_in, w_in, c_out, h_out, w_out,
                   config=self._cur_config, weights=weights)
         # Reload state
-        for k, v in self._cur_inputs.items():
-            self.set_input(v, flag=k)
-        if self._cur_label is not None:
-            self.set_label(self._cur_label)
         if self._cur_learning_rate:
             self.set_learning_rate(self._cur_learning_rate)
 

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import as _
 import numpy as _np
 import turicreate as _tc
 import mxnet as _mx
+from six.moves.queue import Queue as _Queue
+from threading import Thread as _Thread
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from ._detection import yolo_boxes_to_yolo_map as _yolo_boxes_to_yolo_map
 
@@ -44,6 +46,152 @@ def _is_valid_annotations_list(anns):
     return all([_is_valid_annotation(ann) for ann in anns])
 
 
+# Encapsulates an SFrame, iterating over each row and returning an
+# (image, label, index) tuple.
+class _SFrameDataSource:
+    def __init__(self, sframe, feature_column, annotations_column,
+                 load_labels=True, shuffle=True, samples=None):
+        self.annotations_column = annotations_column
+        self.load_labels = load_labels
+        self.shuffle = shuffle
+        self.num_samples = samples
+        self.cur_sample = 0
+
+        # Make shallow copy, so that temporary columns do not change input
+        self.sframe = sframe.copy()
+
+        # Convert images to raw to eliminate overhead of decoding
+        self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[feature_column].apply(_convert_image_to_raw)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self._next()
+
+    def next(self):
+        return self._next()
+
+    def _next(self):
+        if self.cur_sample == self.num_samples:
+            raise StopIteration
+
+        # If we're about to begin a new epoch, shuffle the SFrame if requested.
+        row_index = self.cur_sample % len(self.sframe)
+        if row_index == 0 and self.cur_sample > 0 and self.shuffle:
+            self.sframe[_TMP_COL_RANDOM_ORDER] = _np.random.uniform(size=len(self.sframe))
+            self.sframe = self.sframe.sort(_TMP_COL_RANDOM_ORDER)
+        self.cur_sample += 1
+
+        # Copy the image data for this row into a NumPy array.
+        row = self.sframe[row_index]
+        image = row[_TMP_COL_RAW_IMAGE].pixel_data
+
+        # Copy the annotated bounding boxes for this image, if requested.
+        if self.load_labels:
+            label = row[self.annotations_column]
+            if label == None:
+                label = []
+            elif type(label) == dict:
+                label = [label]
+        else:
+            label = None
+
+        return image, label, row_index
+
+    def reset(self):
+        self.cur_sample = 0
+
+
+# A wrapper around _SFrameDataSource that uses a dedicated worker thread for
+# performing SFrame operations.
+class _SFrameAsyncDataSource:
+    def __init__(self, sframe, feature_column, annotations_column,
+                 load_labels=True, shuffle=True, samples=None, buffer_size=256):
+        # This buffer_reset_queue will be used to communicate to the background
+        # thread. Each "message" is itself a _Queue that the background thread
+        # will use to communicate with us.
+        buffer_reset_queue = _Queue()
+        def worker():
+            data_source = _SFrameDataSource(
+                sframe, feature_column, annotations_column,
+                load_labels=load_labels, shuffle=shuffle, samples=samples)
+            while True:
+                buffer = buffer_reset_queue.get()
+                if buffer is None:
+                    break  # No more work to do, exit this thread.
+
+                for row in data_source:
+                    buffer.put(row)
+
+                    # Check if we've been reset (or told to exit).
+                    if not buffer_reset_queue.empty():
+                        break
+
+                # Always end each output buffer with None to signal completion.
+                buffer.put(None)
+                data_source.reset()
+        self.worker_thread = _Thread(target=worker)
+        self.worker_thread.daemon = True
+        self.worker_thread.start()
+
+        self.buffer_reset_queue = buffer_reset_queue
+        self.buffer_size = buffer_size
+
+        # Create the initial buffer and send it to the background thread, so
+        # that it begins sending us annotated images.
+        self.buffer = _Queue(self.buffer_size)
+        self.buffer_reset_queue.put(self.buffer)
+
+    def __del__(self):
+        # Tell the background thread to shut down.
+        self.buffer_reset_queue.put(None)
+
+        # Drain self.buffer to ensure that the background thread isn't stuck
+        # waiting to put something into it (and therefore never receives the
+        # shutdown request).
+        if self.buffer is not None:
+            while self.buffer.get() is not None:
+                pass
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self._next()
+
+    def next(self):
+        return self._next()
+
+    def _next(self):
+        # Guard against repeated calls after we've finished.
+        if self.buffer is None:
+            raise StopIteration
+
+        result = self.buffer.get()
+        if result is None:
+            # Any future attempt to get from self.buffer will block forever,
+            # since the background thread won't put anything else into it.
+            self.buffer = None
+            raise StopIteration
+
+        return result
+
+    def reset(self):
+        # Send a new buffer to the background thread, telling it to reset.
+        buffer = _Queue(self.buffer_size)
+        self.buffer_reset_queue.put(buffer)
+
+        # Drain self.buffer to ensure that the background thread isn't stuck
+        # waiting to put something into it (and therefore never receives the
+        # new buffer).
+        if self.buffer is not None:
+            while self.buffer.get() is not None:
+                pass
+
+        self.buffer = buffer
+
+
 class SFrameDetectionIter(_mx.io.DataIter):
     def __init__(self,
                  sframe,
@@ -58,6 +206,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
                  loader_type='augmented',
                  load_labels=True,
                  shuffle=True,
+                 use_io_threads=False,
                  epochs=None,
                  iterations=None):
 
@@ -103,32 +252,23 @@ class SFrameDetectionIter(_mx.io.DataIter):
         self.input_shape = input_shape
         self.output_shape = output_shape
         self.num_classes = num_classes
-        self.feature_column = feature_column
-        self.annotations_column = annotations_column
         self.anchors = anchors
-        self.load_labels = load_labels
         self.class_to_index = class_to_index
-        self.shuffle = shuffle
-        self.cur_epoch = 0
-        self.cur_sample = 0
         self.cur_iteration = 0
         self.num_epochs = epochs
         self.num_iterations = iterations
 
-        # Make shallow copy, so that temporary columns do not change input
-        self.sframe = sframe.copy()
-
-        if self.load_labels:
+        if load_labels:
             is_annotations_list = sframe[annotations_column].dtype == list
             # Check that all annotations are valid
             if is_annotations_list:
-                valids = self.sframe[annotations_column].apply(_is_valid_annotations_list)
+                valids = sframe[annotations_column].apply(_is_valid_annotations_list)
             else:
-                valids = self.sframe[annotations_column].apply(_is_valid_annotation)
+                valids = sframe[annotations_column].apply(_is_valid_annotation)
                 # Deal with Nones, which are valid (pure negatives)
                 valids = valids.fillna(1)
 
-            if valids.nnz() != len(self.sframe):
+            if valids.nnz() != len(sframe):
                 # Fetch invalid row ids
                 invalid_ids = _tc.SFrame({'valid': valids}).add_row_number()[valids == 0]['id']
                 count = len(invalid_ids)
@@ -138,7 +278,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
                 for row_id in invalid_ids[:num_examples]:
                     # Find which annotations were invalid in the list
                     s += "\n\nRow ID {}:".format(row_id)
-                    anns = self.sframe[row_id][annotations_column]
+                    anns = sframe[row_id][annotations_column]
                     if not isinstance(anns, list):
                         anns = [anns]
                     for ann in anns:
@@ -154,8 +294,28 @@ class SFrameDetectionIter(_mx.io.DataIter):
                     "the latter being a dictionary that defines 'x', 'y', 'width', and 'height'.\n"
                     "The following row(s) did not conform to this format:" + s)
 
-        # Convert images to raw to eliminate overhead of decoding
-        self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[self.feature_column].apply(_convert_image_to_raw)
+        # Compute the number of times we'll read a row from the SFrame.
+        sample_limits = []
+        if iterations is not None:
+            sample_limits.append(iterations * batch_size)
+        if epochs is not None:
+            sample_limits.append(epochs * len(sframe))
+        samples = min(sample_limits) if len(sample_limits) > 0 else None
+        if use_io_threads:
+            # Delegate SFrame operations to a background thread, leaving this
+            # thread to Python-based work of copying to MxNet and scheduling
+            # augmentation work in the MXNet backend.
+            #
+            # Note that the large buffer size is an attempt to mitigate against
+            # the SFrame shuffle operation that can occur after each epoch.
+            self.data_source = _SFrameAsyncDataSource(
+                sframe, feature_column, annotations_column,
+                load_labels=load_labels, shuffle=shuffle, samples=samples,
+                buffer_size=batch_size*8)
+        else:
+            self.data_source = _SFrameDataSource(
+                sframe, feature_column, annotations_column,
+                load_labels=load_labels, shuffle=shuffle, samples=samples)
 
         self._provide_data = [
             _mx.io.DataDesc(name='image',
@@ -174,7 +334,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
         return self
 
     def reset(self):
-        self.cur_sample = 0
+        self.data_source.reset()
         self.cur_iteration = 0
 
     def __next__(self):
@@ -191,12 +351,6 @@ class SFrameDetectionIter(_mx.io.DataIter):
     def provide_label(self):
         return self._provide_label
 
-    @property
-    def has_next(self):
-        return not (self.cur_epoch == self.num_epochs or
-                    self.cur_iteration == self.num_iterations or
-                    len(self.sframe) == 0)
-
     def _next(self):
         images = []
         ymaps = []
@@ -204,7 +358,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
         orig_shapes = []
         bboxes = []
         classes = []
-        if not self.has_next:
+        if self.cur_iteration == self.num_iterations:
             raise StopIteration
 
         # Since we pre-screened the annotations, at this point we just want to
@@ -214,18 +368,29 @@ class SFrameDetectionIter(_mx.io.DataIter):
 
         pad = None
         for b in range(self.batch_size):
-            row = self.sframe[self.cur_sample]
-            orig_image = _mx.nd.array(row[_TMP_COL_RAW_IMAGE].pixel_data)
+            try:
+                row = next(self.data_source)
+            except StopIteration:
+                if b == 0:
+                    # Don't return an empty batch.
+                    raise
+                else:
+                    # It's time to finish, so we need to pad the batch
+                    pad = self.batch_size - b
+                    for p in range(pad):
+                        images.append(_mx.nd.zeros(images[0].shape))
+                        ymaps.append(_mx.nd.zeros(ymaps[0].shape))
+                        indices.append(0)
+                        orig_shapes.append([0, 0, 0])
+                    break
 
+            raw_image, label, cur_sample = row
+
+            orig_image = _mx.nd.array(raw_image)
             image = orig_image
             oshape = orig_image.shape
-            if self.load_labels:
-                label = row[self.annotations_column]
-                if label == None:
-                    label = []
-                elif type(label) == dict:
-                    label = [label]
 
+            if label is not None:
                 # Unchanged boxes, for evaluation
                 raw_bbox = _np.array([[
                         ann['coordinates']['x'],
@@ -266,27 +431,10 @@ class SFrameDetectionIter(_mx.io.DataIter):
 
             images.append(_mx.nd.transpose(image01, [2, 0, 1]))
             ymaps.append(ymap)
-            indices.append(self.cur_sample)
+            indices.append(cur_sample)
             orig_shapes.append(oshape)
             bboxes.append(raw_bbox)
             classes.append(bbox[:, 0].astype(_np.int32))
-
-            self.cur_sample += 1
-            if self.cur_sample == len(self.sframe):
-                self.cur_epoch += 1
-                if self.cur_epoch == self.num_epochs:
-                    # It's time to finish, so we need to pad the batch
-                    pad = self.batch_size - b - 1
-                    for p in range(pad):
-                        images.append(_mx.nd.zeros(images[0].shape))
-                        ymaps.append(_mx.nd.zeros(ymaps[0].shape))
-                        indices.append(0)
-                        orig_shapes.append([0, 0, 0])
-                    break
-                self.cur_sample = 0
-                if self.shuffle:
-                    self.sframe[_TMP_COL_RANDOM_ORDER] = _np.random.uniform(size=len(self.sframe))
-                    self.sframe = self.sframe.sort(_TMP_COL_RANDOM_ORDER)
 
         b_images = _mx.nd.stack(*images)
         b_ymaps = _mx.nd.stack(*ymaps)

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -206,7 +206,7 @@ class SFrameDetectionIter(_mx.io.DataIter):
                  loader_type='augmented',
                  load_labels=True,
                  shuffle=True,
-                 use_io_threads=False,
+                 io_thread_buffer_size=0,
                  epochs=None,
                  iterations=None):
 
@@ -301,17 +301,14 @@ class SFrameDetectionIter(_mx.io.DataIter):
         if epochs is not None:
             sample_limits.append(epochs * len(sframe))
         samples = min(sample_limits) if len(sample_limits) > 0 else None
-        if use_io_threads:
+        if io_thread_buffer_size > 0:
             # Delegate SFrame operations to a background thread, leaving this
             # thread to Python-based work of copying to MxNet and scheduling
             # augmentation work in the MXNet backend.
-            #
-            # Note that the large buffer size is an attempt to mitigate against
-            # the SFrame shuffle operation that can occur after each epoch.
             self.data_source = _SFrameAsyncDataSource(
                 sframe, feature_column, annotations_column,
                 load_labels=load_labels, shuffle=shuffle, samples=samples,
-                buffer_size=batch_size*8)
+                buffer_size=io_thread_buffer_size * batch_size)
         else:
             self.data_source = _SFrameDataSource(
                 sframe, feature_column, annotations_column,

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -247,7 +247,9 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         'learning_rate': 1.0e-3,
         'shuffle': True,
         'mps_loss_mult': 8,
-        'use_io_threads': True,
+        # This large buffer size (8 batches) is an attempt to mitigate against
+        # the SFrame shuffle operation that can occur after each epoch.
+        'io_thread_buffer_size': 8,
     }
 
     if '_advanced_parameters' in kwargs:
@@ -274,7 +276,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
     # to be problematic to run independently of a MXNet-powered neural network
     # in a separate thread. For this reason, we restrict IO threads to when
     # the neural network backend is MPS.
-    use_io_threads = use_mps and params['use_io_threads']
+    io_thread_buffer_size = params['io_thread_buffer_size'] if use_mps else 0
 
     if verbose:
         if use_mps:
@@ -335,7 +337,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
                                   loader_type='augmented',
                                   feature_column=feature,
                                   annotations_column=annotations,
-                                  use_io_threads=use_io_threads,
+                                  io_thread_buffer_size=io_thread_buffer_size,
                                   iterations=num_iterations)
 
     # Predictions per anchor box: x/y + w/h + object confidence + class probs

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -376,6 +376,35 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
     # easily hide bugs caused by names getting out of sync.
     ref_model.available_parameters_subset(net_params).load(ref_model.model_path, ctx)
 
+    if verbose:
+        # Print progress table header
+        column_names = ['Iteration', 'Loss', 'Elapsed Time']
+        num_columns = len(column_names)
+        column_width = max(map(lambda x: len(x), column_names)) + 2
+        hr = '+' + '+'.join(['-' * column_width] * num_columns) + '+'
+        print(hr)
+        print(('| {:<{width}}' * num_columns + '|').format(*column_names, width=column_width-1))
+        print(hr)
+
+    progress = {'smoothed_loss': None, 'last_time': 0}
+    iteration = 0
+
+    def update_progress(cur_loss, iteration):
+        iteration_base1 = iteration + 1
+        if progress['smoothed_loss'] is None:
+            progress['smoothed_loss'] = cur_loss
+        else:
+            progress['smoothed_loss'] = 0.9 * progress['smoothed_loss'] + 0.1 * cur_loss
+        cur_time = _time.time()
+        if verbose and (cur_time > progress['last_time'] + 10 or
+                        iteration_base1 == max_iterations):
+            # Print progress table row
+            elapsed_time = cur_time - start_time
+            print("| {cur_iter:<{width}}| {loss:<{width}.3f}| {time:<{width}.1f}|".format(
+                cur_iter=iteration_base1, loss=progress['smoothed_loss'],
+                time=elapsed_time , width=column_width-1))
+            progress['last_time'] = cur_time
+
     if use_mps:
         net.forward(_mx.nd.uniform(0, 1, (batch_size_each,) + input_image_shape))
         mps_net_params = {}
@@ -414,7 +443,104 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
                                   anchors=anchors,
                                   config=mps_config,
                                   weights=mps_net_params)
-    else:
+
+        # Use worker threads to isolate different points of synchronization
+        # and/or waiting for non-Python tasks to finish. The
+        # sframe_worker_thread will spend most of its time waiting for SFrame
+        # operations, largely image I/O and decoding, along with scheduling
+        # MXNet data augmentation. The numpy_worker_thread will spend most of
+        # its time waiting for MXNet data augmentation to complete, along with
+        # copying the results into NumPy arrays. Finally, the main thread will
+        # spend most of its time copying NumPy data into MPS and waiting for the
+        # results. Note that using three threads here only makes sense because
+        # each thread spends time waiting for non-Python code to finish (so that
+        # no thread hogs the global interpreter lock).
+        mxnet_batch_queue = _Queue(1)
+        numpy_batch_queue = _Queue(1)
+        def sframe_worker():
+            # Once a batch is loaded into NumPy, pass it immediately to the
+            # numpy_worker so that we can start I/O and decoding for the next
+            # batch.
+            for batch in loader:
+                mxnet_batch_queue.put(batch)
+            mxnet_batch_queue.put(None)
+        def numpy_worker():
+            while True:
+                batch = mxnet_batch_queue.get()
+                if batch is None:
+                    break
+
+                for x, y in zip(batch.data, batch.label):
+                    # Convert to NumPy arrays with required shapes. Note that
+                    # asnumpy waits for any pending MXNet operations to finish.
+                    input_data = _mxnet_to_mps(x.asnumpy())
+                    label_data = y.asnumpy().reshape(y.shape[:-2] + (-1,))
+
+                    # Convert to packed 32-bit arrays.
+                    input_data = input_data.astype(_np.float32)
+                    if not input_data.flags.c_contiguous:
+                        input_data = input_data.copy()
+                    label_data = label_data.astype(_np.float32)
+                    if not label_data.flags.c_contiguous:
+                        label_data = label_data.copy()
+
+                    # Push this batch to the main thread.
+                    numpy_batch_queue.put({'input'     : input_data,
+                                           'label'     : label_data,
+                                           'iteration' : batch.iteration})
+            # Tell the main thread there's no more data.
+            numpy_batch_queue.put(None)
+        sframe_worker_thread = _Thread(target=sframe_worker)
+        sframe_worker_thread.start()
+        numpy_worker_thread = _Thread(target=numpy_worker)
+        numpy_worker_thread.start()
+
+        batches_started = 0
+        batches_finished = 0
+        while True:
+            batch = numpy_batch_queue.get()
+            if batch is None:
+                break
+
+            # Adjust learning rate according to our schedule.
+            if batch['iteration'] in steps:
+                ii = steps.index(batch['iteration']) + 1
+                new_lr = factors[ii] * base_lr
+                mps_net.set_learning_rate(new_lr / mps_loss_mult)
+
+            # Submit this match to MPS.
+            mps_net.start_batch(batch['input'], label=batch['label'])
+            batches_started += 1
+
+            # If we have two batches in flight, wait for the first one.
+            if batches_started - batches_finished > 1:
+                batches_finished += 1
+                cur_loss = mps_net.wait_for_batch().sum() / mps_loss_mult
+
+                # If we just submitted the first batch of an iteration, update
+                # progress for the iteration completed by the last batch we just
+                # waited for.
+                if batch['iteration'] > iteration:
+                    update_progress(cur_loss, iteration)
+            iteration = batch['iteration']
+
+        # Wait for any pending batches and finalize our progress updates.
+        while batches_finished < batches_started:
+            batches_finished += 1
+            cur_loss = mps_net.wait_for_batch().sum() / mps_loss_mult
+        update_progress(cur_loss, iteration)
+
+        sframe_worker_thread.join()
+        numpy_worker_thread.join()
+
+        # Load back into mxnet
+        mps_net_params = mps_net.export()
+        keys = mps_net_params.keys()
+        for k in keys:
+            if k in net_params:
+                net_params[k].set_data(_mps_to_mxnet(mps_net_params[k]))
+
+    else:  # Use MxNet
         options = {'learning_rate': base_lr, 'lr_scheduler': lr_scheduler,
                    'momentum': params['sgd_momentum'], 'wd': params['weight_decay'], 'rescale_grad': 1.0}
         clip_grad = params.get('clip_gradients')
@@ -422,22 +548,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
             options['clip_gradient'] = clip_grad
         trainer = _mx.gluon.Trainer(net.collect_params(), 'sgd', options)
 
-    progress = {'smoothed_loss': None, 'last_time': 0}
-
-    def handle_request(batch):
-        if use_mps:
-            for x, y in zip(batch.data, batch.label):
-                input_data = _mxnet_to_mps(x.asnumpy())
-                label_data = y.asnumpy().reshape(y.shape[:-2] + (-1,))
-
-                if batch.iteration in steps:
-                    ii = steps.index(batch.iteration) + 1
-                    new_lr = factors[ii] * base_lr
-                    mps_net.set_learning_rate(new_lr / mps_loss_mult)
-
-                mps_net.start_batch(input_data, label=label_data)
-                cur_loss = mps_net.wait_for_batch().sum() / mps_loss_mult
-        else:
+        for batch in loader:
             data = _mx.gluon.utils.split_and_load(batch.data[0], ctx_list=ctx, batch_axis=0)
             label = _mx.gluon.utils.split_and_load(batch.label[0], ctx_list=ctx, batch_axis=0)
 
@@ -455,79 +566,9 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
 
             trainer.step(1)
             cur_loss = _np.mean([L.asnumpy()[0] for L in Ls])
-        return cur_loss
 
-    def consume_response(cur_loss, iteration):
-        iteration_base1 = iteration + 1
-        if progress['smoothed_loss'] is None:
-            progress['smoothed_loss'] = cur_loss
-        else:
-            progress['smoothed_loss'] = 0.9 * progress['smoothed_loss'] + 0.1 * cur_loss
-        cur_time = _time.time()
-        if verbose and (cur_time > progress['last_time'] + 10 or
-                        iteration_base1 == max_iterations):
-            # Print progress table row
-            elapsed_time = cur_time - start_time
-            print("| {cur_iter:<{width}}| {loss:<{width}.3f}| {time:<{width}.1f}|".format(
-                cur_iter=iteration_base1, loss=progress['smoothed_loss'],
-                time=elapsed_time , width=column_width-1))
-            progress['last_time'] = cur_time
-
-    request_queue = _Queue()
-    response_queue = _Queue()
-
-    if verbose:
-        # Print progress table header
-        column_names = ['Iteration', 'Loss', 'Elapsed Time']
-        num_columns = len(column_names)
-        column_width = max(map(lambda x: len(x), column_names)) + 2
-        hr = '+' + '+'.join(['-' * column_width] * num_columns) + '+'
-        print(hr)
-        print(('| {:<{width}}' * num_columns + '|').format(*column_names, width=column_width-1))
-        print(hr)
-
-    iteration = 0
-    if not use_io_threads:
-        for batch in loader:
-            cur_loss = handle_request(batch)
-            consume_response(cur_loss, batch.iteration)
+            update_progress(cur_loss, batch.iteration)
             iteration = batch.iteration
-    else:
-        def model_worker():
-            while True:
-                batch = request_queue.get()  # Consume request
-                if batch is None:
-                    # No more work remains. Allow the thread to finish.
-                    return
-                response_queue.put((handle_request(batch), batch.iteration))  # Produce response
-        model_worker_thread = _Thread(target=model_worker)
-        model_worker_thread.start()
-
-        try:
-            # Attempt to have two requests in progress at any one time (double
-            # buffering), so that the iterator is creating one batch while MXNet
-            # performs inference on the other.
-            if loader.has_next:
-                request_queue.put(next(loader))
-                while loader.has_next:
-                    request_queue.put(next(loader))
-                    consume_response(*response_queue.get())
-                consume_response(*response_queue.get())
-
-        finally:
-            # Tell the worker thread to shut down.
-            request_queue.put(None)
-
-        model_worker_thread.join()
-
-    # If mps was used, load model back into mxnet
-    if use_mps:
-        mps_net_params = mps_net.export()
-        keys = mps_net_params.keys()
-        for k in keys:
-            if k in net_params:
-                net_params[k].set_data(_mps_to_mxnet(mps_net_params[k]))
-
 
     training_time = _time.time() - start_time
     if verbose:

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -335,6 +335,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
                                   loader_type='augmented',
                                   feature_column=feature,
                                   annotations_column=annotations,
+                                  use_io_threads=use_io_threads,
                                   iterations=num_iterations)
 
     # Predictions per anchor box: x/y + w/h + object confidence + class probs
@@ -593,7 +594,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         'num_examples': num_images,
         'num_bounding_boxes': num_instances,
         'training_time': training_time,
-        'training_epochs': loader.cur_epoch,
+        'training_epochs': training_iterations * batch_size // num_images,
         'training_iterations': training_iterations,
         'max_iterations': max_iterations,
         'training_loss': progress['smoothed_loss'],

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.mm
@@ -53,7 +53,7 @@ void MPSCNNModule::Init(int network_id, int n, int c_in, int h_in, int w_in,
   LowLevelMode network_mode = (LowLevelMode) get_array_map_scalar(config, "mode", kLowLevelModeTrain);
 
   if (kLowLevelModeTest == network_mode){
-      MPSImageDescriptor *output_desc = [MPSImageDescriptor
+      output_desc_ = [MPSImageDescriptor
           imageDescriptorWithChannelFormat:MPSImageFeatureChannelFormatFloat32
                                      width:w_out
                                     height:h_out

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
@@ -1,33 +1,59 @@
 #ifndef MPS_GRAPH_MODULE_H_
 #define MPS_GRAPH_MODULE_H_
 
-#include <assert.h>
-#import <vector>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 
-#import <dispatch/dispatch.h>
-#import <Accelerate/Accelerate.h>
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
-#import "mps_dev.h"
 #import "mps_utils.h"
 #import "mps_graph_networks.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+// Forward declaration of internal Objective-C class used in the implementation
+// of MPSGraphModule below.
+@class TCMPSGraphModuleBatch;
 
 class MPSGraphModule {
 public:
   MPSGraphModule();
-  ~MPSGraphModule();
+
   void Init(int network_id, int n, int c_in, int h_in, int w_in, int c_out,
             int h_out, int w_out,
             const FloatArrayMap &config,
             const FloatArrayMap &weights);
+
+  // Each call to a Start*Batch function must be paired with a call to a
+  // WaitFor*Batch function. These functions must match the graph mode used to
+  // initialize the module.
+  //
+  // TODO: Replace this API with a more user-friendly one: each Start*Batch
+  // function could return a handle wrapping the MPSImage containing the
+  // expected output. Attempting to read from the MPSImage would trigger a wait
+  // if necessary, a la MXNet NDArray.
+
+  // Training
   void SetLearningRate(float lr);
-  void SetInput(void * _Nonnull ptr, int64_t sz, int64_t * _Nonnull shape, int dim, int flag);
-  void SetLossState(float *ptr);
-  void RunGraph(float *out = nullptr, float *loss = nullptr);
-  void WaitUntilCompleted();
+  void StartTrainingBatch(void *ptr, int64_t sz, int64_t *shape, int dim,
+                          float *labels_ptr);
+  void WaitForTrainingBatch(float *loss);
+
+  // Inference
+  void StartInferenceBatch(void *ptr, int64_t sz, int64_t *shape, int dim);
+  void WaitForInferenceBatch(float *out_ptr);
+
+  // Forward-backward pass with specified input and top-gradient images
+  void StartTrainReturnGradBatch(void *ptr, int64_t sz, int64_t *shape, int dim,
+                                 void *grad_ptr, int64_t grad_sz,
+                                 int64_t *grad_shape, int grad_dim);
+  void WaitForTrainReturnGradBatch(float *out_ptr);
+
   void Export();
   int NumParams();
 
@@ -36,23 +62,28 @@ public:
       table_;
 
 private:
-  void SetupNetwork(int network_id, const std::vector<int> &params);
+  MPSImageBatch *CreateImageBatch(MPSImageDescriptor *desc);
+  MPSImageBatch *CopyInput(void *ptr, int64_t sz, int64_t *shape, int dim);
+  MPSImageBatch *CopyGrad(void *ptr, int64_t sz, int64_t *shape, int dim);
+  MPSCNNLossLabelsBatch *CopyLabels(float *ptr);
 
-private:
-  id<MTLDevice> _Nonnull dev_;
-  id<MTLCommandQueue> _Nonnull cmd_queue_;
-  id<MTLCommandBuffer> _Nullable last_cmd_buf_ = nil;
-  dispatch_semaphore_t _Nonnull double_buffering_semaphore_;
-  MPSImageBatch *_Nonnull input_;
-  MPSImageBatch *_Nonnull output_;
-  MPSImageBatch *_Nonnull grad_;
-  MPSCNNLossLabelsBatch * _Nonnull loss_state_ = nil;
-  MPSGraphNetwork *_Nonnull network_;
+  void Blob2MPSImage(float *ptr, MPSImageBatch *batch);
+  void MPSImage2Blob(float *ptr, MPSImageBatch *batch);
+
+  id<MTLDevice> dev_;
+  id<MTLCommandQueue> cmd_queue_;
+  NSMutableArray<TCMPSGraphModuleBatch *> *pending_batches_;
+
   GraphMode mode_;
+  std::unique_ptr<MPSGraphNetwork> network_;
 
-private:
-  void Blob2MPSImage(float *_Nonnull ptr, MPSImageBatch *_Nonnull batch);
-  void MPSImage2Blob(float *_Nonnull ptr, MPSImageBatch *_Nonnull batch);
+  MPSImageDescriptor * _Nullable input_desc_ = nil;
+  MPSImageDescriptor * _Nullable output_desc_ = nil;
+
+  MPSImageBatch * _Nullable recycled_input_ = nil;
+  MPSImageBatch * _Nullable recycled_grad_ = nil;
 };
+
+NS_ASSUME_NONNULL_END
 
 #endif

--- a/src/unity/toolkits/tcmps/mps_graph_networks.h
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.h
@@ -49,9 +49,9 @@ struct MPSGraphNetwork {
 };
 
 // Factory function to create a network
-MPSGraphNetwork *_Nonnull createNetworkGraph(GraphNetworkType network_id,
-                                             const std::vector<int> &params,
-                                             const FloatArrayMap &config);
+std::unique_ptr<MPSGraphNetwork> createNetworkGraph(
+    GraphNetworkType network_id, const std::vector<int> &params,
+    const FloatArrayMap &config);
 
 // Various networks
 // ---------------------------------------------------------------------------------------------

--- a/src/unity/toolkits/tcmps/mps_graph_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.mm
@@ -11,23 +11,30 @@
 + (BOOL)supportsSecureCoding;
 @end
 
-MPSGraphNetwork *_Nonnull createNetworkGraph(GraphNetworkType network_id,
-                                             const std::vector<int> &params,
-                                             const FloatArrayMap &config) {
+std::unique_ptr<MPSGraphNetwork> createNetworkGraph(
+    GraphNetworkType network_id, const std::vector<int> &params,
+    const FloatArrayMap &config) {
+  std::unique_ptr<MPSGraphNetwork> result;
   switch (network_id) {
   case kSingleReLUGraphNet:
-    return new SingleReLUNetworkGraph(params, config);
+    result.reset(new SingleReLUNetworkGraph(params, config));
+    break;
   case kSingleConvGraphNet:
-    return new SingleConvNetworkGraph(params, config);
+    result.reset(new SingleConvNetworkGraph(params, config));
+    break;
   case kSingleMPGraphNet:
-    return new SingleMPNetworkGraph(params, config);
+    result.reset(new SingleMPNetworkGraph(params, config));
+    break;
   case kSingleBNGraphNet:
-    return new SingleBNNetworkGraph(params, config);
+    result.reset(new SingleBNNetworkGraph(params, config));
+    break;
   case kODGraphNet:
-    return new ODNetworkGraph(params, config);
+    result.reset(new ODNetworkGraph(params, config));
+    break;
   default:
     throw std::invalid_argument("Undefined network.");
   }
+  return result;
 }
 
 // MPS Network base class

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.h
@@ -32,11 +32,18 @@ EXPORT int MetalDeviceName(char *name, int max_len);
 EXPORT int CreateMPSGraph(MPSHandle *handle);
 EXPORT int DeleteMPSGraph(MPSHandle handle);
 
-EXPORT int SetInputGraph(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim, int flag);
-EXPORT int SetLossStateGraph(MPSHandle handle, void *ptr);
+EXPORT int StartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+                                   int64_t *shape, int dim, float *labels_ptr);
+EXPORT int WaitForTrainingBatchGraph(MPSHandle handle, float *loss);
 
-EXPORT int RunGraph(MPSHandle handle, float *out, float *loss);
-EXPORT int WaitUntilCompletedGraph(MPSHandle handle);
+EXPORT int StartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+                                    int64_t *shape, int dim);
+EXPORT int WaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr);
+
+EXPORT int StartTrainReturnGradBatchGraph(
+    MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
+    void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim);
+EXPORT int WaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr);
 
 EXPORT int InitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
                      int c_out, int h_out, int w_out,

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.mm
@@ -37,33 +37,51 @@ int DeleteMPSGraph(MPSHandle handle) {
   API_END();
 }
 
-int SetInputGraph(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
-             int flag) {
+int StartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+                            int64_t *shape, int dim, float *labels_ptr) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->SetInput(ptr, sz, shape, dim, flag);
+  obj->StartTrainingBatch(ptr, sz, shape, dim, labels_ptr);
   API_END();
 }
 
-int SetLossStateGraph(MPSHandle handle, void *ptr) {
+int WaitForTrainingBatchGraph(MPSHandle handle, float *loss) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->SetLossState((float *)ptr);
+  obj->WaitForTrainingBatch(loss);
   API_END();
 }
 
-int RunGraph(MPSHandle handle, float *out, float *loss) {
+int StartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+                             int64_t *shape, int dim) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->RunGraph(out, loss);
+  obj->StartInferenceBatch(ptr, sz, shape, dim);
   API_END();
 }
 
-int WaitUntilCompletedGraph(MPSHandle handle) {
-    API_BEGIN();
-    MPSGraphModule *obj = (MPSGraphModule *)handle;
-    obj->WaitUntilCompleted();
-    API_END();
+int WaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr) {
+  API_BEGIN();
+  MPSGraphModule *obj = (MPSGraphModule *)handle;
+  obj->WaitForInferenceBatch(out_ptr);
+  API_END();
+}
+
+int StartTrainReturnGradBatchGraph(
+    MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
+    void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim) {
+  API_BEGIN();
+  MPSGraphModule *obj = (MPSGraphModule *)handle;
+  obj->StartTrainReturnGradBatch(ptr, sz, shape, dim,
+                                 grad_ptr, grad_sz, grad_shape, grad_dim);
+  API_END();
+}
+
+int WaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr) {
+  API_BEGIN();
+  MPSGraphModule *obj = (MPSGraphModule *)handle;
+  obj->WaitForTrainReturnGradBatch(out_ptr);
+  API_END();
 }
 
 int InitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,

--- a/src/unity/toolkits/tcmps/mps_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_layers.mm
@@ -449,7 +449,6 @@ void BNLayer::Load(const FloatArrayMap &weights) {
   std::string beta_key = name + "_beta";
   std::string var_key = name + "_running_var";
   std::string mean_key = name + "_running_mean";
-  int num_channel = ishape[3];
 
   if (weights.count(gamma_key) > 0){
     const FloatArray &arr = weights.at(gamma_key);
@@ -702,7 +701,6 @@ void SmceLossLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_
                          const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
 
   assert(iparams.size() >= 1);
-  int batch_size = iparams[0];
 
   MPSCNNLossDescriptor *lossDesc = [MPSCNNLossDescriptor
       cnnLossDescriptorWithType:MPSCNNLossTypeSoftMaxCrossEntropy

--- a/src/unity/toolkits/tcmps/mps_utils.h
+++ b/src/unity/toolkits/tcmps/mps_utils.h
@@ -42,7 +42,8 @@ struct OptimizerOptions {
   float adamBeta1;
   float adamBeta2;
   float adamEpsilon;
-  
+
+  API_AVAILABLE(macos(10.14))
   MPSNNOptimizerDescriptor * _Nonnull mpsDescriptor() {
     
     MPSNNRegularizationType regType;
@@ -109,7 +110,12 @@ enum LowLevelMode {
 //
 
 // Sum image along all dimensions
+API_AVAILABLE(macos(10.14))
 float sumImage(MPSImage * _Nonnull image);
+
+// The API_AVAILABLE macro does not play well with C++ function templates.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
 
 template<typename T>
 float sumSingleImage(MPSImage * _Nonnull image){
@@ -125,5 +131,7 @@ float sumSingleImage(MPSImage * _Nonnull image){
   }
   return sum;
 }
+
+#pragma clang diagnostic pop
 
 #endif /* mps_utils_h */

--- a/src/unity/toolkits/tcmps/mps_weight.h
+++ b/src/unity/toolkits/tcmps/mps_weight.h
@@ -32,6 +32,7 @@
 #import <vector>
 #import "mps_utils.h"
 
+API_AVAILABLE(macos(10.14))
 @interface RandomWeights : NSObject <MPSCNNConvolutionDataSource> {
 @private
   NSUInteger _outputFeatureChannels;
@@ -117,6 +118,7 @@ updateWithCommandBuffer:(__nonnull id<MTLCommandBuffer>)commandBuffer
 - (void)checkpointWithCommandQueue:(nonnull id<MTLCommandQueue>)commandQueue;
 @end /* RandomWeights */
 
+API_AVAILABLE(macos(10.14))
 @interface BNData : NSObject <MPSCNNBatchNormalizationDataSource> {
 @private
   NSUInteger _channels;


### PR DESCRIPTION
With these changes, training an object-detection model for our demo dataset takes around 31 minutes on an iMac Pro, instead of 55.

- Resolve warnings in the TC-MPS library
- Replace the synchronous API for evaluating an MPS graph with an async one
- On the Python side, use four threads: one that waits for SFrame operations, one Python-heavy one that schedules data augmentation, one that waits for data augmentation and copies into NumPy, and one that copies into MPS and waits for MPS.

We still don't keep the GPU busy all the time, but it's not clear how much farther we can get with so much logic implemented in Python and subject to the global interpreter lock.