### PR TITLE
Remove "Turi Server" from documentation

### DIFF
--- a/src/unity/lib/gl_sframe.hpp
+++ b/src/unity/lib/gl_sframe.hpp
@@ -373,8 +373,8 @@ groupby_descriptor_type ARGMIN(const std::string& agg, const std::string& out);
  * \ingroup group_glsdk
  * A tabular, column-mutable dataframe object that can scale to big data. 
  *
- * The data in \ref gl_sframe is stored column-wise on the Turi Server
- * side, and is stored on persistent storage (e.g. disk) to avoid being
+ * The data in \ref gl_sframe is stored column-wise on persistent
+ * storage (e.g. disk) to avoid being
  * constrained by memory size.  Each column in an \ref gl_sframe is a
  * immutable \ref gl_sarray, but \ref gl_sframe objects
  * are mutable in that columns can be added and subtracted with ease.  

--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -8,7 +8,7 @@ This module defines the SArray class which provides the
 ability to create, access and manipulate a remote scalable array object.
 
 SArray acts similarly to pandas.Series but without indexing.
-The data is immutable, homogeneous, and is stored on the Turi Server side.
+The data is immutable and homogeneous.
 '''
 from __future__ import print_function as _
 from __future__ import division as _

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -8,7 +8,7 @@ This module defines the SFrame class which provides the
 ability to create, access and manipulate a remote scalable dataframe object.
 
 SFrame acts similarly to pandas.DataFrame, but the data is completely immutable
-and is stored column wise on the Turi Server side.
+and is stored column wise.
 '''
 from __future__ import print_function as _
 from __future__ import division as _
@@ -171,7 +171,7 @@ def _force_cast_sql_types(data, result_types, force_cast_cols):
 class SFrame(object):
     """
     A tabular, column-mutable dataframe object that can scale to big data. The
-    data in SFrame is stored column-wise on the Turi Server side, and is
+    data in SFrame is stored column-wise, and is
     stored on persistent storage (e.g. disk) to avoid being constrained by
     memory size.  Each column in an SFrame is a size-immutable
     :class:`~turicreate.SArray`, but SFrames are mutable in that columns can be
@@ -192,7 +192,7 @@ class SFrame(object):
     and from the following sources:
 
     * your local file system
-    * the Turi Server's file system
+    * a network file system mounted locally
     * HDFS
     * Amazon S3
     * HTTP(S).

--- a/userguide/README.md
+++ b/userguide/README.md
@@ -23,7 +23,7 @@ If you haven’t already installed Turi Create, you can find instructions
 ## SFrame
 
 SFrame is a scalable, tabular, column-mutable dataframe object. The data
-in SFrame is stored column-wise on the Turi Server side, and is stored
+in SFrame is stored column-wise, and is stored
 on persistent storage (e.g. disk) to avoid being constrained by memory
 size. Each column in an SFrame is a size-immutable SArray, but SFrames
 are mutable in that columns can be added and subtracted with ease. An
@@ -35,8 +35,8 @@ directory where an Sframe was saved previously), general text file (with
 csv parsing options; see read_csv()), Python dictionary,
 pandas.DataFrame and JSON.
 
-An SFrame can be constructed with data from your local file system, the
-Turi server’s file system, HDFS, Amazon S3, or HTTP(S).
+An SFrame can be constructed with data from your local file system, a
+network file system mounted locally, HDFS, Amazon S3, or HTTP(S).
 
 See [Working with data](sframe/README.md) for more guidance on
 data structures and the [API


### PR DESCRIPTION
There are several places we still refer to a "Turi Server" in the
API docs and user guide. This commit removes that wording (at this
point it's very confusing and not clear what it refers to), and in
some places, adds clarification that network filesystems should
work with SFrame/SArray.