### PR TITLE
 Add in mechanism for registering base class methods in extension types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,8 @@ if(HAS_FTRACER)
         set(EXTRA_OPTIMIZATION_FLAGS "${EXTRA_OPTIMIZATION_FLAGS} -ftracer")
 endif()
 
+
+
 set(DEBUG_OPTIMIZATION_LEVEL -O0)
 
 if(${RELEASE_OPT_FOR_SIZE})
@@ -398,6 +400,7 @@ set(CMAKE_CXX_FLAGS_RELEASE
 #*       Some C++ Implementation Oddities between libc++ and stdc++       */
 #*                                                                        */
 #**************************************************************************/
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS_DEBUG})
 check_cxx_source_compiles("#include <ios>
                            #include <system_error>
                            int main(int argc, char** argv) {
@@ -410,6 +413,24 @@ if(COMPILER_HAS_IOS_BASE_FAILURE_WITH_ERROR_CODE)
 else()
   message(STATUS "Compiler does not support ios_base::failure(str, error_code)")
 endif()
+
+check_cxx_source_compiles("#include <ios>
+                           #include <system_error>
+                                                    
+                           class io_error : public std::ios_base::failure {
+                             public:   /* The noexcept here is different between C++ 17 and C++ 11. */
+                              const char *what() const noexcept { return \"\"; } 
+                           };
+                           int main(int argc, char** argv) { return 0; }" 
+                          COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS)
+
+if(COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS)
+  message(STATUS "Compiler supports noexcept on what() with ios_base::failure.")
+  add_definitions(-DCOMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS)
+else()
+  message(STATUS "Compiler uses throw() on what() with ios_base::failure.")
+endif()
+
 
 #**************************************************************************/
 #*                                                                        */

--- a/src/logger/error.cpp
+++ b/src/logger/error.cpp
@@ -12,9 +12,19 @@
 
 using namespace turi::error;
 
+#ifdef COMPILER_HAS_IOS_BASE_FAILURE_WITH_ERROR_CODE
 io_error::io_error(const std::string &message)
-  : std::ios_base::failure(message), m_message(message) {}
+: std::ios_base::failure(message, std::error_code()), m_message(message) {}
+#else
+io_error::io_error(const std::string &message)
+: std::ios_base::failure(message), m_message(message) {}
+#endif
 
+
+#ifdef COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS
 const char *io_error::what() const noexcept {
+#else
+const char *io_error::what() const {
+#endif
   return m_message.c_str();
 }

--- a/src/logger/error.hpp
+++ b/src/logger/error.hpp
@@ -20,7 +20,12 @@ class io_error : public std::ios_base::failure {
 
   public:
     explicit io_error(const std::string &message);
-    virtual const char *what() const noexcept override;
+
+#ifdef COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS
+  virtual const char *what() const noexcept override;
+#else
+  virtual const char *what() const override;
+#endif
 };
 
 } // namespace error

--- a/src/unity/lib/extensions/ml_model.cpp
+++ b/src/unity/lib/extensions/ml_model.cpp
@@ -72,14 +72,14 @@ void ml_model_base::set_options(const std::map<std::string, flexible_type>& _opt
 /**
  * Return the "state" map.
  */
-std::map<std::string, variant_type> ml_model_base::get_state() const{
+const std::map<std::string, variant_type>& ml_model_base::get_state() const{
   return state;
 }
 
 /**
  * Get value in the given dictionary.
  */
-variant_type ml_model_base::get_value_from_state(std::string key){
+const variant_type& ml_model_base::get_value_from_state(std::string key){
 
   // Field does not exist
   if(state.count(key) == 0){

--- a/src/unity/lib/extensions/ml_model.hpp
+++ b/src/unity/lib/extensions/ml_model.hpp
@@ -129,7 +129,7 @@ class EXPORT ml_model_base: public model_base {
    * [] operator in python.
    *
    */
-  variant_type get_value_from_state(std::string key);
+  const variant_type& get_value_from_state(std::string key);
 
 
   /**
@@ -167,7 +167,7 @@ class EXPORT ml_model_base: public model_base {
    *
    * \returns Model map.
    */
-  std::map<std::string, variant_type> get_state() const;
+  const std::map<std::string, variant_type>& get_state() const;
 
   /**
    * Is this model trained.
@@ -198,6 +198,21 @@ class EXPORT ml_model_base: public model_base {
    *  parameters.
    */
   const std::vector<option_handling::option_info>& get_option_info() const;
+
+  // Code to perform the registration for the rest of the tools. 
+  BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
+
+  REGISTER_CLASS_MEMBER_FUNCTION(ml_model_base::list_fields);
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("get_value",
+                                       ml_model_base::get_value_from_state,
+                                       "field");
+  REGISTER_CLASS_MEMBER_FUNCTION(ml_model_base::get_option_value);
+  REGISTER_CLASS_MEMBER_FUNCTION(ml_model_base::is_trained);
+  REGISTER_CLASS_MEMBER_FUNCTION(ml_model_base::get_default_options);
+  REGISTER_CLASS_MEMBER_FUNCTION(ml_model_base::get_state);
+  REGISTER_CLASS_MEMBER_FUNCTION(ml_model_base::set_options);
+
+  END_CLASS_MEMBER_REGISTRATION
 
  protected:
 

--- a/src/unity/lib/toolkit_class_macros.hpp
+++ b/src/unity/lib/toolkit_class_macros.hpp
@@ -135,6 +135,45 @@
                     toolkit_class_wrapper_impl::generate_member_function_wrapper_indirect( \
                     &function, ##__VA_ARGS__));
 
+/**
+ * Begins a class member registration block for base classes.  These 
+ *
+ * BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
+ *
+ * The basic usage is to put this inside a class to be published, and go:
+ * \code
+ * BEGIN_BASE_CLASS_MEMBER_REGISTRATION("python_facing_classname")
+ * REGISTER_ ... OTHER MEMBERS ...
+ * END_CLASS_MEMBER_REGISTRATION
+ * \endcode
+ *
+ * In the parent class, you would register 
+ *
+ *
+ */
+#define BEGIN_BASE_CLASS_MEMBER_REGISTRATION() \
+ public:                                       \
+  virtual inline void perform_registration() { \
+
+
+/**
+ * Begins a class member registration block for a base class.  
+ *
+ * BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
+ *
+ * The basic usage is to put this inside a class that is the base class of an inherited, and go:
+ * \code
+ * BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
+ * REGISTER_ ... OTHER MEMBERS ...
+ * END_CLASS_MEMBER_REGISTRATION
+ * \endcode
+ */
+#define IMPORT_BASE_CLASS_REGISTRATION(base_class)                     \
+  static_assert(                                                       \
+      !std::is_same<decltype(*this), base_class>::value,               \
+      "IMPORT_BASE_CLASS_REGISTRATION must be called on base class."); \
+  this->base_class::perform_registration();
+
 // /*
 //  * Like REGISTER_CLASS_MEMBER_FUNCTION but to be used when the function to
 //  * be exposed is overloaded. 

--- a/src/unity/toolkits/supervised_learning/boosted_trees.hpp
+++ b/src/unity/toolkits/supervised_learning/boosted_trees.hpp
@@ -42,9 +42,10 @@ class EXPORT boosted_trees_regression: public xgboost_model {
 
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "boosted_trees_regression", 
-      boosted_trees_regression)
+
+  BEGIN_CLASS_MEMBER_REGISTRATION("boosted_trees_regression");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 
 };
 
@@ -109,9 +110,9 @@ class EXPORT boosted_trees_classifier : public xgboost_model {
  
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "boosted_trees_classifier", 
-      boosted_trees_classifier)
+  BEGIN_CLASS_MEMBER_REGISTRATION("boosted_trees_classifier");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 
 };
 

--- a/src/unity/toolkits/supervised_learning/decision_tree.hpp
+++ b/src/unity/toolkits/supervised_learning/decision_tree.hpp
@@ -37,9 +37,9 @@ class EXPORT decision_tree_regression: public xgboost_model {
   
   std::shared_ptr<coreml::MLModelWrapper>  export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "decision_tree_regression", 
-      decision_tree_regression)
+  BEGIN_CLASS_MEMBER_REGISTRATION("decision_tree_regression");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 };
 
 class EXPORT decision_tree_classifier: public xgboost_model {  
@@ -99,9 +99,9 @@ class EXPORT decision_tree_classifier: public xgboost_model {
   
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "decision_tree_classifier", 
-      decision_tree_classifier)
+  BEGIN_CLASS_MEMBER_REGISTRATION("decision_tree_classifier");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 
 
 };

--- a/src/unity/toolkits/supervised_learning/linear_regression.hpp
+++ b/src/unity/toolkits/supervised_learning/linear_regression.hpp
@@ -131,9 +131,9 @@ class EXPORT linear_regression: public supervised_learning_model_base {
 
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "regression_linear_regression", linear_regression); 
-      
+  BEGIN_CLASS_MEMBER_REGISTRATION("regression_linear_regression");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 };
 
 } // supervised

--- a/src/unity/toolkits/supervised_learning/linear_svm.hpp
+++ b/src/unity/toolkits/supervised_learning/linear_svm.hpp
@@ -175,8 +175,9 @@ class EXPORT linear_svm: public supervised_learning_model_base {
   
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "classifier_svm", linear_svm); 
+  BEGIN_CLASS_MEMBER_REGISTRATION("classifier_svm");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
  
 };
 

--- a/src/unity/toolkits/supervised_learning/logistic_regression.hpp
+++ b/src/unity/toolkits/supervised_learning/logistic_regression.hpp
@@ -172,8 +172,9 @@ class EXPORT logistic_regression: public supervised_learning_model_base {
   
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "classifier_logistic_regression", logistic_regression);
+  BEGIN_CLASS_MEMBER_REGISTRATION("classifier_logistic_regression");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 
 };
 } // supervised

--- a/src/unity/toolkits/supervised_learning/random_forest.hpp
+++ b/src/unity/toolkits/supervised_learning/random_forest.hpp
@@ -42,9 +42,9 @@ class EXPORT random_forest_regression: public xgboost_model {
   
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "random_forest_regression", 
-      random_forest_regression)
+  BEGIN_CLASS_MEMBER_REGISTRATION("random_forest_regression");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
 
 };
 
@@ -109,10 +109,11 @@ class EXPORT random_forest_classifier: public xgboost_model {
   }
 
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml() override;
- 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION(
-      "random_forest_classifier", 
-      random_forest_classifier)
+  
+  BEGIN_CLASS_MEMBER_REGISTRATION("random_forest_classifier");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
+
 
 };
  }  // namespace xgboost

--- a/src/unity/toolkits/supervised_learning/supervised_learning.hpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.hpp
@@ -703,97 +703,96 @@ class EXPORT supervised_learning_model_base : public ml_model_base {
 
   std::shared_ptr<coreml::MLModelWrapper> api_export_to_coreml(const std::string& file);
 
-#define SUPERVISED_LEARNING_METHODS_REGISTRATION(name, class_name)             \
-                                                                               \
-  BEGIN_CLASS_MEMBER_REGISTRATION(name)                                        \
-                                                                               \
-  REGISTER_CLASS_MEMBER_FUNCTION(class_name::list_fields)                      \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(                                        \
-      "get_value", class_name::get_value_from_state, "field");                 \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("train", class_name::api_train, "data", \
-                                       "target", "validation_data",            \
-                                       "options");                             \
-  register_defaults(                                                           \
-      "train",                                                                 \
-      {{"validation_data", to_variant(gl_sframe())},                           \
-       {"options", to_variant(std::map<std::string, flexible_type>())}});      \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("predict", class_name::api_predict,     \
-                                       "data", "missing_value_action",         \
-                                       "output_type");                         \
-                                                                               \
-  register_defaults("predict", {{"missing_value_action", std::string("auto")}, \
-                     {"output_type", std::string("")}});                       \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("fast_predict",                         \
-                                       class_name::fast_predict, "rows",       \
-                                       "missing_value_action", "output_type"); \
-                                                                               \
-  register_defaults("fast_predict",                                            \
-                    {{"missing_value_action", std::string("auto")},            \
-                     {"output_type", std::string("")}});                       \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(                                        \
-      "predict_topk", class_name::api_predict_topk, "data",                    \
-      "missing_value_action", "output_type", "topk");                          \
-                                                                               \
-  register_defaults("predict_topk",                                            \
-                    {{"missing_value_action", std::string("error")},           \
-                     {"output_type", std::string("")}});                       \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(                                        \
-      "fast_predict_topk", class_name::fast_predict_topk, "rows",              \
-      "missing_value_action", "output_type", "topk");                          \
-                                                                               \
-  register_defaults("fast_predict_topk",                                       \
-                    {{"missing_value_action", std::string("auto")},            \
-                     {"output_type", std::string("")}});                       \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("classify", class_name::api_classify,   \
-                                       "data", "missing_value_action");        \
-                                                                               \
-  register_defaults("classify",                                                \
-                    {{"missing_value_action", std::string("auto")}});          \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("fast_classify",                        \
-                                       class_name::fast_classify, "rows",      \
-                                       "missing_value_action");                \
-                                                                               \
-  register_defaults("fast_classify",                                           \
-                    {{"missing_value_action", std::string("auto")}});          \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("evaluate", class_name::api_evaluate,   \
-                                       "data", "missing_value_action",         \
-                                       "metric");                              \
-                                                                               \
-  register_defaults("evaluate",                                                \
-                    {{"metric", std::string("_report")},                        \
-                     {"missing_value_action", std::string("auto")}});          \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION("extract_features",                     \
-                                       class_name::api_extract_features,       \
-                                       "data", "missing_value_action");        \
-                                                                               \
-  register_defaults("extract_features",                                        \
-                    {{"missing_value_action", std::string("auto")}});          \
-                                                                               \
-  REGISTER_CLASS_MEMBER_FUNCTION(class_name::is_trained);                      \
-  REGISTER_CLASS_MEMBER_FUNCTION(class_name::get_train_stats);                 \
-  REGISTER_CLASS_MEMBER_FUNCTION(class_name::get_feature_names);               \
-  REGISTER_CLASS_MEMBER_FUNCTION(class_name::get_option_value);                \
-                                                                               \
-  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(                                        \
-      "export_to_coreml", class_name::api_export_to_coreml, "filename");       \
-                                                                               \
-  register_defaults("export_to_coreml", {{"filename", std::string("")}});      \
-                                                                               \
+  //////////////////////////////////////////////////////////////////////////////
+
+  BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
+  
+    IMPORT_BASE_CLASS_REGISTRATION(ml_model_base);
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "train", supervised_learning_model_base::api_train, "data", "target",
+      "validation_data", "options");
+  register_defaults("train",
+                    {{"validation_data", to_variant(gl_sframe())},
+                     {"options",
+                      to_variant(std::map<std::string, flexible_type>())}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "predict", supervised_learning_model_base::api_predict, "data",
+      "missing_value_action", "output_type");
+
+  register_defaults("predict", {{"missing_value_action", std::string("auto")},
+                                {"output_type", std::string("")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "fast_predict", supervised_learning_model_base::fast_predict, "rows",
+      "missing_value_action", "output_type");
+
+  register_defaults("fast_predict",
+                    {{"missing_value_action", std::string("auto")},
+                     {"output_type", std::string("")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "predict_topk", supervised_learning_model_base::api_predict_topk, "data",
+      "missing_value_action", "output_type", "topk");
+
+  register_defaults("predict_topk",
+                    {{"missing_value_action", std::string("error")},
+                     {"output_type", std::string("")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "fast_predict_topk", supervised_learning_model_base::fast_predict_topk,
+      "rows", "missing_value_action", "output_type", "topk");
+
+  register_defaults("fast_predict_topk",
+                    {{"missing_value_action", std::string("auto")},
+                     {"output_type", std::string("")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "classify", supervised_learning_model_base::api_classify, "data",
+      "missing_value_action");
+
+  register_defaults("classify",
+                    {{"missing_value_action", std::string("auto")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "fast_classify", supervised_learning_model_base::fast_classify, "rows",
+      "missing_value_action");
+
+  register_defaults("fast_classify",
+                    {{"missing_value_action", std::string("auto")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "evaluate", supervised_learning_model_base::api_evaluate, "data",
+      "missing_value_action", "metric");
+
+  register_defaults("evaluate",
+                    {{"metric", std::string("_report")},
+                     {"missing_value_action", std::string("auto")}});
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "extract_features", supervised_learning_model_base::api_extract_features,
+      "data", "missing_value_action");
+
+  register_defaults("extract_features",
+                    {{"missing_value_action", std::string("auto")}});
+
+  REGISTER_CLASS_MEMBER_FUNCTION(
+      supervised_learning_model_base::get_train_stats);
+  REGISTER_CLASS_MEMBER_FUNCTION(
+      supervised_learning_model_base::get_feature_names);
+
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "export_to_coreml", supervised_learning_model_base::api_export_to_coreml,
+      "filename");
+
+  register_defaults("export_to_coreml", {{"filename", std::string("")}});
+
   END_CLASS_MEMBER_REGISTRATION
 
-
-  protected:
-   ml_missing_value_action get_missing_value_enum_from_string(
-       const std::string& missing_value_str) const;
+ protected:
+  ml_missing_value_action get_missing_value_enum_from_string(
+      const std::string& missing_value_str) const;
 };
 
 /**

--- a/test/toolkits/supervised_learning/supervised_learning_mock_test_model.cxx
+++ b/test/toolkits/supervised_learning/supervised_learning_mock_test_model.cxx
@@ -64,8 +64,10 @@ class predict_constant : public supervised_learning_model_base {
    * -------------------------------------------------------------------------
    */
 
-  SUPERVISED_LEARNING_METHODS_REGISTRATION("predict_constant", predict_constant)
-
+  BEGIN_CLASS_MEMBER_REGISTRATION("predict_constant");
+  IMPORT_BASE_CLASS_REGISTRATION(supervised_learning_model_base);
+  END_CLASS_MEMBER_REGISTRATION
+  
   /**
    * Train a supervised_learning model.
    */


### PR DESCRIPTION
This PR adds in a method for registering class methods of extension
classes when the method is defined in a base class of the class
registered as an extension type.

Two new macros are provided, BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
and IMPORT_BASE_CLASS_REGISTRATION.
BEGIN_BASE_CLASS_MEMBER_REGISTRATION takes no arguments and creates a
registration block with the same form as
BEGIN_CLASS_MEMBER_REGISTRATION but taking no class name.  Then, any
classes inheriting from this can include
IMPORT_BASE_CLASS_REGISTRATION(base_class) as part of their registration
block, which causes the base class registration to be executed.