### PR TITLE
Clarify Vision example app behavior

### DIFF
--- a/userguide/object_detection/export-coreml.md
+++ b/userguide/object_detection/export-coreml.md
@@ -35,8 +35,15 @@ let objectRecognition = VNCoreMLRequest(model: visionModel,
 
 For more details on the integration with Core ML and a sample app to get
 you started, please look at the the article on
-[Recognizing Objects in Live Capture](https://developer.apple.com/documentation/vision)[Recognizing Objects
-in Live Capture].
+[Recognizing Objects in Live Capture](https://developer.apple.com/documentation/vision/recognizing_objects_in_live_capture).
+
+**Note:** Only models that were exported with *non-maximum suppression* (the default
+behavior in Turi Create 5.0+) will work with this example app. Older models
+or models that specify `include_non_maximum_suppression=False` will not give
+results as `VNRecognizedObjectObservation` objects and instead as
+`VNCoreMLFeatureValueObservation` objects; these are silently ignored in
+this example app. To learn how to work with `VNCoreMLFeatureValueObservation`
+objects, please continue reading.
 
 #### Deployment for iOS 11 and  macOS 10.13
 


### PR DESCRIPTION
Also fixes the link markdown syntax and the link itself to the app.

Fixes #877 - this takes a stab at address the confusion in this issue. However, I think we should also see if we can get the folks behind the Vision example app to add an error/warning if someone replaces their default model with one that does not produce results as `VNRecognizedObjectObservation` objects.