### PR TITLE
Automatic regression should attempt multiple models and compare the r…

### DIFF
--- a/src/unity/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/unity/python/turicreate/toolkits/_supervised_learning.py
@@ -13,9 +13,9 @@ from __future__ import absolute_import as _
 import turicreate as _turicreate
 
 from turicreate.toolkits._model import Model
-from turicreate.toolkits._internal_utils import _toolkits_select_columns
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
 from turicreate.toolkits._internal_utils import _SGraphFromJsonTree
+from turicreate.toolkits._internal_utils import _validate_data
 from turicreate.toolkits._main import ToolkitError
 from turicreate.cython.cy_server import QuietProgress
 
@@ -307,44 +307,19 @@ def create(dataset, target, model_name, features=None,
         Additional parameter options that can be passed
     """
 
-    _raise_error_if_not_sframe(dataset, "training dataset")
+    # Perform error-checking and trim inputs to specified columns
+    dataset, validation_set = _validate_data(dataset, target, features,
+                                             validation_set)
 
-    # Determine columns to keep
-    if features is None:
-        features = [feat for feat in dataset.column_names() if feat != target]
-    if not hasattr(features, '__iter__'):
-        raise TypeError("Input 'features' must be a list.")
-    if not all([isinstance(x, str) for x in features]):
-        raise TypeError(
-            "Invalid feature %s: Feature names must be of type str" % x)
-
-    # Create a validation set
+    # Sample a validation set from the training data if requested
     if isinstance(validation_set, str):
-        if validation_set == 'auto':
-            if dataset.num_rows() >= 100:
-                if verbose:
-                    print_validation_track_notification()
-                dataset, validation_set = dataset.random_split(.95, seed=seed)
-            else:
-                validation_set = None
+        assert validation_set == 'auto'
+        if dataset.num_rows() >= 100:
+            if verbose:
+                print_validation_track_notification()
+            dataset, validation_set = dataset.random_split(.95, seed=seed)
         else:
-            raise TypeError('Unrecognized value for validation_set.')
-    if validation_set is None:
-        validation_set = _turicreate.SFrame()
-    else:
-        if not isinstance(validation_set, _turicreate.SFrame):
-            raise TypeError("validation_set must be either 'auto' or an SFrame "
-                            "matching the training data.")
-
-        # Attempt to append the two datasets together to check schema
-        validation_set.head().append(dataset.head())
-
-        # Reduce validation set to requested columns
-        validation_set = _toolkits_select_columns(
-            validation_set, features + [target])
-
-    # Reduce training set to requested columns
-    dataset = _toolkits_select_columns(dataset, features + [target])
+            validation_set = _turicreate.SFrame()
 
     # Sanitize model-specific options
     options = {k.lower(): kwargs[k] for k in kwargs}
@@ -355,62 +330,6 @@ def create(dataset, target, model_name, features=None,
         model.train(dataset, target, validation_set, options)
 
     return SupervisedLearningModel(model, model_name)
-
-
-def create_regression_with_model_selector(dataset, target, model_selector,
-    features = None, validation_set='auto', verbose = True):
-    """
-    Create a :class:`~turicreate.toolkits.SupervisedLearningModel`,
-
-    This is generic function that allows you to create any model that
-    implements SupervisedLearningModel This function is normally not called, call
-    specific model's create function instead
-
-    Parameters
-    ----------
-    dataset : SFrame
-        Dataset for training the model.
-
-    target : string
-        Name of the column containing the target variable. The values in this
-        column must be 0 or 1, of integer type.
-
-    model_name : string
-        Name of the model
-
-    model_selector: function
-        Provide a model selector.
-
-    features : list[string], optional
-        List of feature names used by feature column
-
-    verbose : boolean
-        whether print out messages during training
-
-    """
-
-    # Error checking
-    _raise_error_if_not_sframe(dataset, "training dataset")
-    if features is None:
-        features = dataset.column_names()
-        if target in features:
-            features.remove(target)
-    if not hasattr(features, '__iter__'):
-        raise TypeError("Input 'features' must be a list.")
-    if not all([isinstance(x, str) for x in features]):
-        raise TypeError("Invalid feature %s: Feature names must be of type str" % x)
-
-    # Sample the data
-    features_sframe = _toolkits_select_columns(dataset, features)
-    if features_sframe.num_rows() > 1e5:
-        fraction = 1.0 * 1e5 / features_sframe.num_rows()
-        features_sframe = features_sframe.sample(fraction, seed = 0)
-
-    # Run the model selector.
-    selected_model_name = model_selector(features_sframe)
-    model = create_selected(selected_model_name, dataset, target, features, validation_set, verbose)
-
-    return model
 
 
 def create_classification_with_model_selector(dataset, target, model_selector,
@@ -445,19 +364,12 @@ def create_classification_with_model_selector(dataset, target, model_selector,
 
     """
 
-    # Error checking
-    _raise_error_if_not_sframe(dataset, "training dataset")
-    if features is None:
-        features = dataset.column_names()
-        if target in features:
-            features.remove(target)
-    if not hasattr(features, '__iter__'):
-        raise TypeError("Input 'features' must be a list.")
-    if not all([isinstance(x, str) for x in features]):
-        raise TypeError("Invalid feature %s: Feature names must be of type str" % x)
+    # Perform error-checking and trim inputs to specified columns
+    dataset, validation_set = _validate_data(dataset, target, features,
+                                             validation_set)
 
     # Sample the data
-    features_sframe = _toolkits_select_columns(dataset, features)
+    features_sframe = dataset
     if features_sframe.num_rows() > 1e5:
         fraction = 1.0 * 1e5 / features_sframe.num_rows()
         features_sframe = features_sframe.sample(fraction, seed = 0)
@@ -554,33 +466,38 @@ def create_selected(selected_model_name, dataset, target, features,
         validation_set=validation_set,
         verbose=verbose)
 
+    return wrap_model_proxy(model.__proxy__)
+
+def wrap_model_proxy(model_proxy):
+    selected_model_name = model_proxy.__class__.__name__
+
     # Return the model
     if selected_model_name == 'boosted_trees_regression':
         return _turicreate.boosted_trees_regression.BoostedTreesRegression(\
-            model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'random_forest_regression':
         return _turicreate.random_forest_regression.RandomForestRegression(\
-            model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'decision_tree_regression':
         return _turicreate.decision_tree_classifier.DecisionTreeRegression(\
-          model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'regression_linear_regression':
         return _turicreate.linear_regression.LinearRegression(\
-            model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'boosted_trees_classifier':
         return _turicreate.boosted_trees_classifier.BoostedTreesClassifier(\
-          model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'random_forest_classifier':
         return _turicreate.random_forest_classifier.RandomForestClassifier(\
-          model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'decision_tree_classifier':
         return _turicreate.decision_tree_classifier.DecisionTreeClassifier(\
-          model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'classifier_logistic_regression':
         return _turicreate.logistic_classifier.LogisticClassifier(\
-          model.__proxy__)
+            model_proxy)
     elif selected_model_name == 'classifier_svm':
-        return _turicreate.svm_classifier.SVMClassifier(model.__proxy__)
+        return _turicreate.svm_classifier.SVMClassifier(model_proxy)
     else:
         raise ToolkitError("Internal error: Incorrect model returned.")
 

--- a/src/unity/python/turicreate/toolkits/_tree_model_mixin.py
+++ b/src/unity/python/turicreate/toolkits/_tree_model_mixin.py
@@ -306,10 +306,11 @@ class TreeModelMixin(object):
             ("Training time (sec)", 'training_time')]
 
         for m in ['accuracy', 'log_loss', 'auc', 'rmse', 'max_error']:
-            required_fields = ['training_%s' % m, 'validation_%s' %m]
-            if (all(i in self._list_fields() for i in required_fields)):
+            if 'training_%s' % m in self._list_fields():
                 training_fields.append(('Training %s' % m, 'training_%s' % m))
-                training_fields.append(('Validation %s' % m, 'validation_%s' % m))
+                if 'validation_%s' % m in self._list_fields():
+                    training_fields.append(('Validation %s' % m,
+                                            'validation_%s' % m))
 
         return ([data_fields, training_fields], ["Schema", "Settings"])
 

--- a/src/unity/python/turicreate/toolkits/regression/_regression.py
+++ b/src/unity/python/turicreate/toolkits/regression/_regression.py
@@ -8,6 +8,8 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import turicreate as _turicreate
 from turicreate.toolkits import _supervised_learning as _sl
+from turicreate.toolkits._internal_utils import _validate_data
+from turicreate.cython.cy_server import QuietProgress
 
 def create(dataset, target, features=None, validation_set = 'auto',
         verbose=True):
@@ -102,10 +104,11 @@ def create(dataset, target, features=None, validation_set = 'auto',
       >>> results = model.evaluate(data)
 
     """
-    return _sl.create_regression_with_model_selector(
-        dataset,
-        target,
-        model_selector = _turicreate.extensions._supervised_learning._regression_model_selector,
-        features = features,
-        validation_set = validation_set,
-        verbose = verbose)
+
+    dataset, validation_set = _validate_data(dataset, target, features,
+                                             validation_set)
+
+    model_proxy = _turicreate.extensions.create_automatic_regression_model(
+        dataset, target, validation_set, {})
+
+    return _sl.wrap_model_proxy(model_proxy)

--- a/src/unity/toolkits/supervised_learning/automatic_model_creation.cpp
+++ b/src/unity/toolkits/supervised_learning/automatic_model_creation.cpp
@@ -1,5 +1,12 @@
-#include <unity/lib/api/unity_sframe_interface.hpp>
 #include <unity/toolkits/supervised_learning/automatic_model_creation.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <unity/lib/api/unity_sframe_interface.hpp>
+#include <unity/lib/unity_sframe.hpp>
 #include <unity/toolkits/supervised_learning/boosted_trees.hpp>
 #include <unity/toolkits/supervised_learning/decision_tree.hpp>
 #include <unity/toolkits/supervised_learning/linear_regression.hpp>
@@ -7,10 +14,141 @@
 #include <unity/toolkits/supervised_learning/logistic_regression.hpp>
 #include <unity/toolkits/supervised_learning/random_forest.hpp>
 #include <unity/toolkits/supervised_learning/supervised_learning.hpp>
+#include <unity/toolkits/supervised_learning/supervised_learning_utils-inl.hpp>
 
 
 namespace turi {
 namespace supervised {
+
+namespace {
+
+// Threshold on the number of feature columns, used to determine the
+// applicability of certain models.
+constexpr size_t WIDE_DATA = 200;
+
+/**
+ * Compute the width of the data.
+ *
+ * \param[in] X  Input SFrame
+ * \returns width
+ *
+ * The width is the same as the num_coefficients.
+ *
+ */
+size_t compute_data_width(sframe X){
+  ml_data data;
+  data.fill(X);
+  return get_number_of_coefficients(data.metadata());
+}
+
+
+// If `field_name` is present in `model_fields`, populates `*output` with the
+// value of `model->get_value_from_state(field_name)` and returns
+// true. Otherwise, returns false.
+bool read_model_field(
+    const std::shared_ptr<supervised_learning_model_base>& model,
+    const std::vector<std::string>& model_fields,
+    const char* field_name, variant_type* output) {
+  auto iter = std::find(model_fields.begin(), model_fields.end(), field_name);
+  bool success = iter != model_fields.end();
+  if (success) {
+    *output = model->get_value_from_state(field_name);
+  }
+  return success;
+}
+
+// Returns the regressors worth trying for the given data.
+std::vector<std::shared_ptr<supervised_learning_model_base>>
+get_regression_models(std::shared_ptr<unity_sframe> X) {
+
+  std::vector<std::shared_ptr<supervised_learning_model_base>> models;
+
+  const size_t data_width = compute_data_width(*X->get_underlying_sframe());
+
+  // Always try linear regression.
+  models.push_back(std::make_shared<linear_regression>());
+
+  if (data_width < WIDE_DATA) {
+    models.push_back(std::make_shared<xgboost::boosted_trees_regression>());
+  }
+
+  return models;
+}
+
+// Returns the validation Root Mean Squared Error if it exists, otherwise
+// returns training RMSE. Throws if neither field exists.
+double get_regression_rmse(
+    const std::shared_ptr<supervised_learning_model_base>& model) {
+
+  variant_type rmse;
+  std::vector<std::string> model_fields = model->list_fields();
+  bool success = false;
+  if (!success) {
+    success = read_model_field(model, model_fields, "validation_rmse", &rmse);
+  }
+  if (!success) {
+    success = read_model_field(model, model_fields, "training_rmse", &rmse);
+  }
+  if (!success) {
+    log_and_throw("Model does not have metrics that can be used for model "
+                  "selection.");
+  }
+
+  double result = variant_get_value<flexible_type>(rmse).to<double>();
+  ASSERT_TRUE(result >= 0);
+
+  return result;
+}
+
+}  // anonymous namespace
+
+/**
+ * Rule based better than stupid model selector.
+ */
+std::string _classifier_model_selector(std::shared_ptr<unity_sframe> _X){
+
+  sframe X = *(_X->get_underlying_sframe());
+
+  size_t data_width = compute_data_width(X);
+  if (data_width < WIDE_DATA){
+    return "boosted_trees_classifier";
+  } else {
+    return "classifier_logistic_regression";
+  }
+}
+
+/**
+ * Rule based better than stupid model selector.
+ */
+std::vector<std::string> _classifier_available_models(size_t num_classes,
+                                         std::shared_ptr<unity_sframe> _X){
+  sframe X = *(_X->get_underlying_sframe());
+
+  // Throw error if only one class.
+  // If number of classes more than 2, use boosted trees
+  if (num_classes == 1) {
+    log_and_throw("One-class classification is not currently supported. Please check your target column.");
+  } else if (num_classes > 2) {
+    return {"boosted_trees_classifier",
+            "random_forest_classifier",
+            "decision_tree_classifier",
+            "classifier_logistic_regression"};
+  } else {
+    size_t data_width = compute_data_width(X);
+    if (data_width < WIDE_DATA){
+      return {"boosted_trees_classifier",
+              "random_forest_classifier",
+              "decision_tree_classifier",
+              "classifier_svm",
+              "classifier_logistic_regression"};
+    } else {
+      return {"classifier_logistic_regression",
+              "classifier_svm"};
+    }
+  }
+
+  return std::vector<std::string>();
+}
 
 std::shared_ptr<supervised_learning_model_base> create_classifier(const std::string& model_name) {
   std::shared_ptr<supervised_learning_model_base> result;
@@ -62,10 +200,15 @@ std::shared_ptr<supervised_learning_model_base> create_automatic_classifier_mode
   gl_sframe validation_data;
   std::tie(data, validation_data) = create_validation_data(data, _validation_data);  
 
+  // TODO: The original Python code path only runs the model selector on at most
+  // 100000 rows of data. Should we do the same here?
   size_t num_classes = data[target].unique().size();
   std::vector<std::string> possible_models = _classifier_available_models(num_classes, data);
 
   // If no validation set and enough training data, create a validation set.
+  // TODO: The original Python code path allowed users to specify no validation
+  // set (use all data for training) by providing an empty SFrame or None.
+  // Should these behaviors be unified?
   if(validation_data.empty() && data.size() >= 100) {
     std::pair<gl_sframe, gl_sframe>  split = data.random_split(.95);
     data = split.first;
@@ -97,12 +240,16 @@ std::shared_ptr<supervised_learning_model_base> create_automatic_regression_mode
     gl_sframe data, const std::string target, const variant_type& _validation_data,
     const std::map<std::string, flexible_type>& options) {
 
+  // Perform training/validation split if necessary.
   gl_sframe validation_data;
   std::tie(data, validation_data) = create_validation_data(data, _validation_data);  
 
-  std::string model_name = _regression_model_selector(data);
-
   // If the data is more than 1e5 rows, sample 1e5 rows.
+  // TODO: The original Python implementation only sampled the training data for
+  // the purposes of determining what models to attempt. It used all the
+  // provided data for training. Probably this code path should do the same,
+  // although the running time of this function could increase dramatically for
+  // very large data sets.
   gl_sframe train_sframe;
   if (data.size() > 1e5) {
     float fraction = 1e5 / data.size();
@@ -111,16 +258,21 @@ std::shared_ptr<supervised_learning_model_base> create_automatic_regression_mode
     train_sframe = data;
   }
 
-  std::shared_ptr<supervised_learning_model_base> m;
-  if(model_name == "boosted_trees_regression") {
-    m = std::make_shared<xgboost::boosted_trees_regression>();
-  } else {
-    DASSERT_TRUE(model_name == "regression_linear_regression");
-    m = std::make_shared<linear_regression>();
-  }
-  m->api_train(train_sframe, target, validation_data, options);
+  // Determine what regression models to try.
+  using shared_model_ptr = std::shared_ptr<supervised_learning_model_base>;
+  std::vector<shared_model_ptr> models = get_regression_models(train_sframe);
+  ASSERT_GT(models.size(), 0);
 
-  return m; 
+  // Perform training on each model.
+  for (const shared_model_ptr& model : models) {
+    model->api_train(train_sframe, target, validation_data, options);
+  }
+
+  // Return the model with the lowest validation (or training) RMSE.
+  auto compare_rmse = [](const shared_model_ptr& a, const shared_model_ptr& b) {
+    return get_regression_rmse(a) < get_regression_rmse(b);
+  };
+  return *std::min_element(models.begin(), models.end(), compare_rmse);
 }
 
 std::pair<gl_sframe, gl_sframe> create_validation_data(gl_sframe data, const variant_type& _validation_data) {

--- a/src/unity/toolkits/supervised_learning/automatic_model_creation.hpp
+++ b/src/unity/toolkits/supervised_learning/automatic_model_creation.hpp
@@ -6,6 +6,17 @@
 namespace turi {
 namespace supervised {
 
+/**
+ * Rule based better than stupid model selector.
+ */
+std::string _classifier_model_selector(std::shared_ptr<unity_sframe> _X);
+
+/**
+ * Rule-based method for getting a list of potential models.
+ */
+std::vector<std::string> _classifier_available_models(
+    size_t num_classes, std::shared_ptr<unity_sframe> _X);
+
 std::shared_ptr<supervised_learning_model_base> create_automatic_classifier_model(
     gl_sframe data, const std::string target, const variant_type& validation_data,
     const std::map<std::string, flexible_type>& options);

--- a/src/unity/toolkits/supervised_learning/class_registrations.cpp
+++ b/src/unity/toolkits/supervised_learning/class_registrations.cpp
@@ -31,7 +31,6 @@ END_CLASS_REGISTRATION
  * Defines get_toolkit_function_registration for the supervised_learning toolkit
  */
 BEGIN_FUNCTION_REGISTRATION
-REGISTER_FUNCTION(_regression_model_selector, "_X");
 REGISTER_FUNCTION(_classifier_model_selector, "_X");
 REGISTER_FUNCTION(_classifier_available_models, "num_classes", "_X");
 REGISTER_FUNCTION(_get_metadata_mapping, "model");

--- a/src/unity/toolkits/supervised_learning/supervised_learning.cpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.cpp
@@ -30,8 +30,6 @@
 namespace turi {
 namespace supervised {
 
-constexpr size_t WIDE_DATA = 200;
-
 // TODO: List of todo's for this file
 //------------------------------------------------------------------------------
 
@@ -1216,83 +1214,6 @@ supervised_learning_model_base::get_missing_value_enum_from_string(
   } else {
     log_and_throw("Missing value type '" + missing_value_str + "' not supported.");
   }
-}
-
-/**
- * Compute the width of the data.
- *
- * \param[in] X  Input SFrame
- * \returns width
- *
- * The width is the same as the num_coefficients.
- *
- */
-size_t compute_data_width(sframe X){
-  ml_data data;
-  data.fill(X);
-  return get_number_of_coefficients(data.metadata());
-}
-
-/**
- * Rule based better than stupid model selector.
- */
-std::string _regression_model_selector(std::shared_ptr<unity_sframe> _X){
-
-  sframe X = *(_X->get_underlying_sframe());
-  size_t data_width = compute_data_width(X);
-  if (data_width < WIDE_DATA){
-    return "boosted_trees_regression";
-  } else {
-    return "regression_linear_regression";
-  }
-}
-
-/**
- * Rule based better than stupid model selector.
- */
-std::string _classifier_model_selector(std::shared_ptr<unity_sframe> _X){
-
-  sframe X = *(_X->get_underlying_sframe());
-
-  size_t data_width = compute_data_width(X);
-  if (data_width < WIDE_DATA){
-    return "boosted_trees_classifier";
-  } else {
-    return "classifier_logistic_regression";
-  }
-}
-
-/**
- * Rule based better than stupid model selector.
- */
-std::vector<std::string> _classifier_available_models(size_t num_classes,
-                                         std::shared_ptr<unity_sframe> _X){
-  sframe X = *(_X->get_underlying_sframe());
-
-  // Throw error if only one class.
-  // If number of classes more than 2, use boosted trees
-  if (num_classes == 1) {
-    log_and_throw("One-class classification is not currently supported. Please check your target column.");
-  } else if (num_classes > 2) {
-    return {"boosted_trees_classifier",
-            "random_forest_classifier",
-            "decision_tree_classifier",
-            "classifier_logistic_regression"};
-  } else {
-    size_t data_width = compute_data_width(X);
-    if (data_width < WIDE_DATA){
-      return {"boosted_trees_classifier",
-              "random_forest_classifier",
-              "decision_tree_classifier",
-              "classifier_svm",
-              "classifier_logistic_regression"};
-    } else {
-      return {"classifier_logistic_regression",
-              "classifier_svm"};
-    }
-  }
-
-  return std::vector<std::string>();
 }
 
 /**

--- a/src/unity/toolkits/supervised_learning/supervised_learning.hpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.hpp
@@ -845,22 +845,6 @@ gl_sframe _fast_classify(
 std::vector<std::vector<flexible_type>> _get_metadata_mapping(
     std::shared_ptr<supervised_learning_model_base> model);
 
-/**
- * Rule based better than stupid model selector.
- */
-std::string _regression_model_selector(std::shared_ptr<unity_sframe> _X);
-
-/**
- * Rule based better than stupid model selector.
- */
-std::string _classifier_model_selector(std::shared_ptr<unity_sframe> _X);
-
-/**
- * Rule-based method for getting a list of potential models.
- */
-std::vector<std::string> _classifier_available_models(size_t num_classes, 
-                                         std::shared_ptr<unity_sframe> _X);
-
 } // supervised
 } // turicreate
 

--- a/src/unity/toolkits/supervised_learning/xgboost.cpp
+++ b/src/unity/toolkits/supervised_learning/xgboost.cpp
@@ -1092,8 +1092,6 @@ void xgboost_model::_save_training_state(size_t iteration,
     info["training_" + metric] = training_metrics[i];
     if (validation_metrics.size() > 0) {
       info["validation_" + metric] = validation_metrics[i];
-    } else {
-      info["validation_" + metric] = FLEX_UNDEFINED;
     }
   }
   // Store trees


### PR DESCRIPTION
…esults

The automatic classification feature already trains multiple models, returning the one with the highest validation accuracy. We should do the same thing for regression, using RMSE to choose the final model.

Note that the current automatic regression logic simply uses boosted trees for any dataset with fewer than 200 columns, and linear otherwise. For small datasets, linear is much more likely to be the best bet.

These changes unify the Python (turicreate.regression.create) and C API (create_automatic_regression_model) implementations. The automatic classification implementations both train multiple models but have some subtle differences, so unification there is deferred for now to minimize risk.

Fixes #858 