### PR TITLE
Fix strange JSON parsing bug

### DIFF
--- a/src/flexible_type/string_parser.hpp
+++ b/src/flexible_type/string_parser.hpp
@@ -82,7 +82,7 @@ struct stack_buffer {
   }
 
   std::string& get_string() {
-    if (pos < STACK_BUF_SIZE) altbuf = std::string(buf, pos);
+    if (pos <= STACK_BUF_SIZE) altbuf = std::string(buf, pos);
     return altbuf;
   }
 };

--- a/src/unity/python/turicreate/test/test_json.py
+++ b/src/unity/python/turicreate/test/test_json.py
@@ -20,6 +20,7 @@ import datetime
 import json # Python built-in JSON module
 import math
 import os
+import pandas
 import pytz
 import sys
 import unittest
@@ -287,3 +288,15 @@ class JSONTest(unittest.TestCase):
         self.assertRaises(IOError, SArray.read_json, '/nonexistant.json')
         self.assertRaises(IOError, SFrame.read_json, '/nonexistant.json')
 
+    def test_strange_128_char_corner_case(self):
+        json_text = """
+{"foo":[{"bar":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. In eget odio velit. Suspendisse potenti. Vivamus a urna feugiat nullam."}]}
+"""
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write(json_text)
+            f.flush()
+
+            df = pandas.read_json(f.name, lines=True)
+            sf_actual = SFrame.read_json(f.name, orient='lines')
+            sf_expected = SFrame(df)
+            _SFrameComparer._assert_sframe_equal(sf_expected, sf_actual)


### PR DESCRIPTION
When there are exactly 128-char strings within a nested JSON
structure, they were silently dropped due to an off-by-one
comparison. This change fixes the bug, and adds a unit test to
ensure correct behavior. (Verified that this test failed prior
to this change, and passes now with this change.)