### PR TITLE
Fix release build break on 10.13 / Xcode 9

### DIFF
--- a/src/unity/python/turicreate/cython/CMakeLists.txt
+++ b/src/unity/python/turicreate/cython/CMakeLists.txt
@@ -14,6 +14,7 @@ function(cython_add_turicreate_module _module_name _sources)
   set_property(TARGET ${_module_name} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-rpath,\\$ORIGIN -Wl,-rpath,\\$ORIGIN/.. -Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR} ")
   target_link_libraries(${_module_name} boost nanomsg ${UNITY_EXTENSION_LIBRARY})
   set_property(TARGET ${_module_name} APPEND_STRING PROPERTY COMPILE_FLAGS " -include ${CMAKE_CURRENT_SOURCE_DIR}/cython_cpp_error_handler.hpp ")
+  set_property(TARGET ${_module_name} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-writable-strings")
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set_property(TARGET ${_module_name} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-sign-compare")


### PR DESCRIPTION
With macOS 10.13 and Xcode 9, I am now getting a build break on latest
master, due to the `-Werror` change that went in. I'm not sure why this
doesn't repro on macOS 10.14 beta / Xcode 10 beta, but the Cython
generated code on my machine gives warnings (now treated as error). This
change suppresses the specific warning in the compilation of the
generated code.