### PR TITLE
Warning for CUDA GPUs if not enough free memory

### DIFF
--- a/src/unity/python/turicreate/toolkits/_mxnet_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mxnet_utils.py
@@ -122,8 +122,5 @@ def get_gluon_net_params_state(net_params):
 def load_net_params_from_state(net_params, state, ctx = None):
     net_params_dict = params_from_dict(state, ctx)
     for k in net_params_dict:
-        #net_params[k].initialize(ctx)
-        #import pdb; pdb.set_trace()
-        #net_params[k].set_data(net_params_dict[k])
         net_params[k]._load_init(net_params_dict[k], ctx)
     return net_params

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -31,7 +31,6 @@ from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from .. import _pre_trained_models
 from ._evaluation import average_precision as _average_precision
 from .._mps_utils import (use_mps as _use_mps,
-                          mps_device_name as _mps_device_name,
                           mps_device_memory_limit as _mps_device_memory_limit,
                           MpsGraphAPI as _MpsGraphAPI,
                           MpsGraphNetworkType as _MpsGraphNetworkType,
@@ -272,7 +271,8 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
 
     if batch_size < 1:
         batch_size = 32  # Default if not user-specified
-    num_mxnet_gpus = _mxnet_utils.get_num_gpus_in_use(max_devices=batch_size)
+    cuda_gpus = _mxnet_utils.get_gpus_in_use(max_devices=batch_size)
+    num_mxnet_gpus = len(cuda_gpus)
     use_mps = _use_mps() and num_mxnet_gpus == 0
     batch_size_each = batch_size // max(num_mxnet_gpus, 1)
     if use_mps and _mps_device_memory_limit() < 4 * 1024 * 1024 * 1024:
@@ -291,14 +291,11 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
     io_thread_buffer_size = params['io_thread_buffer_size'] if use_mps else 0
 
     if verbose:
-        if use_mps:
-            print('Using GPU to create model ({})'.format(_mps_device_name()))
-        elif num_mxnet_gpus == 1:
-            print('Using GPU to create model (CUDA)')
-        elif num_mxnet_gpus > 1:
-            print('Using {} GPUs to create model (CUDA)'.format(num_mxnet_gpus))
-        else:
-            print('Using CPU to create model')
+        # Estimate memory usage (based on experiments)
+        cuda_mem_req = 550 + batch_size_each * 85
+
+        _tkutl._print_neural_compute_device(cuda_gpus=cuda_gpus, use_mps=use_mps,
+                                            cuda_mem_req=cuda_mem_req)
 
     grid_shape = params['grid_shape']
     input_image_shape = (3,
@@ -558,6 +555,8 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
                 net_params[k].set_data(_mps_to_mxnet(mps_net_params[k]))
 
     else:  # Use MxNet
+        net.hybridize()
+
         options = {'learning_rate': base_lr, 'lr_scheduler': lr_scheduler,
                    'momentum': params['sgd_momentum'], 'wd': params['weight_decay'], 'rescale_grad': 1.0}
         clip_grad = params.get('clip_gradients')

--- a/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -227,15 +227,15 @@ def create(style_dataset, content_dataset, style_feature=None,
     smoothed_loss = None
     last_time = 0
 
-    num_mxnet_gpus = _mxnet_utils.get_num_gpus_in_use(max_devices=params['batch_size'])
-    if verbose:
-        if num_mxnet_gpus == 1:
-            print('Using GPU to create model (CUDA)')
-        elif num_mxnet_gpus > 1:
-            print('Using {} GPUs to create model (CUDA)'.format(num_mxnet_gpus))
-        else:
-            print('Using CPU to create model')
+    cuda_gpus = _mxnet_utils.get_gpus_in_use(max_devices=params['batch_size'])
+    num_mxnet_gpus = len(cuda_gpus)
 
+    if verbose:
+        # Estimate memory usage (based on experiments)
+        cuda_mem_req = 260 + batch_size_each * 880 + num_styles * 1.4
+
+        _tkutl._print_neural_compute_device(cuda_gpus=cuda_gpus, use_mps=False,
+                                            cuda_mem_req=cuda_mem_req, has_mps_impl=False)
     #
     # Pre-compute gram matrices for style images
     #


### PR DESCRIPTION
This PR primarily introduces warnings if a user tries to use a CUDA GPU with insufficient free memory. This may happen if for instance Tensorflow has allocated the memory unbeknownst the user. 

- Note, the estimated memory requirements are experimental estimates. These experiments were conducted by first allocating a specific amount of memory and then trying to train the model. I did this for values that the should influence the memory usage (batch size, and number of style in ST) and then fit a simple line to it. Since it's only an estimate, I don't want to cause a fatal error, so this is just a warning that should help the user understand if there is subsequent fatal error.
- Also show name of CUDA GPUs (just like for MPS)
- Consolidate device printing code between OD/ST
- Provide feedback on macOS if CPU is used that an upgrade to 10.14+
  could potentially enable faster model creation. We don't know this for
  sure, because the code that checks for a capable GPU is in libtcmps,
  which is exactly what is not even compiled before 10.14.
- Facilitate use of static graph in OD. This reduces memory usage by
  13%. This allows training on a 2 GiB GPU with batch_size=16.

Note, this PR does not extend device verbosity to image classifier/similarity and only modifies OD and ST that currently prints this information. I think it would be reasonable to also add this to IC/IS, but did not include it in this PR.


Fixes #137
Fixes #656
