### PR TITLE
Fix libRecommender iOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,14 @@ endif()
 #*                                                                        *
 #**************************************************************************
 if(APPLE)
-  SET(TC_BASE_SDK macosx)
   if(TC_BUILD_IOS)
     SET(TC_BASE_SDK iphoneos)
-    SET(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-c++11-narrowing")
+    SET(COMPILER_FLAGS "${COMPILER_FLAGS} -miphoneos-version-min=12.0 -Wno-c++11-narrowing")
+  else()
+    SET(TC_BASE_SDK macosx)
+
+    # Sets -mmacosx-version-min
+    SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
   endif()
 
   EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-version OUTPUT_VARIABLE TC_BASE_SDK_VERSION RETURN_VALUE _xcrun_ret)
@@ -348,9 +352,6 @@ if(WIN32)
         # like that.
         set(DEBUG_OPTIMIZATION_LEVEL -O2)
 endif()
-
-# Set mac os minimum version
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 
 # Set the debug flags
 set(EXTERNAL_CMAKE_C_FLAGS_DEBUG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,47 @@ endif()
 #*                       Platform Specific Stuff                          *
 #*                                                                        *
 #**************************************************************************
+if(APPLE)
+  SET(TC_BASE_SDK macosx)
+  if(TC_BUILD_IOS)
+    SET(TC_BASE_SDK iphoneos)
+    SET(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-c++11-narrowing")
+  endif()
+
+  EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-version OUTPUT_VARIABLE TC_BASE_SDK_VERSION RETURN_VALUE _xcrun_ret)
+  if(NOT ${_xcrun_ret} EQUAL 0)
+    message(ERROR, "xcrun command failed with return code ${_xcrun_ret}.")
+  endif()
+
+  EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-path OUTPUT_VARIABLE TC_BASE_SDK_PATH RETURN_VALUE _xcrun_ret)
+  if(NOT ${_xcrun_ret} EQUAL 0)
+    message(ERROR, "xcrun command failed with return code ${_xcrun_ret}.")
+  endif()
+
+  SET(CMAKE_OSX_SYSROOT "${TC_BASE_SDK_PATH}")
+  SET(COMPILER_FLAGS "${COMPILER_FLAGS} -isysroot ${TC_BASE_SDK_PATH}")
+
+  # Core ML is only present on macOS 10.13 or higher.
+  # Logic reversed to get around what seems to be a CMake bug.
+  if(NOT TC_BASE_SDK_VERSION VERSION_LESS 10.13)
+    add_definitions(-DHAS_CORE_ML)
+    set(HAS_CORE_ML TRUE)
+  endif()
+
+  # Core ML only supports batch inference on macOS 10.14 or higher
+  # Logic reversed to get around what seems to be a CMake bug.
+  if(NOT TC_BASE_SDK_VERSION VERSION_LESS 10.14)
+    add_definitions(-DHAS_CORE_ML_BATCH_INFERENCE)
+
+    # GPU-accelerated training with MPS backend requires macOS 10.14 or higher
+    set(HAS_MPS TRUE)
+
+    # CoreML MLCustomModel requires macOS 10.14 or higher
+    set(HAS_MLCUSTOMMODEL TRUE)
+  endif()
+endif()
+
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CLANG false)
 elseif(WIN32)
@@ -708,47 +749,6 @@ function (make_boost_test NAME)
 
   add_test(${NAME} ${NAME}test)
 endfunction()
-
-
-if(APPLE)
-  SET(TC_BASE_SDK macosx)
-  if(TC_BUILD_IOS)
-    SET(TC_BASE_SDK iphoneos)
-    SET(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-c++11-narrowing")
-  endif()
-
-  EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-version OUTPUT_VARIABLE TC_BASE_SDK_VERSION RETURN_VALUE _xcrun_ret)
-  if(NOT ${_xcrun_ret} EQUAL 0)
-    message(ERROR, "xcrun command failed with return code ${_xcrun_ret}.")
-  endif()
-
-  EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-path OUTPUT_VARIABLE TC_BASE_SDK_PATH RETURN_VALUE _xcrun_ret)
-  if(NOT ${_xcrun_ret} EQUAL 0)
-    message(ERROR, "xcrun command failed with return code ${_xcrun_ret}.")
-  endif()
-
-  SET(CMAKE_OSX_SYSROOT "${TC_BASE_SDK_PATH}")
-  SET(COMPILER_FLAGS "${COMPILER_FLAGS} -isysroot ${TC_BASE_SDK_PATH}")
-
-  # Core ML is only present on macOS 10.13 or higher.
-  # Logic reversed to get around what seems to be a CMake bug.
-  if(NOT TC_BASE_SDK_VERSION VERSION_LESS 10.13)
-    add_definitions(-DHAS_CORE_ML)
-    set(HAS_CORE_ML TRUE)
-  endif()
-
-  # Core ML only supports batch inference on macOS 10.14 or higher
-  # Logic reversed to get around what seems to be a CMake bug.
-  if(NOT TC_BASE_SDK_VERSION VERSION_LESS 10.14)
-    add_definitions(-DHAS_CORE_ML_BATCH_INFERENCE)
-
-    # GPU-accelerated training with MPS backend requires macOS 10.14 or higher
-    set(HAS_MPS TRUE)
-
-    # CoreML MLCustomModel requires macOS 10.14 or higher
-    set(HAS_MLCUSTOMMODEL TRUE)
-  endif()
-endif()
 
 
 # This is an external function

--- a/src/objc/CMakeLists.txt
+++ b/src/objc/CMakeLists.txt
@@ -1,25 +1,10 @@
 project(TuriCreateObjC)
 
 if(APPLE AND HAS_MLCUSTOMMODEL)
-  set(_SDK_NAME "macosx")
-  if(TC_BUILD_IOS)
-    set(_SDK_NAME "iphoneos")
-  endif()
-
-  execute_process(
-    COMMAND bash -c "xcrun --sdk ${_SDK_NAME} --show-sdk-path" 
-    OUTPUT_VARIABLE _SDK_PATH 
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-  set(_FRAMEWORK_SEARCH_PATH "${_SDK_PATH}/System/Library/Frameworks/;/System/Library/Frameworks/")
-
-  find_library(FOUNDATION NAMES Foundation
-    REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(FOUNDATION NAMES Foundation)
   message("Foundation found at ${FOUNDATION}.")
 
-  find_library(CORE_ML NAMES CoreML
-    REQUIRED PATHS ${_FRAMEWORK_SEARCH_PATH} NO_DEFAULT_PATH)
+  find_library(CORE_ML NAMES CoreML)
   message("CoreML found at ${CORE_ML}.")
 
   make_library(Recommender


### PR DESCRIPTION
- Moves adjustments to COMPILER_FLAGS up before COMPILER_FLAGS is used to construct downstream CMake variables
- Use -miphoneos-version-min instead of -mmacosx-version-min when building for iOS, to avoid copious warnings about -isysroot not matching deployment target
- Update libobjc CMakeLists.txt to avoid redundant xcrun invocation
