### PR TITLE
Implement initialization of pre-trained model for C-API object detector

### DIFF
--- a/src/unity/toolkits/neural_net/CMakeLists.txt
+++ b/src/unity/toolkits/neural_net/CMakeLists.txt
@@ -44,7 +44,13 @@ endif()
 make_library(unity_neural_net
   SOURCES
     cnn_module.cpp
+    coreml_import.cpp
     float_array.cpp
   REQUIRES
+    logger
+    unity_coreml_model_export
     ${additional_unity_neural_net_requirements}
+  COMPILE_FLAGS_EXTRA_GCC
+    -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
+    -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
 )

--- a/src/unity/toolkits/neural_net/coreml_import.cpp
+++ b/src/unity/toolkits/neural_net/coreml_import.cpp
@@ -1,0 +1,201 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <unity/toolkits/neural_net/coreml_import.hpp>
+
+#include <fstream>
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+#include <logger/assertions.hpp>
+#include <logger/logger.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
+
+namespace turi {
+namespace neural_net {
+
+namespace {
+
+using CoreML::Specification::BatchnormLayerParams;
+using CoreML::Specification::ConvolutionLayerParams;
+using CoreML::Specification::Model;
+using CoreML::Specification::NeuralNetwork;
+using CoreML::Specification::NeuralNetworkLayer;
+using CoreML::Specification::Pipeline;
+using CoreML::Specification::WeightParams;
+
+size_t multiply(size_t a, size_t b) { return a * b; }
+
+class weight_params_float_array final: public float_array {
+public:
+  // Convenience function to help the compiler convert initializer lists to
+  // std::vector first, before trying to resolve the std::make_shared template.
+  static shared_float_array create_shared(
+      std::vector<size_t> shape, WeightParams* weights) {
+    return shared_float_array(
+        std::make_shared<weight_params_float_array>(std::move(shape), weights));
+  }
+
+  // Adopts (destructively) the data inside weights.
+  weight_params_float_array(std::vector<size_t> shape, WeightParams* weights)
+    : shape_(std::move(shape))
+  {
+    weights_.Swap(weights);
+
+    size_t size_from_shape =
+        std::accumulate(shape_.begin(), shape_.end(), 1u, multiply);
+    ASSERT_MSG(weights_.floatvalue_size() == static_cast<int>(size_from_shape),
+               "WeightParams size %d inconsistent with expected size %d",
+               weights_.floatvalue_size(), static_cast<int>(size_from_shape));
+  }
+
+  const float* data() const override { return weights_.floatvalue().data(); }
+  size_t size() const override { return weights_.floatvalue_size(); }
+  const size_t* shape() const override { return shape_.data(); }
+  size_t dim() const override { return shape_.size(); }
+
+private:
+  std::vector<size_t> shape_;
+  WeightParams weights_;
+};
+
+// The overloaded extract_network_params functions below traverse a CoreML spec
+// proto recursively, destructively moving the WeightParams values it finds
+// inside of neural networks into an output float_array_map.
+
+void extract_network_params(const std::string& name,
+                            ConvolutionLayerParams* convolution,
+                            float_array_map* params_out) {
+  ASSERT_EQ(2, convolution->kernelsize_size());
+  const size_t n = convolution->outputchannels();
+  const size_t c = convolution->kernelchannels();
+  const size_t h = convolution->kernelsize(0);
+  const size_t w = convolution->kernelsize(1);
+
+  shared_float_array weights = weight_params_float_array::create_shared(
+      {n, c, h, w}, convolution->mutable_weights());
+  params_out->emplace(name + "_weight", std::move(weights));
+
+  if (convolution->has_bias()) {
+    shared_float_array bias = weight_params_float_array::create_shared(
+        {n}, convolution->mutable_bias());
+    params_out->emplace(name + "_bias", std::move(bias));
+  }
+}
+
+void extract_network_params(const std::string& name,
+                            BatchnormLayerParams* batch_norm,
+                            float_array_map* params_out) {
+  const size_t n = batch_norm->channels();
+
+  shared_float_array gamma = weight_params_float_array::create_shared(
+      {n}, batch_norm->mutable_gamma());
+  params_out->emplace(name + "_gamma", std::move(gamma));
+
+  shared_float_array beta = weight_params_float_array::create_shared(
+      {n}, batch_norm->mutable_beta());
+  params_out->emplace(name + "_beta", std::move(beta));
+
+  shared_float_array mean = weight_params_float_array::create_shared(
+      {n}, batch_norm->mutable_mean());
+  params_out->emplace(name + "_running_mean", std::move(mean));
+
+  shared_float_array variance = weight_params_float_array::create_shared(
+      {n}, batch_norm->mutable_variance());
+  params_out->emplace(name + "_running_var", std::move(variance));
+}
+
+void extract_network_params(NeuralNetworkLayer* neural_net_layer,
+                            float_array_map* params_out) {
+  switch (neural_net_layer->layer_case()) {
+  case NeuralNetworkLayer::kConvolution:
+    extract_network_params(neural_net_layer->name(),
+                           neural_net_layer->mutable_convolution(), params_out);
+    break;
+  case NeuralNetworkLayer::kBatchnorm:
+    extract_network_params(neural_net_layer->name(),
+                           neural_net_layer->mutable_batchnorm(), params_out);
+    break;
+  default:
+    break;
+  }
+}
+
+void extract_network_params(NeuralNetwork* neural_net,
+                            float_array_map* params_out) {
+  for (NeuralNetworkLayer& layer : *neural_net->mutable_layers()) {
+    extract_network_params(&layer, params_out);
+  }
+}
+
+// Forward declaration necessary due to mutual recursion.
+void extract_network_params(Model* model, float_array_map* params_out);
+
+void extract_network_params(Pipeline* pipeline, float_array_map* params_out) {
+  for (Model& model : *pipeline->mutable_models()) {
+    extract_network_params(&model, params_out);
+  }
+}
+
+void extract_network_params(Model* model, float_array_map* params_out) {
+  switch (model->Type_case()) {
+  case Model::kNeuralNetwork:
+    extract_network_params(model->mutable_neuralnetwork(), params_out);
+    break;
+  case Model::kPipeline:
+    extract_network_params(model->mutable_pipeline(), params_out);
+    break;
+  default:
+    break;
+  }
+}
+
+std::vector<char> load_file(const std::string& path) {
+  // Open file in binary mode at end of file.
+  std::ifstream input_stream(path, std::ios::binary | std::ios::ate);
+  if (!input_stream) {
+    log_and_throw("Error opening " + path);
+  }
+
+  // Allocate buffer.
+  std::vector<char> buffer(input_stream.tellg());
+
+  // Read file.
+  input_stream.seekg(0);
+  if (!input_stream.read(buffer.data(), buffer.size())) {
+    log_and_throw("Error reading " + path);
+  }
+
+  return buffer;
+}
+
+}  // namespace
+
+float_array_map extract_network_params(Model* model) {
+  float_array_map result;
+  extract_network_params(model, &result);
+  return result;
+}
+
+float_array_map load_network_params(const std::string& mlmodel_path) {
+  CoreML::Specification::Model mlmodel;
+
+  // Read file.
+  std::vector<char> mlmodel_buffer = load_file(mlmodel_path);
+
+  // Parse into CoreML spec.
+  if (!mlmodel.ParseFromArray(mlmodel_buffer.data(),
+                              static_cast<int>(mlmodel_buffer.size()))) {
+    log_and_throw("Error parsing CoreML specification from " + mlmodel_path);
+  }
+
+  // Rip out the parameters.
+  return extract_network_params(&mlmodel);
+}
+
+}  // neural_net
+}  // turi

--- a/src/unity/toolkits/neural_net/coreml_import.hpp
+++ b/src/unity/toolkits/neural_net/coreml_import.hpp
@@ -1,0 +1,60 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef UNITY_TOOLKITS_NEURAL_NET_COREML_IMPORT_HPP_
+#define UNITY_TOOLKITS_NEURAL_NET_COREML_IMPORT_HPP_
+
+#include <string>
+
+#include <unity/toolkits/neural_net/float_array.hpp>
+
+// Forward declare CoreML::Specification::Model in lieu of including problematic
+// protocol buffer headers.
+
+namespace CoreML {
+namespace Specification {
+
+class Model;
+
+}  // namespace Specification
+}  // namespace CoreML
+
+namespace turi {
+namespace neural_net {
+
+/**
+ * Destructively converts a CoreML specification into a dictionary mapping
+ * layer names and parameters to neural_net::shared_float_array values.
+ *
+ * \param model CoreML specification that includes at least one neural network
+ *              layer. This value is mutated to avoid copies: the returned
+ *              float_array_map takes ownership of desired components.
+ * \return A dictionary whose keys are of the form "$layername_$paramname". The
+ *         layer names are taken from the name field of each NeuralNetworkLayer
+ *         containing a supported layer.  The supported layers are
+ *         ConvolutionLayerParams (with params "weight" (in NCHW order) and
+ *         "bias") and BatchnormLayerParams (with params "gamma", "beta",
+ *         "running_mean", and "running_var").
+ * \throw If a NeuralNetworkLayer in the provided specification seems malformed
+ *        (e.g. WeightParams with size inconsistent with declared layer shape).
+ */
+float_array_map extract_network_params(CoreML::Specification::Model* model);
+
+/**
+ * Convenience function that loads a CoreML specification from disk and
+ * extracts the layer names and parameters found.
+ *
+ * \param mlmodel_path Path to a CoreML proto on disk.
+ * \return A dictionary as returned by `extract_network_params`.
+ * \throw If the indicated path could not be read or parsed.
+ * \see extract_network_params()
+ */
+float_array_map load_network_params(const std::string& mlmodel_path);
+
+}  // neural_net
+}  // turi
+
+#endif  // UNITY_TOOLKITS_NEURAL_NET_COREML_IMPORT_HPP_

--- a/src/unity/toolkits/neural_net/float_array.hpp
+++ b/src/unity/toolkits/neural_net/float_array.hpp
@@ -87,6 +87,23 @@ private:
   std::vector<float> data_;
 };
 
+// A float_array implementation that just wraps a single scalar value.
+class float_scalar: public float_array {
+public:
+  float_scalar() = default;
+
+  float_scalar(float value): value_(value) {}
+
+  const float* data() const override { return &value_; }
+  size_t size() const override { return 1; }
+
+  const size_t* shape() const override { return nullptr; }
+  size_t dim() const override { return 0; }
+
+private:
+  float value_ = 0.f;
+};
+
 // A float_array implementation that maintains a view into another float_array
 // (that is possibly shared with others shared_float_array instances). Instances
 // of this class can be efficiently copied (in constant time and incurring no
@@ -102,6 +119,9 @@ public:
                                  std::vector<size_t> shape) {
     return shared_float_array(
         std::make_shared<float_buffer>(std::move(data), std::move(shape)));
+  }
+  static shared_float_array wrap(float value) {
+    return shared_float_array(std::make_shared<float_scalar>(value));
   }
 
   // Simply wraps an existing float_array shared_ptr.

--- a/src/unity/toolkits/neural_net/mps_cnn_module_factory.mm
+++ b/src/unity/toolkits/neural_net/mps_cnn_module_factory.mm
@@ -17,7 +17,8 @@ std::unique_ptr<cnn_module> create_mps_object_detector(
 
   std::unique_ptr<mps_graph_cnn_module> result(new mps_graph_cnn_module);
 
-  // TODO: Initialize
+  result->init(/* netword_id */ kODGraphNet, n, c_in, h_in, w_in, c_out, h_out,
+               w_out, config, weights);
 
   return result;
 }

--- a/src/unity/toolkits/object_detection/object_detector.cpp
+++ b/src/unity/toolkits/object_detection/object_detector.cpp
@@ -6,7 +6,13 @@
 
 #include <unity/toolkits/object_detection/object_detector.hpp>
 
+#include <logger/logger.hpp>
+#include <unity/toolkits/neural_net/coreml_import.hpp>
+
 using turi::neural_net::cnn_module;
+using turi::neural_net::float_array_map;
+using turi::neural_net::load_network_params;
+using turi::neural_net::shared_float_array;
 
 namespace turi {
 namespace object_detection {
@@ -15,27 +21,90 @@ namespace {
 
 constexpr size_t OBJECT_DETECTOR_VERSION = 1;
 
+// TODO: Batch size should be a user-configurable parameter.
+constexpr int BATCH_SIZE = 32;
+
+// We assume RGB input.
+constexpr int NUM_INPUT_CHANNELS = 3;
+
+// TODO: This should be computed dynamically from the number of class labels and
+// the number of anchor boxes. The current value assumes 15 anchor boxes and
+// 11 outputs per anchor (4 bounding-box coordinates + 1 confidence + 6 labels).
+constexpr int NUM_OUTPUT_CHANNELS = 165;
+
+// Annotated and predicted bounding boxes are defined relative to a
+// GRID_SIZE x GRID_SIZE grid laid over the image.
+constexpr int GRID_SIZE = 13;
+
+// The spatial reduction depends on the input size of the pre-trained model
+// (relative to the grid size).
+// TODO: When we support alternative base models, we will have to generalize.
+constexpr int SPATIAL_REDUCTION = 32;
+
+// These are the fixed values that the Python implementation currently passes
+// into TCMPS.
+// TODO: These should be exposed in a way that facilitates experimentation.
+// TODO: A struct instead of a map would be nice, too.
+float_array_map get_training_config() {
+  float_array_map config;
+  config["gradient_clipping"]        = shared_float_array::wrap(0.2f);
+  config["learning_rate"]            = shared_float_array::wrap(0.000125f);
+  config["mode"]                     = shared_float_array::wrap(0.f);
+  config["od_include_loss"]          = shared_float_array::wrap(1.0f);
+  config["od_include_network"]       = shared_float_array::wrap(1.0f);
+  config["od_max_iou_for_no_object"] = shared_float_array::wrap(0.3f);
+  config["od_min_iou_for_object"]    = shared_float_array::wrap(0.7f);
+  config["od_rescore"]               = shared_float_array::wrap(1.0f);
+  config["od_scale_class"]           = shared_float_array::wrap(16.0f);
+  config["od_scale_no_object"]       = shared_float_array::wrap(40.0f);
+  config["od_scale_object"]          = shared_float_array::wrap(800.0f);
+  config["od_scale_wh"]              = shared_float_array::wrap(80.0f);
+  config["od_scale_xy"]              = shared_float_array::wrap(80.0f);
+  config["use_sgd"]                  = shared_float_array::wrap(1.0f);
+  config["weight_decay"]             = shared_float_array::wrap(0.0005f);
+  return config;
+}
+
 }  // namespace
 
-void object_detector::init_options(const std::map<std::string,
-                                   flexible_type>& options) {
+object_detector::object_detector()
+  : object_detector(&load_network_params, &cnn_module::create_object_detector)
+{}
 
-  // TODO: Parse real factory arguments from `options`.
-  cnn_module_ = cnn_module::create_object_detector(
-      0, 0, 0, 0, 0, 0, 0, neural_net::float_array_map(),
-      neural_net::float_array_map());
-}
+object_detector::object_detector(coreml_importer coreml_importer_fn,
+                                 module_factory module_factory_fn)
+  : coreml_importer_fn_(std::move(coreml_importer_fn)),
+    module_factory_fn_(std::move(module_factory_fn))
+{}
+
+void object_detector::init_options(const std::map<std::string,
+                                   flexible_type>& options) {}
 
 size_t object_detector::get_version() const {
   return OBJECT_DETECTOR_VERSION;
 }
 
-void object_detector::save_impl(oarchive& oarc) const {
-}
+void object_detector::save_impl(oarchive& oarc) const {}
 
-void object_detector::load_version(iarchive& iarc, size_t version) {
-}
+void object_detector::load_version(iarchive& iarc, size_t version) {}
 
+void object_detector::train(gl_sframe data,
+                            std::string annotations_column_name,
+                            std::string image_column_name,
+                            std::map<std::string, flexible_type> options) {
+  auto options_iter = options.find("model_params_path");
+  if (options_iter == options.end()) {
+    log_and_throw("Expected option \"model_params_path\" not found.");
+  }
+  const std::string model_params_path = options_iter->second;
+  float_array_map model_params = coreml_importer_fn_(model_params_path);
+
+  training_module_ = module_factory_fn_(
+      BATCH_SIZE, NUM_INPUT_CHANNELS, /* h_in */ GRID_SIZE * SPATIAL_REDUCTION,
+      /* w_in */ GRID_SIZE * SPATIAL_REDUCTION, NUM_OUTPUT_CHANNELS,
+      /* h_out */ GRID_SIZE, /* w_out */ GRID_SIZE, get_training_config(),
+      std::move(model_params));
+}
 
 }  // object_detection
 }  // turi 

--- a/test/unity/toolkits/CMakeLists.txt
+++ b/test/unity/toolkits/CMakeLists.txt
@@ -6,6 +6,8 @@ add_subdirectory(synthetic_timings)
 add_subdirectory(recsys)
 add_subdirectory(sparse_similarity)
 add_subdirectory(pattern_mining)
+add_subdirectory(neural_net)
+add_subdirectory(object_detection)
 
 make_boost_test(kmeans_test.cxx
   REQUIRES unity_clustering util numerics

--- a/test/unity/toolkits/neural_net/CMakeLists.txt
+++ b/test/unity/toolkits/neural_net/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(unity_test_toolkits)
+
+make_boost_test(test_coreml_import.cxx
+  REQUIRES
+    unity_neural_net
+  COMPILE_FLAGS_EXTRA_GCC
+    -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
+    -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
+)

--- a/test/unity/toolkits/neural_net/test_coreml_import.cxx
+++ b/test/unity/toolkits/neural_net/test_coreml_import.cxx
@@ -1,0 +1,133 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_coreml_import
+
+#include <unity/toolkits/neural_net/coreml_import.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
+#include <util/test_macros.hpp>
+
+using turi::neural_net::extract_network_params;
+using turi::neural_net::float_array_map;
+
+using CoreML::Specification::Model;
+
+BOOST_AUTO_TEST_CASE(test_extract_empty) {
+  Model model;
+  float_array_map params = extract_network_params(&model);
+  TS_ASSERT(params.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_extract_conv_params) {
+  // Build a CoreML spec with just a single conv layer.
+  Model model;
+  auto* conv_layer = model.mutable_neuralnetwork()->add_layers();
+  conv_layer->set_name("conv_test");
+  auto* conv_params = conv_layer->mutable_convolution();
+  conv_params->set_outputchannels(2);  // N
+  conv_params->set_kernelchannels(3);  // C
+  conv_params->add_kernelsize(4);      // H
+  conv_params->add_kernelsize(5);      // W
+  const size_t size = 2*3*4*5;
+  auto* weights = conv_params->mutable_weights();
+  for (size_t i = 0; i < size; ++i) {
+    weights->add_floatvalue(100.f + i);
+  }
+
+  // Extract the parameters from the spec.
+  float_array_map params = extract_network_params(&model);
+
+  // The result should have just one float array.
+  TS_ASSERT_EQUALS(params.size(), 1);
+  auto float_array = params["conv_test_weight"];
+
+  // Shape must be [N, C, H, W], which is [2, 3, 4, 5]
+  TS_ASSERT_EQUALS(float_array.dim(), 4);
+  for (size_t i = 0; i < 4; ++i) {
+    TS_ASSERT_EQUALS(float_array.shape()[i], i + 2);
+  }
+
+  // Verify the data was extracted intact.
+  TS_ASSERT_EQUALS(float_array.size(), size);
+  for (size_t i = 0; i < size; ++i) {
+    TS_ASSERT_EQUALS(float_array.data()[i], 100.f + i);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_extract_conv_params_invalid) {
+  Model model;
+  auto* conv_layer = model.mutable_neuralnetwork()->add_layers();
+  conv_layer->set_name("conv_test");
+  conv_layer->mutable_convolution();
+  // The default ConvolutionLayerParams value is not valid.
+
+  TS_ASSERT_THROWS_ANYTHING(extract_network_params(&model));
+}
+
+BOOST_AUTO_TEST_CASE(test_extract_batchnorm_params) {
+  // Build a CoreML spec with just a single batchnorm layer.
+  Model model;
+  auto* batchnorm_layer = model.mutable_neuralnetwork()->add_layers();
+  batchnorm_layer->set_name("batchnorm_test");
+  auto* batchnorm_params = batchnorm_layer->mutable_batchnorm();
+  batchnorm_params->set_channels(1);
+  batchnorm_params->mutable_gamma()->add_floatvalue(2.0f);
+  batchnorm_params->mutable_beta()->add_floatvalue(3.0f);
+  batchnorm_params->mutable_mean()->add_floatvalue(4.0f);
+  batchnorm_params->mutable_variance()->add_floatvalue(5.0f);
+
+  // Extract the parameters from the spec.
+  float_array_map params = extract_network_params(&model);
+
+  // The result should have four float arrays.
+  TS_ASSERT_EQUALS(params.size(), 4);
+
+  TS_ASSERT_EQUALS(params["batchnorm_test_gamma"].dim(), 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_gamma"].shape()[0], 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_gamma"].data()[0], 2.0f);
+
+  TS_ASSERT_EQUALS(params["batchnorm_test_beta"].dim(), 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_beta"].shape()[0], 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_beta"].data()[0], 3.0f);
+
+  TS_ASSERT_EQUALS(params["batchnorm_test_running_mean"].dim(), 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_running_mean"].shape()[0], 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_running_mean"].data()[0], 4.0f);
+
+  TS_ASSERT_EQUALS(params["batchnorm_test_running_var"].dim(), 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_running_var"].shape()[0], 1);
+  TS_ASSERT_EQUALS(params["batchnorm_test_running_var"].data()[0], 5.0f);
+}
+
+BOOST_AUTO_TEST_CASE(test_extract_pipeline) {
+  // Build a CoreML spec with just a single conv layer, embedded inside a
+  // pipeline model.
+  Model model;
+  auto* conv_layer = model.mutable_pipeline()->add_models()
+      ->mutable_neuralnetwork()->add_layers();
+  conv_layer->set_name("conv_test");
+  auto* conv_params = conv_layer->mutable_convolution();
+  conv_params->set_outputchannels(2);  // N
+  conv_params->set_kernelchannels(3);  // C
+  conv_params->add_kernelsize(4);      // H
+  conv_params->add_kernelsize(5);      // W
+  const size_t size = 2*3*4*5;
+  auto* weights = conv_params->mutable_weights();
+  for (size_t i = 0; i < size; ++i) {
+    weights->add_floatvalue(100.f + i);
+  }
+
+  // Extract the parameters from the spec.
+  float_array_map params = extract_network_params(&model);
+
+  // The result should have just one float array.
+  TS_ASSERT_EQUALS(params.size(), 1);
+  auto float_array = params["conv_test_weight"];
+  TS_ASSERT_EQUALS(float_array.size(), size);
+}
+

--- a/test/unity/toolkits/object_detection/CMakeLists.txt
+++ b/test/unity/toolkits/object_detection/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(unity_test_toolkits)
+
+make_boost_test(test_object_detector.cxx REQUIRES unity_toolkits)

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -1,0 +1,133 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_object_detector
+
+#include <unity/toolkits/object_detection/object_detector.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <util/test_macros.hpp>
+
+namespace turi {
+namespace object_detection {
+
+namespace {
+
+using turi::neural_net::cnn_module;
+using turi::neural_net::deferred_float_array;
+using turi::neural_net::float_array;
+using turi::neural_net::float_array_map;
+using turi::neural_net::shared_float_array;
+
+// Dependencies we can inject into the object_detector class for testing.
+using coreml_importer =
+    std::function<turi::neural_net::float_array_map(const std::string&)>;
+using module_factory =
+    std::function<std::unique_ptr<turi::neural_net::cnn_module>(
+        int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+        const turi::neural_net::float_array_map& config,
+        const turi::neural_net::float_array_map& weights)>;
+
+constexpr float TEST_PARAM_VALUE = 3.14159f;
+
+// Create a float_array_map for the mock coreml_importer to return.
+float_array_map create_test_params() {
+  float_array_map result;
+  result["test_param"] = shared_float_array::wrap(TEST_PARAM_VALUE);
+  return result;
+}
+
+// Create a deferred_float_array for the stub cnn_module to return.
+deferred_float_array wrap_float_array(shared_float_array params) {
+  std::vector<size_t> shape(params.shape(), params.shape() + params.dim());
+
+  std::promise<shared_float_array> promise;
+  promise.set_value(std::move(params));
+  return deferred_float_array(promise.get_future(), std::move(shape));
+}
+
+// A trivial cnn_module implementation for the mock module_factory to return.
+// TODO: Move this somewhere shared.
+// TODO: Adopt a real mocking library.
+class stub_cnn_module: public cnn_module {
+public:
+  void set_learning_rate(float lr) override {}
+  deferred_float_array train(const float_array& input_batch,
+                             const float_array& label_batch) override {
+    return wrap_float_array(shared_float_array());
+  }
+  deferred_float_array predict(const float_array& input_batch) const override {
+    return wrap_float_array(shared_float_array());
+  }
+  float_array_map export_weights() const override {
+    return create_test_params();
+  }
+};
+
+// Test implementation of the object_detector that differs from the production
+// implementation only in that we can inject the dependencies.
+class test_object_detector: public object_detector {
+public:
+  test_object_detector(coreml_importer coreml_importer_fn,
+                       module_factory module_factory_fn)
+    : object_detector(std::move(coreml_importer_fn),
+                      std::move(module_factory_fn))
+  {}
+};
+
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(test_object_detector_train) {
+  const std::string test_path = "/test/foo.mlmodel";
+
+  // Create a mock coreml_importer that just returns some dummy parameters.
+  int num_coreml_importer_calls = 0;
+  coreml_importer coreml_importer_fn = [&](const std::string& path) {
+    ++num_coreml_importer_calls;
+
+    // Verify that we receive the expected model_params_path.
+    TS_ASSERT_EQUALS(test_path, path);
+
+    return create_test_params();
+  };
+
+  // Create a mock module_factory that just returns a stub cnn_module.
+  int num_module_factory_calls = 0;
+  stub_cnn_module* stub_module = new stub_cnn_module;
+  std::unique_ptr<cnn_module> unique_stub_module(stub_module);
+  module_factory module_factory_fn = [&](
+      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+      const float_array_map& config, const float_array_map& weights) {
+    ++num_module_factory_calls;
+
+    // Verify that the weights we received was the output of the mock
+    // coreml_importer above.
+    TS_ASSERT_EQUALS(weights.size(), 1);
+    auto it = weights.find("test_param");
+    TS_ASSERT(it != weights.end());
+    const auto& test_param_value = it->second;
+    TS_ASSERT_EQUALS(test_param_value.size(), 1);
+    TS_ASSERT_EQUALS(test_param_value.data()[0], TEST_PARAM_VALUE);
+
+    TS_ASSERT(unique_stub_module != nullptr);
+    return std::move(unique_stub_module);
+  };
+
+  // Inject the two mocks into a test_object_detector instance.
+  test_object_detector od_instance(coreml_importer_fn, module_factory_fn);
+
+  // Invoke training.
+  // TODO: Use some non-empty training data.
+  od_instance.train(gl_sframe(), std::string(), std::string(),
+                    { { "model_params_path", test_path } });
+
+  // Verify that each mock dependency was invoked once.
+  TS_ASSERT_EQUALS(num_coreml_importer_calls, 1);
+  TS_ASSERT_EQUALS(num_module_factory_calls, 1);
+}
+
+}  // namespace object_detection
+}  // namespace turi


### PR DESCRIPTION
The very first step of the `train` method will be to import the pre-trained (darknet) model parameters from a provided CoreML file. For now, this import is just a mapping from layer names to float_array values.

In addition, the object_detector class is structured in such a way as to facilitate dependency injection for proper unit testing.