### PR TITLE
Better error message for unwritable cache path

### DIFF
--- a/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
+++ b/src/unity/python/turicreate/toolkits/_image_feature_extractor.py
@@ -24,8 +24,6 @@ def _create_feature_extractor(model_name):
         return MXFeatureExtractor(ptModel)
 
     download_path = _get_model_cache_dir()
-    if not os.path.exists(download_path):
-        os.makedirs(download_path)
 
     if(model_name == 'resnet-50'):
         mlmodel_resnet_save_path = download_path + "/Resnet50.mlmodel"

--- a/src/unity/python/turicreate/toolkits/_pre_trained_models.py
+++ b/src/unity/python/turicreate/toolkits/_pre_trained_models.py
@@ -15,14 +15,24 @@ from six.moves.urllib import parse as _urlparse
 
 MODELS_URL_ROOT = 'https://docs-assets.developer.apple.com/turicreate/models/'
 
+
 def _get_model_cache_dir():
-    tmp_dir = _tc.config.get_runtime_config()['TURI_CACHE_FILE_LOCATIONS']
-    return _os.path.join(tmp_dir, 'model_cache')
+    cache_dir = _tc.config.get_runtime_config()['TURI_CACHE_FILE_LOCATIONS']
+    download_path = _os.path.join(cache_dir, 'model_cache')
+
+    if not _os.path.exists(download_path):
+        try:
+            _os.makedirs(download_path)
+        except:
+            raise RuntimeError("Could not write to the turicreate file cache, which is currently set to \"{cache_dir}\".\n"
+                               "To continue you must update this location to a writable path by calling:\n"
+                               "\ttc.config.set_runtime_config(\'TURI_CACHE_FILE_LOCATIONS\', <path>)\n"
+                               "Where <path> is a writable file path that exists.".format(cache_dir=cache_dir))
+
+    return download_path
+
 
 def _download_and_checksum_files(urls, dirname, delete=False):
-    if not _os.path.exists(dirname):
-        _os.makedirs(dirname)
-
     def url_sha_pair(url_or_pair):
         if isinstance(url_or_pair, tuple):
             return url_or_pair


### PR DESCRIPTION
Fixes #286 

Give a useful error message to the user when we can't write to the cache path. Also only create the model caches directory in one place. 