### PR TITLE
Avoid passing nil for nonnull parameter of -encodeBatchToCommandBuffer:...

### DIFF
--- a/src/unity/toolkits/tcmps/mps_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_layers.mm
@@ -356,8 +356,6 @@ void BNLayer::Forward(MPSImageBatch *_Nonnull src,
                       id<MTLCommandBuffer> _Nonnull cb,
                       bool is_train) {
     
-  MPSCNNBatchNormalizationState * state_to_encode;
-    
   if (use_temp_images_){
       fwd_output = AllocTempImageBatch(cb, false);
   }
@@ -369,20 +367,19 @@ void BNLayer::Forward(MPSImageBatch *_Nonnull src,
                                           sourceStates:nil
                                       destinationImage:fwd_output[0]];
     }
-    state_to_encode = bn_state;
     input = src;
     [stat encodeBatchToCommandBuffer:cb
                         sourceImages:src
              batchNormalizationState:bn_state];
+    [op_forward encodeBatchToCommandBuffer:cb
+                              sourceImages:src
+                   batchNormalizationState:bn_state
+                         destinationImages:fwd_output];
   } else {
-    state_to_encode = nil;
+    [op_forward encodeBatchToCommandBuffer:cb
+                              sourceImages:src
+                         destinationImages:fwd_output];
   }
-
-  [op_forward encodeBatchToCommandBuffer:cb
-                            sourceImages:src
-                 batchNormalizationState:state_to_encode
-                       destinationImages:fwd_output];
-
 }
 
 void BNLayer::Backward(MPSImageBatch *_Nonnull src,


### PR DESCRIPTION
As a result of a change to MetalPerformanceShaders in the last seed, our passing a nil state into `-[MPSCNNBatchNormalization -encodeBatchToCommandBuffer:sourceImages:batchNormalizationState:destinationImages:]` now results in a crash. (This is an error on our end, since the relevant parameter is marked nonnull.)

This changes fixes a crash in test_activity_classifier.py, when testing on a Mac with a discrete AMD GPU on the current seed.