### PR TITLE
Fix build on gcc7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,26 +225,28 @@ if (CLANG)
     set(_cpp11_optional_flags "${_cpp11_optional_flags} -Wno-stdlibcxx-not-found")
   endif()
 
-  set(CPP11_FLAGS "-std=c++11 -stdlib=libc++ -Wno-deprecated-register -Wno-enum-compare -Wno-conversion-null -Wno-constant-logical-operand -Wno-parentheses-equality -ftemplate-depth=900 ${_cpp11_optional_flags}" CACHE STRING "C++11 enabling flags")
+  set(CPP11_FLAGS "-std=c++11 -stdlib=libc++ -Wno-deprecated-register -Wno-enum-compare -Wno-conversion-null -Wno-constant-logical-operand -Wno-parentheses-equality -ftemplate-depth=900 ${_cpp11_optional_flags}")
 
   set(WERROR_FLAGS "-Werror")
 else()
-set(CPP11_FLAGS "-std=c++11 -Wno-enum-compare -Wno-conversion-null -ftemplate-depth=900" CACHE STRING "C++11 enabling flags")
-set(WERROR_FLAGS "-Werror")
+  # non-clang
+  set(CPP11_FLAGS "-std=c++11 -Wno-enum-compare -Wno-conversion-null -ftemplate-depth=900")
+  set(WERROR_FLAGS "-Werror")
 endif()
+
 # Shared compiler flags used by all builds (debug, profile, release)
 # Allow COMPILER_FLAGS to be used as options from the ./configure without
 # forcing all the other options I want to add to be lost
-set(C_REAL_COMPILER_FLAGS "-Wall -g ${COMPILER_FLAGS}" CACHE STRING "common compiler options")
-set(CPP_REAL_COMPILER_FLAGS "-Wall -g ${CPP11_FLAGS} ${COMPILER_FLAGS}" CACHE STRING "common compiler options")
+set(C_REAL_COMPILER_FLAGS "-Wall -g ${COMPILER_FLAGS}")
+set(CPP_REAL_COMPILER_FLAGS "-Wall -g ${CPP11_FLAGS} ${COMPILER_FLAGS}")
 
 if (CLANG)
   # clang 9.0.0 and earlier will warn (error with -Werror) on unused -pthread during linking
   # so adding only to compile options is what we need.
   add_compile_options(-pthread)
 else()
-  set(C_REAL_COMPILER_FLAGS "${C_REAL_COMPILER_FLAGS} -pthread" CACHE STRING "common compiler options")
-  set(CPP_REAL_COMPILER_FLAGS "${CPP_REAL_COMPILER_FLAGS} -pthread" CACHE STRING "common compiler options")
+  set(C_REAL_COMPILER_FLAGS "${C_REAL_COMPILER_FLAGS} -pthread")
+  set(CPP_REAL_COMPILER_FLAGS "${CPP_REAL_COMPILER_FLAGS} -pthread")
 endif()
 
 # Disable address space randomization for OSX lion and above

--- a/src/platform/parallel/pthread_tools.hpp
+++ b/src/platform/parallel/pthread_tools.hpp
@@ -986,10 +986,6 @@ namespace turi {
      * thrown by the thread is forwarded to the join() function.
      */
     inline void join() {
-      if(ptrdiff_t(this) == 0) {
-        std::cout << "Failure on join()" << std::endl;
-        abort();
-      }
       join(*this);
     }
 

--- a/src/unity/toolkits/coreml_export/MLModel/src/NeuralNetworkShapes.hpp
+++ b/src/unity/toolkits/coreml_export/MLModel/src/NeuralNetworkShapes.hpp
@@ -14,6 +14,8 @@
 #include "ValidatorUtils-inl.hpp"
 #include "LayerShapeConstraints.hpp"
 #include "transforms/NeuralNetwork.hpp"
+
+#include <functional>
 #include <iostream>
 
 #define COREML_VALIDATOR_VERBOSE 0

--- a/src/unity/toolkits/coreml_export/MLModel/src/NeuralNetworkValidator.cpp
+++ b/src/unity/toolkits/coreml_export/MLModel/src/NeuralNetworkValidator.cpp
@@ -14,6 +14,7 @@
 #include "QuantizationValidationUtils.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <sstream>
 
 namespace CoreML {

--- a/src/unity/toolkits/coreml_export/MLModel/src/Utils.cpp
+++ b/src/unity/toolkits/coreml_export/MLModel/src/Utils.cpp
@@ -179,7 +179,7 @@ WeightParamType CoreML::getWeightParamType(const Specification::NeuralNetworkLay
                 || valueType(layer.simplerecurrent().recursionmatrix()) == FLOAT16
                 || valueType(layer.simplerecurrent().biasvector()) == FLOAT16)
                 retval = FLOAT16;
-                break;
+            break;
         case Specification::NeuralNetworkLayer::LayerCase::kGru:
             if (valueType(layer.gru().updategateweightmatrix()) == FLOAT16
                 || valueType(layer.gru().resetgateweightmatrix()) == FLOAT16


### PR DESCRIPTION
Tested on Ubuntu 18.04 with gcc 7.3.0

The gcc7 build seems to have broken (further) since #108 went in.
This change fixes various build breaks in gcc7 due to a combination
of new warnings, warnings as error, and misuse of cache variables
in CMake.