### PR TITLE
Resolve leaked MPSTemporaryImage instances found via Metal API validation

### DIFF
--- a/src/unity/python/turicreate/toolkits/activity_classifier/_mps_model_architecture.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_mps_model_architecture.py
@@ -165,7 +165,7 @@ def _predict_mps(pred_model, data_iter):
         input_data = batch.data
         pad = batch.pad
 
-        output = pred_model.forward(input_data)
+        output = pred_model.forward(input_data, is_train=False)
         trimmed_output = output[0:output.shape[0]-pad].copy()
         output_list.append(trimmed_output)
 

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.mm
@@ -286,6 +286,14 @@ void MPSCNNModule::TrainingWithLoss(
                 for (NSUInteger i = 0; i < [bottom_grad count]; ++i) {
                     [bottom_grad[i] synchronizeOnCommandBuffer:commandBuffer];
                 }
+            } else {
+                // No one reads the result images from the backward pass.
+                // Decrement the read count now so that MPS can deallocate them,
+                // and to prevent assertion failures with Metal API validation
+                // enabled.
+                // TODO: Images intended for clients to (optionally) read should
+                // be non-temporary.
+                MPSImageBatchIncrementReadCount(bottom_grad, -1);
             }
         }
         

--- a/src/unity/toolkits/tcmps/mps_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_layers.mm
@@ -933,6 +933,9 @@ void LstmLayer::CopyImageBatchToBuffer(MPSImageBatch *imgBatch, id <MTLBuffer> b
         image_to_matrix_kernel_.destinationMatrixOrigin = MTLOriginMake(i, 0, 0);
         [image_to_matrix_kernel_ encodeToCommandBuffer:cb sourceImage:img destinationMatrix:matrix];
     }
+
+    // Release the image memory back to MPS.
+    MPSImageBatchIncrementReadCount(imgBatch, -1);
 }
 
 MPSImageBatch *LstmLayer::CopyImageBatchFromBuffer(id <MTLBuffer> buffer,

--- a/src/unity/toolkits/tcmps/mps_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_networks.mm
@@ -68,8 +68,10 @@ MPSImageBatch *_Nonnull MPSNetwork::Forward(MPSImageBatch *_Nonnull src,
     // BN layer uses each image twice - once for calculating batch statistics,
     // and again for the BN kernel itself. So it would need 4 reads altogether,
     // including backward pass.
-    int num_remaining_reads = (layers[i]->type == kBN)? 3 : 1;
-    MPSImageBatchIncrementReadCount(input, num_remaining_reads);
+    if (is_train) {
+      int num_remaining_reads = (layers[i]->type == kBN) ? 3 : 1;
+      MPSImageBatchIncrementReadCount(input, num_remaining_reads);
+    }
       
     layers[i]->Forward(input, cb, is_train);
     input = layers[i]->fwd_output;

--- a/src/unity/toolkits/tcmps/mps_weight.mm
+++ b/src/unity/toolkits/tcmps/mps_weight.mm
@@ -301,6 +301,15 @@ updateWithCommandBuffer:(__nonnull id<MTLCommandBuffer>)commandBuffer
                resultValuesVector:biasVector];
   }
 
+  // TODO: Adopt the convenience MPSNNOptimizer API that handles more of these
+  // fiddly details.
+  if (gradientState.isTemporary) {
+    gradientState.readCount -= 1;
+  }
+  if (sourceState.isTemporary) {
+    sourceState.readCount -= 1;
+  }
+
   return convWtsAndBias;
 }
 


### PR DESCRIPTION
These changes are more on the quick-fix side. Our management of MPSImage allocations in general could use some cleaning up.