### PR TITLE
Object-oriented interface for TCMPS inputs and parameters

### DIFF
--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -256,6 +256,8 @@ class MpsFloatArray(object):
     def __init__(self, x):
         """Wrap a numpy array"""
 
+        assert isinstance(x, _np.ndarray)
+
         # Load TCMPS backend library.
         self._LIB = _load_tcmps_lib()
         assert self._LIB is not None, "Cannot use MpsFloatArray without libtcmps.dylib"

--- a/src/unity/toolkits/tcmps/CMakeLists.txt
+++ b/src/unity/toolkits/tcmps/CMakeLists.txt
@@ -3,6 +3,7 @@ project(unity_toolkits)
 if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
     make_library(tcmps
         SOURCES
+        mps_float_array.cpp
         mps_graph_trainer.mm
         mps_graph_networks.mm
         mps_updater.mm

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.h
@@ -23,7 +23,8 @@ public:
   MPSCNNModule();
   ~MPSCNNModule();
   void Init(int network_id, int n, int c_in, int h_in, int w_in, int c_out,
-            int h_out, int w_out, int updater_id, const FloatArrayMap &config);
+            int h_out, int w_out, int updater_id,
+            const float_array_map& config);
   void Forward(const float_array& inputs, float* out, bool is_train = true);
   void Backward(const float_array& gradient, float* out);
   void ForwardBackward(const float_array& inputs, const float_array& labels,
@@ -45,7 +46,7 @@ public:
   void GetLossImages(float *_Nonnull out);
   void Update();
   void GpuUpdate();
-  void Load(const FloatArrayMap &weights);
+  void Load(const float_array_map& weights);
   void Export();
   void SetLearningRate(float new_lr) {
     if (updater_ != nil) {

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.h
@@ -10,6 +10,8 @@
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
+#include "mps_float_array.hpp"
+
 #import "mps_networks.h"
 #import "mps_updater.h"
 
@@ -22,35 +24,23 @@ public:
   ~MPSCNNModule();
   void Init(int network_id, int n, int c_in, int h_in, int w_in, int c_out,
             int h_out, int w_out, int updater_id, const FloatArrayMap &config);
-  void Forward(void *_Nonnull ptr, int64_t sz, int64_t *_Nonnull shape, int dim,
-               float *_Nonnull out, bool is_train = true);
-  void Backward(void *_Nonnull ptr, size_t sz, int64_t *_Nonnull shape, int dim,
-                float *_Nonnull out);
-  void ForwardBackward(void *_Nonnull ptr, size_t sz, int64_t *_Nonnull shape, int dim,
-                       void *_Nonnull label_ptr, size_t label_sz, int64_t *_Nonnull label_shape, int label_dim,
-                       void *_Nonnull weight_ptr, size_t weight_sz, int64_t *_Nonnull weight_shape, int weight_dim,
-                       bool loss_image_required,
-                       float *_Nonnull out);
-  void Forward(void *_Nonnull ptr, size_t sz, int64_t *_Nonnull shape, int dim,
-               void *_Nonnull label_ptr, size_t label_sz, int64_t *_Nonnull label_shape, int label_dim,
-               void *_Nonnull weight_ptr, size_t weight_sz, int64_t *_Nonnull weight_shape, int weight_dim,
-               bool loss_image_required, bool is_train,
-               float *_Nonnull out);
-  void Loss(void *_Nonnull ptr, size_t sz, int64_t *_Nonnull shape, int dim,
-            void *_Nonnull label_ptr, size_t label_sz, int64_t *_Nonnull label_shape, int label_dim,
-            void *_Nonnull weight_ptr, size_t weight_sz, int64_t *_Nonnull weight_shape, int weight_dim,
-            bool loss_image_required,
-            float *_Nonnull out);
+  void Forward(const float_array& inputs, float* out, bool is_train = true);
+  void Backward(const float_array& gradient, float* out);
+  void ForwardBackward(const float_array& inputs, const float_array& labels,
+                       const float_array& weights, bool loss_image_required,
+                       float* out);
+  void Forward(const float_array& inputs, const float_array& labels,
+               const float_array& weights, bool loss_image_required,
+               bool is_train, float* out);
+  void Loss(const float_array& inputs, const float_array& labels,
+            const float_array& weights, bool loss_image_required,
+            float* out);
   void BeginForwardBatch(
-      int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
-      void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-      void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
-      bool loss_image_required, bool is_train);
+      int batch_id, const float_array& inputs, const float_array& labels,
+      const float_array& weights, bool loss_image_required, bool is_train);
   void BeginForwardBackwardBatch(
-      int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
-      void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-      void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
-      bool loss_image_required);
+      int batch_id, const float_array& inputs, const float_array& labels,
+      const float_array& weights, bool loss_image_required);
   void WaitForBatch(int batch_id, float *forward_out, float *loss_out);
   void GetLossImages(float *_Nonnull out);
   void Update();
@@ -102,28 +92,27 @@ private:
   Batch* StartBatch(int batch_id);  // Throws if ID is already in use
 
   void SetupUpdater(int updater_id);
-  void Blob2MPSImage(float *_Nonnull ptr, MPSImageBatch *_Nonnull batch);
+  void Blob2MPSImage(const float_array& blob, MPSImageBatch *batch);
   void MPSImage2Blob(float *_Nonnull ptr, MPSImageBatch *_Nonnull batch);
 
-  static NSData *EncodeLabels(float* labels, NSUInteger sequenceLength,
+  static NSData *EncodeLabels(const float* labels, NSUInteger sequenceLength,
                               NSUInteger numClasses);
-  static NSData *EncodeWeights(float* weights, NSUInteger sequenceLength,
+  static NSData *EncodeWeights(const float* weights, NSUInteger sequenceLength,
                                NSUInteger numClasses);
 
-  MPSCNNLossLabelsBatch *_Nonnull initLossLabelsBatch(
-      id<MTLDevice> _Nonnull device, float *_Nonnull labels_ptr, float *_Nonnull weights_ptr,
-      int batch_size, int seq_len, int num_classes);
+  MPSCNNLossLabelsBatch *initLossLabelsBatch(
+      id<MTLDevice> device, const float_array& labels,
+      const float_array& weights, int batch_size, int seq_len, int num_classes);
   static void FillLossLabelsBatch(
       MPSCNNLossLabelsBatch *labelsBatch, id <MTLDevice> device,
-      float* labels_ptr, float* weights_ptr,
+      const float_array& labels, const float_array& weights,
       int batch_size, int seq_len, int num_classes);
   static MPSImageBatch *ExtractLossImages(MPSCNNLossLabelsBatch *labelsBatch,
                                           id<MTLCommandBuffer> cb);
     
   void TrainingWithLoss(
-      Batch *batch, void *ptr, size_t sz, int64_t *shape, int dim,
-      void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-      void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
+      Batch *batch, const float_array& inputs, const float_array& labels,
+      const float_array& weights,
       bool loss_image_required, bool wait_until_completed, float *out,
       bool do_backward, bool is_train = true);
 };

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.h
@@ -14,6 +14,7 @@
 
 #import "mps_networks.h"
 #import "mps_updater.h"
+#import "mps_utils.h"
 
 namespace turi {
 namespace mps {
@@ -47,18 +48,13 @@ public:
   void Update();
   void GpuUpdate();
   void Load(const float_array_map& weights);
-  void Export();
+  float_array_map Export() const;
   void SetLearningRate(float new_lr) {
     if (updater_ != nil) {
       updater_->SetLearningRate(new_lr);
     }
   }
   int NumParams();
-
-
-  std::unordered_map<std::string,
-                     std::tuple<std::string, float *, int, std::vector<int>>>
-      table_;
 
 private:
   // Used by the asynchronous API.

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.mm
@@ -350,9 +350,9 @@ void MPSCNNModule::GpuUpdate(){
 void MPSCNNModule::Load(const float_array_map& weights) {
   network_->Load(weights);
 }
-void MPSCNNModule::Export() {
-  table_.clear();
-  network_->Export(table_);
+
+float_array_map MPSCNNModule::Export() const {
+  return network_->Export();
 }
 int MPSCNNModule::NumParams() { return network_->NumParams(); }
 

--- a/src/unity/toolkits/tcmps/mps_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_cnnmodule.mm
@@ -36,7 +36,7 @@ MPSCNNModule::MPSCNNModule() {
 
 void MPSCNNModule::Init(int network_id, int n, int c_in, int h_in, int w_in,
                         int c_out, int h_out, int w_out, int updater_id,
-                        const FloatArrayMap &config) {
+                        const float_array_map& config) {
 
   // Save output shape, used for initializing the labels (that can not
   // be pre-initialized without the data)
@@ -347,7 +347,7 @@ void MPSCNNModule::GpuUpdate(){
     }
 }
 
-void MPSCNNModule::Load(const FloatArrayMap &weights) {
+void MPSCNNModule::Load(const float_array_map& weights) {
   network_->Load(weights);
 }
 void MPSCNNModule::Export() {

--- a/src/unity/toolkits/tcmps/mps_float_array.cpp
+++ b/src/unity/toolkits/tcmps/mps_float_array.cpp
@@ -10,15 +10,10 @@ namespace mps {
 namespace {
 
 #ifndef NDEBUG
-bool is_all_positive(const size_t* shape, size_t dim) {
-  return std::all_of(shape, shape + dim, [](size_t s) { return s > 0; });
-}
+bool is_positive(size_t x) { return x > 0; }
 #endif
 
-size_t product(const size_t* shape, size_t dim) {
-  return std::accumulate(shape, shape + dim, 1,
-                         [](size_t a, size_t b) { return a * b; });
-}
+size_t multiply(size_t a, size_t b) { return a * b; }
 
 }  // namespace
 
@@ -26,8 +21,45 @@ external_float_array::external_float_array(const float* data, size_t size,
                                            const size_t* shape, size_t dim)
   : data_(data), size_(size), shape_(shape), dim_(dim)
 {
-  assert(is_all_positive(shape, dim));
-  assert(size == product(shape, dim));
+  assert(std::all_of(shape, shape + dim, is_positive));
+  assert(size == std::accumulate(shape, shape + dim, 1, multiply));
+}
+
+float_buffer::float_buffer(const float* data, std::vector<size_t> shape)
+  : shape_(std::move(shape)),
+    size_(std::accumulate(shape_.begin(), shape_.end(), 1, multiply)),
+    data_(data, data + size_)
+{
+  assert(size_ > 0);
+}
+
+shared_float_array::shared_float_array(
+    std::shared_ptr<float_array> impl, const float* data, const size_t* shape,
+    size_t dim)
+  : impl_(std::move(impl)),
+    data_(data),
+    shape_(shape),
+    dim_(dim),
+    size_(std::accumulate(shape_, shape_ + dim_, 1, multiply))
+{
+  // The provided data array must be a view into the impl's data array.
+  assert(impl_->data() <= data_);
+  assert(data_ + size_ <= impl_->data() + impl_->size());
+
+  // The provided shape array must be a view into the impl's shape array.
+  assert(impl_->shape() <= shape_);
+  assert(shape_ + dim_ <= impl_->shape() + impl_->dim());
+}
+
+// static
+std::shared_ptr<float_array> shared_float_array::default_value() {
+  // n.b. static variables should have trivial destructors
+  static const float default_scalar = 0.f;
+  static const std::shared_ptr<float_array>* const singleton =
+      new std::shared_ptr<float_array>(
+          std::make_shared<external_float_array>(&default_scalar, /* size */ 1,
+                                                 nullptr, /* dim */ 0));
+  return *singleton;
 }
 
 }  // namespace mps

--- a/src/unity/toolkits/tcmps/mps_float_array.cpp
+++ b/src/unity/toolkits/tcmps/mps_float_array.cpp
@@ -1,0 +1,34 @@
+#include "mps_float_array.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <numeric>
+
+namespace turi {
+namespace mps {
+
+namespace {
+
+#ifndef NDEBUG
+bool is_all_positive(const size_t* shape, size_t dim) {
+  return std::all_of(shape, shape + dim, [](size_t s) { return s > 0; });
+}
+#endif
+
+size_t product(const size_t* shape, size_t dim) {
+  return std::accumulate(shape, shape + dim, 1,
+                         [](size_t a, size_t b) { return a * b; });
+}
+
+}  // namespace
+
+external_float_array::external_float_array(const float* data, size_t size,
+                                           const size_t* shape, size_t dim)
+  : data_(data), size_(size), shape_(shape), dim_(dim)
+{
+  assert(is_all_positive(shape, dim));
+  assert(size == product(shape, dim));
+}
+
+}  // namespace mps
+}  // namespace turi

--- a/src/unity/toolkits/tcmps/mps_float_array.hpp
+++ b/src/unity/toolkits/tcmps/mps_float_array.hpp
@@ -1,0 +1,57 @@
+#ifndef MPS_FLOAT_ARRAY_HPP_
+#define MPS_FLOAT_ARRAY_HPP_
+
+#include <cstddef>
+
+namespace turi {
+namespace mps {
+
+// Pure virtual (but low-level) interface for an n-dimensional array. The inputs
+// and outputs of the TCMPS library are largely expressed with this type.
+class float_array {
+public:
+  virtual ~float_array() = default;
+
+  // Returns a pointer to the first float value in the data. This pointer is
+  // guaranteed to remain valid for the lifetime of this float_array instance.
+  virtual const float* data() const = 0;
+
+  // Returns the total number of float values present, beginning at the pointer
+  // returned by data(). This number must equal the product of all the sizes in
+  // the shape array.
+  virtual size_t size() const = 0;
+
+  // Returns a pointer to the first element of the shape array. This pointer is
+  // guaranteed to remain valid for the lifetime of this float_array instance.
+  virtual const size_t* shape() const = 0;
+
+  // Returns the total number of elements in the array returned by shape().
+  virtual size_t dim() const = 0;
+};
+
+// Wrapper around raw C pointers into an external n-dimensional array. Users
+// must manually ensure that the external array outlives instances of this
+// wrapper.
+class external_float_array: public float_array {
+public:
+  external_float_array(const float* data, size_t size, const size_t* shape,
+                       size_t dim);
+
+  const float* data() const override { return data_; }
+  size_t size() const override { return size_; }
+
+  const size_t* shape() const override { return shape_; }
+  size_t dim() const override { return dim_; }
+
+private:
+  const float* data_ = nullptr;
+  size_t size_ = 0;
+
+  const size_t* shape_ = nullptr;
+  size_t dim_ = 0;
+};
+
+}  // namespace mps
+}  // namespace turi
+
+#endif  // MPS_FLOAT_ARRAY_HPP_

--- a/src/unity/toolkits/tcmps/mps_float_array.hpp
+++ b/src/unity/toolkits/tcmps/mps_float_array.hpp
@@ -2,6 +2,8 @@
 #define MPS_FLOAT_ARRAY_HPP_
 
 #include <cstddef>
+#include <memory>
+#include <vector>
 
 namespace turi {
 namespace mps {
@@ -49,6 +51,66 @@ private:
 
   const size_t* shape_ = nullptr;
   size_t dim_ = 0;
+};
+
+// A float_array implementation that directly owns the memory containing the
+// float data.
+class float_buffer: public float_array {
+public:
+  // Copies enough float values from `data` to fill the given `shape`.
+  float_buffer(const float* data, std::vector<size_t> shape);
+
+  const float* data() const override { return data_.data(); }
+  size_t size() const override { return size_; }
+
+  const size_t* shape() const override { return shape_.data(); }
+  size_t dim() const override { return shape_.size(); }
+
+private:
+  std::vector<size_t> shape_;
+  size_t size_;
+  std::vector<float> data_;
+};
+
+// A float_array implementation that maintains a view into another float_array
+// (that is possibly shared with others shared_float_array instances). Instances
+// of this class can be efficiently copied (in constant time and incurring no
+// additional allocations).
+class shared_float_array: public float_array {
+public:
+  // Convenience function for creating a shared float_buffer.
+  static shared_float_array copy(const float* data, std::vector<size_t> shape) {
+    return shared_float_array(
+        std::make_shared<float_buffer>(data, std::move(shape)));
+  }
+
+  // Simply wraps an existing float_array shared_ptr.
+  explicit shared_float_array(std::shared_ptr<float_array> impl)
+    : shared_float_array(impl, impl->data(), impl->shape(), impl->dim())
+  {}
+
+  // Creates an array containing the scalar 0.f.
+  shared_float_array(): shared_float_array(default_value()) {}
+
+  const float* data() const override { return data_; }
+  size_t size() const override { return size_; }
+
+  const size_t* shape() const override { return shape_; }
+  size_t dim() const override { return dim_; }
+
+protected:
+  shared_float_array(std::shared_ptr<float_array> impl, const float* data,
+                     const size_t* shape, size_t dim);
+
+private:
+  static std::shared_ptr<float_array> default_value();
+
+  std::shared_ptr<float_array> impl_;
+
+  const float* data_ = nullptr;
+  const size_t* shape_ = nullptr;
+  size_t dim_ = 0;
+  size_t size_ = 0;
 };
 
 }  // namespace mps

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
@@ -11,6 +11,8 @@
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
+#include "mps_float_array.hpp"
+
 #import "mps_utils.h"
 #import "mps_graph_networks.h"
 
@@ -43,18 +45,17 @@ public:
 
   // Training
   void SetLearningRate(float lr);
-  void StartTrainingBatch(void *ptr, int64_t sz, int64_t *shape, int dim,
-                          float *labels_ptr);
+  void StartTrainingBatch(const float_array& input_batch,
+                          const float_array& label_batch);
   void WaitForTrainingBatch(float *loss);
 
   // Inference
-  void StartInferenceBatch(void *ptr, int64_t sz, int64_t *shape, int dim);
+  void StartInferenceBatch(const float_array& input_batch);
   void WaitForInferenceBatch(float *out_ptr);
 
   // Forward-backward pass with specified input and top-gradient images
-  void StartTrainReturnGradBatch(void *ptr, int64_t sz, int64_t *shape, int dim,
-                                 void *grad_ptr, int64_t grad_sz,
-                                 int64_t *grad_shape, int grad_dim);
+  void StartTrainReturnGradBatch(const float_array& input_batch,
+                                 const float_array& gradient_batch);
   void WaitForTrainReturnGradBatch(float *out_ptr);
 
   void Export();
@@ -66,11 +67,11 @@ public:
 
 private:
   MPSImageBatch *CreateImageBatch(MPSImageDescriptor *desc);
-  MPSImageBatch *CopyInput(void *ptr, int64_t sz, int64_t *shape, int dim);
-  MPSImageBatch *CopyGrad(void *ptr, int64_t sz, int64_t *shape, int dim);
-  MPSCNNLossLabelsBatch *CopyLabels(float *ptr);
+  MPSImageBatch *CopyInput(const float_array& input);
+  MPSImageBatch *CopyGrad(const float_array& gradient);
+  MPSCNNLossLabelsBatch *CopyLabels(const float_array& labels);
 
-  void Blob2MPSImage(float *ptr, MPSImageBatch *batch);
+  void Blob2MPSImage(const float_array& blob, MPSImageBatch *batch);
   void MPSImage2Blob(float *ptr, MPSImageBatch *batch);
 
   id<MTLDevice> dev_;

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
@@ -57,12 +57,8 @@ public:
                                  const float_array& gradient_batch);
   void WaitForTrainReturnGradBatch(float *out_ptr);
 
-  void Export();
+  float_array_map Export() const;
   int NumParams();
-
-  std::unordered_map<std::string,
-                     std::tuple<std::string, float *, int, std::vector<int>>>
-      table_;
 
 private:
   MPSImageBatch *CreateImageBatch(MPSImageDescriptor *desc);

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.h
@@ -31,8 +31,7 @@ public:
 
   void Init(int network_id, int n, int c_in, int h_in, int w_in, int c_out,
             int h_out, int w_out,
-            const FloatArrayMap &config,
-            const FloatArrayMap &weights);
+            const float_array_map& config, const float_array_map& weights);
 
   // Each call to a Start*Batch function must be paired with a call to a
   // WaitFor*Batch function. These functions must match the graph mode used to

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
@@ -80,8 +80,8 @@ void MPSGraphModule::Init(int network_id, int n, int c_in, int h_in, int w_in,
   }
 }
 
-void MPSGraphModule::StartTrainingBatch(void *ptr, int64_t sz, int64_t *shape,
-                                        int dim, float *labels_ptr) {
+void MPSGraphModule::StartTrainingBatch(const float_array& input_batch,
+                                        const float_array& label_batch) {
   @autoreleasepool {
 
   assert(mode_ == kGraphModeTrain);
@@ -90,8 +90,8 @@ void MPSGraphModule::StartTrainingBatch(void *ptr, int64_t sz, int64_t *shape,
   TCMPSGraphModuleBatch *batch = [[TCMPSGraphModuleBatch alloc] initWithCommandBuffer:cb];
 
   // Copy from raw C inputs to MPS images and loss labels.
-  batch.input = CopyInput(ptr, sz, shape, dim);
-  batch.lossState = CopyLabels(labels_ptr);
+  batch.input = CopyInput(input_batch);
+  batch.lossState = CopyLabels(label_batch);
 
   // Encode the forward-backward pass.
   batch.output = network_->RunGraph(cb, batch.input, batch.lossState);
@@ -134,8 +134,7 @@ void MPSGraphModule::WaitForTrainingBatch(float *loss) {
   }  // @autoreleasepool
 }
 
-void MPSGraphModule::StartInferenceBatch(void *ptr, int64_t sz, int64_t *shape,
-                                         int dim) {
+void MPSGraphModule::StartInferenceBatch(const float_array& input_batch) {
   @autoreleasepool {
 
   assert(mode_ == kGraphModeInference);
@@ -144,7 +143,7 @@ void MPSGraphModule::StartInferenceBatch(void *ptr, int64_t sz, int64_t *shape,
   TCMPSGraphModuleBatch *batch = [[TCMPSGraphModuleBatch alloc] initWithCommandBuffer:cb];
 
   // Copy from raw C inputs to MPS images. Encode the forward pass.
-  batch.input = CopyInput(ptr, sz, shape, dim);
+  batch.input = CopyInput(input_batch);
   batch.output = network_->RunGraph(cb, @{@"input" : batch.input});
 
   // Schedule synchronization of the output from GPU to CPU.
@@ -181,8 +180,7 @@ void MPSGraphModule::WaitForInferenceBatch(float *out_ptr) {
 }
 
 void MPSGraphModule::StartTrainReturnGradBatch(
-    void *ptr, int64_t sz, int64_t *shape, int dim,
-    void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim) {
+    const float_array& input_batch, const float_array& gradient_batch) {
   @autoreleasepool {
 
   assert(mode_ == kGraphModeTrainReturnGrad);
@@ -191,8 +189,8 @@ void MPSGraphModule::StartTrainReturnGradBatch(
   TCMPSGraphModuleBatch *batch = [[TCMPSGraphModuleBatch alloc] initWithCommandBuffer:cb];
 
   // Copy from raw C inputs to MPS images. Encode the forward-backward pass.
-  batch.input = CopyInput(ptr, sz, shape, dim);
-  batch.grad = CopyGrad(grad_ptr, grad_sz, grad_shape, grad_dim);
+  batch.input = CopyInput(input_batch);
+  batch.grad = CopyGrad(gradient_batch);
   batch.output = network_->RunGraph(cb, @{@"input" : batch.input,
                                           @"grad"  : batch.grad   });
 
@@ -256,8 +254,7 @@ MPSImageBatch *MPSGraphModule::CreateImageBatch(MPSImageDescriptor *desc) {
   return [result copy];
 }
 
-MPSImageBatch *MPSGraphModule::CopyInput(void *ptr, int64_t sz, int64_t *shape,
-                                         int dim) {
+MPSImageBatch *MPSGraphModule::CopyInput(const float_array& input) {
   @autoreleasepool {
     // may check shape
 
@@ -268,13 +265,12 @@ MPSImageBatch *MPSGraphModule::CopyInput(void *ptr, int64_t sz, int64_t *shape,
       // Allocate a new MPSImageBatch if necessary.
       batch = CreateImageBatch(input_desc_);
     }
-    Blob2MPSImage((float *)ptr, batch);
+    Blob2MPSImage(input, batch);
     return batch;
   }
 }
 
-MPSImageBatch *MPSGraphModule::CopyGrad(void *ptr, int64_t sz, int64_t *shape,
-                                        int dim) {
+MPSImageBatch *MPSGraphModule::CopyGrad(const float_array& gradient) {
   @autoreleasepool {
     // may check shape
 
@@ -285,20 +281,22 @@ MPSImageBatch *MPSGraphModule::CopyGrad(void *ptr, int64_t sz, int64_t *shape,
       // Allocate a new MPSImageBatch if necessary.
       batch = CreateImageBatch(output_desc_);
     }
-    Blob2MPSImage((float *)ptr, batch);
+    Blob2MPSImage(gradient, batch);
     return batch;
   }
 }
 
-MPSCNNLossLabelsBatch *MPSGraphModule::CopyLabels(float *ptr) {
+MPSCNNLossLabelsBatch *MPSGraphModule::CopyLabels(const float_array& labels) {
   @autoreleasepool {
-    return network_->loss_layer_->CreateLossState(dev_, ptr);
+    return network_->loss_layer_->CreateLossState(dev_, labels);
   }
 }
 
-void MPSGraphModule::Blob2MPSImage(float *ptr, MPSImageBatch *batch) {
+void MPSGraphModule::Blob2MPSImage(const float_array& blob,
+                                   MPSImageBatch *batch) {
   // add size chcek later
   assert([batch count] > 0);
+  const float* ptr = blob.data();
   MPSImage *img = batch[0];
   int stride = [img width] * [img height] * [img featureChannels];
   for (int i = 0; i < [batch count]; ++i) {

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
@@ -52,8 +52,8 @@ MPSGraphModule::MPSGraphModule() {
 
 void MPSGraphModule::Init(int network_id, int n, int c_in, int h_in, int w_in,
                           int c_out, int h_out, int w_out,
-                          const FloatArrayMap &config,
-                          const FloatArrayMap &weights) {
+                          const float_array_map& config,
+                          const float_array_map& weights) {
   @autoreleasepool {
     mode_ = (GraphMode)get_array_map_scalar(config, "mode", kGraphModeTrainReturnGrad);
     

--- a/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_cnnmodule.mm
@@ -228,10 +228,9 @@ void MPSGraphModule::WaitForTrainReturnGradBatch(float *out_ptr) {
   }  // @autoreleasepool
 }
 
-void MPSGraphModule::Export() {
+float_array_map MPSGraphModule::Export() const {
   @autoreleasepool {
-    table_.clear();
-    network_->Export(table_);
+    return network_->Export();
   }
 }
 

--- a/src/unity/toolkits/tcmps/mps_graph_layers.h
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.h
@@ -30,10 +30,7 @@ struct GraphLayer {
   virtual void InitBwd(MPSNNImageNode *_Nonnull src) = 0;
   virtual void Load(const float_array_map& weights) {}
   virtual void SetLearningRate(float lr) {}
-  virtual void
-  Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
-                                                    std::vector<int>>> &table) {
-  }
+  virtual float_array_map Export() const { return float_array_map(); }
 
   virtual ~GraphLayer() {}
 
@@ -130,10 +127,8 @@ struct ConvGraphLayer : public GraphLayer {
   void InitBwd(MPSNNImageNode * _Nonnull src) override;
   void SetLearningRate(float lr) override;
 
-  void
-  Export(std::unordered_map<
-         std::string, std::tuple<std::string, float *, int, std::vector<int>>>
-             &table) override;
+  float_array_map Export() const override;
+
   // content
   bool use_bias{false};
   MPSCNNConvolutionNode *_Nonnull node_fwd;
@@ -163,10 +158,7 @@ struct BNGraphLayer : public GraphLayer {
   void InitBwd(MPSNNImageNode * _Nonnull src) override;
   void SetLearningRate(float lr) override;
 
-  void
-  Export(std::unordered_map<
-         std::string, std::tuple<std::string, float *, int, std::vector<int>>>
-             &table) override;
+  float_array_map Export() const override;
 
   TCMPSBatchNormWeights *_Nonnull data;
   MPSCNNBatchNormalizationNode *_Nonnull node_fwd;

--- a/src/unity/toolkits/tcmps/mps_graph_layers.h
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.h
@@ -24,11 +24,11 @@ namespace mps {
 struct GraphLayer {
   virtual void Init(id<MTLDevice> _Nonnull device,
                     id<MTLCommandQueue> _Nonnull cmd_queue,
-                    const FloatArrayMap &config,
-                    const FloatArrayMap &weights) {}
+                    const float_array_map& config,
+                    const float_array_map& weights) {}
   virtual void InitFwd(MPSNNImageNode *_Nonnull src) = 0;
   virtual void InitBwd(MPSNNImageNode *_Nonnull src) = 0;
-  virtual void Load(const FloatArrayMap &weights) {}
+  virtual void Load(const float_array_map& weights) {}
   virtual void SetLearningRate(float lr) {}
   virtual void
   Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
@@ -38,15 +38,15 @@ struct GraphLayer {
   virtual ~GraphLayer() {}
 
   void _Load(const std::string &key,
-             const FloatArrayMap &weights,
-             int dst_size,
+             const float_array_map& weights,
+             size_t dst_size,
              float *_Nonnull dst) {
     if (weights.count(key) > 0) {
       LogStdString("Loading weight: " + key);
-      assert(weights.at(key).size == dst_size);
+      assert(weights.at(key).size() == dst_size);
       size_t size = dst_size * sizeof(float);
       void *dest = (void *)dst;
-      void *src = (void *)weights.at(key).data;
+      const float *src = weights.at(key).data();
       std::memcpy(dest, src, size);
     }
   }
@@ -124,8 +124,8 @@ struct ConvGraphLayer : public GraphLayer {
   ~ConvGraphLayer() {}
 
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> _Nonnull cmd_queue,
-            const FloatArrayMap &config,
-            const FloatArrayMap &weights) override;
+            const float_array_map& config,
+            const float_array_map& weights) override;
   void InitFwd(MPSNNImageNode * _Nonnull src) override;
   void InitBwd(MPSNNImageNode * _Nonnull src) override;
   void SetLearningRate(float lr) override;
@@ -157,8 +157,8 @@ struct BNGraphLayer : public GraphLayer {
   ~BNGraphLayer() {}
 
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> _Nonnull cmd_queue,
-            const FloatArrayMap &config,
-            const FloatArrayMap &weights) override;
+            const float_array_map& config,
+            const float_array_map& weights) override;
   void InitFwd(MPSNNImageNode * _Nonnull src) override;
   void InitBwd(MPSNNImageNode * _Nonnull src) override;
   void SetLearningRate(float lr) override;
@@ -214,8 +214,8 @@ public:
                      Options options);
 
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> _Nonnull cmd_queue,
-            const FloatArrayMap &config,
-            const FloatArrayMap &weights) override;
+            const float_array_map& config,
+            const float_array_map& weights) override;
   void InitFwd(MPSNNImageNode *src) override;
   void InitBwd(MPSNNImageNode *src) override;
 

--- a/src/unity/toolkits/tcmps/mps_graph_layers.h
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.h
@@ -1,16 +1,20 @@
 #ifndef MPS_GRAPH_LAYERS_H_
 #define MPS_GRAPH_LAYERS_H_
 
-#import "mps_layers.h"
-#import "mps_weight.h"
-#import "mps_utils.h"
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #import <Accelerate/Accelerate.h>
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#import <string>
-#import <unordered_map>
-#import <vector>
+
+#include "mps_float_array.hpp"
+
+#import "mps_layers.h"
+#import "mps_weight.h"
+#import "mps_utils.h"
 
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
 
@@ -78,8 +82,8 @@ struct GraphLayer {
 struct LossGraphLayer: public GraphLayer {
   MPSNNLabelsNode *labels_node = nil;
 
-  virtual MPSCNNLossLabelsBatch *CreateLossState(id<MTLDevice> _Nonnull device,
-                                                 float *data) const = 0;
+  virtual MPSCNNLossLabelsBatch *CreateLossState(
+      id<MTLDevice> _Nonnull device, const float_array& labels_batch) const = 0;
 };
 
 // Individual Layers
@@ -215,7 +219,9 @@ public:
   void InitFwd(MPSNNImageNode *src) override;
   void InitBwd(MPSNNImageNode *src) override;
 
-  MPSCNNLossLabelsBatch *CreateLossState(id<MTLDevice> _Nonnull device, float *data) const override;
+  MPSCNNLossLabelsBatch *CreateLossState(
+      id<MTLDevice> _Nonnull device,
+      const float_array& labels_batch) const override;
 
 private:
   Options options_;

--- a/src/unity/toolkits/tcmps/mps_graph_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_layers.mm
@@ -301,8 +301,9 @@ void YoloLossGraphLayer::InitBwd(MPSNNImageNode *src) {
   bwd_img_node = fwd_img_node;
 }
 
-MPSCNNLossLabelsBatch *YoloLossGraphLayer::CreateLossState(id<MTLDevice> _Nonnull device,
-                                                      float *data) const {
+MPSCNNLossLabelsBatch *YoloLossGraphLayer::CreateLossState(
+    id<MTLDevice> _Nonnull device, const float_array &labels_array) const {
+  const float* data = labels_array.data();
   MPSCNNLossLabelsBatch *loss_state = @[];
   int batch_size = oshape[0];
   MTLSize loss_image_size = {1, 1, 1};

--- a/src/unity/toolkits/tcmps/mps_graph_networks.h
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.h
@@ -41,9 +41,7 @@ struct MPSGraphNetwork {
   MPSImageBatch * _Nonnull RunGraph(id<MTLCommandBuffer>_Nonnull  cb, MPSImageBatch *_Nonnull src,
                           MPSCNNLossLabelsBatch *_Nonnull loss_state);
   MPSImageBatch * _Nonnull RunGraph(id<MTLCommandBuffer> _Nonnull  cb, NSDictionary *_Nonnull inputs);
-  void
-  Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
-                                                    std::vector<int>>> &table);
+  float_array_map Export() const;
   int NumParams();
   MPSNNGraph *_Nonnull  graph;
   MPSNNImageNode *_Nonnull  input_node;

--- a/src/unity/toolkits/tcmps/mps_graph_networks.h
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.h
@@ -37,8 +37,7 @@ struct MPSGraphNetwork {
   virtual ~MPSGraphNetwork();
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> _Nonnull cmd_queue,
             GraphMode mode,
-            const FloatArrayMap &config,
-            const FloatArrayMap &weights);
+            const float_array_map& config, const float_array_map& weights);
   MPSImageBatch * _Nonnull RunGraph(id<MTLCommandBuffer>_Nonnull  cb, MPSImageBatch *_Nonnull src,
                           MPSCNNLossLabelsBatch *_Nonnull loss_state);
   MPSImageBatch * _Nonnull RunGraph(id<MTLCommandBuffer> _Nonnull  cb, NSDictionary *_Nonnull inputs);
@@ -54,7 +53,7 @@ struct MPSGraphNetwork {
 // Factory function to create a network
 std::unique_ptr<MPSGraphNetwork> createNetworkGraph(
     GraphNetworkType network_id, const std::vector<int> &params,
-    const FloatArrayMap &config);
+    const float_array_map& config);
 
 // Various networks
 // ---------------------------------------------------------------------------------------------
@@ -65,7 +64,8 @@ std::unique_ptr<MPSGraphNetwork> createNetworkGraph(
 // ---------------------------------------------------------------------------------------------
 
 struct SingleConvNetworkGraph : public MPSGraphNetwork {
-  SingleConvNetworkGraph(const std::vector<int> &iparam, const FloatArrayMap& config) {
+  SingleConvNetworkGraph(const std::vector<int> &iparam,
+                         const float_array_map& config) {
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -81,7 +81,8 @@ struct SingleConvNetworkGraph : public MPSGraphNetwork {
 };
 
 struct SingleReLUNetworkGraph : public MPSGraphNetwork {
-  SingleReLUNetworkGraph(const std::vector<int> &iparam, const FloatArrayMap& config) {
+  SingleReLUNetworkGraph(const std::vector<int> &iparam,
+                         const float_array_map& config) {
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -96,7 +97,8 @@ struct SingleReLUNetworkGraph : public MPSGraphNetwork {
 };
 
 struct SingleBNNetworkGraph : public MPSGraphNetwork {
-  SingleBNNetworkGraph(const std::vector<int> &iparam, const FloatArrayMap& config) {
+  SingleBNNetworkGraph(const std::vector<int> &iparam,
+                       const float_array_map& config) {
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -110,7 +112,8 @@ struct SingleBNNetworkGraph : public MPSGraphNetwork {
 };
 
 struct SingleMPNetworkGraph : public MPSGraphNetwork {
-  SingleMPNetworkGraph(const std::vector<int> &iparam, const FloatArrayMap& config) {
+  SingleMPNetworkGraph(const std::vector<int> &iparam,
+                       const float_array_map& config) {
     layers.resize(1);
     int n = iparam[0];
     int hi = iparam[1];
@@ -127,7 +130,8 @@ struct SingleMPNetworkGraph : public MPSGraphNetwork {
 };
 
 struct ODNetworkGraph : public MPSGraphNetwork {
-  ODNetworkGraph(const std::vector<int> &iparam, const FloatArrayMap& config) {
+  ODNetworkGraph(const std::vector<int> &iparam,
+                 const float_array_map& config) {
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];

--- a/src/unity/toolkits/tcmps/mps_graph_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.mm
@@ -129,13 +129,15 @@ MPSImageBatch *MPSGraphNetwork::RunGraph(id<MTLCommandBuffer> cb, MPSImageBatch 
   return ret;
 }
 
-void MPSGraphNetwork::Export(
-    std::unordered_map<std::string,
-                       std::tuple<std::string, float *, int, std::vector<int>>>
-        &table) {
+float_array_map MPSGraphNetwork::Export() const {
+  float_array_map table;
   for (int i = 0; i < layers.size(); ++i) {
-    layers[i]->Export(table);
+    float_array_map layer_table = layers[i]->Export();
+    table.insert(layer_table.begin(), layer_table.end());
+    // TODO: In C++17, we can use std::map::merge to move the table entries
+    // instead of copying them: table.merge(layers[i]->Export());
   }
+  return table;
 }
 
 int MPSGraphNetwork::NumParams() {

--- a/src/unity/toolkits/tcmps/mps_graph_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.mm
@@ -16,7 +16,7 @@ namespace mps {
 
 std::unique_ptr<MPSGraphNetwork> createNetworkGraph(
     GraphNetworkType network_id, const std::vector<int> &params,
-    const FloatArrayMap &config) {
+    const float_array_map& config) {
   std::unique_ptr<MPSGraphNetwork> result;
   switch (network_id) {
   case kSingleReLUGraphNet:
@@ -51,8 +51,8 @@ MPSGraphNetwork::~MPSGraphNetwork() {
 void MPSGraphNetwork::Init(id<MTLDevice> _Nonnull device,
                            id<MTLCommandQueue> cmd_queue,
                            GraphMode mode,
-                           const FloatArrayMap &config,
-                           const FloatArrayMap &weights) {
+                           const float_array_map& config,
+                           const float_array_map& weights) {
   for (int i = 0; i < layers.size(); ++i) {
     layers[i]->Init(device, cmd_queue, config, weights);
   }

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.h
@@ -14,17 +14,16 @@ EXPORT int TCMPSMetalDeviceMemoryLimit(uint64_t *size);
 EXPORT int TCMPSCreateGraphModule(MPSHandle *handle);
 EXPORT int TCMPSDeleteGraphModule(MPSHandle handle);
 
-EXPORT int TCMPSStartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
-                                   int64_t *shape, int dim, float *labels_ptr);
+EXPORT int TCMPSStartTrainingBatchGraph(
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels);
 EXPORT int TCMPSWaitForTrainingBatchGraph(MPSHandle handle, float *loss);
 
-EXPORT int TCMPSStartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
-                                    int64_t *shape, int dim);
+EXPORT int TCMPSStartInferenceBatchGraph(
+    MPSHandle handle, TCMPSFloatArrayRef inputs);
 EXPORT int TCMPSWaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr);
 
 EXPORT int TCMPSStartTrainReturnGradBatchGraph(
-    MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
-    void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim);
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef gradient);
 EXPORT int TCMPSWaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr);
 
 EXPORT int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.h
@@ -35,8 +35,8 @@ EXPORT int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int
 
 EXPORT int TCMPSNumParamsGraph(MPSHandle handle, int *num);
 
-EXPORT int TCMPSExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
-           int **shape);
+EXPORT int TCMPSExportGraph(MPSHandle handle,
+                            TCMPSFloatArrayMapIteratorRef* float_array_map_out);
 
 EXPORT int TCMPSSetLearningRateGraph(MPSHandle handle, float new_lr);
 

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.mm
@@ -10,6 +10,7 @@
 using turi::mps::MPSGraphModule;
 using turi::mps::float_array;
 using turi::mps::float_array_map;
+using turi::mps::float_array_map_iterator;
 using turi::mps::make_array_map;
 
 int TCMPSHasHighPowerMetalDevice(bool *has_device) {
@@ -133,19 +134,13 @@ int TCMPSNumParamsGraph(MPSHandle handle, int *num) {
   API_END();
 }
 
-int TCMPSExportGraph(MPSHandle handle, char **names, void **arrs, int64_t *dim,
-           int **shape) {
+int TCMPSExportGraph(MPSHandle handle,
+                     TCMPSFloatArrayMapIteratorRef* float_array_map_out) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->Export();
-  auto &table = obj->table_;
-  int cnt = 0;
-  for (auto &p : table) {
-    names[cnt] = (char *)std::get<0>(p.second).c_str();
-    arrs[cnt] = (void *)std::get<1>(p.second);
-    dim[cnt] = std::get<2>(p.second);
-    shape[cnt++] = &(std::get<3>(p.second)[0]);
-  }
+  auto* float_array_map = new float_array_map_iterator(obj->Export());
+  *float_array_map_out =
+      reinterpret_cast<TCMPSFloatArrayMapIteratorRef>(float_array_map);
   API_END();
 }
 

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.mm
@@ -7,9 +7,9 @@
 #import "mps_device_manager.h"
 #import "mps_graph_cnnmodule.h"
 
-using turi::mps::FloatArrayMap;
 using turi::mps::MPSGraphModule;
 using turi::mps::float_array;
+using turi::mps::float_array_map;
 using turi::mps::make_array_map;
 
 int TCMPSHasHighPowerMetalDevice(bool *has_device) {
@@ -115,8 +115,10 @@ int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, 
               int64_t *weight_sizes, int weight_len) {
   API_BEGIN();
   
-  FloatArrayMap config = make_array_map(config_names, config_arrays, config_sizes, config_len);
-  FloatArrayMap weights = make_array_map(weight_names, weight_arrays, weight_sizes, weight_len);
+  float_array_map config =
+      make_array_map(config_names, config_arrays, config_sizes, config_len);
+  float_array_map weights =
+      make_array_map(weight_names, weight_arrays, weight_sizes, weight_len);
 
   MPSGraphModule *obj = (MPSGraphModule *)handle;
   obj->Init(network_id, n, c_in, h_in, w_in, c_out, h_out, w_out,

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.mm
@@ -2,11 +2,14 @@
 
 #include <tuple>
 
+#include "mps_float_array.hpp"
+
 #import "mps_device_manager.h"
 #import "mps_graph_cnnmodule.h"
 
 using turi::mps::FloatArrayMap;
 using turi::mps::MPSGraphModule;
+using turi::mps::float_array;
 using turi::mps::make_array_map;
 
 int TCMPSHasHighPowerMetalDevice(bool *has_device) {
@@ -55,11 +58,13 @@ int TCMPSDeleteGraphModule(MPSHandle handle) {
   API_END();
 }
 
-int TCMPSStartTrainingBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
-                            int64_t *shape, int dim, float *labels_ptr) {
+int TCMPSStartTrainingBatchGraph(
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->StartTrainingBatch(ptr, sz, shape, dim, labels_ptr);
+  float_array* inputs_ptr = reinterpret_cast<float_array*>(inputs);
+  float_array* labels_ptr = reinterpret_cast<float_array*>(labels);
+  obj->StartTrainingBatch(*inputs_ptr, *labels_ptr);
   API_END();
 }
 
@@ -70,11 +75,11 @@ int TCMPSWaitForTrainingBatchGraph(MPSHandle handle, float *loss) {
   API_END();
 }
 
-int TCMPSStartInferenceBatchGraph(MPSHandle handle, void *ptr, int64_t sz,
-                             int64_t *shape, int dim) {
+int TCMPSStartInferenceBatchGraph(MPSHandle handle, TCMPSFloatArrayRef inputs) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->StartInferenceBatch(ptr, sz, shape, dim);
+  float_array* inputs_ptr = reinterpret_cast<float_array*>(inputs);
+  obj->StartInferenceBatch(*inputs_ptr);
   API_END();
 }
 
@@ -86,12 +91,12 @@ int TCMPSWaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr) {
 }
 
 int TCMPSStartTrainReturnGradBatchGraph(
-    MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
-    void *grad_ptr, int64_t grad_sz, int64_t *grad_shape, int grad_dim) {
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef gradient) {
   API_BEGIN();
   MPSGraphModule *obj = (MPSGraphModule *)handle;
-  obj->StartTrainReturnGradBatch(ptr, sz, shape, dim,
-                                 grad_ptr, grad_sz, grad_shape, grad_dim);
+  float_array* inputs_ptr = reinterpret_cast<float_array*>(inputs);
+  float_array* gradient_ptr = reinterpret_cast<float_array*>(gradient);
+  obj->StartTrainReturnGradBatch(*inputs_ptr, *gradient_ptr);
   API_END();
 }
 

--- a/src/unity/toolkits/tcmps/mps_layers.h
+++ b/src/unity/toolkits/tcmps/mps_layers.h
@@ -8,6 +8,8 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#import <map>
 #import <string>
 #import <unordered_map>
 #import <vector>
@@ -129,10 +131,7 @@ struct Layer {
                     const float_array_map& config, bool is_train,
                     LowLevelMode net_mode, bool is_output_layer) = 0;
   virtual void Load(const float_array_map& weights) {}
-  virtual void
-  Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
-                                                    std::vector<int>>> &table) {
-  }
+  virtual float_array_map Export() const { return float_array_map(); }
   virtual void Update(MPSUpdater *_Nonnull updater, int lid) {}
   virtual void GpuUpdate(id<MTLCommandBuffer> _Nonnull cb) {}
 
@@ -308,10 +307,7 @@ struct ConvLayer : public Layer {
             bool is_output_layer) override;
   void Load(const float_array_map& weights) override;
 
-  void
-  Export(std::unordered_map<
-         std::string, std::tuple<std::string, float *, int, std::vector<int>>>
-             &table) override;
+  float_array_map Export() const override;
   void Update(MPSUpdater *_Nonnull updater, int lid) override;
   void GpuUpdate(id<MTLCommandBuffer> _Nonnull cb) override;
 
@@ -347,10 +343,7 @@ struct BNLayer : public Layer {
             const float_array_map& config, bool is_train, LowLevelMode net_mode,
             bool is_output_layer) override;
   void Load(const float_array_map& weights) override;
-  void
-  Export(std::unordered_map<
-         std::string, std::tuple<std::string, float *, int, std::vector<int>>>
-             &table) override;
+  float_array_map Export() const override;
 
   void Update(MPSUpdater *_Nonnull updater, int lid) override;
   void GpuUpdate(id<MTLCommandBuffer> _Nonnull cb) override;
@@ -506,10 +499,7 @@ struct LstmLayer : public Layer {
             const float_array_map& config, bool is_train, LowLevelMode net_mode,
             bool is_output_layer) override;
   void Load(const float_array_map& weights) override;
-  void
-  Export(std::unordered_map<
-         std::string, std::tuple<std::string, float *, int, std::vector<int>>>
-         &table) override;
+  float_array_map Export() const override;
   void GpuUpdate(id<MTLCommandBuffer> _Nonnull cb) override;
   
 private:

--- a/src/unity/toolkits/tcmps/mps_layers.h
+++ b/src/unity/toolkits/tcmps/mps_layers.h
@@ -126,9 +126,9 @@ struct Layer {
   virtual void Backward(MPSImageBatch *_Nonnull src,
                         id<MTLCommandBuffer> _Nonnull cb) = 0;
   virtual void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                    const FloatArrayMap &config, bool is_train,
+                    const float_array_map& config, bool is_train,
                     LowLevelMode net_mode, bool is_output_layer) = 0;
-  virtual void Load(const FloatArrayMap &weights) {}
+  virtual void Load(const float_array_map& weights) {}
   virtual void
   Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
                                                     std::vector<int>>> &table) {
@@ -202,16 +202,15 @@ virtual void AllocImage(id<MTLDevice> _Nonnull device , bool is_train = true) {
 
   virtual ~Layer() {}
 
-  void _Load(const std::string &key,
-             const FloatArrayMap &weights, int dst_size,
-             float *_Nonnull dst) {
+  void _Load(const std::string &key, const float_array_map& weights,
+             int dst_size, float *_Nonnull dst) {
     if (weights.count(key) > 0) {
-      const FloatArray &arr = weights.at(key);
+      const shared_float_array &arr = weights.at(key);
       LogStdString("Loading weight: " + key);
-      assert(arr.size == dst_size);
+      assert(arr.size() == dst_size);
       size_t size = dst_size * sizeof(float);
       void *dest = (void *)dst;
-      void *src = (void *)arr.data;
+      const float* src = arr.data();
       std::memcpy(dest, src, size);
     }
   }
@@ -278,7 +277,8 @@ struct ReLULayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
+            const float_array_map& config, bool is_train,
+            LowLevelMode net_mode, bool is_output_layer) override;
 
   // content
   MPSCNNNeuronReLU *_Nonnull op_forward;
@@ -304,8 +304,9 @@ struct ConvLayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
-  void Load(const FloatArrayMap &weights) override;
+            const float_array_map& config, bool is_train, LowLevelMode net_mode,
+            bool is_output_layer) override;
+  void Load(const float_array_map& weights) override;
 
   void
   Export(std::unordered_map<
@@ -343,8 +344,9 @@ struct BNLayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
-  void Load(const FloatArrayMap &weights) override;
+            const float_array_map& config, bool is_train, LowLevelMode net_mode,
+            bool is_output_layer) override;
+  void Load(const float_array_map& weights) override;
   void
   Export(std::unordered_map<
          std::string, std::tuple<std::string, float *, int, std::vector<int>>>
@@ -383,7 +385,8 @@ struct MaxPoolLayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
+            const float_array_map& config, bool is_train, LowLevelMode net_mode,
+            bool is_output_layer) override;
 
   MPSCNNPoolingMax *_Nonnull op_forward;
   MPSCNNPoolingMaxGradient *_Nullable op_backward{nil};
@@ -411,7 +414,8 @@ struct DropOutLayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
+            const float_array_map& config, bool is_train, LowLevelMode net_mode,
+            bool is_output_layer) override;
 
   // content
   MPSCNNDropout *_Nonnull op_forward;
@@ -440,7 +444,8 @@ struct SoftMaxLayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
+            const float_array_map& config, bool is_train, LowLevelMode net_mode,
+            bool is_output_layer) override;
 
   // content
   MPSCNNSoftMax *_Nonnull op_forward;
@@ -469,7 +474,7 @@ struct SmceLossLayer : public LossLayer {
                     MPSCNNLossLabelsBatch *_Nonnull labels,
                     id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train = true,
+            const float_array_map& config, bool is_train = true,
             LowLevelMode net_mode = kLowLevelModeTrain, bool is_output_layer = true) override;
 
   // content
@@ -498,8 +503,9 @@ struct LstmLayer : public Layer {
   void Backward(MPSImageBatch *_Nonnull src,
                 id<MTLCommandBuffer> _Nonnull cb) override;
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) override;
-  void Load(const FloatArrayMap &weights) override;
+            const float_array_map& config, bool is_train, LowLevelMode net_mode,
+            bool is_output_layer) override;
+  void Load(const float_array_map& weights) override;
   void
   Export(std::unordered_map<
          std::string, std::tuple<std::string, float *, int, std::vector<int>>>

--- a/src/unity/toolkits/tcmps/mps_layers.mm
+++ b/src/unity/toolkits/tcmps/mps_layers.mm
@@ -180,7 +180,8 @@ void ReLULayer::Backward(MPSImageBatch *_Nonnull src,
 }
 
 void ReLULayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                     const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                     const float_array_map& config, bool is_train,
+                     LowLevelMode net_mode, bool is_output_layer) {
   assert(fparams.size() > 0);
   float a = fparams[0];
 
@@ -230,7 +231,8 @@ void ConvLayer::Backward(MPSImageBatch *_Nonnull src,
 }
 
 void ConvLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                     const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                     const float_array_map& config, bool is_train,
+                     LowLevelMode net_mode, bool is_output_layer) {
   assert(iparams.size() >= 8);
   int k_h = iparams[0];
   int k_w = iparams[1];
@@ -275,18 +277,18 @@ void ConvLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
   }
 }
 
-void ConvLayer::Load(const FloatArrayMap &weights) {
+void ConvLayer::Load(const float_array_map& weights) {
   std::string weight_key = name + "_weight";
   std::string bias_key = name + "_bias";
 
     if (weights.count(weight_key) > 0){
         LogStdString("Loading weight: " + weight_key);
-        [weight loadWeight:(float*) weights.at(weight_key).data];
+        [weight loadWeight: const_cast<float*>(weights.at(weight_key).data())];
 
     }
     if (weights.count(bias_key) > 0){
         LogStdString("Loading weight: " + bias_key);
-        [weight loadBias:(float*) weights.at(bias_key).data];
+        [weight loadBias: const_cast<float*>(weights.at(bias_key).data())];
         
     }
     
@@ -402,7 +404,8 @@ void BNLayer::Backward(MPSImageBatch *_Nonnull src,
 }
 
 void BNLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                   const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                   const float_array_map& config, bool is_train,
+                   LowLevelMode net_mode, bool is_output_layer) {
     assert(ishape.size() == 4);
     int ch = ishape[3];
 
@@ -446,34 +449,34 @@ void BNLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
   }
 }
 
-void BNLayer::Load(const FloatArrayMap &weights) {
+void BNLayer::Load(const float_array_map& weights) {
   std::string gamma_key = name + "_gamma";
   std::string beta_key = name + "_beta";
   std::string var_key = name + "_running_var";
   std::string mean_key = name + "_running_mean";
 
   if (weights.count(gamma_key) > 0){
-    const FloatArray &arr = weights.at(gamma_key);
-    assert(arr.size == [data numberOfFeatureChannels]);
-    [data loadGamma:arr.data];
+    const shared_float_array &arr = weights.at(gamma_key);
+    assert(arr.size() == [data numberOfFeatureChannels]);
+    [data loadGamma: const_cast<float*>(arr.data())];
   }
 
   if (weights.count(beta_key) > 0){
-    const FloatArray &arr = weights.at(beta_key);
-    assert(arr.size == [data numberOfFeatureChannels]);
-    [data loadBeta:arr.data];
+    const shared_float_array &arr = weights.at(beta_key);
+    assert(arr.size() == [data numberOfFeatureChannels]);
+    [data loadBeta: const_cast<float*>(arr.data())];
   }
 
   if (weights.count(mean_key) > 0){
-    const FloatArray &arr = weights.at(mean_key);
-    assert(arr.size == [data numberOfFeatureChannels]);
-    [data loadMovingAvg:arr.data];
+    const shared_float_array &arr = weights.at(mean_key);
+    assert(arr.size() == [data numberOfFeatureChannels]);
+    [data loadMovingAvg: const_cast<float*>(arr.data())];
   }
 
   if (weights.count(var_key) > 0){
-    const FloatArray &arr = weights.at(var_key);
-    assert(arr.size == [data numberOfFeatureChannels]);
-    [data loadMovingVar:arr.data];
+    const shared_float_array &arr = weights.at(var_key);
+    assert(arr.size() == [data numberOfFeatureChannels]);
+    [data loadMovingVar: const_cast<float*>(arr.data())];
   }
 
   [op_forward reloadGammaAndBetaFromDataSource];
@@ -548,7 +551,8 @@ void MaxPoolLayer::Backward(MPSImageBatch *_Nonnull src,
                                         gradientStates:state];
 }
 void MaxPoolLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                        const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                        const float_array_map& config, bool is_train,
+                        LowLevelMode net_mode, bool is_output_layer) {
   assert(iparams.size() >= 4);
   int kH = iparams[0];
   int kW = iparams[1];
@@ -610,7 +614,8 @@ void DropOutLayer::Backward(MPSImageBatch *_Nonnull src,
 }
 
 void DropOutLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                        const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                        const float_array_map& config, bool is_train,
+                        LowLevelMode net_mode, bool is_output_layer) {
   assert(iparams.size() >= 2);
   float fKeepProb = (float)iparams[0] / 100.0;
   int nSeed = iparams[1];
@@ -667,7 +672,8 @@ void SoftMaxLayer::Backward(MPSImageBatch *_Nonnull src,
 }
 
 void SoftMaxLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                        const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                        const float_array_map& config, bool is_train,
+                        LowLevelMode net_mode, bool is_output_layer) {
 
 
   op_forward = [[MPSCNNSoftMax alloc] initWithDevice:device];
@@ -694,7 +700,8 @@ void SmceLossLayer::Loss(MPSImageBatch *_Nonnull src,
 }
 
 void SmceLossLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                         const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                         const float_array_map& config, bool is_train,
+                         LowLevelMode net_mode, bool is_output_layer) {
 
   assert(iparams.size() >= 1);
 
@@ -714,7 +721,8 @@ void SmceLossLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_
 // LSTM
 // ------------------------------------------------------------------------------------
 void LstmLayer::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                     const FloatArrayMap &config, bool is_train, LowLevelMode net_mode, bool is_output_layer) {
+                     const float_array_map& config, bool is_train,
+                     LowLevelMode net_mode, bool is_output_layer) {
     batch_size_ = (NSUInteger)ishape[0];
     sequence_length_ = (NSUInteger)ishape[2];
     num_input_features_ = (NSUInteger)ishape[3];
@@ -1025,7 +1033,7 @@ void LstmLayer::Backward(MPSImageBatch *_Nonnull src, id<MTLCommandBuffer> _Nonn
     bwd_output = CopyImageBatchFromBuffer(bwd_dst_buffer_, num_input_features_, cb);
 }
 
-void LstmLayer::Load(const FloatArrayMap &init_weights) {
+void LstmLayer::Load(const float_array_map& init_weights) {
 
     id<MTLCommandBuffer> commandBuffer = [cmd_q_ commandBuffer];
 
@@ -1033,12 +1041,12 @@ void LstmLayer::Load(const FloatArrayMap &init_weights) {
         std::string full_key = name + "_" + lstm_weight_name;
 
         if (init_weights.count(full_key) > 0){
-            const FloatArray &arr = init_weights.at(full_key);
+            const shared_float_array &arr = init_weights.at(full_key);
             MPSRNNMatrixId wMatId = MxnetNameToMatrixId(lstm_weight_name);
             MPSMatrix * weightMat = copy_weight_matrices_.at(lstm_weight_name);
             LogStdString("Loading weight: " + full_key);
-            assert (arr.size*sizeof(float) == weightMat.data.length);
-            memcpy(weightMat.data.contents, arr.data, weightMat.data.length);
+            assert(arr.size()*sizeof(float) == weightMat.data.length);
+            memcpy(weightMat.data.contents, arr.data(), weightMat.data.length);
             [weightMat.data didModifyRange:NSMakeRange(0, weightMat.data.length)];
             
             [filter encodeCopyWeightsToCommandBuffer: commandBuffer

--- a/src/unity/toolkits/tcmps/mps_networks.h
+++ b/src/unity/toolkits/tcmps/mps_networks.h
@@ -44,14 +44,14 @@ struct MPSNetwork {
   MPSNetwork(){};
   virtual ~MPSNetwork();
     
-  MPSNetwork(const FloatArrayMap &config){
+  explicit MPSNetwork(const float_array_map& config) {
       std::string mode_key = "mode";
       network_mode_ = (LowLevelMode) get_array_map_scalar(config, mode_key, kLowLevelModeTrain);
       is_train_ = (kLowLevelModeTrain == network_mode_ || kLowLevelModeTest == network_mode_);
   }
 
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-            const FloatArrayMap &config);
+            const float_array_map& config);
   MPSImageBatch *_Nonnull Forward(MPSImageBatch *_Nonnull src,
                                   id<MTLCommandBuffer> _Nonnull cb,
                                   bool is_train = true);
@@ -61,7 +61,7 @@ struct MPSNetwork {
                                MPSCNNLossLabelsBatch *_Nonnull labels,
                                id<MTLCommandBuffer> _Nonnull cb);
   void SyncState(id<MTLCommandBuffer> _Nonnull cb);
-  void Load(const FloatArrayMap &weights);
+  void Load(const float_array_map& weights);
   void
   Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
                                                     std::vector<int>>> &table);
@@ -77,7 +77,7 @@ struct MPSNetwork {
 // Factory function to create a network
 MPSNetwork *_Nonnull createNetwork(NetworkType network_id,
                                    const std::vector<int> &params,
-                                   const FloatArrayMap &config);
+                                   const float_array_map& config);
 
 // Various networks
 // ---------------------------------------------------------------------------------------------
@@ -85,7 +85,9 @@ MPSNetwork *_Nonnull createNetwork(NetworkType network_id,
 // Unit testing networks
 // ---------------------------------------------------------------------------------------------
 struct SingleConvNetwork : public MPSNetwork {
-    explicit SingleConvNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleConvNetwork(const std::vector<int> &iparam,
+                    const float_array_map& config) : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -100,7 +102,9 @@ struct SingleConvNetwork : public MPSNetwork {
 };
 
 struct Single1DConvNetwork : public MPSNetwork {
-    explicit Single1DConvNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  Single1DConvNetwork(const std::vector<int> &iparam,
+                      const float_array_map& config) : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -116,7 +120,9 @@ struct Single1DConvNetwork : public MPSNetwork {
   }
 };
 struct SingleReLUNetwork : public MPSNetwork {
-  explicit SingleReLUNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleReLUNetwork(const std::vector<int> &iparam,
+                    const float_array_map& config) : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -130,7 +136,9 @@ struct SingleReLUNetwork : public MPSNetwork {
 };
 
 struct SingleBNNetwork : public MPSNetwork {
-  explicit SingleBNNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleBNNetwork(const std::vector<int> &iparam,
+                  const float_array_map& config) : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -144,7 +152,9 @@ struct SingleBNNetwork : public MPSNetwork {
 };
 
 struct SingleMPNetwork : public MPSNetwork {
-  explicit SingleMPNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleMPNetwork(const std::vector<int> &iparam,
+                  const float_array_map& config) : MPSNetwork(config) {
+
     layers.resize(1);
     int n = iparam[0];
     int hi = iparam[1];
@@ -159,7 +169,9 @@ struct SingleMPNetwork : public MPSNetwork {
 };
 
 struct ODNetwork : public MPSNetwork {
-  ODNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  ODNetwork(const std::vector<int> &iparam, const float_array_map& config)
+      : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -193,7 +205,9 @@ struct ODNetwork : public MPSNetwork {
 };
 
 struct SingleDropOutNetwork : public MPSNetwork {
-  SingleDropOutNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleDropOutNetwork(const std::vector<int> &iparam,
+                       const float_array_map& config) : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -208,7 +222,10 @@ struct SingleDropOutNetwork : public MPSNetwork {
 };
 
 struct ActivityClassifierNetwork : public MPSNetwork {
-  ActivityClassifierNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  ActivityClassifierNetwork(const std::vector<int> &iparam,
+                            const float_array_map& config)
+      : MPSNetwork(config) {
+
     assert(iparam.size() >= 7);
     int n = iparam[0];
     int hi = iparam[1];
@@ -255,7 +272,9 @@ struct ActivityClassifierNetwork : public MPSNetwork {
 };
 
 struct SingleFcNetwork : public MPSNetwork {
-  SingleFcNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleFcNetwork(const std::vector<int> &iparam, const float_array_map& config)
+      : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -270,7 +289,9 @@ struct SingleFcNetwork : public MPSNetwork {
 };
 
 struct SingleSoftMaxNetwork : public MPSNetwork {
-  SingleSoftMaxNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleSoftMaxNetwork(const std::vector<int> &iparam,
+                       const float_array_map& config) : MPSNetwork(config) {
+
     int n = iparam[0];
     int hi = iparam[1];
     int wi = iparam[2];
@@ -285,7 +306,9 @@ struct SingleSoftMaxNetwork : public MPSNetwork {
 };
 
 struct SingleLstmNetwork : public MPSNetwork {
-    explicit SingleLstmNetwork(const std::vector<int> &iparam, const FloatArrayMap& config) : MPSNetwork(config) {
+  SingleLstmNetwork(const std::vector<int> &iparam,
+                    const float_array_map& config) : MPSNetwork(config) {
+
         int n = iparam[0];
         int hi = iparam[1];
         int wi = iparam[2];

--- a/src/unity/toolkits/tcmps/mps_networks.h
+++ b/src/unity/toolkits/tcmps/mps_networks.h
@@ -62,9 +62,7 @@ struct MPSNetwork {
                                id<MTLCommandBuffer> _Nonnull cb);
   void SyncState(id<MTLCommandBuffer> _Nonnull cb);
   void Load(const float_array_map& weights);
-  void
-  Export(std::unordered_map<std::string, std::tuple<std::string, float *, int,
-                                                    std::vector<int>>> &table);
+  float_array_map Export() const;
   int NumParams();
 
   void Update(MPSUpdater *_Nonnull updater);

--- a/src/unity/toolkits/tcmps/mps_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_networks.mm
@@ -118,13 +118,15 @@ void MPSNetwork::Load(const float_array_map& weights) {
   }
 }
 
-void MPSNetwork::Export(
-    std::unordered_map<std::string,
-                       std::tuple<std::string, float *, int, std::vector<int>>>
-        &table) {
+float_array_map MPSNetwork::Export() const {
+  float_array_map table;
   for (int i = 0; i < layers.size(); ++i) {
-    layers[i]->Export(table);
+    float_array_map layer_table = layers[i]->Export();
+    table.insert(layer_table.begin(), layer_table.end());
+    // TODO: In C++17, we can use std::map::merge to move the table entries
+    // instead of copying them: table.merge(layers[i]->Export());
   }
+  return table;
 }
 
 void MPSNetwork::Update(MPSUpdater *_Nonnull updater) {

--- a/src/unity/toolkits/tcmps/mps_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_networks.mm
@@ -6,7 +6,7 @@ namespace mps {
 
 MPSNetwork *_Nonnull createNetwork(NetworkType network_id,
                                    const std::vector<int> &params,
-                                   const FloatArrayMap& config) {
+                                   const float_array_map& config) {
   switch (network_id) {
   case kSingleReLUNet:
     return new SingleReLUNetwork(params, config);
@@ -45,7 +45,7 @@ MPSNetwork::~MPSNetwork() {
 }
 
 void MPSNetwork::Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> cmd_q,
-                      const FloatArrayMap &config) {
+                      const float_array_map& config) {
     
   for (int i = 0; i < layers.size(); ++i) {
     layers[i]->Init(device, cmd_q, config, is_train_, network_mode_ ,(i == layers.size() - 1));
@@ -112,7 +112,7 @@ void MPSNetwork::SyncState(id<MTLCommandBuffer> _Nonnull cb) {
   }
 }
 
-void MPSNetwork::Load(const FloatArrayMap &weights) {
+void MPSNetwork::Load(const float_array_map& weights) {
   for (int i = 0; i < layers.size(); ++i) {
     layers[i]->Load(weights);
   }

--- a/src/unity/toolkits/tcmps/mps_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_trainer.h
@@ -28,6 +28,7 @@ extern "C" {
 
 typedef void *MPSHandle;
 typedef void *TCMPSFloatArrayRef;
+typedef void *TCMPSFloatArrayMapIteratorRef;
 
 EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
 EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
@@ -35,6 +36,12 @@ EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
 EXPORT int TCMPSCreateFloatArray(TCMPSFloatArrayRef *array_out, float* data,
                                  size_t size, size_t* shape, size_t dim);
 EXPORT int TCMPSDeleteFloatArray(TCMPSFloatArrayRef array_ref);
+
+EXPORT int TCMPSNextFloatArray(
+    TCMPSFloatArrayMapIteratorRef iter_ref, char** name_out, float** data_out,
+    size_t** shape_out, size_t* dim_out);
+EXPORT int TCMPSDeleteFloatArrayMapIterator(
+    TCMPSFloatArrayMapIteratorRef iter_ref);
 
 EXPORT int TCMPSForward(MPSHandle handle, TCMPSFloatArrayRef inputs, float *out,
                         bool is_train);
@@ -79,8 +86,8 @@ EXPORT int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, i
 
 EXPORT int TCMPSNumParams(MPSHandle handle, int *num);
 
-EXPORT int TCMPSExport(MPSHandle handle, char **names, void **arrs, int64_t *dim,
-                  int **shape);
+EXPORT int TCMPSExport(MPSHandle handle,
+                       TCMPSFloatArrayMapIteratorRef* float_array_map_out);
 
 EXPORT int TCMPSCpuUpdate(MPSHandle handle);
 EXPORT int TCMPSUpdate(MPSHandle handle);

--- a/src/unity/toolkits/tcmps/mps_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_trainer.h
@@ -27,46 +27,44 @@ extern "C" {
 #endif // __cplusplus
 
 typedef void *MPSHandle;
+typedef void *TCMPSFloatArrayRef;
 
 EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
 EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
 
-EXPORT int TCMPSForward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
-                   float *out, bool is_train);
+EXPORT int TCMPSCreateFloatArray(TCMPSFloatArrayRef *array_out, float* data,
+                                 size_t size, size_t* shape, size_t dim);
+EXPORT int TCMPSDeleteFloatArray(TCMPSFloatArrayRef array_ref);
 
-EXPORT int TCMPSBackward(MPSHandle handle, void *ptr, int64_t sz, int64_t *shape, int dim,
-                    float *out);
+EXPORT int TCMPSForward(MPSHandle handle, TCMPSFloatArrayRef inputs, float *out,
+                        bool is_train);
 
-EXPORT int TCMPSLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
-                void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-                void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
-                bool loss_image_required,
-                float *out);
+EXPORT int TCMPSBackward(MPSHandle handle, TCMPSFloatArrayRef gradient,
+                         float *out);
+
+EXPORT int TCMPSLoss(MPSHandle handle, TCMPSFloatArrayRef inputs,
+                     TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
+                     bool loss_image_required, float *out);
     
-EXPORT int TCMPSForwardBackward(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
-                           void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-                           void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
-                           bool loss_image_required,
-                           float *out);
+EXPORT int TCMPSForwardBackward(
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
+    TCMPSFloatArrayRef weights, bool loss_image_required, float *out);
 
-EXPORT int TCMPSForwardWithLoss(MPSHandle handle, void *ptr, size_t sz, int64_t *shape, int dim,
-                           void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-                           void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
-                           bool loss_image_required, bool is_train,
-                           float *out);
+EXPORT int TCMPSForwardWithLoss(
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
+    TCMPSFloatArrayRef weights, bool loss_image_required, bool is_train,
+    float *out);
 
 EXPORT int TCMPSGetLossImages(MPSHandle handle, float *out);
 
 EXPORT int TCMPSBeginForwardBatch(
-    MPSHandle handle, int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
-    void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-    void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
+    MPSHandle handle, int batch_id, TCMPSFloatArrayRef inputs,
+    TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
     bool loss_image_required, bool is_train);
 
 EXPORT int TCMPSBeginForwardBackwardBatch(
-    MPSHandle handle, int batch_id, void *ptr, size_t sz, int64_t *shape, int dim,
-    void *label_ptr, size_t label_sz, int64_t *label_shape, int label_dim,
-    void *weight_ptr, size_t weight_sz, int64_t *weight_shape, int weight_dim,
+    MPSHandle handle, int batch_id, TCMPSFloatArrayRef inputs,
+    TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
     bool loss_image_required);
 
 EXPORT int TCMPSWaitForBatch(MPSHandle handle, int batch_id, float *forward_out,

--- a/src/unity/toolkits/tcmps/mps_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_trainer.mm
@@ -10,10 +10,10 @@
 #import "mps_cnnmodule.h"
 #import "mps_utils.h"
 
+using turi::mps::MPSCNNModule;
 using turi::mps::external_float_array;
 using turi::mps::float_array;
-using turi::mps::FloatArrayMap;
-using turi::mps::MPSCNNModule;
+using turi::mps::float_array_map;
 using turi::mps::make_array_map;
 
 int TCMPSCreateCNNModule(MPSHandle *out) {
@@ -159,7 +159,8 @@ int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w
          int64_t *config_sizes, int config_len) {
   API_BEGIN();
 
-  FloatArrayMap config = make_array_map(config_names, config_arrays, config_sizes, config_len);
+  float_array_map config =
+      make_array_map(config_names, config_arrays, config_sizes, config_len);
 
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   obj->Init(network_id, n, c_in, h_in, w_in, c_out, h_out, w_out, updater_id, config);
@@ -169,7 +170,7 @@ int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w
 int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len) {
   API_BEGIN();
 
-  FloatArrayMap weights = make_array_map(names, arrs, sz, len);
+  float_array_map weights = make_array_map(names, arrs, sz, len);
 
   MPSCNNModule *obj = (MPSCNNModule *)handle;
   obj->Load(weights);

--- a/src/unity/toolkits/tcmps/mps_utils.h
+++ b/src/unity/toolkits/tcmps/mps_utils.h
@@ -84,6 +84,24 @@ bool get_array_map_bool(const float_array_map &config, const std::string &key,
                         bool default_value);
 OptimizerOptions get_array_map_optimizer_options(const float_array_map &config);
 
+// Intended to be wrapped as a Python-style iterator.
+class float_array_map_iterator {
+public:
+  using value_type = float_array_map::value_type;
+
+  float_array_map_iterator(float_array_map array_map)
+    : array_map_(std::move(array_map)), iter_(array_map_.begin())
+  {}
+
+  bool has_next() const { return iter_ != array_map_.end(); }
+
+  const value_type& next() { return *iter_++; }
+
+private:
+  float_array_map array_map_;
+  float_array_map::const_iterator iter_;
+};
+
 // Graph mode
 
 enum GraphMode {

--- a/src/unity/toolkits/tcmps/mps_utils.h
+++ b/src/unity/toolkits/tcmps/mps_utils.h
@@ -12,9 +12,12 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#include <vector>
+
+#include <map>
 #include <string>
-#include <unordered_map>
+#include <vector>
+
+#include "mps_float_array.hpp"
 
 namespace turi {
 namespace mps {
@@ -68,23 +71,18 @@ struct OptimizerOptions {
   }
 };
 
-//
-// FloatArrayMap is a (str -> float array pointer) dictionary is used to
-// pass weights and config into the library
-//
-struct FloatArray {
-  size_t size;
-  float * _Nullable data;
-};
+// Convenient typedef for data structure used to pass configuration and weights
+// into and out of TCMPS.
+using float_array_map = std::map<std::string, shared_float_array>;
 
-typedef std::unordered_map<std::string, FloatArray> FloatArrayMap;
+float_array_map make_array_map(char **names, void **arrays,
+                               int64_t *sizes, int len);
 
-FloatArrayMap make_array_map(char **names, void **arrays,
-                             int64_t *sizes, int len);
-
-float get_array_map_scalar(const FloatArrayMap &config, const std::string &key, float default_value);
-BOOL get_array_map_bool(const FloatArrayMap &config, const std::string &key, BOOL default_value);
-OptimizerOptions get_array_map_optimizer_options(const FloatArrayMap &config);
+float get_array_map_scalar(const float_array_map &config,
+                           const std::string &key, float default_value);
+bool get_array_map_bool(const float_array_map &config, const std::string &key,
+                        bool default_value);
+OptimizerOptions get_array_map_optimizer_options(const float_array_map &config);
 
 // Graph mode
 


### PR DESCRIPTION
These changes clean up how TCMPS receives input data and how it imports/exports network weights. They should make it easier to reason about memory management and simplify future C++ toolkit development.

It may be helpful to look at the diffs for each of the three commits individually. Each one introduces some new code and has a bunch of corollary boilerplate/mechanical changes.

Fixes #762