### PR TITLE
Propagate -mmacosx-version-min=10.12 to external dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,9 @@ if(APPLE)
   else()
     SET(TC_BASE_SDK macosx)
 
-    # Sets -mmacosx-version-min
-    SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+    # Modify COMPILER_FLAGS instead of setting CMAKE_OSX_DEPLOYMENT_TARGET so
+    # that this setting propagates to external dependencies.
+    SET(COMPILER_FLAGS "${COMPILER_FLAGS} -mmacosx-version-min=10.12")
   endif()
 
   EXEC_PROGRAM(xcrun ARGS --sdk ${TC_BASE_SDK} --show-sdk-version OUTPUT_VARIABLE TC_BASE_SDK_VERSION RETURN_VALUE _xcrun_ret)


### PR DESCRIPTION
I almost got this right the last time. In the macOS case, I had erred on the side of continuing to use CMAKE_OSX_DEPLOYMENT_TARGET, but we need to modify COMPILER_FLAGS to propagate to the external CMake invocations.

Fixes #729 