### PR TITLE
Fixes #608

### DIFF
--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -79,8 +79,10 @@ class _SFrameDataSource:
         # If we're about to begin a new epoch, shuffle the SFrame if requested.
         row_index = self.cur_sample % len(self.sframe)
         if row_index == 0 and self.cur_sample > 0 and self.shuffle:
+            self.sframe = self.sframe.remove_column(_TMP_COL_RAW_IMAGE)
             self.sframe[_TMP_COL_RANDOM_ORDER] = _np.random.uniform(size=len(self.sframe))
             self.sframe = self.sframe.sort(_TMP_COL_RANDOM_ORDER)
+            self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[feature_column].apply(_convert_image_to_raw)
         self.cur_sample += 1
 
         # Copy the image data for this row into a NumPy array.

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -52,6 +52,7 @@ class _SFrameDataSource:
     def __init__(self, sframe, feature_column, annotations_column,
                  load_labels=True, shuffle=True, samples=None):
         self.annotations_column = annotations_column
+        self.feature_column = feature_column
         self.load_labels = load_labels
         self.shuffle = shuffle
         self.num_samples = samples
@@ -61,7 +62,7 @@ class _SFrameDataSource:
         self.sframe = sframe.copy()
 
         # Convert images to raw to eliminate overhead of decoding
-        self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[feature_column].apply(_convert_image_to_raw)
+        self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[self.feature_column].apply(_convert_image_to_raw)
 
     def __iter__(self):
         return self
@@ -82,7 +83,7 @@ class _SFrameDataSource:
             self.sframe = self.sframe.remove_column(_TMP_COL_RAW_IMAGE)
             self.sframe[_TMP_COL_RANDOM_ORDER] = _np.random.uniform(size=len(self.sframe))
             self.sframe = self.sframe.sort(_TMP_COL_RANDOM_ORDER)
-            self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[feature_column].apply(_convert_image_to_raw)
+            self.sframe[_TMP_COL_RAW_IMAGE] = self.sframe[self.feature_column].apply(_convert_image_to_raw)
         self.cur_sample += 1
 
         # Copy the image data for this row into a NumPy array.


### PR DESCRIPTION
Got rid of the raw image column while shuffling. 

Using the data that @dhgokul sent to us, we noticed that just the raw image column was causing the size of the SFrame to blow up (from around 40 MB to around 760 MB) because of which `shuffle` was taking a long (but finite) amount of time. 

Since that was the bottleneck, we now get rid of the raw image column just during the shuffle. After a lightning fast shuffle, we add the raw image column back and training proceeds like before.

Consequently, training time for that model went down from 79 minutes to 39 minutes for Turi Create 4.3.2 on a GPU in Linux.