### PR TITLE
Fix test_json failure in Python 3

### DIFF
--- a/src/unity/python/turicreate/test/test_json.py
+++ b/src/unity/python/turicreate/test/test_json.py
@@ -276,7 +276,7 @@ class JSONTest(unittest.TestCase):
   }
  ]
  """
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile('w') as f:
             f.write(out)
             f.flush()
 


### PR DESCRIPTION
Make sure we open a NamedTemporaryFile in a way that allows writing
strings (not just bytes). In Python 3, string literals are unicode.