### PR TITLE
Fix metrics-related failures in unit tests

### DIFF
--- a/src/unity/python/turicreate/test/test_tree_tracking_metrics.py
+++ b/src/unity/python/turicreate/test/test_tree_tracking_metrics.py
@@ -26,6 +26,17 @@ class TreeRegressionTrackingMetricsTest(unittest.TestCase):
                       'dt': tc.regression.decision_tree_regression}
         return cls
 
+    def _metric_display_name(self, metric):
+        metric_display_names = {'accuracy'  : 'Accuracy',
+                                'auc'       : 'Area Under Curve',
+                                'log_loss'  : 'Log Loss',
+                                'max_error' : 'Max Error',
+                                'rmse'      : 'Root-Mean-Square Error'}
+        if metric in metric_display_names:
+            return metric_display_names[metric]
+        else:
+            return metric
+
     def _run_test(self, train, valid, metric):
         for (name, model) in self.models.items():
             m = model.create(train, 'target', validation_set=valid, max_depth=2, metric=metric)
@@ -41,13 +52,13 @@ class TreeRegressionTrackingMetricsTest(unittest.TestCase):
                 raise TypeError('Invalid metric type')
 
             for name in test_metrics:
-                column_name = 'Training %s' % name
+                column_name = 'Training %s' % self._metric_display_name(name)
                 self.assertTrue(column_name in history_header)
                 final_eval = m.evaluate(train, name)[name]
                 progress_evals = m.progress[column_name]
                 self.assertAlmostEqual(float(progress_evals[-1]), final_eval, delta=1e-4)
                 if valid is not None:
-                    column_name = 'Validation %s' % name
+                    column_name = 'Validation %s' % self._metric_display_name(name)
                     self.assertTrue(column_name in history_header)
 
     def test_auto_metric(self):
@@ -77,8 +88,8 @@ class TreeRegressionTrackingMetricsTest(unittest.TestCase):
 
         m_last = rf_models[-1]
         for name in self.test_metrics:
-            train_column_name = 'Training %s' % name
-            test_column_name = 'Validation %s' % name
+            train_column_name = 'Training %s' % self._metric_display_name(name)
+            test_column_name = 'Validation %s' % self._metric_display_name(name)
             train_evals = [float(x) for x in m_last.progress[train_column_name]]
             test_evals = [float(x) for x in m_last.progress[test_column_name]]
             # Check the final model's metric at iteration i against the ith model's last metric

--- a/src/unity/toolkits/supervised_learning/supervised_learning.cpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.cpp
@@ -351,6 +351,7 @@ std::vector<std::string>
 std::string supervised_learning_model_base::get_metric_display_name(const std::string& metric) const {
   const static std::unordered_map<std::string, std::string> display_names = {
     {"accuracy", "Accuracy"},
+    {"auc", "Area Under Curve"},
     {"log_loss", "Log Loss"},
     {"max_error", "Max Error"},
     {"rmse", "Root-Mean-Square Error"},

--- a/src/unity/toolkits/supervised_learning/supervised_learning.hpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.hpp
@@ -686,7 +686,7 @@ class EXPORT supervised_learning_model_base : public ml_model_base {
    */
   // TODO: This function should be const
   variant_map_type api_evaluate(
-      gl_sframe data, std::string missing_value_action, std::string metric, gl_sarray predictions = gl_sarray());
+      gl_sframe data, std::string missing_value_action, std::string metric);
 
   /**
    *  API interface through the unity server.
@@ -769,7 +769,6 @@ class EXPORT supervised_learning_model_base : public ml_model_base {
                                                                                \
   register_defaults("evaluate",                                                \
                     {{"metric", std::string("_report")},                        \
-                     {"predictions", gl_sarray()},                             \
                      {"missing_value_action", std::string("auto")}});          \
                                                                                \
   REGISTER_NAMED_CLASS_MEMBER_FUNCTION("extract_features",                     \


### PR DESCRIPTION
Reverts #746, since the functionality added with this change appears to be unused. The parameter added to `api_evaluate()` wasn't even being exposed to the C API. All this change did was remove metrics from models and break unit tests for a month.

Updates test_tree_tracking_metrics to incorporate changes for #818 and #868 

Fixes #831 

With these changes there are still test failures in test_recommender.py, but I'll leave that for a separate issue. I'm hoping someone more familiar with that toolkit can look at those.