### PR TITLE
Resolve #614 - a few bug fixes in AC train-test split 

### DIFF
--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -126,7 +126,7 @@ class ActivityClassifierAutoValdSetTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fraction = 0.9
-        self.seed = 4
+        self.seed = 42
 
     def _create_auto_validation_set(self):
         model = tc.activity_classifier.create(self.data,
@@ -145,7 +145,7 @@ class ActivityClassifierAutoValdSetTest(unittest.TestCase):
         train_frac = float(train_num_sessions / num_sessions)
         expected_frac = 1.0 if is_small else self.fraction
 
-        self.assertAlmostEqual(train_frac, expected_frac, places=2,
+        self.assertAlmostEqual(train_frac, expected_frac, places=1,
                                msg= "Got {} train sessions out of {}, which is {:.3f}, and not the expected {}".format(
                                train_num_sessions, num_sessions, train_frac, expected_frac))
 
@@ -157,7 +157,7 @@ class ActivityClassifierAutoValdSetTest(unittest.TestCase):
         valid_frac = float(valid_num_sessions / num_sessions)
         expected_valid_frac = 1.0 - self.fraction
 
-        self.assertAlmostEqual(valid_frac, expected_valid_frac, places=2,
+        self.assertAlmostEqual(valid_frac, expected_valid_frac, places=1,
                                msg= "Got {} train sessions out of {}, which is {:.3f}, and not the expected {}".format(
                                valid_num_sessions, num_sessions, valid_frac, expected_valid_frac))
 
@@ -175,23 +175,15 @@ class ActivityClassifierAutoValdSetTest(unittest.TestCase):
         self._test_random_split_by_session(num_sessions, is_small=True)
 
     def test_create_auto_validation_set_typical(self):
-        num_sessions = tc.activity_classifier.util._MAX_SESSIONS_TO_USE_IS_IN // 4
+        num_sessions = tc.activity_classifier.util._MIN_NUM_SESSIONS_FOR_SPLIT * 4
         _load_data(self, num_examples=10000, max_num_sessions=num_sessions, randomize_num_sessions=False,
                    enforce_all_sessions=True)
 
         self._create_auto_validation_set()
         self._test_random_split_by_session(num_sessions)
 
-    def test_create_auto_validation_set_large(self):
-        num_sessions = tc.activity_classifier.util._MAX_SESSIONS_TO_USE_IS_IN + 200
-        _load_data(self, num_examples=10000, max_num_sessions=num_sessions, randomize_num_sessions=False,
-                   enforce_all_sessions = True)
-
-        self._create_auto_validation_set()
-        self._test_random_split_by_session(num_sessions)
-
     def test_create_auto_validation_set_string_session_id(self):
-        num_sessions = tc.activity_classifier.util._MAX_SESSIONS_TO_USE_IS_IN // 4
+        num_sessions = tc.activity_classifier.util._MIN_NUM_SESSIONS_FOR_SPLIT * 4
         _load_data(self, num_examples=10000, max_num_sessions=num_sessions, randomize_num_sessions=False,
                    enforce_all_sessions=True)
 

--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -59,10 +59,8 @@ def _random_session_ids(num_examples , num_sessions):
     max_lines_per_session = int(1.15 * examples_per_session)
 
     lines_in_each_session = [random.randint(min_lines_per_session, max_lines_per_session) for i in range(num_sessions)]
+    lines_in_each_session = [(x * (num_examples)) // sum(lines_in_each_session) for x in lines_in_each_session]
     lines_in_each_session[-1] += num_examples - sum(lines_in_each_session)
-
-    if lines_in_each_session[-1] < 0:
-        raise ValueError()
 
     session_ids = []
     for value, num_lines in enumerate(lines_in_each_session):

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -164,6 +164,9 @@ def create(dataset, session_id, target, features=None, prediction_window=100,
     _tkutl._raise_error_if_sarray_not_expected_dtype(dataset[target], target, [str, int])
     _tkutl._raise_error_if_sarray_not_expected_dtype(dataset[session_id], session_id, [str, int])
 
+    if isinstance(validation_set, str) and validation_set == 'auto':
+        dataset, validation_set = _random_split_by_session(dataset, session_id)
+
     # Encode the target column to numerical values
     use_target = target is not None
     dataset, target_map = _encode_target(dataset, target)
@@ -171,12 +174,6 @@ def create(dataset, session_id, target, features=None, prediction_window=100,
     predictions_in_chunk = 20
     chunked_data, num_sessions = _prep_data(dataset, features, session_id, prediction_window,
                                             predictions_in_chunk, target=target, verbose=verbose)
-
-    if isinstance(validation_set, str) and validation_set == 'auto':
-        if num_sessions < 100:
-            validation_set = None
-        else:
-            dataset, validation_set = _random_split_by_session(dataset, session_id)
 
     # Decide whether to use MPS GPU, MXnet GPU or CPU
     num_mxnet_gpus = _mxnet_utils.get_num_gpus_in_use(max_devices=num_sessions)

--- a/src/unity/python/turicreate/toolkits/activity_classifier/util.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/util.py
@@ -11,6 +11,7 @@ from turicreate.util import _raise_error_if_not_of_type
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _numeric_param_check_range
 
+MIN_NUM_SESSIONS_FOR_SPLIT = 100
 
 def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
     """
@@ -68,6 +69,10 @@ def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
             'Input "dataset" must contain a column called %s.' % session_id)
 
     unique_sessions = _SFrame({'session': dataset[session_id].unique()})
+    if len(unique_sessions) < MIN_NUM_SESSIONS_FOR_SPLIT:
+        print ("The dataset has less than the minimum of", MIN_NUM_SESSIONS_FOR_SPLIT, "sessions required for train-validation split. Continuing without validation set")
+        return dataset, None
+
     chosen, not_chosen = unique_sessions.random_split(fraction, seed)
     train = dataset.filter_by(chosen['session'], session_id)
     valid = dataset.filter_by(not_chosen['session'], session_id)

--- a/src/unity/python/turicreate/toolkits/activity_classifier/util.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/util.py
@@ -10,7 +10,7 @@ from turicreate import SFrame as _SFrame
 from turicreate.util import _raise_error_if_not_of_type
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _numeric_param_check_range
-import random as _random
+from random import Random
 
 _MIN_NUM_SESSIONS_FOR_SPLIT = 100
 
@@ -80,7 +80,9 @@ def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
     if seed is None:
         import time
         seed = long(time.time() * 256)
-
+    
+    random = Random()
+    
     # Create a random binary filter (boolean SArray), using the same probability across all lines
     # that belong to the same session. In expectancy - the desired fraction of the sessions will
     # go to the training set.
@@ -88,9 +90,9 @@ def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
     def random_session_pick(session_id):
         # If we will use only the session_id as the seed - the split will be constant for the
         # same dataset across different runs, which is of course undesired
-        _random.seed(hash(session_id) + seed)
-        return _random.uniform(0, 1) < fraction
-
+        random.seed(hash(session_id) + seed)
+        return random.uniform(0, 1) < fraction
+    
     chosen_filter = dataset[session_id].apply(random_session_pick)
     train = dataset[chosen_filter]
     valid = dataset[1 - chosen_filter]

--- a/src/unity/python/turicreate/toolkits/activity_classifier/util.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/util.py
@@ -11,8 +11,8 @@ from turicreate.util import _raise_error_if_not_of_type
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _numeric_param_check_range
 
-MIN_NUM_SESSIONS_FOR_SPLIT = 100
-MAX_SESSIONS_TO_USE_IS_IN = 2000
+_MIN_NUM_SESSIONS_FOR_SPLIT = 100
+_MAX_SESSIONS_TO_USE_IS_IN = 2000
 
 def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
     """
@@ -70,8 +70,8 @@ def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
             'Input "dataset" must contain a column called %s.' % session_id)
 
     unique_sessions = _SFrame({'session': dataset[session_id].unique()})
-    if len(unique_sessions) < MIN_NUM_SESSIONS_FOR_SPLIT:
-        print ("The dataset has less than the minimum of", MIN_NUM_SESSIONS_FOR_SPLIT, "sessions required for train-validation split. Continuing without validation set")
+    if len(unique_sessions) < _MIN_NUM_SESSIONS_FOR_SPLIT:
+        print ("The dataset has less than the minimum of", _MIN_NUM_SESSIONS_FOR_SPLIT, "sessions required for train-validation split. Continuing without validation set")
         return dataset, None
 
     chosen, not_chosen = unique_sessions.random_split(fraction, seed)
@@ -106,7 +106,7 @@ def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
     # For a small number of unique sessions, creating a filter using SFrame.is_in() would
     # be efficient - since filtering with a binary SArray maintains order, and no sorting
     # is required.
-    if len(unique_sessions) < MAX_SESSIONS_TO_USE_IS_IN:
+    if len(unique_sessions) < _MAX_SESSIONS_TO_USE_IS_IN:
         return split_using_is_in(dataset, session_id, not_chosen)
     else:
         return split_using_filter(dataset, session_id, chosen, not_chosen)

--- a/src/unity/python/turicreate/toolkits/activity_classifier/util.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/util.py
@@ -10,9 +10,9 @@ from turicreate import SFrame as _SFrame
 from turicreate.util import _raise_error_if_not_of_type
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _numeric_param_check_range
+import random as _random
 
 _MIN_NUM_SESSIONS_FOR_SPLIT = 100
-_MAX_SESSIONS_TO_USE_IS_IN = 2000
 
 def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
     """
@@ -74,39 +74,24 @@ def random_split_by_session(dataset, session_id, fraction=0.9, seed=None):
         print ("The dataset has less than the minimum of", _MIN_NUM_SESSIONS_FOR_SPLIT, "sessions required for train-validation split. Continuing without validation set")
         return dataset, None
 
-    chosen, not_chosen = unique_sessions.random_split(fraction, seed)
+    # We need an actual seed number, which we will later use in the apply function (see below).
+    # If the user didn't provide a seed - we can generate one based on current system time
+    # (similarly to mechanism behind random.seed(None) )
+    if seed is None:
+        import time
+        seed = long(time.time() * 256)
 
-    def split_using_is_in(data, session_id, not_chosen):
-        not_chosen_filter = data[session_id].is_in(not_chosen['session'])
+    # Create a random binary filter (boolean SArray), using the same probability across all lines
+    # that belong to the same session. In expectancy - the desired fraction of the sessions will
+    # go to the training set.
+    # Since boolean filters preserve order - there is no need to re-sort the lines within each session.
+    def random_session_pick(session_id):
+        # If we will use only the session_id as the seed - the split will be constant for the
+        # same dataset across different runs, which is of course undesired
+        _random.seed(hash(session_id) + seed)
+        return _random.uniform(0, 1) < fraction
 
-        train = data[1 - not_chosen_filter]
-        valid = data[not_chosen_filter]
-
-        return train, valid
-
-    def split_using_filter(data, session_id, chosen, not_chosen):
-
-        # The activty classifier assumes that lines within each session
-        # are consecutive samples, ordered in ascending time order.
-        # Since filter_by() does not maintain order - we will need to re-sort
-        # after the split.
-        id_column = "original_data_row_id"
-        data = data.add_row_number(id_column)
-
-        train = data.filter_by(chosen['session'], session_id)
-        valid = data.filter_by(not_chosen['session'], session_id)
-
-        train = train.sort(id_column)
-        valid = valid.sort(id_column)
-        train = train.remove_column(id_column)
-        valid = valid.remove_column(id_column)
-
-        return train, valid
-
-    # For a small number of unique sessions, creating a filter using SFrame.is_in() would
-    # be efficient - since filtering with a binary SArray maintains order, and no sorting
-    # is required.
-    if len(unique_sessions) < _MAX_SESSIONS_TO_USE_IS_IN:
-        return split_using_is_in(dataset, session_id, not_chosen)
-    else:
-        return split_using_filter(dataset, session_id, chosen, not_chosen)
+    chosen_filter = dataset[session_id].apply(random_session_pick)
+    train = dataset[chosen_filter]
+    valid = dataset[1 - chosen_filter]
+    return train, valid


### PR DESCRIPTION
1. Solved two bugs in the way the train-validation split was used in the Activity Classifier (causing `create()` to crash when `validation_set='auto'`).
2. Improved the `random_split_by_session() ` mechanism. The current implementation might have broken line order - which is not allowed for the AC. The new mechanism is optimized for the typical case of 100-1000 training sessions.
3. Added explicit unit test that covers the auto validation set in all relevant cases.