### PR TITLE
Convert empty numpy.ndarray values to array([]) in SArray initializer

### DIFF
--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -353,12 +353,6 @@ class SArray(object):
             self.__proxy__ = data.__proxy__
         else:
             self.__proxy__ = UnitySArrayProxy()
-
-            # Guard against numpy.matrix, which cannot be traversed recursively,
-            # since subscripting a matrix always yields another (2d) matrix.
-            if HAS_NUMPY and isinstance(data, numpy.matrix):
-                data = numpy.asarray(data)
-
             # we need to perform type inference
             if dtype is None:
                 if HAS_PANDAS and isinstance(data, pandas.Series):

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -46,6 +46,7 @@ class SArrayTest(unittest.TestCase):
         self.string_data = ["abc", "def", "hello", "world", "pika", "chu", "hello", "world"]
         self.vec_data = [array.array('d', [i, i+1]) for i in self.int_data]
         self.np_array_data = [np.array(x) for x in self.vec_data]
+        self.empty_np_array_data = [np.array([])]
         self.np_matrix_data = [np.matrix(x) for x in self.vec_data]
         self.list_data = [[i, str(i), i * 1.0] for i in self.int_data]
         self.dict_data =  [{str(i): i, i : float(i)} for i in self.int_data]
@@ -111,6 +112,8 @@ class SArrayTest(unittest.TestCase):
 
         self.__test_creation(self.vec_data, array.array, self.vec_data)
         self.__test_creation(self.np_array_data, np.ndarray, self.np_array_data)
+        self.__test_creation(self.empty_np_array_data, np.ndarray,
+                             self.empty_np_array_data)
         self.__test_creation(self.np_matrix_data, np.ndarray, self.np_matrix_data)
         self.__test_creation(self.list_data, list, self.list_data)
 
@@ -124,6 +127,9 @@ class SArrayTest(unittest.TestCase):
         self.__test_creation_type_inference(self.vec_data, array.array, self.vec_data)
         self.__test_creation_type_inference(self.np_array_data, np.ndarray,
                                             self.np_array_data)
+        self.__test_creation_type_inference(self.empty_np_array_data,
+                                            np.ndarray,
+                                            self.empty_np_array_data)
         self.__test_creation_type_inference(self.np_matrix_data, np.ndarray,
                                             self.np_matrix_data)
         self.__test_creation_type_inference([np.bool_(True),np.bool_(False)],int,[1,0])

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -45,6 +45,8 @@ class SArrayTest(unittest.TestCase):
         self.float_data = [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]
         self.string_data = ["abc", "def", "hello", "world", "pika", "chu", "hello", "world"]
         self.vec_data = [array.array('d', [i, i+1]) for i in self.int_data]
+        self.np_array_data = [np.array(x) for x in self.vec_data]
+        self.np_matrix_data = [np.matrix(x) for x in self.vec_data]
         self.list_data = [[i, str(i), i * 1.0] for i in self.int_data]
         self.dict_data =  [{str(i): i, i : float(i)} for i in self.int_data]
         self.url = "http://s3-us-west-2.amazonaws.com/testdatasets/a_to_z.txt.gz"
@@ -52,7 +54,14 @@ class SArrayTest(unittest.TestCase):
     def __test_equal(self, _sarray, _data, _type):
         self.assertEqual(_sarray.dtype, _type)
         self.assertEqual(len(_sarray), len(_data))
-        self.assertSequenceEqual(list(_sarray.head(len(_sarray))), _data)
+        sarray_contents = list(_sarray.head(len(_sarray)))
+        if _type == np.ndarray:
+            # Special case for np.ndarray elements, which assertSequenceEqual
+            # does not handle.
+            np.testing.assert_array_equal(sarray_contents, _data)
+        else:
+            # Use unittest methods when possible for better consistency.
+            self.assertSequenceEqual(sarray_contents, _data)
 
     def __test_almost_equal(self, _sarray, _data, _type):
         self.assertEqual(_sarray.dtype, _type)
@@ -101,6 +110,8 @@ class SArrayTest(unittest.TestCase):
         self.__test_equal(SArray(self.url, str), expected_output, str)
 
         self.__test_creation(self.vec_data, array.array, self.vec_data)
+        self.__test_creation(self.np_array_data, np.ndarray, self.np_array_data)
+        self.__test_creation(self.np_matrix_data, np.ndarray, self.np_matrix_data)
         self.__test_creation(self.list_data, list, self.list_data)
 
         self.__test_creation(self.dict_data, dict, self.dict_data)
@@ -111,6 +122,10 @@ class SArrayTest(unittest.TestCase):
         self.__test_creation_type_inference(self.bool_data, int, [int(x) for x in self.bool_data])
         self.__test_creation_type_inference(self.string_data, str, self.string_data)
         self.__test_creation_type_inference(self.vec_data, array.array, self.vec_data)
+        self.__test_creation_type_inference(self.np_array_data, np.ndarray,
+                                            self.np_array_data)
+        self.__test_creation_type_inference(self.np_matrix_data, np.ndarray,
+                                            self.np_matrix_data)
         self.__test_creation_type_inference([np.bool_(True),np.bool_(False)],int,[1,0])
         self.__test_creation((1,2,3,4), int, [1,2,3,4])
 


### PR DESCRIPTION
The C++ backend represents all empty ndarray values as 0-dimensional: it assumes that each element of the shape array is positive. This design is enshrined in our serialization, so we should avoid changing it.
    
We use `numpy.asarray` on a buffer-protocol wrapper around the backend to reconstitute a `numpy.ndarray` value, but `asarray` does something unexpected when given a zero-dimensional buffer: it creates a one-dimensional, size-1 value read from undefined memory.
    
Instead, we canonicalize empty backend values to `array([])`. This is consistent with how scalar inputs round-trip to 1-d, size-1 values (e.g., `np.array(3.0)` becomes `np.array([3.0])`). (That behavior is due to the C++ ndarray constructor. Given an empty shape vector, it infers a 1-d shape from the flattened (size-1) data buffer.)

Also, while developing this fix, I realized that my fix in #932 only handled the case for initializing an SArray from a top-level np.matrix. The fix for lists of np.matrix subsumes that fix (which is reverted in this PR): we need to add np.matrix to the types handled by the Cython layer so that np.matrix instances get routed to the code for handling ndarray, not for handling generic sequences.

Fixes #357, fixes #359 