### PR TITLE
Refactor vega_spec and data_spec munging into show method

### DIFF
--- a/src/unity/lib/visualization/plot.cpp
+++ b/src/unity/lib/visualization/plot.cpp
@@ -19,7 +19,7 @@ namespace turi{
 
       ::turi::visualization::run_thread([self, path_to_client]() {
         process_wrapper ew(path_to_client);
-        ew << self->m_vega_spec;
+        ew << "{\"vega_spec\": " << self->m_vega_spec << "}\n";
 
         while(ew.good()) {
           vega_data vd;
@@ -29,7 +29,7 @@ namespace turi{
           double num_rows_processed =  static_cast<double>(self->m_transformer->get_rows_processed());
           double percent_complete = num_rows_processed/self->m_size_array;
 
-          ew << vd.get_data_spec(percent_complete);
+          ew << "{\"data_spec\": " << vd.get_data_spec(percent_complete) << "}\n";
 
           if (self->m_transformer->eof()) {
              break;

--- a/src/unity/lib/visualization/vega_data.cpp
+++ b/src/unity/lib/visualization/vega_data.cpp
@@ -12,11 +12,11 @@ namespace turi {
 namespace visualization {
 
 vega_data::vega_data() {
-  m_spec << "{\"data_spec\": {\"name\": \"source_2\", \"values\": [";
+  m_spec << "{\"name\": \"source_2\", \"values\": [";
 }
 
 std::string vega_data::get_data_spec(double progress) {
-  m_spec << "], \"progress\": "+std::to_string(progress)+" }}\n";
+  m_spec << "], \"progress\": "+std::to_string(progress)+" }";
   return m_spec.str();
 }
 

--- a/src/unity/lib/visualization/vega_spec.cpp
+++ b/src/unity/lib/visualization/vega_spec.cpp
@@ -57,11 +57,9 @@ std::string extra_label_escape(const std::string& str){
 }
 
 /*
- * Prepares a raw JSON format string (from one of the *.json files in vega_spec/)
+ * Prepares a raw JSON format string
  * by doing the following:
  * 1. Strips all newlines.
- * 2. Wraps format string inside {"vega_spec": ...}.
- * 3. Adds back a single newline at the end.
  */
 static std::string make_format_string(unsigned char *raw_format_str_ptr,
                                       size_t raw_format_str_len) {
@@ -70,10 +68,7 @@ static std::string make_format_string(unsigned char *raw_format_str_ptr,
     raw_format_str_len);
 
   boost::replace_all(raw_format_str, "\n", "");
-
-  std::stringstream ss;
-  ss << "{\"vega_spec\": " << raw_format_str << "}\n";
-  return ss.str();
+  return raw_format_str;
 }
 
 

--- a/src/unity/python/turicreate/visualization/_plot.py
+++ b/src/unity/python/turicreate/visualization/_plot.py
@@ -239,15 +239,15 @@ class Plot(object):
 
     def _get_vega(self, include_data=True):
         if(include_data):
-            spec = _json.loads(self.__proxy__.call_function('get_spec'))["vega_spec"]
-            data = _json.loads(self.__proxy__.call_function('get_data'))["data_spec"]
+            spec = _json.loads(self.__proxy__.call_function('get_spec'))
+            data = _json.loads(self.__proxy__.call_function('get_data'))
             for x in range(len(spec["data"])):
                 if(spec["data"][x]["name"] == "source_2"):
                     spec["data"][x] = data
                     break
             return spec
         else:
-            return _json.loads(self.__proxy__.call_function('get_spec'))["vega_spec"]
+            return _json.loads(self.__proxy__.call_function('get_spec'))
 
     def _repr_javascript_(self):
         from IPython.core.display import display, HTML


### PR DESCRIPTION
With this change, the C++ plot API matches the Python plot API,
which returns Vega-compatible spec and data JSON objects. Only
in the case of the show method (in either Python or C++) should
we prepend each with "vega_spec" or "data_spec" containers, as
those are specific to the way data is handled in tcviz. Prior
to this change, the outputs from C++ plot API were not
compatible with Vega without removing those containers.