### PR TITLE
Skip object detector unit tests in Travis CI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ script:
   # Check whether O_NONBLOCK is set (should print "0"):
   - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print(flags&os.O_NONBLOCK);'
 
-  # Remove style transfer unit tests
-  - rm  src/unity/python/turicreate/test/test_style_transfer.py 
+  # Remove object detector and style transfer unit tests
+  - rm src/unity/python/turicreate/test/test_style_transfer.py src/unity/python/turicreate/test/test_object_detector.py
 
   # Build the wheel
   - travis_wait 180 bash scripts/make_wheel.sh --build_number=$CI_PIPELINE_ID --num_procs=2 --debug --skip_cpp_test


### PR DESCRIPTION
We need to get our Travis CI build under two hours more reliably. We can skip the OD tests for now, since I'll likely be running then manually a bunch anyway in the near future (aside from any other CI coverage).

Builds on the black list we already added to cover issues with style transfer (see #1031)