### PR TITLE
Added check for noexcept on what() in exceptions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,8 @@ if(HAS_FTRACER)
         set(EXTRA_OPTIMIZATION_FLAGS "${EXTRA_OPTIMIZATION_FLAGS} -ftracer")
 endif()
 
+
+
 set(DEBUG_OPTIMIZATION_LEVEL -O0)
 
 if(${RELEASE_OPT_FOR_SIZE})
@@ -398,6 +400,7 @@ set(CMAKE_CXX_FLAGS_RELEASE
 #*       Some C++ Implementation Oddities between libc++ and stdc++       */
 #*                                                                        */
 #**************************************************************************/
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS_DEBUG})
 check_cxx_source_compiles("#include <ios>
                            #include <system_error>
                            int main(int argc, char** argv) {
@@ -410,6 +413,24 @@ if(COMPILER_HAS_IOS_BASE_FAILURE_WITH_ERROR_CODE)
 else()
   message(STATUS "Compiler does not support ios_base::failure(str, error_code)")
 endif()
+
+check_cxx_source_compiles("#include <ios>
+                           #include <system_error>
+                                                    
+                           class io_error : public std::ios_base::failure {
+                             public:   /* The noexcept here is different between C++ 17 and C++ 11. */
+                              const char *what() const noexcept { return \"\"; } 
+                           };
+                           int main(int argc, char** argv) { return 0; }" 
+                          COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS)
+
+if(COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS)
+  message(STATUS "Compiler supports noexcept on what() with ios_base::failure.")
+  add_definitions(-DCOMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS)
+else()
+  message(STATUS "Compiler uses throw() on what() with ios_base::failure.")
+endif()
+
 
 #**************************************************************************/
 #*                                                                        */

--- a/src/logger/error.cpp
+++ b/src/logger/error.cpp
@@ -12,9 +12,19 @@
 
 using namespace turi::error;
 
+#ifdef COMPILER_HAS_IOS_BASE_FAILURE_WITH_ERROR_CODE
 io_error::io_error(const std::string &message)
-  : std::ios_base::failure(message), m_message(message) {}
+: std::ios_base::failure(message, std::error_code()), m_message(message) {}
+#else
+io_error::io_error(const std::string &message)
+: std::ios_base::failure(message), m_message(message) {}
+#endif
 
+
+#ifdef COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS
 const char *io_error::what() const noexcept {
+#else
+const char *io_error::what() const {
+#endif
   return m_message.c_str();
 }

--- a/src/logger/error.hpp
+++ b/src/logger/error.hpp
@@ -20,7 +20,12 @@ class io_error : public std::ios_base::failure {
 
   public:
     explicit io_error(const std::string &message);
-    virtual const char *what() const noexcept override;
+
+#ifdef COMPILER_HAS_NOEXCEPT_WHAT_ON_EXCEPTIONS
+  virtual const char *what() const noexcept override;
+#else
+  virtual const char *what() const override;
+#endif
 };
 
 } // namespace error


### PR DESCRIPTION
gcc on travis and clang on mac OSX differ in whether std::exception has the noexcept decorator on the what() method.  Normally this is a warning, but with -Werror it fails to compile.  This adds a compile-time check for this behavior 