### PR TITLE
Fixes #995

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,8 +235,17 @@ endif()
 # Shared compiler flags used by all builds (debug, profile, release)
 # Allow COMPILER_FLAGS to be used as options from the ./configure without
 # forcing all the other options I want to add to be lost
-set(C_REAL_COMPILER_FLAGS "-Wall -pthread -g ${COMPILER_FLAGS}" CACHE STRING "common compiler options")
-set(CPP_REAL_COMPILER_FLAGS "-Wall -pthread -g ${CPP11_FLAGS} ${COMPILER_FLAGS}" CACHE STRING "common compiler options")
+set(C_REAL_COMPILER_FLAGS "-Wall -g ${COMPILER_FLAGS}" CACHE STRING "common compiler options")
+set(CPP_REAL_COMPILER_FLAGS "-Wall -g ${CPP11_FLAGS} ${COMPILER_FLAGS}" CACHE STRING "common compiler options")
+
+if (CLANG)
+  # clang 9.0.0 and earlier will warn (error with -Werror) on unused -pthread during linking
+  # so adding only to compile options is what we need.
+  add_compile_options(-pthread)
+else()
+  set(C_REAL_COMPILER_FLAGS "${C_REAL_COMPILER_FLAGS} -pthread" CACHE STRING "common compiler options")
+  set(CPP_REAL_COMPILER_FLAGS "${CPP_REAL_COMPILER_FLAGS} -pthread" CACHE STRING "common compiler options")
+endif()
 
 # Disable address space randomization for OSX lion and above
 if (APPLE)

--- a/src/unity/python/turicreate/test/test_style_transfer.py
+++ b/src/unity/python/turicreate/test/test_style_transfer.py
@@ -221,11 +221,12 @@ class StyleTransferTest(unittest.TestCase):
             img = self._coreml_python_predict(coreml_model, img_fixed)
             self.assertEqual(img.shape, (256, 256, 3))
 
-            # Test for flexible shape
-            img = self.style_sf[0:2][self.style_feature][1]
-            img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
-            img = self._coreml_python_predict(coreml_model, img_fixed)
-            self.assertEqual(img.shape, (512, 512, 3))
+            if _mac_ver() >= (10, 14):
+                # Test for flexible shape
+                img = self.style_sf[0:2][self.style_feature][1]
+                img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
+                img = self._coreml_python_predict(coreml_model, img_fixed)
+                self.assertEqual(img.shape, (512, 512, 3))
 
         # Also check if we can train a second model and export it (there could
         # be naming issues in mxnet)

--- a/src/unity/python/turicreate/test/test_style_transfer.py
+++ b/src/unity/python/turicreate/test/test_style_transfer.py
@@ -207,7 +207,7 @@ class StyleTransferTest(unittest.TestCase):
             img = img[..., 0:3]
             return img
 
-    def test_export_coreml_with_flexible_shape(self):
+    def test_export_coreml(self):
         import coremltools
         model = self.model
         for flexible_shape_on in [True, False]:

--- a/src/unity/python/turicreate/test/test_style_transfer.py
+++ b/src/unity/python/turicreate/test/test_style_transfer.py
@@ -211,7 +211,10 @@ class StyleTransferTest(unittest.TestCase):
         import coremltools
         filename = tempfile.mkstemp('my_style_transfer.mlmodel')[1]
         model = self.model
-        model.export_coreml(filename)
+        if _mac_ver() >= (10, 14):
+            model.export_coreml(filename)
+        else:
+            model.export_coreml(filename, include_flexible_shape=False)
 
         coreml_model = coremltools.models.MLModel(filename)
 

--- a/src/unity/python/turicreate/test/test_style_transfer.py
+++ b/src/unity/python/turicreate/test/test_style_transfer.py
@@ -212,40 +212,34 @@ class StyleTransferTest(unittest.TestCase):
         model = self.model
         for flexible_shape_on in [True, False]:
             filename = tempfile.mkstemp('my_style_transfer.mlmodel')[1]
-            # The following if statement should vanish once #207 on coremltools
-            # which is already merged into master, becomes part of a release.
-            if _mac_ver() < (10,14):
-                model.export_coreml(filename, 
-                    include_flexible_shape = False)
-            else:
-                model.export_coreml(filename, 
-                    include_flexible_shape = flexible_shape_on)
-            
-            coreml_model = coremltools.models.MLModel(filename)
+            model.export_coreml(filename, 
+                include_flexible_shape = flexible_shape_on)
+            if not flexible_shape_on or _mac_ver() >= (10,14):
+                coreml_model = coremltools.models.MLModel(filename)
 
-            mac_os_version_threshold = (10,14) if flexible_shape_on else (10,13)
+                mac_os_version_threshold = (10,14) if flexible_shape_on else (10,13)
 
-            if _mac_ver() >= mac_os_version_threshold:
-                img = self.style_sf[0:2][self.style_feature][0]
-                img_fixed = tc.image_analysis.resize(img, 256, 256, 3)
-                img = self._coreml_python_predict(coreml_model, img_fixed)
-                self.assertEqual(img.shape, (256, 256, 3))
-
-                if flexible_shape_on:
-                    # Test for flexible shape
-                    img = self.style_sf[0:2][self.style_feature][1]
-                    img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
+                if _mac_ver() >= mac_os_version_threshold:
+                    img = self.style_sf[0:2][self.style_feature][0]
+                    img_fixed = tc.image_analysis.resize(img, 256, 256, 3)
                     img = self._coreml_python_predict(coreml_model, img_fixed)
-                    self.assertEqual(img.shape, (512, 512, 3))
+                    self.assertEqual(img.shape, (256, 256, 3))
 
-            # Also check if we can train a second model and export it (there could
-            # be naming issues in mxnet)
-            filename2 = tempfile.mkstemp('my_style_transfer2.mlmodel')[1]
-            # We also test at the same time if we can export a model with a single
-            # class
+                    if flexible_shape_on:
+                        # Test for flexible shape
+                        img = self.style_sf[0:2][self.style_feature][1]
+                        img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
+                        img = self._coreml_python_predict(coreml_model, img_fixed)
+                        self.assertEqual(img.shape, (512, 512, 3))
 
-            model2 = tc.style_transfer.create(self.style_sf, self.content_sf, max_iterations=1)
-            model2.export_coreml(filename2)
+                # Also check if we can train a second model and export it (there could
+                # be naming issues in mxnet)
+                filename2 = tempfile.mkstemp('my_style_transfer2.mlmodel')[1]
+                # We also test at the same time if we can export a model with a single
+                # class
+
+                model2 = tc.style_transfer.create(self.style_sf, self.content_sf, max_iterations=1)
+                model2.export_coreml(filename2)
 
     def test_repr(self):
         model = self.model

--- a/src/unity/python/turicreate/test/test_style_transfer.py
+++ b/src/unity/python/turicreate/test/test_style_transfer.py
@@ -211,25 +211,23 @@ class StyleTransferTest(unittest.TestCase):
         import coremltools
         filename = tempfile.mkstemp('my_style_transfer.mlmodel')[1]
         model = self.model
-        if _mac_ver() >= (10, 14):
-            model.export_coreml(filename)
-        else:
-            model.export_coreml(filename, include_flexible_shape=False)
-
+        model.export_coreml(filename)
+        
         coreml_model = coremltools.models.MLModel(filename)
 
-        if _mac_ver() >= (10, 13):
+        if _mac_ver() >= (10, 14):
+            # It should work in 10.13 but there is a coremltools issue (#198)
+            # that is fixed in master but not in a release yet (as of 2.0b1)
             img = self.style_sf[0:2][self.style_feature][0]
             img_fixed = tc.image_analysis.resize(img, 256, 256, 3)
             img = self._coreml_python_predict(coreml_model, img_fixed)
             self.assertEqual(img.shape, (256, 256, 3))
 
-            if _mac_ver() >= (10, 14):
-                # Test for flexible shape
-                img = self.style_sf[0:2][self.style_feature][1]
-                img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
-                img = self._coreml_python_predict(coreml_model, img_fixed)
-                self.assertEqual(img.shape, (512, 512, 3))
+            # Test for flexible shape
+            img = self.style_sf[0:2][self.style_feature][1]
+            img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
+            img = self._coreml_python_predict(coreml_model, img_fixed)
+            self.assertEqual(img.shape, (512, 512, 3))
 
         # Also check if we can train a second model and export it (there could
         # be naming issues in mxnet)

--- a/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -836,13 +836,14 @@ class StyleTransfer(_CustomModel):
         coremltools.utils.rename_feature(spec,
                 'transformer__mulscalar0_output', stylized_image, True, True)
 
-        # Support flexible shape
-        flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
-        img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()
-        img_size_ranges.add_height_range((64, -1))
-        img_size_ranges.add_width_range((64, -1))
-        flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
-        flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
+        if include_flexible_shape:
+            # Support flexible shape
+            flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
+            img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()
+            img_size_ranges.add_height_range((64, -1))
+            img_size_ranges.add_width_range((64, -1))
+            flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
+            flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
 
         model_type = 'style transfer (%s)' % self.model
         spec.description.metadata.shortDescription = _coreml_utils._mlmodel_short_description(

--- a/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -11,7 +11,7 @@ from datetime import datetime as _datetime
 
 import turicreate.toolkits._internal_utils as _tkutl
 from turicreate.toolkits import _coreml_utils
-from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
+from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe, _mac_ver
 from .. import _mxnet_utils
 from ._utils import _seconds_as_string
 from .. import _pre_trained_models
@@ -832,13 +832,14 @@ class StyleTransfer(_CustomModel):
         coremltools.utils.rename_feature(spec,
                 'transformer__mulscalar0_output', stylized_image, True, True)
 
-        # Support flexible shape
-        flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
-        img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()
-        img_size_ranges.add_height_range((64, -1))
-        img_size_ranges.add_width_range((64, -1))
-        flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
-        flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
+        if _mac_ver() >= (10, 14):
+            # Support flexible shape
+            flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
+            img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()
+            img_size_ranges.add_height_range((64, -1))
+            img_size_ranges.add_width_range((64, -1))
+            flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
+            flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
 
         model_type = 'style transfer (%s)' % self.model
         spec.description.metadata.shortDescription = _coreml_utils._mlmodel_short_description(

--- a/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -840,14 +840,14 @@ class StyleTransfer(_CustomModel):
         flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
         flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
 
-        mlmodel = coremltools.models.MLModel(spec)
         model_type = 'style transfer (%s)' % self.model
-        mlmodel.short_description = _coreml_utils._mlmodel_short_description(
+        spec.description.metadata.shortDescription = _coreml_utils._mlmodel_short_description(
             model_type)
-        mlmodel.input_description[self.content_feature] = 'Input image'
-        mlmodel.input_description['index'] = u'Style index array (set index I to 1.0 to enable Ith style)'
-        mlmodel.output_description[stylized_image] = 'Stylized image'
-        _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, {
+        spec.description.input[0].shortDescription = 'Input image'
+        spec.description.input[1].shortDescription = u'Style index array (set index I to 1.0 to enable Ith style)'
+        spec.description.output[0].shortDescription = 'Stylized image'
+        user_defined_metadata = _coreml_utils._get_model_metadata(
+            self.__class__.__name__, {
                 'model': self.model,
                 'num_styles': str(self.num_styles),
                 'content_feature': self.content_feature,
@@ -855,7 +855,9 @@ class StyleTransfer(_CustomModel):
                 'max_iterations': str(self.max_iterations),
                 'training_iterations': str(self.training_iterations),
             }, version=StyleTransfer._PYTHON_STYLE_TRANSFER_VERSION)
-        mlmodel.save(path)
+        spec.description.metadata.userDefined.update(user_defined_metadata)
+        from coremltools.models.utils import save_spec as _save_spec
+        _save_spec(spec, path)
 
     def get_styles(self, style=None):
         """

--- a/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -836,14 +836,13 @@ class StyleTransfer(_CustomModel):
         coremltools.utils.rename_feature(spec,
                 'transformer__mulscalar0_output', stylized_image, True, True)
 
-        if include_flexible_shape:
-            # Support flexible shape
-            flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
-            img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()
-            img_size_ranges.add_height_range((64, -1))
-            img_size_ranges.add_width_range((64, -1))
-            flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
-            flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
+        # Support flexible shape
+        flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
+        img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()
+        img_size_ranges.add_height_range((64, -1))
+        img_size_ranges.add_width_range((64, -1))
+        flexible_shape_utils.update_image_size_range(spec, feature_name=self.content_feature, size_range=img_size_ranges)
+        flexible_shape_utils.update_image_size_range(spec, feature_name=stylized_image, size_range=img_size_ranges)
 
         model_type = 'style transfer (%s)' % self.model
         spec.description.metadata.shortDescription = _coreml_utils._mlmodel_short_description(

--- a/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/unity/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -758,7 +758,8 @@ class StyleTransfer(_CustomModel):
         image.type.imageType.width = width
         image.type.imageType.height = height
 
-    def export_coreml(self, path, image_shape=(256, 256)):
+    def export_coreml(self, path, image_shape=(256, 256), 
+        include_flexible_shape=True):
         """
         Save the model in Core ML format. The Core ML model takes an image of
         fixed size, and a style index inputs and produces an output
@@ -771,6 +772,9 @@ class StyleTransfer(_CustomModel):
 
         image_shape: tuple
             A tuple (defaults to (256, 256)) will bind the coreml model to a fixed shape.
+
+        include_flexible_shape: bool
+            A boolean value indicating whether flexible_shape should be included or not.
 
         See Also
         --------
@@ -832,7 +836,7 @@ class StyleTransfer(_CustomModel):
         coremltools.utils.rename_feature(spec,
                 'transformer__mulscalar0_output', stylized_image, True, True)
 
-        if _mac_ver() >= (10, 14):
+        if include_flexible_shape:
             # Support flexible shape
             flexible_shape_utils = _mxnet_converter._coremltools.models.neural_network.flexible_shape_utils
             img_size_ranges = flexible_shape_utils.NeuralNetworkImageSizeRange()


### PR DESCRIPTION
- Avoids call to `coremltools.models.MLModel`
- Only runs flexible shape code if macOS version is >= 10.14