### PR TITLE
Update build instructions to reflect updated Xcode beta requirement

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ Build Dependencies
 
 You will need:
 
-* On macOS, [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) with command line tools (tested with Xcode 9 and Xcode 10 beta)
+* On macOS, [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) with command line tools (tested with Xcode 9 and Xcode 10 beta 3)
 * On Linux:
   * A C++ compiler toolchain with C++11 support
   * `xxd` (typically provided by the `vim-common` package)


### PR DESCRIPTION
PR #823 introduced a new dependency on Xcode 10 beta 3 (which introduced some new MetalPerformanceShaders API) but neglected to update the build instructions

(Xcode 9 is still supported, since in that case we don't attempt to build the relevant code against the macOS 10.14 SDK)