### PR TITLE
Enhance evaluation toolkit to accept explicit index map

### DIFF
--- a/src/unity/python/turicreate/test/test_activity_classifier.py
+++ b/src/unity/python/turicreate/test/test_activity_classifier.py
@@ -340,6 +340,23 @@ class ActivityClassifierTest(unittest.TestCase):
             expected_len = self._calc_expected_predictions_length(self.data.head(100), top_k=5)
             self.assertEqual(len(preds), expected_len)
 
+    def test_evaluate_with_incomplete_targets(self):
+        """
+        Check that evaluation does not require the test data to span all labels.
+        """
+
+        # Arbitrarily filter out all rows whose label matches the first row's.
+        filtered_label = self.data[self.target][0]
+        filtered_data = self.data[self.data[self.target] != filtered_label]
+
+        # Run evaluation.
+        evaluation = self.model.evaluate(filtered_data)
+
+        # Verify that all metrics were computed and included in the result.
+        for metric in ['accuracy', 'auc', 'precision', 'recall', 'f1_score',
+                       'log_loss', 'confusion_matrix', 'roc_curve']:
+            self.assertIn(metric, evaluation)
+
     def test__list_fields(self):
         """
         Check the list fields function.

--- a/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/unity/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -723,7 +723,7 @@ class ActivityClassifier(_CustomModel):
         if 'accuracy' in metrics:
             ret['accuracy'] = _evaluation.accuracy(dataset[self.target], classes)
         if 'auc' in metrics:
-            ret['auc'] = _evaluation.auc(dataset[self.target], probs)
+            ret['auc'] = _evaluation.auc(dataset[self.target], probs, index_map=self._target_id_map)
         if 'precision' in metrics:
             ret['precision'] = _evaluation.precision(dataset[self.target], classes)
         if 'recall' in metrics:
@@ -731,11 +731,11 @@ class ActivityClassifier(_CustomModel):
         if 'f1_score' in metrics:
             ret['f1_score'] = _evaluation.f1_score(dataset[self.target], classes)
         if 'log_loss' in metrics:
-            ret['log_loss'] = _evaluation.log_loss(dataset[self.target], probs)
+            ret['log_loss'] = _evaluation.log_loss(dataset[self.target], probs, index_map=self._target_id_map)
         if 'confusion_matrix' in metrics:
             ret['confusion_matrix'] = _evaluation.confusion_matrix(dataset[self.target], classes)
         if 'roc_curve' in metrics:
-            ret['roc_curve'] = _evaluation.roc_curve(dataset[self.target], probs)
+            ret['roc_curve'] = _evaluation.roc_curve(dataset[self.target], probs, index_map=self._target_id_map)
 
         return ret
 

--- a/src/unity/toolkits/evaluation/metrics.cpp
+++ b/src/unity/toolkits/evaluation/metrics.cpp
@@ -85,8 +85,9 @@ variant_type _supervised_streaming_evaluator(
   for (const auto& kvp: kwargs) {
     opts[kvp.first] = to_variant(kvp.second);
   } 
-  if ((metric == "auc") || (metric == "roc_curve") || 
-      (metric == "binary_logloss") || (metric == "multiclass_logloss")) {
+  const bool needs_index_map = (metric == "auc") || (metric == "roc_curve") ||
+      (metric == "binary_logloss") || (metric == "multiclass_logloss");
+  if (needs_index_map && opts.count("index_map") == 0) {
     opts["index_map"] =  to_variant(
         get_index_map(unity_targets, unity_predictions));
   }


### PR DESCRIPTION
The log loss, ROC curve, and AUC metrics support multiclass classification by accepting probability vectors as predictions. They infer the semantics of the probability vector by sorting all the labels found in their targets input. If the number of distinct labels is smaller than the probability vectors' length, these metrics throw an error.

With this change, these metrics support an explicit mapping from label to index into the probability vector. The activity classifier's evaluate method adopts this new API, making it robust to evaluation data that doesn't span all the training labels.

Fixes #969, fixes #1007 

Note: if we aren't comfortable committing to this new API for the evaluation toolkit (at the last minute before cutting 5.0), we could instead implement it on an interval version of these functions (and handle #1007 in the future).

(Maybe instead of an index map we should take a list of target labels, of same size as the probability vectors? Note also that we're currently limited in our ability to (conveniently) validate the index map. We don't check that the labels in the map match the labels in the targets SArray, and the backend currently ignores any labels not found in the index map.)