### PR TITLE
Added boost to direct dependencies of capi 

### DIFF
--- a/src/capi/CMakeLists.txt
+++ b/src/capi/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(_capi_objects OBJECT
   ${_turi_capi_source_files}
 )
 
-set(_capi_requires unity unity_core numerics)
+set(_capi_requires unity unity_core numerics boost)
 add_dependencies(_capi_objects ${_capi_requires})
 
 make_library(capi 


### PR DESCRIPTION
to ensure boost setup is run before attempted compilation of capi source files.  Without this, compilation can fail due to missing headers. 