### PR TITLE
Use only the lite source files from protobuf

### DIFF
--- a/src/external/google/protobuf/CMakeLists.txt
+++ b/src/external/google/protobuf/CMakeLists.txt
@@ -3,44 +3,21 @@ project(TuriExternalDependencies)
 make_library(protobuf
   SOURCES
     # Don't need to pull in the compiler source files here.
-    any.cc
-    any.pb.cc
-    api.pb.cc
+    # Or any non-lite sources.
     arena.cc
     arenastring.cc
-    descriptor.cc
-    descriptor.pb.cc
-    descriptor_database.cc
-    duration.pb.cc
-    dynamic_message.cc
-    empty.pb.cc
     extension_set.cc
-    extension_set_heavy.cc
-    field_mask.pb.cc
-    generated_message_reflection.cc
     generated_message_util.cc
+    message_lite.cc
+    repeated_field.cc
     io/coded_stream.cc
-    io/gzip_stream.cc
-    io/printer.cc
-    io/strtod.cc
-    io/tokenizer.cc
     io/zero_copy_stream.cc
     io/zero_copy_stream_impl.cc
     io/zero_copy_stream_impl_lite.cc
-    map_field.cc
-    message.cc
-    message_lite.cc
-    reflection_ops.cc
-    repeated_field.cc
-    service.cc
-    source_context.pb.cc
-    struct.pb.cc
     stubs/atomicops_internals_x86_gcc.cc
     stubs/atomicops_internals_x86_msvc.cc
-    stubs/bytestream.cc
     stubs/common.cc
     stubs/int128.cc
-    stubs/mathlimits.cc
     stubs/once.cc
     stubs/status.cc
     stubs/statusor.cc
@@ -48,34 +25,7 @@ make_library(protobuf
     stubs/stringprintf.cc
     stubs/structurally_valid.cc
     stubs/strutil.cc
-    stubs/substitute.cc
-    stubs/time.cc
-    text_format.cc
-    timestamp.pb.cc
-    type.pb.cc
-    unknown_field_set.cc
-    util/field_comparator.cc
-    util/field_mask_util.cc
-    util/internal/datapiece.cc
-    util/internal/default_value_objectwriter.cc
-    util/internal/error_listener.cc
-    util/internal/field_mask_utility.cc
-    util/internal/json_escaping.cc
-    util/internal/json_objectwriter.cc
-    util/internal/json_stream_parser.cc
-    util/internal/object_writer.cc
-    util/internal/proto_writer.cc
-    util/internal/protostream_objectsource.cc
-    util/internal/protostream_objectwriter.cc
-    util/internal/type_info.cc
-    util/internal/utility.cc
-    util/json_util.cc
-    util/message_differencer.cc
-    util/time_util.cc
-    util/type_resolver_util.cc
-    wire_format.cc
     wire_format_lite.cc
-    wrappers.pb.cc
   )
 
 # Add this in so that the protobuf namespace is globally redefined to __tc_google.


### PR DESCRIPTION
Previously, the CMakeLists.txt was including most protobuf source files,
even though we are only including the headers for the lite version.