### PR TITLE
Fix build on 10.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,16 +103,6 @@ if(WIN32 AND MINGW)
   SET(COMPILER_FLAGS "${COMPILER_FLAGS} -Wa,-mbig-obj")
 endif()
 
-if(TC_BUILD_IOS)
-  EXECUTE_PROCESS(
-    COMMAND xcrun --sdk iphoneos --show-sdk-path
-    OUTPUT_VARIABLE IOS_ISYSROOT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  SET(CMAKE_OSX_SYSROOT "${IOS_ISYSROOT}")
-  SET(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-c++11-narrowing -isysroot ${IOS_ISYSROOT}")
-endif()
-
 set(MINGW_ROOT "/mingw64/bin")
 # Separate variable so that cython's CMakeLists.txt can use it too
 if (WIN32)
@@ -721,22 +711,35 @@ endfunction()
 
 
 if(APPLE)
-  EXEC_PROGRAM(xcrun ARGS --show-sdk-version OUTPUT_VARIABLE mac_version RETURN_VALUE _xcrun_ret)
+  SET(TC_BASE_SDK macosx)
+  if(TC_BUILD_IOS)
+    SET(TC_BASE_SDK iphoneos)
+    SET(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-c++11-narrowing")
+  endif()
 
+  EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-version OUTPUT_VARIABLE TC_BASE_SDK_VERSION RETURN_VALUE _xcrun_ret)
   if(NOT ${_xcrun_ret} EQUAL 0)
     message(ERROR, "xcrun command failed with return code ${_xcrun_ret}.")
   endif()
 
+  EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-path OUTPUT_VARIABLE TC_BASE_SDK_PATH RETURN_VALUE _xcrun_ret)
+  if(NOT ${_xcrun_ret} EQUAL 0)
+    message(ERROR, "xcrun command failed with return code ${_xcrun_ret}.")
+  endif()
+
+  SET(CMAKE_OSX_SYSROOT "${TC_BASE_SDK_PATH}")
+  SET(COMPILER_FLAGS "${COMPILER_FLAGS} -isysroot ${TC_BASE_SDK_PATH}")
+
   # Core ML is only present on macOS 10.13 or higher.
   # Logic reversed to get around what seems to be a CMake bug.
-  if(NOT mac_version VERSION_LESS 10.13)
+  if(NOT TC_BASE_SDK_VERSION VERSION_LESS 10.13)
     add_definitions(-DHAS_CORE_ML)
     set(HAS_CORE_ML TRUE)
   endif()
 
   # Core ML only supports batch inference on macOS 10.14 or higher
   # Logic reversed to get around what seems to be a CMake bug.
-  if(NOT mac_version VERSION_LESS 10.14)
+  if(NOT TC_BASE_SDK_VERSION VERSION_LESS 10.14)
     add_definitions(-DHAS_CORE_ML_BATCH_INFERENCE)
 
     # GPU-accelerated training with MPS backend requires macOS 10.14 or higher

--- a/src/toolkits/image_deep_feature_extractor/CMakeLists.txt
+++ b/src/toolkits/image_deep_feature_extractor/CMakeLists.txt
@@ -1,32 +1,16 @@
 if(HAS_CORE_ML)
   project(image_deep_feature_extractor)
 
-  # We need to get the proper SDK paths in the build
-  execute_process(
-    COMMAND bash -c "xcrun --sdk macosx --show-sdk-path"
-    OUTPUT_VARIABLE _macosx_sdk_path
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  message("MacOSX SDK path: ${_macosx_sdk_path}")
-
-  set(_FRAMEWORK_SEARCH_PATH "${_macosx_sdk_path}/System/Library/Frameworks/;/System/Library/Frameworks/")
-
-  message("Framework library search paths: ${_FRAMEWORK_SEARCH_PATH}")
-
-  find_library(core_ml NAMES CoreML
-    REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(core_ml NAMES CoreML)
   message("CoreML found at ${core_ml}.")
 
-  find_library(core_foundation NAMES CoreFoundation
-    REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(core_foundation NAMES CoreFoundation)
   message("CoreFoundation found at ${core_foundation}.")
 
-  find_library(foundation NAMES Foundation
-    REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(foundation NAMES Foundation)
   message("Foundation found at ${foundation}.")
 
-  find_library(core_video NAMES CoreVideo
-    REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(core_video NAMES CoreVideo)
   message("CoreVideo found at ${core_video}.")
 
   make_library(image_deep_feature_extractor


### PR DESCRIPTION
Restructures the use of `xcrun` in CMakeLists to make sure we are
setting appropriate environment variables for base SDK version/path,
then using the default path(s) to find libraries and frameworks. This
(combined with a fix from the iOS build for macOS as well) seems to make
framework header warnings get ignored as part of our build.

Fixes #638