### PR TITLE
Update and clarify Linux build requirements

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,10 +23,14 @@ Build Dependencies
 
 You will need:
 
-* On macOS, [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) with command line tools (tested with Xcode 9)
-* On Linux, a C++ compiler toolchain with C++11 support
-* [Node.js](https://nodejs.org) 6.x or later with `node` and `npm` in `$PATH`
-* The python `virtualenv` package.
+* On macOS, [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) with command line tools (tested with Xcode 9 and Xcode 10 beta)
+* On Linux:
+  * A C++ compiler toolchain with C++11 support
+  * `xxd` (typically provided by the `vim-common` package)
+  * For visualization support, X11 libraries (typically provided by `libx11-dev` or `libX11-devel` packages)
+* On both macOS and Linux:
+  * [Node.js](https://nodejs.org) 6.x or later with `node` and `npm` in `$PATH`
+  * The python `virtualenv` package.
 
 Turi Create automatically satisfies other dependencies in the `deps/` directory,
 which includes compiler support and dependent libraries.


### PR DESCRIPTION
Note that `xxd` and X11 development libraries are required to build on Linux.

Fixes #554