### PR TITLE
Support for initializing SArray using numpy.matrix

### DIFF
--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -353,6 +353,12 @@ class SArray(object):
             self.__proxy__ = data.__proxy__
         else:
             self.__proxy__ = UnitySArrayProxy()
+
+            # Guard against numpy.matrix, which cannot be traversed recursively,
+            # since subscripting a matrix always yields another (2d) matrix.
+            if HAS_NUMPY and isinstance(data, numpy.matrix):
+                data = numpy.array(data)
+
             # we need to perform type inference
             if dtype is None:
                 if HAS_PANDAS and isinstance(data, pandas.Series):

--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -357,7 +357,7 @@ class SArray(object):
             # Guard against numpy.matrix, which cannot be traversed recursively,
             # since subscripting a matrix always yields another (2d) matrix.
             if HAS_NUMPY and isinstance(data, numpy.matrix):
-                data = numpy.array(data)
+                data = numpy.asarray(data)
 
             # we need to perform type inference
             if dtype is None:

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -114,6 +114,17 @@ class SArrayTest(unittest.TestCase):
         self.__test_creation_type_inference([np.bool_(True),np.bool_(False)],int,[1,0])
         self.__test_creation((1,2,3,4), int, [1,2,3,4])
 
+        # Test numpy types, which are not compatible with the pd.Series path in
+        # __test_creation and __test_creation_type_inference
+        self.__test_equal(SArray(np.array(self.vec_data), array.array),
+                          self.vec_data, array.array)
+        self.__test_equal(SArray(np.matrix(self.vec_data), array.array),
+                          self.vec_data, array.array)
+        self.__test_equal(SArray(np.array(self.vec_data)),
+                          self.vec_data, array.array)
+        self.__test_equal(SArray(np.matrix(self.vec_data)),
+                          self.vec_data, array.array)
+
     def test_list_with_none_creation(self):
         tlist=[[2,3,4],[5,6],[4,5,10,None]]
         g=SArray(tlist)


### PR DESCRIPTION
Operations on a numpy.matrix object yield another numpy.matrix object, and each instance always has two-dimensional shape. When our SArray type-deduction or data-loading code attempts to traverse this data structure recursively, we get an unbounded recursion. The simplest solution seems to be to guard explicitly against numpy.matrix and convert to numpy.ndarray up front.

Fixes #357 