### PR TITLE
Clean up TCMPS symbols

### DIFF
--- a/src/unity/toolkits/tcmps/mps_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.h
@@ -15,6 +15,9 @@
 #import "mps_networks.h"
 #import "mps_updater.h"
 
+namespace turi {
+namespace mps {
+
 class MPSCNNModule {
 public:
   MPSCNNModule();
@@ -114,5 +117,8 @@ private:
       bool loss_image_required, bool wait_until_completed, float *out,
       bool do_backward, bool is_train = true);
 };
+
+}  // namespace mps
+}  // namespace turi
 
 #endif

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.mm
@@ -2,6 +2,9 @@
 
 #include <iostream>
 
+namespace turi {
+namespace mps {
+
 namespace {
 
 MPSImageBatch * _Nonnull CreateImageBatch(id<MTLDevice> _Nonnull device,
@@ -461,3 +464,5 @@ MPSImageBatch *_Nonnull MPSCNNModule::ExtractLossImages(MPSCNNLossLabelsBatch *_
     return lossImage;
 }
 
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_dev.h
+++ b/src/unity/toolkits/tcmps/mps_dev.h
@@ -14,6 +14,9 @@
 #import <memory>
 #import <mutex>
 
+namespace turi {
+namespace mps {
+
 template<typename T>
 struct ThreadLocal {
 public:
@@ -46,4 +49,8 @@ struct MetalDefaultDevice {
 };
 
 typedef ThreadLocal<MetalDefaultDevice> MetalDevice;
+
+}  // namespace mps
+}  // namespace turi
+
 #endif /* mps_dev_h */

--- a/src/unity/toolkits/tcmps/mps_dev.mm
+++ b/src/unity/toolkits/tcmps/mps_dev.mm
@@ -7,6 +7,9 @@
 
 #import "mps_dev.h"
 
+namespace turi {
+namespace mps {
+
 API_AVAILABLE(macos(10.13))
 int devicePriority(id<MTLDevice> dev) {
   int prio = 0;
@@ -23,3 +26,6 @@ int devicePriority(id<MTLDevice> dev) {
   }
   return prio;
 }
+
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 // of MPSGraphModule below.
 @class TCMPSGraphModuleBatch;
 
+namespace turi {
+namespace mps {
+
 class MPSGraphModule {
 public:
   MPSGraphModule();
@@ -83,6 +86,9 @@ private:
   MPSImageBatch * _Nullable recycled_input_ = nil;
   MPSImageBatch * _Nullable recycled_grad_ = nil;
 };
+
+}  // namespace mps
+}  // namespace turi
 
 NS_ASSUME_NONNULL_END
 

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_END
 
 @end
 
+namespace turi {
+namespace mps {
+
 MPSGraphModule::MPSGraphModule() {
   @autoreleasepool {
     dev_ = MetalDevice::Get()->dev;
@@ -318,4 +321,5 @@ void MPSGraphModule::MPSImage2Blob(float *ptr, MPSImageBatch *batch) {
   }
 }
 
-
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_graph_layers.h
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.h
@@ -135,7 +135,7 @@ struct ConvGraphLayer : public GraphLayer {
   MPSCNNConvolutionNode *_Nonnull node_fwd;
   MPSCNNConvolutionGradientNode *_Nonnull node_bwd;
   MPSNNDefaultPadding *_Nonnull pad_policy;
-  RandomWeights *_Nonnull weight;
+  TCMPSConvolutionWeights *_Nonnull weight;
 };
 
 // BN Layer
@@ -164,7 +164,7 @@ struct BNGraphLayer : public GraphLayer {
          std::string, std::tuple<std::string, float *, int, std::vector<int>>>
              &table) override;
 
-  BNData *_Nonnull data;
+  TCMPSBatchNormData *_Nonnull data;
   MPSCNNBatchNormalizationNode *_Nonnull node_fwd;
   MPSCNNBatchNormalizationGradientNode * _Nonnull node_bwd;
 };

--- a/src/unity/toolkits/tcmps/mps_graph_layers.h
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.h
@@ -14,6 +14,9 @@
 
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
 
+namespace turi {
+namespace mps {
+
 struct GraphLayer {
   virtual void Init(id<MTLDevice> _Nonnull device,
                     id<MTLCommandQueue> _Nonnull cmd_queue,
@@ -218,5 +221,8 @@ private:
   Options options_;
   MPSCNNYOLOLossNode *yoloNode_;
 };
+
+}  // namespace mps
+}  // namespace turi
 
 #endif

--- a/src/unity/toolkits/tcmps/mps_graph_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.mm
@@ -2,6 +2,9 @@
 #include "mps_utils.h"
 
 
+namespace turi {
+namespace mps {
+
 // --------------------------------------------------------------------------------------------
 //                                 Layer Implementations
 // --------------------------------------------------------------------------------------------
@@ -322,3 +325,6 @@ MPSCNNLossLabelsBatch *YoloLossGraphLayer::CreateLossState(id<MTLDevice> _Nonnul
   }
   return loss_state;
 }
+
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_graph_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.mm
@@ -58,7 +58,7 @@ void ConvGraphLayer::Init(id<MTLDevice> _Nonnull device,
     init_b = weights.at(bias_key).data;
   }
 
-  weight = [RandomWeights alloc];
+  weight = [TCMPSConvolutionWeights alloc];
   weight = [weight initWithKernelWidth:k_w
                           kernelHeight:k_h
                   inputFeatureChannels:c_in
@@ -175,7 +175,7 @@ void BNGraphLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q
   
   float batchNormEpsilon = get_array_map_scalar(config, "batch_norm_epsilon", 1e-5f);
   
-  data = [BNData alloc];
+  data = [TCMPSBatchNormData alloc];
   data = [data initWithChannels:ch
          kernelParamsBinaryName:name.c_str()
                          device:device

--- a/src/unity/toolkits/tcmps/mps_graph_networks.h
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.h
@@ -15,6 +15,9 @@
 #import "mps_networks.h"
 #import "mps_utils.h"
 
+namespace turi {
+namespace mps {
+
 struct GraphLayer;
 
 enum GraphNetworkType {
@@ -171,5 +174,7 @@ struct ODNetworkGraph : public MPSGraphNetwork {
   }
 };
 
+}  // namespace mps
+}  // namespace turi
 
 #endif

--- a/src/unity/toolkits/tcmps/mps_graph_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.mm
@@ -1,7 +1,7 @@
 #include "mps_graph_networks.h"
 #include "mps_graph_layers.h"
 
-@interface MyHandle : NSObject <MPSHandle>
+@interface TCMPSGraphNodeHandle : NSObject <MPSHandle>
 + (nullable instancetype)handleWithLabel:(NSString *)label;
 - (nullable instancetype)initWithLabel:(NSString *)label;
 - (NSString *)label;
@@ -57,7 +57,7 @@ void MPSGraphNetwork::Init(id<MTLDevice> _Nonnull device,
     layers[i]->Init(device, cmd_queue, config, weights);
   }
   input_node =
-      [MPSNNImageNode nodeWithHandle:[MyHandle handleWithLabel:@"input"]];
+      [MPSNNImageNode nodeWithHandle:[TCMPSGraphNodeHandle handleWithLabel:@"input"]];
   MPSNNImageNode *src = input_node;
   for (int i = 0; i < layers.size(); ++i) {
     layers[i]->InitFwd(src);
@@ -67,13 +67,13 @@ void MPSGraphNetwork::Init(id<MTLDevice> _Nonnull device,
     // Construct forward-backward graph
     if (loss_layer_) {
       loss_layer_->Init(device, cmd_queue, config, weights);
-      loss_layer_->labels_node.handle = [MyHandle handleWithLabel:@"labels"];
+      loss_layer_->labels_node.handle = [TCMPSGraphNodeHandle handleWithLabel:@"labels"];
       loss_layer_->InitFwd(src);
       src = loss_layer_->fwd_img_node;
       loss_layer_->InitBwd(src);
       src = loss_layer_->bwd_img_node;
     } else {
-      grad_node = [MPSNNImageNode nodeWithHandle:[MyHandle handleWithLabel:@"grad"]];
+      grad_node = [MPSNNImageNode nodeWithHandle:[TCMPSGraphNodeHandle handleWithLabel:@"grad"]];
       src = grad_node;
     }
     if (layers.size() > 0) {
@@ -166,7 +166,7 @@ int MPSGraphNetwork::NumParams() {
 }  // namespace mps
 }  // namespace turi
 
-@implementation MyHandle {
+@implementation TCMPSGraphNodeHandle {
   NSString *_label;
 }
 
@@ -187,7 +187,7 @@ int MPSGraphNetwork::NumParams() {
 }
 
 - (BOOL)isEqual:(id)what {
-  return [_label isEqual:((MyHandle *)what).label];
+  return [_label isEqual:((TCMPSGraphNodeHandle *)what).label];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -196,12 +196,12 @@ int MPSGraphNetwork::NumParams() {
     return self;
 
   _label =
-      [aDecoder decodeObjectOfClass:NSString.class forKey:@"MyHandleLabel"];
+      [aDecoder decodeObjectOfClass:NSString.class forKey:@"TCMPSGraphNodeHandleLabel"];
   return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  [aCoder encodeObject:_label forKey:@"MyHandleLabel"];
+  [aCoder encodeObject:_label forKey:@"TCMPSGraphNodeHandleLabel"];
 }
 
 + (BOOL)supportsSecureCoding {

--- a/src/unity/toolkits/tcmps/mps_graph_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.mm
@@ -11,6 +11,9 @@
 + (BOOL)supportsSecureCoding;
 @end
 
+namespace turi {
+namespace mps {
+
 std::unique_ptr<MPSGraphNetwork> createNetworkGraph(
     GraphNetworkType network_id, const std::vector<int> &params,
     const FloatArrayMap &config) {
@@ -159,6 +162,9 @@ int MPSGraphNetwork::NumParams() {
   }
   return ret;
 }
+
+}  // namespace mps
+}  // namespace turi
 
 @implementation MyHandle {
   NSString *_label;

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.h
@@ -1,30 +1,11 @@
 #ifndef GRAPH_C_API_H_
 #define GRAPH_C_API_H_
 
-#import "mps_cnnmodule.h"
-#import "mps_graph_cnnmodule.h"
 #import "mps_trainer.h"
-#import <exception>
-
-#define EXPORT __attribute__((visibility("default")))
-
-/*! \brief  macro to guard beginning and end section of all functions */
-#define API_BEGIN() try {
-//\brief every function starts with API_BEGIN();
-//     and finishes with API_END() or API_END_HANDLE_ERROR
-#define API_END()                                                              \
-  }                                                                            \
-  catch (...) {                                                                \
-    NSLog(@"Error");                                                           \
-    return -1;                                                                 \
-  }                                                                            \
-  return 0; // NOLINT(*)
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-typedef void *MPSHandle;
 
 EXPORT int TCMPSHasHighPowerMetalDevice(bool *has_device);
 EXPORT int TCMPSMetalDeviceName(char *name, int max_len);

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.h
@@ -26,38 +26,38 @@ extern "C" {
 
 typedef void *MPSHandle;
 
-EXPORT int HasHighPowerMetalDevice(bool *has_device);
-EXPORT int MetalDeviceName(char *name, int max_len);
+EXPORT int TCMPSHasHighPowerMetalDevice(bool *has_device);
+EXPORT int TCMPSMetalDeviceName(char *name, int max_len);
 
-EXPORT int CreateMPSGraph(MPSHandle *handle);
-EXPORT int DeleteMPSGraph(MPSHandle handle);
+EXPORT int TCMPSCreateGraphModule(MPSHandle *handle);
+EXPORT int TCMPSDeleteGraphModule(MPSHandle handle);
 
-EXPORT int StartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+EXPORT int TCMPSStartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
                                    int64_t *shape, int dim, float *labels_ptr);
-EXPORT int WaitForTrainingBatchGraph(MPSHandle handle, float *loss);
+EXPORT int TCMPSWaitForTrainingBatchGraph(MPSHandle handle, float *loss);
 
-EXPORT int StartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+EXPORT int TCMPSStartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
                                     int64_t *shape, int dim);
-EXPORT int WaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr);
+EXPORT int TCMPSWaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr);
 
-EXPORT int StartTrainReturnGradBatchGraph(
+EXPORT int TCMPSStartTrainReturnGradBatchGraph(
     MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
     void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim);
-EXPORT int WaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr);
+EXPORT int TCMPSWaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr);
 
-EXPORT int InitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
+EXPORT int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
                      int c_out, int h_out, int w_out,
                      char **config_names, void **config_arrays,
                      int64_t *config_sizes, int config_len,
                      char **weight_names, void **weight_arrays,
                      int64_t *weight_sizes, int weight_len);
 
-EXPORT int NumParamsGraph(MPSHandle handle, int *num);
+EXPORT int TCMPSNumParamsGraph(MPSHandle handle, int *num);
 
-EXPORT int ExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
+EXPORT int TCMPSExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
            int **shape);
 
-EXPORT int SetLearningRateGraph(MPSHandle handle, float new_lr);
+EXPORT int TCMPSSetLearningRateGraph(MPSHandle handle, float new_lr);
 
 #ifdef __cplusplus
 }

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.mm
@@ -9,7 +9,7 @@ using turi::mps::MetalDevice;
 using turi::mps::MPSGraphModule;
 using turi::mps::make_array_map;
 
-int HasHighPowerMetalDevice(bool *has_device) {
+int TCMPSHasHighPowerMetalDevice(bool *has_device) {
   API_BEGIN();
   if (has_device) {
     id<MTLDevice> dev = MetalDevice::Get()->dev;
@@ -18,7 +18,7 @@ int HasHighPowerMetalDevice(bool *has_device) {
   API_END();
 }
 
-int MetalDeviceName(char *name, int max_len) {
+int TCMPSMetalDeviceName(char *name, int max_len) {
   API_BEGIN();
   id<MTLDevice> dev = MetalDevice::Get()->dev;
   if (dev == nil) {
@@ -28,21 +28,21 @@ int MetalDeviceName(char *name, int max_len) {
   API_END();
 }
 
-int CreateMPSGraph(MPSHandle *out) {
+int TCMPSCreateGraphModule(MPSHandle *out) {
   API_BEGIN();
   MPSGraphModule *mps = new MPSGraphModule();
   *out = (void *)mps;
   API_END();
 }
 
-int DeleteMPSGraph(MPSHandle handle) {
+int TCMPSDeleteGraphModule(MPSHandle handle) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   delete obj;
   API_END();
 }
 
-int StartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+int TCMPSStartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
                             int64_t *shape, int dim, float *labels_ptr) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
@@ -50,14 +50,14 @@ int StartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
   API_END();
 }
 
-int WaitForTrainingBatchGraph(MPSHandle handle, float *loss) {
+int TCMPSWaitForTrainingBatchGraph(MPSHandle handle, float *loss) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   obj->WaitForTrainingBatch(loss);
   API_END();
 }
 
-int StartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
+int TCMPSStartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
                              int64_t *shape, int dim) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
@@ -65,14 +65,14 @@ int StartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
   API_END();
 }
 
-int WaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr) {
+int TCMPSWaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   obj->WaitForInferenceBatch(out_ptr);
   API_END();
 }
 
-int StartTrainReturnGradBatchGraph(
+int TCMPSStartTrainReturnGradBatchGraph(
     MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
     void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim) {
   API_BEGIN();
@@ -82,14 +82,14 @@ int StartTrainReturnGradBatchGraph(
   API_END();
 }
 
-int WaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr) {
+int TCMPSWaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   obj->WaitForTrainReturnGradBatch(out_ptr);
   API_END();
 }
 
-int InitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
+int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
               int c_out, int h_out, int w_out,
               char **config_names, void **config_arrays,
               int64_t *config_sizes, int config_len,
@@ -106,14 +106,14 @@ int InitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w
   API_END();
 }
 
-int NumParamsGraph(MPSHandle handle, int *num) {
+int TCMPSNumParamsGraph(MPSHandle handle, int *num) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   *num = obj->NumParams();
   API_END();
 }
 
-int ExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
+int TCMPSExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
            int **shape) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
@@ -129,7 +129,7 @@ int ExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
   API_END();
 }
 
-int SetLearningRateGraph(MPSHandle handle, float new_lr) {
+int TCMPSSetLearningRateGraph(MPSHandle handle, float new_lr) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   obj->SetLearningRate(new_lr);

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.mm
@@ -4,6 +4,11 @@
 #import "string"
 #import "unordered_map"
 
+using turi::mps::FloatArrayMap;
+using turi::mps::MetalDevice;
+using turi::mps::MPSGraphModule;
+using turi::mps::make_array_map;
+
 int HasHighPowerMetalDevice(bool *has_device) {
   API_BEGIN();
   if (has_device) {

--- a/src/unity/toolkits/tcmps/mps_layers.h
+++ b/src/unity/toolkits/tcmps/mps_layers.h
@@ -76,6 +76,9 @@ imageForCommandBuffer:(__nonnull id<MTLCommandBuffer>)cmdBuf
 
 @end // MPSCNNWeight
 
+namespace turi {
+namespace mps {
+
 struct MPSUpdater;
 
 enum LayerType {
@@ -554,5 +557,8 @@ private:
   std::unordered_map<std::string, MPSMatrix *> copy_weight_matrices_;
   
 };
+
+}  // namespace mps
+}  // namespace turi
 
 #endif

--- a/src/unity/toolkits/tcmps/mps_layers.h
+++ b/src/unity/toolkits/tcmps/mps_layers.h
@@ -20,7 +20,7 @@
 // Common utilities for all Layers
 // -----------------------------------------------------------------------------------------
 
-@interface MyAllocator : NSObject <MPSImageAllocator>
+@interface TCMPSImageAllocator : NSObject <MPSImageAllocator>
 
 /*! @abstract   Create a new MPSImage
  *  @discussion See class description for sample implementation
@@ -324,7 +324,7 @@ struct ConvLayer : public Layer {
   MPSCNNConvolutionGradient *_Nullable op_backward{nil};
   MPSCNNConvolutionDescriptor *_Nonnull desc;
 //  MPSCNNWeight *_Nonnull weight;
-  RandomWeights *_Nonnull weight;
+  TCMPSConvolutionWeights *_Nonnull weight;
 };
 
 struct BNLayer : public Layer {
@@ -360,7 +360,7 @@ struct BNLayer : public Layer {
   bool is_state_init{false};
   bool is_train_mode_{true};
   bool use_temp_images_{true};
-  BNData *_Nonnull data;
+  TCMPSBatchNormData *_Nonnull data;
   MPSCNNBatchNormalizationStatistics *_Nullable         stat{nil};
   MPSCNNBatchNormalization *_Nonnull                    op_forward;
   MPSCNNBatchNormalizationGradient *_Nullable           op_backward{nil};

--- a/src/unity/toolkits/tcmps/mps_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_layers.mm
@@ -136,6 +136,9 @@ imageForCommandBuffer:(__nonnull id<MTLCommandBuffer>)cmdBuf
 
 @end /* MPSCNNWeight */
 
+namespace turi {
+namespace mps {
+
 // --------------------------------------------------------------------------------------------
 //                                 Layer Implementations
 // --------------------------------------------------------------------------------------------
@@ -1129,9 +1132,5 @@ void LstmLayer::InitWeightCopyMatrices() {
     }
 }
 
-
-
-
-
-
-
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_lstm_helper.h
+++ b/src/unity/toolkits/tcmps/mps_lstm_helper.h
@@ -14,6 +14,9 @@
 #import <map>
 
 
+namespace turi {
+namespace mps {
+
 extern const std::string lstm_weight_names_mxnet_format[12];
 
 API_AVAILABLE(macos(10.13))
@@ -24,5 +27,7 @@ MPSVector * MPSMatrixToVector (MPSMatrix * matrix);
 API_AVAILABLE(macos(10.13))
 void printMatrix(MPSMatrix * matrix, const char* name, NSUInteger byteOffset);
 
+}  // namespace mps
+}  // namespace turi
 
 #endif /* mps_lstm_helper_h */

--- a/src/unity/toolkits/tcmps/mps_lstm_helper.mm
+++ b/src/unity/toolkits/tcmps/mps_lstm_helper.mm
@@ -10,6 +10,9 @@
 
 #define USE_DIAGONAL_PEEPHOLES  1
 
+namespace turi {
+namespace mps {
+
 const std::string lstm_weight_names_mxnet_format[] = {
     "i2h_i_weight",
     "h2h_i_weight",
@@ -175,3 +178,6 @@ void printMatrix(MPSMatrix * matrix, const char* name, NSUInteger byteOffset)
         printf("]\n");
     }
 }
+
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_networks.h
+++ b/src/unity/toolkits/tcmps/mps_networks.h
@@ -13,6 +13,9 @@
 #import "mps_updater.h"
 #import "mps_utils.h"
 
+namespace turi {
+namespace mps {
+
 struct Layer;
 struct Updater;
 struct ConvLayer;
@@ -295,4 +298,8 @@ struct SingleLstmNetwork : public MPSNetwork {
                                   {n, hi, wi, ci}, {n, ho, wo, co});
     }
 };
+
+}  // namespace mps
+}  // namespace turi
+
 #endif

--- a/src/unity/toolkits/tcmps/mps_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_networks.mm
@@ -1,6 +1,9 @@
 #include "mps_networks.h"
 #include "mps_layers.h"
 
+namespace turi {
+namespace mps {
+
 MPSNetwork *_Nonnull createNetwork(NetworkType network_id,
                                    const std::vector<int> &params,
                                    const FloatArrayMap& config) {
@@ -169,3 +172,5 @@ MPSImageBatch *_Nonnull MPSNetwork::Loss(MPSImageBatch *_Nonnull src,
   return lossLayer->bwd_output; // Loss gradients
 }
 
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_trainer.h
@@ -24,66 +24,66 @@ extern "C" {
 
 typedef void *MPSHandle;
 
-EXPORT int CreateMPS(MPSHandle *handle);
-EXPORT int DeleteMPS(MPSHandle handle);
+EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
+EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
 
-EXPORT int Forward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
+EXPORT int TCMPSForward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
                    float *out, bool is_train);
 
-EXPORT int Backward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
+EXPORT int TCMPSBackward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
                     float *out);
 
-EXPORT int Loss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
+EXPORT int TCMPSLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
                 void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
                 void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
                 bool loss_image_required,
                 float *out);
     
-EXPORT int ForwardBackward(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
+EXPORT int TCMPSForwardBackward(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
                            void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
                            void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
                            bool loss_image_required,
                            float *out);
 
-EXPORT int ForwardWithLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
+EXPORT int TCMPSForwardWithLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
                            void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
                            void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
                            bool loss_image_required, bool is_train,
                            float *out);
 
-EXPORT int GetLossImages(MPSHandle handle, float *out);
+EXPORT int TCMPSGetLossImages(MPSHandle handle, float *out);
 
-EXPORT int BeginForwardBatch(
+EXPORT int TCMPSBeginForwardBatch(
     MPSHandle handle, int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
     void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
     void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
     bool loss_image_required, bool is_train);
 
-EXPORT int BeginForwardBackwardBatch(
+EXPORT int TCMPSBeginForwardBackwardBatch(
     MPSHandle handle, int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
     void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
     void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
     bool loss_image_required);
 
-EXPORT int WaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
+EXPORT int TCMPSWaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
                         float *loss_out);
 
-EXPORT int Init(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
+EXPORT int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
                 int c_out, int h_out, int w_out, int updater_id,
                 char **config_names, void **config_arrays,
                 int64_t *config_sizes, int config_len);
 
-EXPORT int Load(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len);
+EXPORT int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len);
 
-EXPORT int NumParams(MPSHandle handle, int *num);
+EXPORT int TCMPSNumParams(MPSHandle handle, int *num);
 
-EXPORT int Export(MPSHandle handle, char **names, void **arrs, int64_t *dim,
+EXPORT int TCMPSExport(MPSHandle handle, char **names, void **arrs, int64_t *dim,
                   int **shape);
 
-EXPORT int CpuUpdate(MPSHandle handle);
-EXPORT int Update(MPSHandle handle);
+EXPORT int TCMPSCpuUpdate(MPSHandle handle);
+EXPORT int TCMPSUpdate(MPSHandle handle);
 
-EXPORT int SetLearningRate(MPSHandle handle, float new_lr);
+EXPORT int TCMPSSetLearningRate(MPSHandle handle, float new_lr);
 
 #ifdef __cplusplus
 }

--- a/src/unity/toolkits/tcmps/mps_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_trainer.h
@@ -7,16 +7,20 @@
 #define EXPORT __attribute__((visibility("default")))
 
 /*! \brief  macro to guard beginning and end section of all functions */
-#define API_BEGIN() try {
+#define API_BEGIN()                                                            \
+  @autoreleasepool {                                                           \
+  try {
+
 /*! \brief every function starts with API_BEGIN();
      and finishes with API_END() or API_END_HANDLE_ERROR */
 #define API_END()                                                              \
-  }                                                                            \
+  }  /* try */                                                                 \
   catch (...) {                                                                \
     NSLog(@"Error");                                                           \
     return -1;                                                                 \
   }                                                                            \
-  return 0; // NOLINT(*)
+  return 0;                                                                    \
+  }  /* @autoreleasepool */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/unity/toolkits/tcmps/mps_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_trainer.mm
@@ -5,6 +5,10 @@
 #import "unordered_map"
 #import "mps_utils.h"
 
+using turi::mps::FloatArrayMap;
+using turi::mps::MPSCNNModule;
+using turi::mps::make_array_map;
+
 int CreateMPS(MPSHandle *out) {
   API_BEGIN();
   MPSCNNModule *mps = new MPSCNNModule();

--- a/src/unity/toolkits/tcmps/mps_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_trainer.mm
@@ -9,21 +9,21 @@ using turi::mps::FloatArrayMap;
 using turi::mps::MPSCNNModule;
 using turi::mps::make_array_map;
 
-int CreateMPS(MPSHandle *out) {
+int TCMPSCreateCNNModule(MPSHandle *out) {
   API_BEGIN();
   MPSCNNModule *mps = new MPSCNNModule();
   *out = (void *)mps;
   API_END();
 }
 
-int DeleteMPS(MPSHandle handle) {
+int TCMPSDeleteCNNModule(MPSHandle handle) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   delete obj;
   API_END();
 }
 
-int Forward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
+int TCMPSForward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
             float *out, bool is_train) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
@@ -31,7 +31,7 @@ int Forward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
   API_END();
 }
 
-int Backward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
+int TCMPSBackward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
              float *out) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
@@ -39,7 +39,7 @@ int Backward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
   API_END();
 }
 
-int Loss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
+int TCMPSLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
          void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
          void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
          bool loss_image_required,
@@ -54,7 +54,7 @@ int Loss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
   API_END();
 }
 
-int ForwardBackward(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
+int TCMPSForwardBackward(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
          void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
          void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
          bool loss_image_required,
@@ -69,7 +69,7 @@ int ForwardBackward(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int 
     API_END();
 }
 
-int ForwardWithLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
+int TCMPSForwardWithLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
                     void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
                     void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
                     bool loss_image_required, bool is_train,
@@ -84,14 +84,14 @@ int ForwardWithLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int 
     API_END();
 }
 
-int GetLossImages(MPSHandle handle, float *out) {
+int TCMPSGetLossImages(MPSHandle handle, float *out) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   obj->GetLossImages(out);
   API_END();
 }
 
-int BeginForwardBatch(
+int TCMPSBeginForwardBatch(
     MPSHandle handle, int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
     void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
     void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
@@ -105,7 +105,7 @@ int BeginForwardBatch(
   API_END();
 }
 
-int BeginForwardBackwardBatch(
+int TCMPSBeginForwardBackwardBatch(
     MPSHandle handle, int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
     void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
     void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
@@ -119,7 +119,7 @@ int BeginForwardBackwardBatch(
   API_END();
 }
 
-int WaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
+int TCMPSWaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
                  float *loss_out) {
   API_BEGIN();
   MPSCNNModule *obj = reinterpret_cast<MPSCNNModule *>(handle);
@@ -127,7 +127,7 @@ int WaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
   API_END();
 }
 
-int Init(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
+int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
          int c_out, int h_out, int w_out,  int updater_id,
          char **config_names, void **config_arrays,
          int64_t *config_sizes, int config_len) {
@@ -140,7 +140,7 @@ int Init(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
   API_END();
 }
 
-int Load(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len) {
+int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len) {
   API_BEGIN();
 
   FloatArrayMap weights = make_array_map(names, arrs, sz, len);
@@ -150,14 +150,14 @@ int Load(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len) {
   API_END();
 }
 
-int NumParams(MPSHandle handle, int *num) {
+int TCMPSNumParams(MPSHandle handle, int *num) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   *num = obj->NumParams();
   API_END();
 }
 
-int Export(MPSHandle handle, char **names, void **arrs, int64_t *dim,
+int TCMPSExport(MPSHandle handle, char **names, void **arrs, int64_t *dim,
            int **shape) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
@@ -173,21 +173,21 @@ int Export(MPSHandle handle, char **names, void **arrs, int64_t *dim,
   API_END();
 }
 
-int CpuUpdate(MPSHandle handle) {
+int TCMPSCpuUpdate(MPSHandle handle) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   obj->Update();
   API_END();
 }
 
-int Update(MPSHandle handle){
+int TCMPSUpdate(MPSHandle handle){
     API_BEGIN();
     MPSCNNModule *obj = (MPSCNNModule *)handle;
     obj->GpuUpdate();
     API_END();
 }
 
-int SetLearningRate(MPSHandle handle, float new_lr) {
+int TCMPSSetLearningRate(MPSHandle handle, float new_lr) {
   API_BEGIN();
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   obj->SetLearningRate(new_lr);

--- a/src/unity/toolkits/tcmps/mps_updater.h
+++ b/src/unity/toolkits/tcmps/mps_updater.h
@@ -6,6 +6,9 @@
 #import "vector"
 #import <Foundation/Foundation.h>
 
+namespace turi {
+namespace mps {
+
 struct Layer;
 
 struct MPSUpdater {
@@ -57,5 +60,8 @@ struct AdamUpdater : public SGDUpdater {
     void NewIteration() override;
 };
 MPSUpdater *createUpdater(int updater_id);
+
+}  // namespace mps
+}  // namespace turi
 
 #endif

--- a/src/unity/toolkits/tcmps/mps_updater.mm
+++ b/src/unity/toolkits/tcmps/mps_updater.mm
@@ -1,5 +1,8 @@
 #import "mps_updater.h"
 
+namespace turi {
+namespace mps {
+
 void SGDUpdater::Init(const std::vector<Layer *> &net,
                       const std::vector<float> &fparam) {
   assert(fparam.size() == 1);
@@ -89,3 +92,5 @@ void AdamUpdater::NewIteration(){
     t++;
 }
 
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_utils.h
+++ b/src/unity/toolkits/tcmps/mps_utils.h
@@ -16,6 +16,9 @@
 #include <string>
 #include <unordered_map>
 
+namespace turi {
+namespace mps {
+
 //
 // Optimizer options
 //
@@ -133,5 +136,8 @@ float sumSingleImage(MPSImage * _Nonnull image){
 }
 
 #pragma clang diagnostic pop
+
+}  // namespace mps
+}  // namespace turi
 
 #endif /* mps_utils_h */

--- a/src/unity/toolkits/tcmps/mps_utils.mm
+++ b/src/unity/toolkits/tcmps/mps_utils.mm
@@ -9,6 +9,9 @@
 #import "mps_utils.h"
 #include <sys/stat.h>
 
+namespace turi {
+namespace mps {
+
 FloatArrayMap make_array_map(char **names, void **arrays,
                              int64_t *sizes, int len) {
   FloatArrayMap ret;
@@ -75,3 +78,6 @@ float sumImage(MPSImage * _Nonnull image) {
     __builtin_trap();
   }
 }
+
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_weight.h
+++ b/src/unity/toolkits/tcmps/mps_weight.h
@@ -33,7 +33,7 @@
 #import "mps_utils.h"
 
 API_AVAILABLE(macos(10.14))
-@interface RandomWeights : NSObject <MPSCNNConvolutionDataSource> {
+@interface TCMPSConvolutionWeights : NSObject <MPSCNNConvolutionDataSource> {
 @private
   NSUInteger _outputFeatureChannels;
   NSUInteger _inputFeatureChannels;
@@ -116,10 +116,11 @@ updateWithCommandBuffer:(__nonnull id<MTLCommandBuffer>)commandBuffer
                 (MPSCNNConvolutionWeightsAndBiasesState *__nonnull)sourceState;
 - (void)checkpoint;
 - (void)checkpointWithCommandQueue:(nonnull id<MTLCommandQueue>)commandQueue;
-@end /* RandomWeights */
+
+@end  // TCMPSConvolutionWeights
 
 API_AVAILABLE(macos(10.14))
-@interface BNData : NSObject <MPSCNNBatchNormalizationDataSource> {
+@interface TCMPSBatchNormData : NSObject <MPSCNNBatchNormalizationDataSource> {
 @private
   NSUInteger _channels;
   float *_betaPointer, *_gammaPointer, *_betaMomentumPointer,
@@ -185,7 +186,7 @@ API_AVAILABLE(macos(10.14))
 - (BOOL)updateGammaAndBetaWithBatchNormalizationState:
     (MPSCNNBatchNormalizationState *__nonnull)batchNormalizationState;
 
-@end // MyBatchNormData
+@end  // TCMPSBatchNormData
 
 
 #endif /* MPS_WEIGHT_H_ */

--- a/src/unity/toolkits/tcmps/mps_weight.h
+++ b/src/unity/toolkits/tcmps/mps_weight.h
@@ -44,7 +44,7 @@ API_AVAILABLE(macos(10.14))
 
   size_t sizeBias, sizeWeights;
   unsigned _seed;
-  OptimizerOptions _optimizerOptions;
+  turi::mps::OptimizerOptions _optimizerOptions;
   float t;
 
   id<MTLBuffer> weightMomentumBuffer, biasMomentumBuffer, weightVelocityBuffer,
@@ -76,7 +76,7 @@ API_AVAILABLE(macos(10.14))
                                   cmd_queue:(id<MTLCommandQueue> _Nonnull) cmd_q
                             init_weight_ptr:(float* __nullable) w_ptr
                               init_bias_ptr:(float* __nullable) b_ptr
-                           optimizerOptions:(OptimizerOptions)optimizerOptions;
+                           optimizerOptions:(turi::mps::OptimizerOptions)optimizerOptions;
 
 - (nonnull instancetype)initWithKernelWidth:(NSUInteger)kernelWidth
                                kernelHeight:(NSUInteger)kernelHeight
@@ -92,7 +92,7 @@ API_AVAILABLE(macos(10.14))
                                   cmd_queue:(id<MTLCommandQueue> _Nonnull) cmd_q
                             init_weight_ptr:(float* __nullable) w_ptr
                               init_bias_ptr:(float* __nullable) b_ptr
-                           optimizerOptions:(OptimizerOptions)optimizerOptions;
+                           optimizerOptions:(turi::mps::OptimizerOptions)optimizerOptions;
 
 - (MPSDataType)dataType;
 - (MPSCNNConvolutionDescriptor *__nonnull)descriptor;
@@ -125,7 +125,7 @@ API_AVAILABLE(macos(10.14))
   float *_betaPointer, *_gammaPointer, *_betaMomentumPointer,
       *_betaVelocityPointer, *_gammaVelocityPointer, *_gammaMomentumPointer,
       *_movingVariancePointer, *_movingMeanPointer;
-  OptimizerOptions _optimizerOptions;
+  turi::mps::OptimizerOptions _optimizerOptions;
   float t;
   float _batchNormEpsilon;
 
@@ -162,7 +162,7 @@ API_AVAILABLE(macos(10.14))
                                     beta:(float *__nullable)b_ptr
                               moving_avg:(float *__nullable)ma_ptr
                               moving_var:(float *__nullable)mv_ptr
-                        optimizerOptions:(OptimizerOptions)optimizerOptions
+                        optimizerOptions:(turi::mps::OptimizerOptions)optimizerOptions
                         batchNormEpsilon:(float)batchNormEpsilon;
 
 // MPSCNNBatchNormalizationDataSource interface methods

--- a/src/unity/toolkits/tcmps/mps_weight.mm
+++ b/src/unity/toolkits/tcmps/mps_weight.mm
@@ -11,7 +11,7 @@ using turi::mps::OptimizerOptions;
 
 
 
-@implementation RandomWeights
+@implementation TCMPSConvolutionWeights
 
 - (nonnull instancetype)initWithKernelWidth:(NSUInteger)kernelWidth
                                kernelHeight:(NSUInteger)kernelHeight
@@ -357,9 +357,9 @@ updateWithCommandBuffer:(__nonnull id<MTLCommandBuffer>)commandBuffer
 
 - (void)dealloc {
 }
-@end /* MyRandomWeights */
+@end  // TCMPSConvolutionWeights
 
-@implementation BNData
+@implementation TCMPSBatchNormData
 
 @synthesize internalLabel = _label;
 
@@ -770,4 +770,4 @@ updateGammaAndBetaWithCommandBuffer:(nonnull id<MTLCommandBuffer>)commandBuffer
     [movingVarianceBuffer didModifyRange:NSMakeRange(0, _channels * sizeof(float))];
 }
 
-@end // MyBatchNormData
+@end  // TCMPSBatchNormData

--- a/src/unity/toolkits/tcmps/mps_weight.mm
+++ b/src/unity/toolkits/tcmps/mps_weight.mm
@@ -7,7 +7,7 @@
 
 #include "mps_weight.h"
 
-
+using turi::mps::OptimizerOptions;
 
 
 


### PR DESCRIPTION
Our libtcmps.dylib really shouldn’t export pure C functions with names like “Init” and “Load”, which are bound to collide someday with someone who links against this library. Instead, we should add a prefix to all C functions and Objective-C classes. Going with “TCMPS” as the best fit for existing names in this code base. While we’re at it, the C++ symbols are moved into a new turi::mps namespace, instead of being declared at the top level.

Also did some miscellaneous cleanup in the top-level C interface for TCMPS. All of these changes should be behavior-preserving, although previously some Objective-C code was running outside of autorelease pools (that we know will drain).