### PR TITLE
SFrame add_column FR

### DIFF
--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -3144,8 +3144,18 @@ class SFrame(object):
         [3 rows x 3 columns]
         """
         # Check type for pandas dataframe or SArray?
+        
+        from collections import Iterable
+        
         if not isinstance(data, SArray):
-            raise TypeError("Must give column as SArray")
+            if isinstance(data, Iterable):
+                data = SArray(data)
+            else:
+                if len(self.column_names()) == 0:
+                    data = SArray([data])
+                else:
+                    data = SArray([data for _ in xrange(self.shape[0])])
+    
         if not isinstance(column_name, str):
             raise TypeError("Invalid column name: must be str")
 

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -3444,6 +3444,20 @@ class SFrameTest(unittest.TestCase):
                 {'long': [12], 'unicode': [unicode('foo')]}))
 
         _assert_sframe_equal(sf, sf2)
+    
+    def test_add_column_nonSArray(self):
+        sf = SFrame()
+        sf.add_column([1,2,3,4],'x')
+    
+    def test_add_column_noniterable1(self):
+        sf = SFrame()
+        sf.add_column([1,2,3,4],'x')
+        sf.add_column(5,'y')
+
+    def test_add_column_noniterable2(self):
+            # If SFrame is empty then the passed data should be treated as an SArray of size 1
+            sf = SFrame()
+            sf.add_column(5,'y')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For feature request #1072 

add_column() in SFrame now handles non-SArray iterables as input and maps constant into SArray when noniterable passed. 