### PR TITLE
Fix Linux build break

### DIFF
--- a/src/capi/impl/capi_sframe.cpp
+++ b/src/capi/impl/capi_sframe.cpp
@@ -203,7 +203,7 @@ EXPORT tc_sframe* tc_sframe_join_on_single_column(tc_sframe* left,
   tc_flexible_type *flex_column = tc_ft_create_from_cstring(column, error);
   if (flex_column == NULL) { assert(false); return NULL; } // error should be populated already
   uint64_t added = tc_flex_list_add_element(join_columns, flex_column, error);
-  if (added == -1) { assert(false); return NULL; } // error should be populated already
+  if (added == uint64_t(-1)) { assert(false); return NULL; } // error should be populated already
 
   tc_sframe *ret = tc_sframe_join_on_multiple_columns(left, right, join_columns, how, error);
   tc_release(flex_column);


### PR DESCRIPTION
In capi_sframe.cpp, there is a comparison between signed and unsigned:

```
/builds/turi/turicreate/src/capi/impl/capi_sframe.cpp: In function 'tc_sframe* tc_sframe_join_on_single_column(tc_sframe*, tc_sframe*, const char*, const char*, tc_error**)':
/builds/turi/turicreate/src/capi/impl/capi_sframe.cpp:206:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (added == -1) { assert(false); return NULL; } // error should be populated already
```

For some reason, this only shows up as an error on Linux and not macOS.