### PR TITLE
Fix visualization compatibility on 10.12 & 10.13

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -53,6 +53,10 @@ function download_file {
 
 $python_scripts/$PIP install --upgrade "pip>=8.1"
 $python_scripts/$PIP install -r scripts/requirements.txt
+if [[ $OSTYPE == darwin* ]]; then
+  # macOS only test dependency
+  $python_scripts/$PIP install pyobjc==4.2.2
+fi
 
 mkdir -p deps/local/lib
 mkdir -p deps/local/include

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -17,3 +17,4 @@ six==1.10.0
 statsmodels==0.8.0
 wheel==0.29.0
 mxnet==1.1.0
+UISoup==2.5.7

--- a/src/unity/python/turicreate/test/test_explore.py
+++ b/src/unity/python/turicreate/test/test_explore.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Apple Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-3-clause license that can
+# be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+
+# Futuristic imports
+from __future__ import print_function as _
+from __future__ import division as _
+from __future__ import absolute_import as _
+
+# Built-in imports
+import os
+import signal
+import time
+import unittest
+import uuid
+
+# Library imports
+import six
+
+# Finally, the package under test
+import turicreate as tc
+from turicreate.toolkits._internal_utils import _mac_ver
+
+class ExploreTest(unittest.TestCase):
+
+    @unittest.skipIf(_mac_ver() < (10, 12), "macOS-only test; UISoup doesn't work on Linux")
+    @unittest.skipIf(_mac_ver() > (10, 13), "macOS 10.14 appears to have broken the UX flow to prompt for accessibility access")
+    @unittest.skipIf(not(six.PY2), "Python 2.7-only test; UISoup doesn't work on 3.x")
+    def test_sanity_on_macOS(self):
+        """
+        Create a simple SFrame, containing a very unique string.
+        Then, using uisoup, look for this string within a window
+        and assert that it appears.
+        """
+
+        # Library imports
+        from uisoup import uisoup
+
+        # Generate some test data
+        unique_str = repr(uuid.uuid4())
+        sf = tc.SFrame({'a': [1,2,3], 'b': ['hello', 'world', unique_str]})
+
+        # Run the explore view and make sure we can see our unique string
+        sf.explore()
+        time.sleep(2)
+
+        window = None
+        try:
+            window = uisoup.get_window('Turi*Create*Visualization')
+            result = window.findall(value=unique_str)
+            self.assertEqual(
+                len(result),
+                1,
+                (
+                    "Expected to find exactly one element containing the unique"
+                    "string %s."
+                ) % unique_str
+            )
+            first = result[0]
+            self.assertEqual(
+                first.acc_name,
+                unique_str,
+                (
+                    "Expected to find the unique string %s as the name of the found"
+                    "element. Instead, got %s."
+                ) % (unique_str, first.acc_name)
+            )
+
+        finally:
+            if window is not None:
+                # Kill the explore process
+                os.kill(window.proc_id, signal.SIGTERM)

--- a/src/visualization/Turi Create Visualization.xcodeproj/project.pbxproj
+++ b/src/visualization/Turi Create Visualization.xcodeproj/project.pbxproj
@@ -467,6 +467,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "Turi Create Visualization/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.turi.visualization-client";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
@@ -480,6 +481,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "Turi Create Visualization/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.turi.visualization-client";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;


### PR DESCRIPTION
Also adds a unit test to sanity check the visualization client, to
ensure that at least the explore view of an SFrame shows the contents of
the SFrame.

Fixes #652