### PR TITLE
Add NSCopying conformance to TCMPSConvolutionWeights and TCMPSBatchNormData

### DIFF
--- a/src/unity/toolkits/tcmps/mps_weight.mm
+++ b/src/unity/toolkits/tcmps/mps_weight.mm
@@ -198,6 +198,17 @@ using turi::mps::OptimizerOptions;
   return self;
 }
 
+// We don't yet trigger any copies of this data source, but real implementations
+// here will be necessary to support training with additional GPUs
+- (instancetype)copyWithZone:(nullable NSZone *)zone {
+  assert(false && "NSCopying not implemented for TCMPSConvolutionWeights");
+  return self;
+}
+
+- (instancetype)copyWithZone:(nullable NSZone *)zone device:(nullable id <MTLDevice>)device {
+  assert(false && "NSCopying not implemented for TCMPSConvolutionWeights");
+  return self;
+}
 
 - (MPSDataType)dataType {
   return MPSDataTypeFloat32;
@@ -553,6 +564,18 @@ updateWithCommandBuffer:(__nonnull id<MTLCommandBuffer>)commandBuffer
   _label = [NSString stringWithCString:kernelParamsBinaryName
                               encoding:[NSString defaultCStringEncoding]];
 
+  return self;
+}
+
+// We don't yet trigger any copies of this data source, but real implementations
+// here will be necessary to support training with additional GPUs
+- (instancetype)copyWithZone:(nullable NSZone *)zone {
+  assert(false && "NSCopying not implemented for TCMPSBatchNormData");
+  return self;
+}
+
+- (instancetype)copyWithZone:(nullable NSZone *)zone device:(nullable id <MTLDevice>)device {
+  assert(false && "NSCopying not implemented for TCMPSBatchNormData");
   return self;
 }
 


### PR DESCRIPTION
With the just-released developer seed 18A326g, MPSCNNConvolutionDataSource and MPSCNNBatchNormalizationDataSource now inherit from NSCopying. We must add conformance to our data source implementations to avoid build breakage, since we compile with -Werror.