### PR TITLE
Normalize save paths given to CustomModel instances

### DIFF
--- a/src/unity/python/turicreate/toolkits/_model.py
+++ b/src/unity/python/turicreate/toolkits/_model.py
@@ -662,7 +662,8 @@ class CustomModel(ExposeAttributesFromProxy):
         import copy
         state = copy.copy(self._get_native_state())
         state['model_version'] = self._get_version()
-        return glconnect.get_unity().save_model2(self.__class__._native_name(), location, state)
+        return glconnect.get_unity().save_model2(
+            self.__class__._native_name(), _make_internal_url(location), state)
 
     @classmethod
     def _native_name(cls):


### PR DESCRIPTION
Adopts in CustomModel.save() the same canonicalization code used in Model.save()

Fixes #593 