### PR TITLE
Fix accuracy metrics used by automatic classification

### DIFF
--- a/src/unity/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/unity/python/turicreate/toolkits/_supervised_learning.py
@@ -320,6 +320,8 @@ def create(dataset, target, model_name, features=None,
             dataset, validation_set = dataset.random_split(.95, seed=seed)
         else:
             validation_set = _turicreate.SFrame()
+    elif validation_set is None:
+        validation_set = _turicreate.SFrame()
 
     # Sanitize model-specific options
     options = {k.lower(): kwargs[k] for k in kwargs}
@@ -414,6 +416,8 @@ def create_classification_with_model_selector(dataset, target, model_selector,
 
         if 'validation_accuracy' in m._list_fields():
             metrics[model_name] = m.validation_accuracy
+        elif 'training_accuracy' in m._list_fields():
+            metrics[model_name] = m.training_accuracy
 
         # Most models have this.
         elif 'progress' in m._list_fields():

--- a/src/unity/python/turicreate/toolkits/regression/_regression.py
+++ b/src/unity/python/turicreate/toolkits/regression/_regression.py
@@ -107,6 +107,8 @@ def create(dataset, target, features=None, validation_set = 'auto',
 
     dataset, validation_set = _validate_data(dataset, target, features,
                                              validation_set)
+    if validation_set is None:
+        validation_set = _turicreate.SFrame()
 
     model_proxy = _turicreate.extensions.create_automatic_regression_model(
         dataset, target, validation_set, {})

--- a/src/unity/toolkits/supervised_learning/supervised_learning_utils-inl.hpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning_utils-inl.hpp
@@ -370,23 +370,6 @@ inline std::vector<std::string> make_evaluation_progress(
   return ret;
 }
 
-inline std::vector<std::pair<std::string, size_t>> make_printer_header(
-    const std::vector<std::string>& metrics, bool has_validation) {
-
-  std::vector<std::pair<std::string, size_t>> header{
-    {"Iteration", 0}, {"Examples", 8}, {"Elapsed Time", 8}
-  };
-
-  for (const auto& m: metrics) {
-    header.push_back({std::string("Training ") + m, 6});
-    if (has_validation)
-      header.push_back({std::string("Validation ") + m, 6});
-  }
-
-  header.push_back({"Examples/second", 0});
-  return header;
-}
-
 inline std::vector<std::string> make_progress_string(
     size_t iter, size_t examples, double time,
     const std::vector<std::string>& train_eval,

--- a/src/unity/toolkits/supervised_learning/xgboost.cpp
+++ b/src/unity/toolkits/supervised_learning/xgboost.cpp
@@ -816,10 +816,13 @@ table_printer xgboost_model::_init_progress_printer(bool has_validation_data) {
     {"Iteration", default_column_width},
     {"Elapsed Time", default_column_width}
   };
-  for (auto& metric : tracking_metrics) {
-    progress_header.push_back({"Training " + metric, metric_column_width});
+  for (const std::string& metric : tracking_metrics) {
+    std::string metric_display_name = get_metric_display_name(metric);
+    progress_header.emplace_back("Training " + metric_display_name,
+                                 metric_column_width);
     if (has_validation_data) {
-      progress_header.push_back({"Validation " + metric, metric_column_width});
+      progress_header.emplace_back("Validation " + metric_display_name,
+                                   metric_column_width);
     }
   }
   table_printer printer(progress_header);


### PR DESCRIPTION
Fixes the failing test_classifier.py

The Python implementation of automatic classification should attempt to query tr
aining_accuracy, not just validation_accuracy, directly from the model state. (Tree-based models recently stopped incorrectly storing 0 for validation metrics, instead not storing these fields at all, due to #864). 

In addition, xgboost.cpp should write metrics to the progress table using the up
dated display name (propagating changes for #818), so that tree-based models now
 have e.g. "Validation Accuracy" instead of "Validation accuracy".

Finally, also fixes another bug in #864: when the user explicitly specifies validation_set=None (as in some tests), the auto-classifier path runs the validation set through `_validate_data` twice. The first call was converting None to an empty SFrame, and the second call was throwing because the empty SFrame does not have the same schema as the training data.