### PR TITLE
Add default constructor to table printer

### DIFF
--- a/src/table_printer/table_printer.hpp
+++ b/src/table_printer/table_printer.hpp
@@ -200,6 +200,8 @@ struct progress_time {
 class table_printer {
 
  public:
+  /** Constructor.  Must be initialized elsewise using copy assignment ops. */
+  table_printer(){}
 
   /** Constructor.  Sets up the columns.
    *


### PR DESCRIPTION
There is no reason the table printer shouldn't have a default
constructor