### PR TITLE
Refactor TCMPS interface for object detection

### DIFF
--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -243,6 +243,33 @@ def _xavier_init(weight):
     c = _np.sqrt(3. / (0.5 * (n_in * scale + n_out * scale)))
     return _np.random.uniform(-c, c, shape).astype(_np.float32)
 
+def _shape_tuple_from_ctypes(shape_ptr, dim):
+    # size_t* shape_ptr
+    assert isinstance(shape_ptr, _ctypes.POINTER(_ctypes.c_size_t))
+
+    # size_t dim
+    assert isinstance(dim, _ctypes.c_size_t)
+
+    # Wrap size_t* as size_t[dim]
+    shape_buf = (_ctypes.c_size_t * dim.value).from_address(
+        _ctypes.addressof(shape_ptr.contents))
+
+    # Convert size_t[dim] to tuple
+    return tuple(shape_buf)
+
+def _numpy_array_from_ctypes(data_ptr, shape_ptr, dim):
+    # float* data_ptr
+    assert isinstance(data_ptr, _ctypes.POINTER(_ctypes.c_float))
+
+    shape = _shape_tuple_from_ctypes(shape_ptr, dim)
+
+    # Wrap float* to float[size]
+    size = _np.prod(shape)
+    data_buf = (_ctypes.c_float * size).from_address(
+        _ctypes.addressof(data_ptr.contents))
+
+    # Convert float[size] to numpy
+    return _np.fromiter(data_buf, _np.float32, size).reshape(shape)
 
 class MpsFloatArray(object):
     """
@@ -254,13 +281,18 @@ class MpsFloatArray(object):
     """
 
     def __init__(self, x):
-        """Wrap a numpy array"""
-
-        assert isinstance(x, _np.ndarray)
+        """Wrap an existing TCMPSFloatArrayRef or a numpy array"""
 
         # Load TCMPS backend library.
         self._LIB = _load_tcmps_lib()
         assert self._LIB is not None, "Cannot use MpsFloatArray without libtcmps.dylib"
+
+        # If `x` is a void*, assume it's the right type and just wrap it.
+        if isinstance(x, _ctypes.c_void_p):
+            self.handle = x
+            return
+
+        assert isinstance(x, _np.ndarray)
 
         # Convert the input if necessary to contain a contiguous float array.
         self.data = x
@@ -289,6 +321,39 @@ class MpsFloatArray(object):
     def __del__(self):
         status_code = self._LIB.TCMPSDeleteFloatArray(self.handle)
         assert status_code == 0, "Error calling TCMPSDeleteFloatArray"
+
+    def shape(self):
+        """Copy the shape from TCMPS as a new numpy ndarray."""
+
+        # Create C variables that will serve as out parameters for TCMPS.
+        shape_ptr = _ctypes.POINTER(_ctypes.c_size_t)()  # size_t* shape_ptr
+        dim = _ctypes.c_size_t()                         # size_t dim
+
+        # Obtain pointer into memory owned by the C++ object self.handle.
+        status_code = self._LIB.TCMPSGetFloatArrayShape(
+            self.handle, _ctypes.byref(shape_ptr), _ctypes.byref(dim))
+        assert status_code == 0, "Error calling TCMPSGetFloatArrayShape"
+
+        return _shape_tuple_from_ctypes(shape_ptr, dim)
+
+    def asnumpy(self):
+        """Copy the data from TCMPS into a new numpy ndarray"""
+
+        # Create C variables that will serve as out parameters for TCMPS.
+        data_ptr = _ctypes.POINTER(_ctypes.c_float)()    # float* data_ptr
+        shape_ptr = _ctypes.POINTER(_ctypes.c_size_t)()  # size_t* shape_ptr
+        dim = _ctypes.c_size_t()                         # size_t dim
+
+        # Obtain pointers into memory owned by the C++ object self.handle.
+        # Note that this may trigger synchronization with another thread
+        # producing the data.
+        status_code = self._LIB.TCMPSReadFloatArray(
+            self.handle, _ctypes.byref(data_ptr), _ctypes.byref(shape_ptr),
+            _ctypes.byref(dim))
+        assert status_code == 0, "Error calling TCMPSReadFloatArray"
+
+        return _numpy_array_from_ctypes(data_ptr, shape_ptr, dim)
+
 
 class MpsFloatArrayIterator(object):
     """
@@ -330,23 +395,11 @@ class MpsFloatArrayIterator(object):
         if status_code != 0:
             raise StopIteration
 
-        # Wrap size_t* as size_t[dim]
-        shape_buf = (_ctypes.c_size_t * dim.value).from_address(
-            _ctypes.addressof(shape_ptr.contents))
-
-        # Convert size_t[dim] to numpy
-        shape = _np.fromiter(shape_buf, _np.uint64, dim.value)
-
-        # Wrap float* to float[size]
-        size = _np.prod(shape)
-        data_buf = (_ctypes.c_float * size).from_address(
-            _ctypes.addressof(data_ptr.contents))
-
-        # Convert float[size] to numpy
-        array = _np.fromiter(data_buf, _np.float32, size).reshape(shape)
-
         # Convert char* to Python string
         name = _decode_bytes_to_native_string(name_ptr.value)
+
+        # Convert data to numpy
+        array = _numpy_array_from_ctypes(data_ptr, shape_ptr, dim)
 
         return (name, array)
 
@@ -418,57 +471,85 @@ class MpsGraphAPI(object):
         self._ishape = (n, h_in, w_in, c_in)
         self._oshape = (n, h_out, w_out, c_out)
 
-    # Submits an input batch to the model. The model will process the input
-    # asynchronously. This call must be matched with a corresponding call to
-    # wait_for_batch. Label data is required for models initialized with
-    # MpsGraphMode.Train; grad data is required for models initialized with
-    # MpsGraphMode.TrainReturnGrad.
-    def start_batch(self, input, label=None, grad=None):
+    def train(self, input, label):
+        """
+        Submits an input batch to the model. Returns a MpsFloatArray
+        representing the batch loss. Calling asnumpy() on this value will wait
+        for the batch to finish and yield the loss as a numpy array.
+        """
+
+        assert self._mode == MpsGraphMode.Train
+        assert input.shape == self._ishape
+        assert label.shape == self._oshape
+
+        input_array = MpsFloatArray(input)
+        label_array = MpsFloatArray(label)
+        result_handle = _ctypes.c_void_p()
+        status_code = self._LIB.TCMPSTrainGraph(
+            self.handle, input_array.handle, label_array.handle,
+                _ctypes.byref(result_handle))
+
+        assert status_code == 0, "Error calling TCMPSTrainGraph"
+        assert result_handle, "TCMPSTrainGraph unexpectedly returned NULL pointer"
+
+        result = MpsFloatArray(result_handle)
+
+        # Output from training should be a one-dimensional array of loss values,
+        # one per example in the batch.
+        assert result.shape() == (self._oshape[0],)
+
+        return result
+
+    def predict(self, input):
+        """
+        Submits an input batch to the model. Returns a MpsFloatArray
+        representing the model predictions. Calling asnumpy() on this value will
+        wait for the batch to finish and yield the predictions as a numpy array.
+        """
+
+        assert self._mode == MpsGraphMode.Inference
         assert input.shape == self._ishape
 
         input_array = MpsFloatArray(input)
+        result_handle = _ctypes.c_void_p()
+        status_code = self._LIB.TCMPSPredictGraph(
+            self.handle, input_array.handle, _ctypes.byref(result_handle))
 
-        if self._mode == MpsGraphMode.Train:
-            assert label is not None, "Training graph requires labels"
-            assert label.shape == self._oshape
+        assert status_code == 0, "Error calling TCMPSPredictGraph"
+        assert result_handle, "TCMPSPredictGraph unexpectedly returned NULL pointer"
 
-            label_array = MpsFloatArray(label)
-            self._LIB.TCMPSStartTrainingBatchGraph(
-                self.handle, input_array.handle, label_array.handle)
+        result = MpsFloatArray(result_handle)
+        assert result.shape() == self._oshape
 
-        elif self._mode == MpsGraphMode.TrainReturnGrad:
-            assert grad is not None, "Training graph (without loss) requires gradient"
-            assert grad.shape == self._oshape
+        return result
 
-            grad_array = MpsFloatArray(grad)
-            self._LIB.TCMPSStartTrainReturnGradBatchGraph(
-                self.handle, input_array.handle, grad_array.handle)
+    def train_return_grad(self, input, grad):
+        """
+        Performs a forward pass from the input batch, followed by a backward
+        pass using the provided gradient (in place of a loss function). Returns
+        a MpsFloatArray representing the output (final gradient) of the backward
+        pass. Calling asnumpy() on this value will wait for the batch to finish
+        and yield the output as a numpy array.
+        """
 
-        else:
-            self._LIB.TCMPSStartInferenceBatchGraph(
-                self.handle, input_array.handle)
+        assert self._mode == MpsGraphMode.TrainReturnGrad
+        assert input.shape == self._ishape
+        assert grad.shape == self._oshape
 
-    # Waits for a previously submitted batch to complete and returns the output.
-    # For models initialized with MpsGraphMode.Train, the return value is the
-    # loss. For models initialized with MpsGraphMode.Inference, the return value
-    # is the model predictions. For models initialized with
-    # MpsGraphMode.TrainReturnGrad, the return value is the gradient for the
-    # input layer.
-    def wait_for_batch(self):
-        if self._mode == MpsGraphMode.Train:
-            self._LIB.TCMPSWaitForTrainingBatchGraph(self.handle, _ctypes.byref(self._buf_loss))
-            loss = _np.frombuffer(self._buf_loss, dtype=_np.float32).copy()
-            return loss
-        elif self._mode == MpsGraphMode.TrainReturnGrad:
-            self._LIB.TCMPSWaitForTrainReturnGradBatchGraph(self.handle, _ctypes.byref(self._buf_out_fp16))
-            raw_out = _np.frombuffer(self._buf_out_fp16, dtype=_np.float16)
-            out = raw_out.reshape(self._ishape).astype(_np.float32).copy()
-            return out
-        else:
-            self._LIB.TCMPSWaitForInferenceBatchGraph(self.handle, _ctypes.byref(self._buf_out_fp16))
-            raw_out = _np.frombuffer(self._buf_out_fp16, dtype=_np.float16)
-            out = raw_out.reshape(self._oshape).astype(_np.float32).copy()
-            return out
+        input_array = MpsFloatArray(input)
+        grad_array = MpsFloatArray(grad)
+        result_handle = _ctypes.c_void_p()
+        status_code = self._LIB.TCMPSTrainGraph(
+            self.handle, input_array.handle, grad_array.handle,
+                _ctypes.byref(result_handle))
+
+        assert status_code == 0, "Error calling TCMPSTrainReturnGradGraph"
+        assert result_handle, "TCMPSTrainReturnGradGraph unexpectedly returned NULL pointer"
+
+        result = MpsFloatArray(result_handle)
+        assert result.shape() == self._ishape
+
+        return result
 
     def set_learning_rate(self, new_lr):
         self._cur_learning_rate = new_lr
@@ -486,11 +567,6 @@ class MpsGraphAPI(object):
         # Reload state
         if self._cur_learning_rate:
             self.set_learning_rate(self._cur_learning_rate)
-
-    def _num_params(self):
-        num = _ctypes.c_int32(0)
-        self._LIB.TCMPSNumParamsGraph(self.handle, _ctypes.byref(num))
-        return num.value
 
     def export(self):
         iter_handle = _ctypes.c_void_p()
@@ -643,11 +719,6 @@ class MpsLowLevelAPI(object):
     def load(self, weights):
         weights_items, weights_name, weights_arr, weights_sz = _prepare_network_parameters(weights)
         self._LIB.TCMPSLoad(self.handle, weights_name, weights_arr, weights_sz, _ctypes.c_int32(len(weights_items)))
-
-    def _num_params(self):
-        num = _ctypes.c_int32(0)
-        self._LIB.TCMPSNumParams(self.handle, _ctypes.byref(num))
-        return num.value
 
     def export(self):
         iter_handle = _ctypes.c_void_p()

--- a/src/unity/toolkits/tcmps/mps_float_array.hpp
+++ b/src/unity/toolkits/tcmps/mps_float_array.hpp
@@ -2,6 +2,7 @@
 #define MPS_FLOAT_ARRAY_HPP_
 
 #include <cstddef>
+#include <future>
 #include <memory>
 #include <vector>
 
@@ -16,6 +17,8 @@ public:
 
   // Returns a pointer to the first float value in the data. This pointer is
   // guaranteed to remain valid for the lifetime of this float_array instance.
+  // Note that for some implementations, calling this function may trigger
+  // synchronization with (waiting for) a thread writing the data.
   virtual const float* data() const = 0;
 
   // Returns the total number of float values present, beginning at the pointer
@@ -60,6 +63,10 @@ public:
   // Copies enough float values from `data` to fill the given `shape`.
   float_buffer(const float* data, std::vector<size_t> shape);
 
+  // Adopts an existing float vector `data`, which must have size consistent
+  // with the provided `shape`.
+  float_buffer(std::vector<float> data, std::vector<size_t> shape);
+
   const float* data() const override { return data_.data(); }
   size_t size() const override { return size_; }
 
@@ -68,7 +75,7 @@ public:
 
 private:
   std::vector<size_t> shape_;
-  size_t size_;
+  size_t size_ = 0;
   std::vector<float> data_;
 };
 
@@ -78,28 +85,35 @@ private:
 // additional allocations).
 class shared_float_array: public float_array {
 public:
-  // Convenience function for creating a shared float_buffer.
+  // Convenience functions for creating a shared float_buffer.
   static shared_float_array copy(const float* data, std::vector<size_t> shape) {
     return shared_float_array(
         std::make_shared<float_buffer>(data, std::move(shape)));
   }
+  static shared_float_array wrap(std::vector<float> data,
+                                 std::vector<size_t> shape) {
+    return shared_float_array(
+        std::make_shared<float_buffer>(std::move(data), std::move(shape)));    
+  }
 
   // Simply wraps an existing float_array shared_ptr.
   explicit shared_float_array(std::shared_ptr<float_array> impl)
-    : shared_float_array(impl, impl->data(), impl->shape(), impl->dim())
+    : shared_float_array(impl, /* offset */ 0, impl->shape(), impl->dim())
   {}
 
   // Creates an array containing the scalar 0.f.
   shared_float_array(): shared_float_array(default_value()) {}
 
-  const float* data() const override { return data_; }
+  const float* data() const override { return impl_->data() + offset_; }
   size_t size() const override { return size_; }
 
   const size_t* shape() const override { return shape_; }
   size_t dim() const override { return dim_; }
 
+  // TODO: Operations such as reshape, slice, etc.?
+
 protected:
-  shared_float_array(std::shared_ptr<float_array> impl, const float* data,
+  shared_float_array(std::shared_ptr<float_array> impl, size_t offset,
                      const size_t* shape, size_t dim);
 
 private:
@@ -107,9 +121,31 @@ private:
 
   std::shared_ptr<float_array> impl_;
 
-  const float* data_ = nullptr;
+  size_t offset_ = 0;
   const size_t* shape_ = nullptr;
   size_t dim_ = 0;
+  size_t size_ = 0;
+};
+
+// A float_array implementation that wraps a future shared_float_array.
+class deferred_float_array: public float_array {
+public:
+  // Wraps `data_future`, which must have a (future) shape matching the provided
+  // (known upfront) `shape`.
+  deferred_float_array(std::shared_future<shared_float_array> data_future,
+                       std::vector<size_t> shape);
+
+  // Waits for the data future if necessary.
+  const float* data() const override;
+
+  // The size and shape of the array are known at construction time.
+  size_t size() const override { return size_; }
+  const size_t* shape() const override { return shape_.data(); }
+  size_t dim() const override { return shape_.size(); }
+
+private:
+  std::shared_future<shared_float_array> data_future_;
+  std::vector<size_t> shape_;
   size_t size_ = 0;
 };
 

--- a/src/unity/toolkits/tcmps/mps_float_array.hpp
+++ b/src/unity/toolkits/tcmps/mps_float_array.hpp
@@ -93,7 +93,7 @@ public:
   static shared_float_array wrap(std::vector<float> data,
                                  std::vector<size_t> shape) {
     return shared_float_array(
-        std::make_shared<float_buffer>(std::move(data), std::move(shape)));    
+        std::make_shared<float_buffer>(std::move(data), std::move(shape)));
   }
 
   // Simply wraps an existing float_array shared_ptr.

--- a/src/unity/toolkits/tcmps/mps_graph_networks.h
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.h
@@ -33,8 +33,10 @@ struct MPSGraphNetwork {
   std::vector<GraphLayer *> layers;
   std::unique_ptr<LossGraphLayer> loss_layer_;
   int batch_size{0};
+
   MPSGraphNetwork(){};
   virtual ~MPSGraphNetwork();
+
   void Init(id<MTLDevice> _Nonnull device, id<MTLCommandQueue> _Nonnull cmd_queue,
             GraphMode mode,
             const float_array_map& config, const float_array_map& weights);
@@ -42,7 +44,7 @@ struct MPSGraphNetwork {
                           MPSCNNLossLabelsBatch *_Nonnull loss_state);
   MPSImageBatch * _Nonnull RunGraph(id<MTLCommandBuffer> _Nonnull  cb, NSDictionary *_Nonnull inputs);
   float_array_map Export() const;
-  int NumParams();
+
   MPSNNGraph *_Nonnull  graph;
   MPSNNImageNode *_Nonnull  input_node;
   MPSNNImageNode * _Nullable grad_node;

--- a/src/unity/toolkits/tcmps/mps_graph_networks.mm
+++ b/src/unity/toolkits/tcmps/mps_graph_networks.mm
@@ -140,31 +140,6 @@ float_array_map MPSGraphNetwork::Export() const {
   return table;
 }
 
-int MPSGraphNetwork::NumParams() {
-  int ret = 0;
-  for (int i = 0; i < layers.size(); ++i) {
-    LayerType type = layers[i]->type;
-    switch (type) {
-    case kConv:
-      {
-        ConvGraphLayer *convLayer = reinterpret_cast<ConvGraphLayer*>(layers[i]);
-        if (convLayer->use_bias) {
-          ret += 2;
-        } else {
-          ret += 1;
-        }
-      }
-      break;
-    case kBN:
-      ret += 4;
-      break;
-    default:
-      break;
-    }
-  }
-  return ret;
-}
-
 }  // namespace mps
 }  // namespace turi
 

--- a/src/unity/toolkits/tcmps/mps_graph_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_graph_trainer.h
@@ -14,18 +14,6 @@ EXPORT int TCMPSMetalDeviceMemoryLimit(uint64_t *size);
 EXPORT int TCMPSCreateGraphModule(MPSHandle *handle);
 EXPORT int TCMPSDeleteGraphModule(MPSHandle handle);
 
-EXPORT int TCMPSStartTrainingBatchGraph(
-    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels);
-EXPORT int TCMPSWaitForTrainingBatchGraph(MPSHandle handle, float *loss);
-
-EXPORT int TCMPSStartInferenceBatchGraph(
-    MPSHandle handle, TCMPSFloatArrayRef inputs);
-EXPORT int TCMPSWaitForInferenceBatchGraph(MPSHandle handle, float *out_ptr);
-
-EXPORT int TCMPSStartTrainReturnGradBatchGraph(
-    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef gradient);
-EXPORT int TCMPSWaitForTrainReturnGradBatchGraph(MPSHandle handle, float *out_ptr);
-
 EXPORT int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
                      int c_out, int h_out, int w_out,
                      char **config_names, void **config_arrays,
@@ -33,12 +21,21 @@ EXPORT int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int
                      char **weight_names, void **weight_arrays,
                      int64_t *weight_sizes, int weight_len);
 
-EXPORT int TCMPSNumParamsGraph(MPSHandle handle, int *num);
+EXPORT int TCMPSSetLearningRateGraph(MPSHandle handle, float new_lr);
+
+EXPORT int TCMPSTrainGraph(MPSHandle handle,
+                           TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
+                           TCMPSFloatArrayRef* loss_out);
+
+EXPORT int TCMPSPredictGraph(
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef* outputs);
+
+EXPORT int TCMPSTrainReturnGradGraph(
+    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef gradient,
+    TCMPSFloatArrayRef* outputs);
 
 EXPORT int TCMPSExportGraph(MPSHandle handle,
                             TCMPSFloatArrayMapIteratorRef* float_array_map_out);
-
-EXPORT int TCMPSSetLearningRateGraph(MPSHandle handle, float new_lr);
 
 #ifdef __cplusplus
 }

--- a/src/unity/toolkits/tcmps/mps_trainer.h
+++ b/src/unity/toolkits/tcmps/mps_trainer.h
@@ -30,18 +30,22 @@ typedef void *MPSHandle;
 typedef void *TCMPSFloatArrayRef;
 typedef void *TCMPSFloatArrayMapIteratorRef;
 
-EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
-EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
-
 EXPORT int TCMPSCreateFloatArray(TCMPSFloatArrayRef *array_out, float* data,
                                  size_t size, size_t* shape, size_t dim);
 EXPORT int TCMPSDeleteFloatArray(TCMPSFloatArrayRef array_ref);
+EXPORT int TCMPSGetFloatArrayShape(TCMPSFloatArrayRef array_ref,
+                                   size_t** shape_out, size_t* dim_out);
+EXPORT int TCMPSReadFloatArray(TCMPSFloatArrayRef array_ref, float** data_out,
+                               size_t** shape_out, size_t* dim_out);
 
 EXPORT int TCMPSNextFloatArray(
     TCMPSFloatArrayMapIteratorRef iter_ref, char** name_out, float** data_out,
     size_t** shape_out, size_t* dim_out);
 EXPORT int TCMPSDeleteFloatArrayMapIterator(
     TCMPSFloatArrayMapIteratorRef iter_ref);
+
+EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
+EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
 
 EXPORT int TCMPSForward(MPSHandle handle, TCMPSFloatArrayRef inputs, float *out,
                         bool is_train);

--- a/src/unity/toolkits/tcmps/mps_trainer.mm
+++ b/src/unity/toolkits/tcmps/mps_trainer.mm
@@ -50,6 +50,33 @@ int TCMPSDeleteFloatArray(TCMPSFloatArrayRef array) {
   API_END();
 }
 
+int TCMPSGetFloatArrayShape(TCMPSFloatArrayRef array_ref,
+                            size_t** shape_out, size_t* dim_out) {
+  API_BEGIN();
+
+  float_array* array = reinterpret_cast<float_array*>(array_ref);
+  *shape_out = const_cast<size_t*>(array->shape());
+  *dim_out = array->dim();
+
+  API_END();
+}
+
+int TCMPSReadFloatArray(TCMPSFloatArrayRef array_ref, float** data_out,
+                        size_t** shape_out, size_t* dim_out) {
+  API_BEGIN();
+
+  float_array* array = reinterpret_cast<float_array*>(array_ref);
+  *data_out = const_cast<float*>(array->data());
+  if (shape_out) {
+    *shape_out = const_cast<size_t*>(array->shape());
+  }
+  if (dim_out) {
+    *dim_out = array->dim();
+  }
+
+  API_END();
+}
+
 int TCMPSNextFloatArray(
     TCMPSFloatArrayMapIteratorRef iter_ref, char** name_out, float** data_out,
     size_t** shape_out, size_t* dim_out) {

--- a/src/unity/toolkits/tcmps/mps_utils.h
+++ b/src/unity/toolkits/tcmps/mps_utils.h
@@ -71,6 +71,13 @@ struct OptimizerOptions {
   }
 };
 
+API_AVAILABLE(macos(10.14))
+shared_float_array copy_image_batch_float16(std::vector<size_t> shape,
+                                        MPSImageBatch * _Nonnull batch);
+
+API_AVAILABLE(macos(10.14))
+void fill_image_batch(const float_array& data, MPSImageBatch * _Nonnull batch);
+
 // Convenient typedef for data structure used to pass configuration and weights
 // into and out of TCMPS.
 using float_array_map = std::map<std::string, shared_float_array>;


### PR DESCRIPTION
Before these changes, clients of the TCMPS backend (for graph-API-based models, such as object detection) had to reason about the backend as having a consumer queue of inputs and a producer queue of outputs, leaving it to the client to track with output corresponds to which input.

With these changes, submitting an input to the backend immediately returns an object that will hold the future output.

I originally wanted to get the low-level-API side too, for activity classification, but I wanted to focus on OD work for now since I'm behind schedule. (I'd rather get one model completely converted sooner and the other later, than have both finish simultaneously later.) For that reason, this addresses only half of #755 (although it includes the work common to both cases).