### PR TITLE
Add missing build order dependency

### DIFF
--- a/src/capi/CMakeLists.txt
+++ b/src/capi/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(_capi_objects OBJECT
 )
 
 set(_capi_requires unity unity_core numerics)
- 
+add_dependencies(_capi_objects ${_capi_requires})
 
 make_library(capi 
   SOURCES


### PR DESCRIPTION
The CAPI object build must depend on its requirements (since in
the case of boost, that creates even the header files), even
though there is no linking stage with the dependencies yet.

Fixes #996