### PR TITLE
Const assignment to empty SFrame

### DIFF
--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -3146,7 +3146,7 @@ class SFrame(object):
         """
         # Check type for pandas dataframe or SArray?
         
-       
+
         if not isinstance(data, SArray):
             if isinstance(data, _Iterable):
                 data = SArray(data)

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -3590,7 +3590,7 @@ class SFrame(object):
             elif _is_non_string_iterable(value):  # wrap list, array... to sarray
                 sa_value = SArray(value)
             else:  # create an sarray  of constant value
-                sa_value = SArray.from_const(value, self.num_rows())
+                sa_value = SArray.from_const(value, max(1, self.num_rows()))
 
             # set new column
             if not key in self.column_names():

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -3479,6 +3479,16 @@ class SFrameTest(unittest.TestCase):
         
         _assert_sframe_equal(sf, sf_test)
 
+    def test_sframe_const_setitem(self):
+        # Check if setitem for const assignments works as intended when assigning to empty SFrame
+        sf = SFrame()
+        sf['x'] = 3
+
+        sf_test = SFrame()
+        sf_test['x'] = [3]
+
+        _assert_sframe_equal(sf, sf_test)
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Fixes #1102 

When SFrame is empty, the original assignment maps constant values to SArray of size 0 - now it maps to size 1.