### PR TITLE
Clean up error messages on model save

### DIFF
--- a/src/fileio/fs_utils.hpp
+++ b/src/fileio/fs_utils.hpp
@@ -45,9 +45,20 @@ std::vector<std::pair<std::string, file_status>> get_directory_listing(const std
  * \ingroup fileio
  * Creates a directory and all parent required directories (like mkdir -p).
  * Path can be hdfs, s3, or regular filesystem.
- * Returns true on success, false on failure.
+ * Returns true on creation, false on failure or if the directory already exists.
+ * To get meaningful error messages thrown on failure, use create_directory_or_throw.
  */
 bool create_directory(const std::string& path);
+
+
+/**
+ * \ingroup fileio
+ * Creates a directory and all parent required directories (like mkdir -p).
+ * Path can be hdfs, s3, or regular filesystem.
+ * Returns true on creation, false if the directory already exists.
+ * Throws std::ios_base::failure on failure.
+ */
+bool create_directory_or_throw(const std::string& path);
 
 /**
  * \ingroup fileio

--- a/src/fileio/general_fstream.cpp
+++ b/src/fileio/general_fstream.cpp
@@ -65,7 +65,12 @@ std::shared_ptr<std::istream> general_ifstream::get_underlying_stream() {
 /*****************************************************************************/
 
 general_ofstream::general_ofstream(std::string filename)
-    try :general_ofstream_base(filename), opened_filename(filename) { } catch (const std::exception& e) {
+    try :general_ofstream_base(filename), opened_filename(filename) {
+      // this space intentionally left blank
+    } catch (const std::ios_base::failure& e) {
+      // an I/O error is already the exception type - just re-throw
+      throw;
+    } catch (const std::exception& e) {
       log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e.what());
     } catch (std::string e) {
       log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e);

--- a/src/fileio/union_fstream.cpp
+++ b/src/fileio/union_fstream.cpp
@@ -16,6 +16,10 @@
 #include <fileio/sanitize_url.hpp>
 #include <boost/algorithm/string.hpp>
 #include <fileio/fs_utils.hpp>
+
+#include <cstring>
+#include <cerrno>
+
 namespace turi {
 /**
  * A simple union of std::fstream and turi::hdfs::fstream, and turi::fileio::cache_stream.
@@ -97,8 +101,7 @@ union_fstream::union_fstream(std::string url,
       // Output stream must be a local openable file.
       output_stream.reset(new std::ofstream(url, std::ofstream::binary));
       if (!output_stream->good()) {
-        output_stream.reset();
-        log_and_throw_io_failure("Cannot open " + url + " for writing");
+        log_and_throw_current_io_failure();
       }
     } else {
 #ifdef TC_ENABLE_REMOTEFS

--- a/src/logger/CMakeLists.txt
+++ b/src/logger/CMakeLists.txt
@@ -8,6 +8,7 @@ project(Turi)
 
 make_library(logger
   SOURCES
+    error.cpp
     logger.cpp
     backtrace.cpp
     log_rotate.cpp

--- a/src/logger/error.cpp
+++ b/src/logger/error.cpp
@@ -12,9 +12,9 @@
 
 using namespace turi::error;
 
-io_error::io_error(const std::string& message, const std::error_code& ec)
-    : std::ios_base::failure(message, ec), m_message(message) { }
+io_error::io_error(const std::string &message, const std::error_code &ec)
+  : std::ios_base::failure(message, ec), m_message(message) {}
 
-const char* io_error::what() const noexcept {
-    return m_message.c_str();
+const char *io_error::what() const noexcept {
+  return m_message.c_str();
 }

--- a/src/logger/error.cpp
+++ b/src/logger/error.cpp
@@ -1,0 +1,20 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Error types to distinguish Turi Create errors from arbitrary C++ exceptions
+ */
+
+#include <logger/error.hpp>
+
+using namespace turi::error;
+
+io_error::io_error(const std::string& message, const std::error_code& ec)
+    : std::ios_base::failure(message, ec), m_message(message) { }
+
+const char* io_error::what() const noexcept {
+    return m_message.c_str();
+}

--- a/src/logger/error.hpp
+++ b/src/logger/error.hpp
@@ -1,0 +1,24 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Error types to distinguish Turi Create errors from arbitrary C++ exceptions
+ */
+
+#include <ios>
+
+namespace turi {
+    namespace error {
+        class io_error: public std::ios_base::failure {
+        private:
+            std::string m_message;
+
+        public:
+            explicit io_error(const std::string& message, const std::error_code& ec = std::io_errc::stream);
+            virtual const char* what() const noexcept override;
+        };
+    }
+}

--- a/src/logger/error.hpp
+++ b/src/logger/error.hpp
@@ -11,14 +11,16 @@
 #include <ios>
 
 namespace turi {
-    namespace error {
-        class io_error: public std::ios_base::failure {
-        private:
-            std::string m_message;
+namespace error {
 
-        public:
-            explicit io_error(const std::string& message, const std::error_code& ec = std::io_errc::stream);
-            virtual const char* what() const noexcept override;
-        };
-    }
-}
+class io_error : public std::ios_base::failure {
+  private:
+    std::string m_message;
+
+  public:
+    explicit io_error(const std::string &message, const std::error_code &ec = std::io_errc::stream);
+    virtual const char *what() const noexcept override;
+};
+
+} // namespace error
+} // namespace turi

--- a/src/logger/logger.hpp
+++ b/src/logger/logger.hpp
@@ -49,6 +49,7 @@
 #include <timer/timer.hpp>
 #include <logger/fail_method.hpp>
 #include <logger/backtrace.hpp>
+#include <logger/error.hpp>
 #include <util/code_optimization.hpp> 
 #include <process/process_util.hpp>
 
@@ -345,7 +346,7 @@
   do {                                                                \
     auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {    \
       logstream(LOG_ERROR) << (message) << std::endl;                 \
-      throw(std::ios_base::failure(message, std::error_code()));      \
+      throw(turi::error::io_error(message, std::error_code()));      \
     };                                                                \
     throw_error();                                                    \
   } while(0)
@@ -354,11 +355,18 @@
   do {                                                                \
     auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {    \
       logstream(LOG_ERROR) << (message) << std::endl;                 \
-      throw(std::ios_base::failure(message));                         \
+      throw(turi::error::io_error(message));                         \
     };                                                                \
     throw_error();                                                    \
   } while(0)
 #endif
+
+#define log_and_throw_current_io_failure()                            \
+  do {                                                                \
+    auto error_code = errno;                                          \
+    std::string error_message = std::strerror(error_code);            \
+    log_and_throw_io_failure(error_message);                          \
+  } while(0)
 
 #define log_func_entry()                                       \
   do {                                                         \

--- a/src/logger/logger.hpp
+++ b/src/logger/logger.hpp
@@ -365,6 +365,7 @@
   do {                                                                \
     auto error_code = errno;                                          \
     std::string error_message = std::strerror(error_code);            \
+    errno = 0; // clear errno
     log_and_throw_io_failure(error_message);                          \
   } while(0)
 

--- a/src/serialization/dir_archive.cpp
+++ b/src/serialization/dir_archive.cpp
@@ -176,7 +176,7 @@ void dir_archive::init_for_write(const std::string& directory) {
   // ok if we get here, everything is good. begin from scratch and create the
   // archive
   m_directory = fileio::convert_to_generic(directory);
-  fileio::create_directory(m_directory);
+  fileio::create_directory_or_throw(m_directory);
 
   // clear index info
   m_index_info = dir_archive_impl::archive_index_information();

--- a/src/unity/lib/unity_global.cpp
+++ b/src/unity/lib/unity_global.cpp
@@ -337,6 +337,9 @@ namespace turi {
         log_and_throw_io_failure(message);
       }
       dir.close();
+    } catch (turi::error::io_error&) {
+      // already in a turi error message; just re-throw it
+      throw;
     } catch (std::ios_base::failure& e) {
       std::string message = "Unable to save model to " + sanitize_url(url) + ": " + e.what();
       log_and_throw_io_failure(message);
@@ -361,6 +364,9 @@ namespace turi {
         std::string message = "Fail to write.";
         log_and_throw_io_failure(message);
       }
+    } catch (turi::error::io_error&) {
+      // already in a turi error message; just re-throw it
+      throw;
     } catch (std::ios_base::failure& e) {
       std::string message = std::string("Unable to save model to data: ") + e.what();
       log_and_throw_io_failure(message);
@@ -394,6 +400,9 @@ namespace turi {
         log_and_throw_io_failure(message);
       }
       dir.close();
+    } catch (turi::error::io_error& e) {
+      // already in a turi error message; just re-throw it
+      throw;
     } catch (std::ios_base::failure& e) {
       std::string message = "Unable to save model to " + sanitize_url(url) + ": " + e.what();
       log_and_throw_io_failure(message);

--- a/test/capi/capi_models.cxx
+++ b/test/capi/capi_models.cxx
@@ -194,7 +194,33 @@ BOOST_AUTO_TEST_CASE(test_boosted_trees_double) {
 
     // Test saving and loading the model.
     {
-      std::string model_path =
+      // sad path 1 - attempting to save without permission to location
+      // ensure the error message contains useful info
+      std::string model_path = "/permission_should_be_denied";
+      tc_model_save(model, model_path.c_str(), &error);
+      TS_ASSERT_DIFFERS(error, nullptr);
+      std::string error_message = tc_error_message(error);
+      std::string expected_substr = "Ensure that you have write permission to this location, or try again with a different path";
+      TS_ASSERT_DIFFERS(error_message.find(expected_substr), error_message.npos);
+      error = nullptr;
+
+      // sad path 2 - attempting to save into an existing non-directory path
+      // ensure the error message contains useful info
+      model_path =
+        turi::fs_util::system_temp_directory_unique_path("", "_save_test_1_tmp_file");
+      {
+        std::ofstream tmp_file(model_path);
+        tmp_file << "Hello world";
+      }
+      tc_model_save(model, model_path.c_str(), &error);
+      TS_ASSERT_DIFFERS(error, nullptr);
+      error_message = tc_error_message(error);
+      expected_substr = "It already exists as a file";
+      TS_ASSERT_DIFFERS(error_message.find(expected_substr), error_message.npos);
+      error = nullptr;
+
+      // happy path - save should succeed
+      model_path =
         turi::fs_util::system_temp_directory_unique_path("", "_save_test_1_tmp_model");
 
       tc_model_save(model, model_path.c_str(), &error);


### PR DESCRIPTION
* Adds a turi::error namespace and io_error class. This can be used to
  distinguish between ios_base::failure coming from the C++ standard
  library, and I/O errors we throw ourselves with a crafted message.
* Use the new io_error from our own log_and_throw macros.
* In some key places related to model saving, avoid handling and
  throwing a new error when we already have a turi::error.

The result is that in a few cases, the previous user-facing error
message about unknown errors has been replaced with meaningful error
messages on model save:

* When the directory path already exists as a file.
* When the directory fails to be created, and does not exist at all.