### PR TITLE
Ensure model state is always updated with training

### DIFF
--- a/src/numerics/armadillo.hpp
+++ b/src/numerics/armadillo.hpp
@@ -19,7 +19,6 @@
 
 namespace turi {
 
-//
 using arma::exp;
 using arma::approx_equal;
 

--- a/src/optimization/accelerated_gradient-inl.hpp
+++ b/src/optimization/accelerated_gradient-inl.hpp
@@ -74,6 +74,10 @@ inline solver_return accelerated_gradient(first_order_opt_interface& model,
     std::stringstream ss;
     ss.str("");
 
+    // First iteration will take longer. Warn the user.
+    logprogress_stream <<"Tuning step size. First iteration could take longer"
+                       <<" than subsequent iterations." << std::endl;
+
     // Print progress 
     table_printer printer(
         model.get_status_header({"Iteration", "Passes", "Step size", "Elapsed Time"}));
@@ -105,10 +109,12 @@ inline solver_return accelerated_gradient(first_order_opt_interface& model,
     double residual = compute_residual(gradient);
     stats.num_passes++;
     
-    // First iteration will take longer. Warn the user.
-    logprogress_stream <<"Tuning step size. First iteration could take longer"
-                       <<" than subsequent iterations." << std::endl;
-    
+    std::vector<std::string> stat_info = {std::to_string(iters),
+                                          std::to_string(stats.num_passes),
+                                          std::to_string(step_size),
+                                          std::to_string(tmr.current_time())};
+    std::vector<std::string> row = model.get_status(point, stat_info);
+    printer.print_progress_row_strs(iters, row);
 
     // Value of parameters t in itersation k-1 and k
     double t = 1;                           // t_k   
@@ -194,11 +200,11 @@ inline solver_return accelerated_gradient(first_order_opt_interface& model,
       }
 
       // Print progress
-      auto stat_info = {std::to_string(iters), 
-                        std::to_string(stats.num_passes),
-                        std::to_string(step_size), 
-                        std::to_string(tmr.current_time())};
-      auto row = model.get_status(point, stat_info);
+      stat_info = {std::to_string(iters),
+                   std::to_string(stats.num_passes),
+                   std::to_string(step_size),
+                   std::to_string(tmr.current_time())};
+      row = model.get_status(point, stat_info);
       printer.print_progress_row_strs(iters, row);
       
       // Log info for debugging. 

--- a/src/optimization/lbfgs-inl.hpp
+++ b/src/optimization/lbfgs-inl.hpp
@@ -144,6 +144,17 @@ inline solver_return lbfgs(first_order_opt_interface& model,
     double fprevious = func_value;
     bool tune_step_size = true;
 
+    std::vector<std::string> stat_info =
+          (simple_mode
+               ? std::vector<std::string>{std::to_string(iters),
+              std::to_string(t.current_time())}
+               : std::vector<std::string>{std::to_string(iters),
+                     std::to_string(stats.num_passes),
+                     "NaN",
+                     std::to_string(t.current_time())});
+    std::vector<std::string> row = model.get_status(point, stat_info);
+    printer.print_progress_row_strs(iters, row);
+
     // LBFGS storage
     // The search steps and gradient differences are stored in a order 
     // controlled by the start point.
@@ -324,16 +335,16 @@ inline solver_return lbfgs(first_order_opt_interface& model,
                           << std::endl;
 
       // Print progress
-      auto stat_info =
+      stat_info =
           (simple_mode
                ? std::vector<std::string>{std::to_string(iters),
                                           std::to_string(t.current_time())}
                : std::vector<std::string>{std::to_string(iters),
                         std::to_string(stats.num_passes),
-                        std::to_string(ls_stats.step_size), 
+                        std::to_string(ls_stats.step_size),
                                           std::to_string(t.current_time())});
 
-      auto row = model.get_status(point, stat_info);
+      row = model.get_status(point, stat_info);
       printer.print_progress_row_strs(iters, row);
 
     }

--- a/src/optimization/newton_method-inl.hpp
+++ b/src/optimization/newton_method-inl.hpp
@@ -98,7 +98,13 @@ inline solver_return newton_method(second_order_opt_interface& model,
       gradient += reg_gradient;
     }
     double residual = compute_residual(gradient);
-    
+
+    std::vector<std::string> stat_info = {std::to_string(iters),
+                                          std::to_string(stats.num_passes),
+                                          std::to_string(t.current_time())};
+    std::vector<std::string> row = model.get_status(point, stat_info);
+    printer.print_progress_row_strs(iters, row);
+
     // Keep track of previous point 
     DenseVector delta_point = point;
     delta_point.zeros();
@@ -129,7 +135,7 @@ inline solver_return newton_method(second_order_opt_interface& model,
         / std::max(arma::norm(gradient, 2), OPTIMIZATION_ZERO);
 
 
-      // LDLT Decomposition failed. 
+      // LDLT Decomposition failed.
       if (relative_error > convergence_threshold){
         logprogress_stream << "WARNING: Matrix is close to being singular or"
           << " badly scaled. The solution is accurate only up to a tolerance of " 
@@ -172,10 +178,10 @@ inline solver_return newton_method(second_order_opt_interface& model,
       }
 
       // Print progress
-      auto stat_info = {std::to_string(iters), 
-                        std::to_string(stats.num_passes),
-                        std::to_string(t.current_time())};
-      auto row = model.get_status(point, stat_info);
+      stat_info = {std::to_string(iters),
+                   std::to_string(stats.num_passes),
+                   std::to_string(t.current_time())};
+      row = model.get_status(point, stat_info);
       printer.print_progress_row_strs(iters, row);
     }
     printer.print_footer();

--- a/src/unity/python/turicreate/test/test_logistic_classifier.py
+++ b/src/unity/python/turicreate/test/test_logistic_classifier.py
@@ -679,6 +679,15 @@ class LogisticRegressionCreateTest(unittest.TestCase):
                     False)
             self._test_create(*args)
 
+    def test_init_residual_of_zero(self):
+        X = tc.SFrame({'col1': [2., 1., 2., 1.], 'target': [1, 1, 2, 2]})
+
+        # Try all three solvers
+        tc.logistic_classifier.create(X, target = 'target', solver = 'newton')
+        tc.logistic_classifier.create(X, target = 'target', solver = 'lbfgs')
+        tc.logistic_classifier.create(X, target = 'target', solver = 'fista')
+
+
 class ListCategoricalLogisticRegressionTest(unittest.TestCase):
     """
     Unit test class for testing logistic regression with a categorical feature.

--- a/src/unity/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/unity/python/turicreate/toolkits/_supervised_learning.py
@@ -284,7 +284,6 @@ def create(dataset, target, model_name, features=None,
         List of feature names used by feature column
 
     validation_set : SFrame, optional
-
         A dataset for monitoring the model's generalization performance.
         For each row of the progress table, the chosen metrics are computed
         for both the provided training dataset and the validation_set. The

--- a/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.cpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression_opt_interface.cpp
@@ -68,7 +68,7 @@ void flattened_sparse_vector_outer_prod(const SparseVector& a,
 logistic_regression_opt_interface::logistic_regression_opt_interface(
     const ml_data& _data, 
     const ml_data& _valid_data, 
-    logistic_regression& _sp_model) {  
+    logistic_regression& _sp_model) {
 
   data = _data;
   if (_valid_data.num_rows() > 0) valid_data = _valid_data;
@@ -176,7 +176,7 @@ size_t logistic_regression_opt_interface::num_classes() const{
 /**
  * Get strings needed to print the header for the progress table.
  */
-std::vector<std::pair<std::string, size_t>> 
+std::vector<std::pair<std::string, size_t>>
 logistic_regression_opt_interface::get_status_header(const std::vector<std::string>& stat_headers) {
   bool has_validation_data = (valid_data.num_rows() > 0);
   auto header = make_progress_header(smodel, stat_headers, has_validation_data); 


### PR DESCRIPTION
`model.get_status(...)` and `printer.print_progress_row_strs(...)` both update state. `model.get_status(...)` updates the models coefficients and values stored by the printer are used by model auto selection code. This change makes sure that both methods are called at least one, even when the initial residuals are zeros. 

Fixes #764

With this change progress printing for models training will now show an entry for the zero-th iteration, instead of starting at one. Besides fixing #734, that should be the only user facing change.

Moved an info message for FISTA so it doesn't get printed inside of the progress table.