### PR TITLE
Clean up toolkit progress header names

### DIFF
--- a/src/logger/assertions.hpp
+++ b/src/logger/assertions.hpp
@@ -375,15 +375,7 @@ extern void __print_back_trace();
 
 
 #define DASSERT_MSG(condition, fmt, ...)                                \
-  do {                                                                  \
-    if (__builtin_expect(!(condition), 0)) {                            \
-      logstream(LOG_ERROR)                                              \
-        << "Check failed: " << #condition << ":\n";                     \
-      logger(LOG_ERROR, fmt, ##__VA_ARGS__);                            \
-      __print_back_trace();                                             \
-      TURI_LOGGER_FAIL_METHOD("assertion failure");                    \
-    }                                                                   \
-  } while(0)
+  ASSERT_MSG(condition, fmt, ##__VA_ARGS__)
 
 #endif
 

--- a/src/unity/python/turicreate/test/test_sentence_classifier.py
+++ b/src/unity/python/turicreate/test/test_sentence_classifier.py
@@ -166,11 +166,11 @@ class SentenceClassifierCreateTests(unittest.TestCase):
 
         # Test with a validation set
         model = tc.sentence_classifier.create(train, target='rating', validation_set=valid)
-        self.assertTrue('Validation-accuracy' in model.classifier.progress.column_names())
+        self.assertTrue('Validation Accuracy' in model.classifier.progress.column_names())
 
         # Test without a validation set
         model = tc.sentence_classifier.create(train, target='rating', validation_set=None)
-        self.assertTrue('Validation-accuracy' not in model.classifier.progress.column_names())
+        self.assertTrue('Validation Accuracy' not in model.classifier.progress.column_names())
 
         # Test 'auto' validation set
         big_data = train.append(tc.SFrame({
@@ -179,7 +179,7 @@ class SentenceClassifierCreateTests(unittest.TestCase):
             'text': ['large enough data for %5 percent validation split to activate'] * 100
         }))
         model = tc.sentence_classifier.create(big_data, target='rating', validation_set='auto')
-        self.assertTrue('Validation-accuracy' in model.classifier.progress.column_names())
+        self.assertTrue('Validation Accuracy' in model.classifier.progress.column_names())
 
         # Test bad validation set string
         with self.assertRaises(TypeError):

--- a/src/unity/python/turicreate/test/test_tree_tracking_metrics.py
+++ b/src/unity/python/turicreate/test/test_tree_tracking_metrics.py
@@ -41,13 +41,13 @@ class TreeRegressionTrackingMetricsTest(unittest.TestCase):
                 raise TypeError('Invalid metric type')
 
             for name in test_metrics:
-                column_name = 'Training-%s' % name
+                column_name = 'Training %s' % name
                 self.assertTrue(column_name in history_header)
                 final_eval = m.evaluate(train, name)[name]
                 progress_evals = m.progress[column_name]
                 self.assertAlmostEqual(float(progress_evals[-1]), final_eval, delta=1e-4)
                 if valid is not None:
-                    column_name = 'Validation-%s' % name
+                    column_name = 'Validation %s' % name
                     self.assertTrue(column_name in history_header)
 
     def test_auto_metric(self):
@@ -77,8 +77,8 @@ class TreeRegressionTrackingMetricsTest(unittest.TestCase):
 
         m_last = rf_models[-1]
         for name in self.test_metrics:
-            train_column_name = 'Training-%s' % name
-            test_column_name = 'Validation-%s' % name
+            train_column_name = 'Training %s' % name
+            test_column_name = 'Validation %s' % name
             train_evals = [float(x) for x in m_last.progress[train_column_name]]
             test_evals = [float(x) for x in m_last.progress[test_column_name]]
             # Check the final model's metric at iteration i against the ith model's last metric

--- a/src/unity/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/unity/python/turicreate/toolkits/_supervised_learning.py
@@ -507,8 +507,8 @@ def create_classification_with_model_selector(dataset, target, model_selector,
         # Most models have this.
         elif 'progress' in m._list_fields():
             prog = m.progress
-            validation_column = 'Validation-accuracy'
-            accuracy_column = 'Training-accuracy'
+            validation_column = 'Validation Accuracy'
+            accuracy_column = 'Training Accuracy'
             if validation_column in prog.column_names():
                 metrics[model_name] = float(prog[validation_column].tail(1)[0])
             else:

--- a/src/unity/toolkits/supervised_learning/supervised_learning.cpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.cpp
@@ -350,6 +350,28 @@ std::vector<std::string>
   return tracking_metrics;
 }
 
+std::string supervised_learning_model_base::get_metric_display_name(const std::string& metric) const {
+  const static std::unordered_map<std::string, std::string> display_names = {
+    {"accuracy", "Accuracy"},
+    {"log_loss", "Log Loss"},
+    {"max_error", "Max Error"},
+    {"rmse", "Root-Mean-Square Error"},
+  };
+
+  auto found = display_names.find(metric);
+  if (found != display_names.end()) {
+    return found->second;
+  }
+
+  // Shouldn't get here; it means we neglected to map to a display name for this metric.
+  // If there is a metric and it's not in the map above, please add it.
+  // In the meantime, we fall back to using the internal name as the display name.
+#ifndef NDEBUG
+  std::string msg = "Could not find a display name for metric " + metric;
+  DASSERT_MSG(false, msg.c_str());
+#endif
+  return metric;
+}
 
 /**
  * Classify (with a probability) using a trained model.

--- a/src/unity/toolkits/supervised_learning/supervised_learning.hpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.hpp
@@ -605,6 +605,11 @@ class EXPORT supervised_learning_model_base : public ml_model_base {
   std::vector<std::string> get_tracking_metrics()  const;
 
   /**
+   * Get metric display name.
+   */
+  std::string get_metric_display_name(const std::string& metric) const;
+
+  /**
    * Display model training data summary for regression.
    *
    * \param[in] model_display_name   Name to be displayed

--- a/src/unity/toolkits/supervised_learning/supervised_learning_utils-inl.hpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning_utils-inl.hpp
@@ -378,9 +378,9 @@ inline std::vector<std::pair<std::string, size_t>> make_printer_header(
   };
 
   for (const auto& m: metrics) {
-    header.push_back({std::string("Training-") + m, 6});
+    header.push_back({std::string("Training ") + m, 6});
     if (has_validation)
-      header.push_back({std::string("Validation-") + m, 6});
+      header.push_back({std::string("Validation ") + m, 6});
   }
 
   header.push_back({"Examples/second", 0});
@@ -429,9 +429,10 @@ inline std::vector<std::pair<std::string, size_t>> make_progress_header(
   }
 
   for (const auto& m: metrics) {
-    header.push_back({std::string("Training-") + m, 6});
+    std::string dm = smodel.get_metric_display_name(m);
+    header.push_back({std::string("Training ") + dm, 6});
     if (has_validation_data) 
-      header.push_back({std::string("Validation-") + m, 6});
+      header.push_back({std::string("Validation ") + dm, 6});
   }
 
   return header;

--- a/src/unity/toolkits/supervised_learning/xgboost.cpp
+++ b/src/unity/toolkits/supervised_learning/xgboost.cpp
@@ -820,9 +820,9 @@ table_printer xgboost_model::_init_progress_printer(bool has_validation_data) {
     {"Elapsed Time", default_column_width}
   };
   for (auto& metric : tracking_metrics) {
-    progress_header.push_back({"Training-" + metric, metric_column_width});
+    progress_header.push_back({"Training " + metric, metric_column_width});
     if (has_validation_data) {
-      progress_header.push_back({"Validation-" + metric, metric_column_width});
+      progress_header.push_back({"Validation " + metric, metric_column_width});
     }
   }
   table_printer printer(progress_header);


### PR DESCRIPTION
* Uses "Training " and "Validation " (capital letter, space at the end)
  as the standard header prefixes.
* Adds a concept of "metric display name", and uses the display name
  whenever there is one defined when adding metric names to the progress
  headers. I.e., "Log Loss" instead of "log_loss".

Fixes #757