### PR TITLE
Use get_temp_name() in SArray and SFrame test_save_load()

### DIFF
--- a/test/unity/unity_sarray.cxx
+++ b/test/unity/unity_sarray.cxx
@@ -1170,8 +1170,10 @@ struct unity_sarray_test {
     // sarray of strings
     sa->construct_from_vector({"abcdef", "ghijkl"}, flex_type_enum::STRING);
 
+    const std::string temp_dir = get_temp_name();
+
     dir_archive write_arc;
-    write_arc.open_directory_for_write("cache://testdir");
+    write_arc.open_directory_for_write(temp_dir);
     oarchive oarc(write_arc);
     oarc << *sa;
     write_arc.close();
@@ -1179,7 +1181,7 @@ struct unity_sarray_test {
 
     auto sa2 = std::make_shared<unity_sarray>();
     dir_archive read_arc;
-    read_arc.open_directory_for_read("cache://testdir");
+    read_arc.open_directory_for_read(temp_dir);
     iarchive iarc(read_arc);
     iarc >> *sa2;
     read_arc.close();

--- a/test/unity/unity_sframe.cxx
+++ b/test/unity/unity_sframe.cxx
@@ -689,8 +689,10 @@ struct unity_sframe_test {
     auto sf = std::make_shared<unity_sframe>();
     sf->construct_from_dataframe(testdf);
 
+    const std::string temp_dir = get_temp_name();
+
     dir_archive write_arc;
-    write_arc.open_directory_for_write("cache://testdir");
+    write_arc.open_directory_for_write(temp_dir);
     oarchive oarc(write_arc);
     oarc << *sf;
     write_arc.close();
@@ -698,7 +700,7 @@ struct unity_sframe_test {
 
     auto sf2 = std::make_shared<unity_sframe>();
     dir_archive read_arc;
-    read_arc.open_directory_for_read("cache://testdir");
+    read_arc.open_directory_for_read(temp_dir);
     iarchive iarc(read_arc);
     iarc >> *sf2;
     read_arc.close();


### PR DESCRIPTION
#862 revealed that `test_save_load()` in the C++ SArray and SFrame tests was not actually saving and loading the model. Using `get_temp_name()` instead of `"cache://testdir"` appears to do the trick