### PR TITLE
Fix build break on Linux

### DIFF
--- a/src/unity/toolkits/activity_classification/sequence_iterator.cpp
+++ b/src/unity/toolkits/activity_classification/sequence_iterator.cpp
@@ -34,10 +34,10 @@ static std::map<std::string,size_t> generate_column_index_map(const std::vector<
 static double vec_mode(const flex_vec& input_vec) {
     std::vector<int> histogram;
     for (size_t i = 0; i < input_vec.size(); ++i) {
-        int value = static_cast<int>(input_vec[i]);
+        size_t value = static_cast<size_t>(input_vec[i]);
 
         // Each value should be in the index of a class label
-        DASSERT_EQ(static_cast<double>(static_cast<int>(input_vec[i])), input_vec[i]);
+        DASSERT_EQ(static_cast<double>(static_cast<size_t>(input_vec[i])), input_vec[i]);
 
         if(histogram.size() < (value + 1)){
           histogram.resize(value + 1);


### PR DESCRIPTION
Use size_t instead of int in `vec_mode` so that the comparison
between `histogram.size()` and the value doesn't conflict with
respect to sign. The values should always be natural numbers
(array indices) so size_t is appropriate.