### PR TITLE
Fix for #1096

### DIFF
--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -1772,6 +1772,11 @@ cdef inline dict pydict_from_flex_dict(const flex_dict& fd):
     for i in range(n):
         first = pyobject_from_flexible_type(fd[i].first)
         second = pyobject_from_flexible_type(fd[i].second)
+
+        if type(first) is list or type(first) is array_type:
+            # Replace this with a hashable type.  
+            first = tuple(first)
+
         ret[first] = second
 
     return ret

--- a/src/unity/python/turicreate/test/test_flexible_type.py
+++ b/src/unity/python/turicreate/test/test_flexible_type.py
@@ -560,7 +560,7 @@ class FlexibleTypeTest(unittest.TestCase):
             sa_int_words.astype(int)
 
     def test_hashable_dict_keys(self):
-        # testing valid sarray of inf's (inf is a float)
+        # Make sure that the keys of a dictionary are actually expressable as keys.
         sa_dictionary = SArray([{(1,2) : 3}])
         out = list(sa_dictionary)
 

--- a/src/unity/python/turicreate/test/test_flexible_type.py
+++ b/src/unity/python/turicreate/test/test_flexible_type.py
@@ -559,6 +559,13 @@ class FlexibleTypeTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             sa_int_words.astype(int)
 
+    def test_hashable_dict_keys(self):
+        # testing valid sarray of inf's (inf is a float)
+        sa_dictionary = SArray([{(1,2) : 3}])
+        out = list(sa_dictionary)
+
+        self.assertEqual(out[0][(1,2)], 3)
+
 
 
 


### PR DESCRIPTION
Casts lists and arrays to tuples when they are the keys for a dictionary type. 