### PR TITLE
Make clear if mlmodel has NMS

### DIFF
--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1532,6 +1532,8 @@ class ObjectDetector(_CustomModel):
         confidenceThresholdString = ('(optional)' + 
             ' Confidence Threshold override (default: {})')
         model_type = 'object detector (%s)' % self.model
+        if include_non_maximum_suppression:
+            model_type += ' with non-maximum suppression'
         model.description.metadata.shortDescription = \
             _coreml_utils._mlmodel_short_description(model_type)
         model.description.input[0].shortDescription = 'Input image'


### PR DESCRIPTION
It's not  entirely  clear today if a detector was exported with NMS. This adds so that if it's included, the description reflects it:

<img width="687" alt="screen shot 2018-07-27 at 4 50 09 pm" src="https://user-images.githubusercontent.com/902935/43350555-2266fe44-91bd-11e8-86c0-b3f729967099.png">
