### PR TITLE
Adopt CoreML/MXNet data layout (NCHW) at library interfaces (for object detection)

### DIFF
--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -126,11 +126,9 @@ def ac_weights_mxnet_to_mps(arg_params, aux_params, lstm_h_size):
 def _prepare_network_parameters(arg_dict):
     items = []
     for name, arr in arg_dict.items():
-        if isinstance(arr, _np.ndarray):
-            if not arr.flags.c_contiguous:
-                arr = arr.copy()
-        else:
-            arr = _np.array(arr, dtype=_np.float32)
+        arr = _np.asarray(arr, dtype=_np.float32)
+        if not arr.flags.c_contiguous:
+            arr = arr.copy()
         assert arr.flags.c_contiguous, "Input weights must be row-major"
         items.append((name, arr.astype(_np.float32)))
 
@@ -146,8 +144,7 @@ def _prepare_network_parameters(arg_dict):
 def _prepare_graph_network_parameters(arg_dict):
     items = []
     for name, arr in arg_dict.items():
-        if not isinstance(arr, _np.ndarray):
-            arr = _np.array(arr, dtype=_np.float32)
+        arr = _np.asarray(arr, dtype=_np.float32)
         items.append((name, MpsFloatArray(arr)))
 
     name = (_ctypes.c_char_p * len(items))()

--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -123,13 +123,6 @@ def ac_weights_mxnet_to_mps(arg_params, aux_params, lstm_h_size):
 
     return mps_weights
 
-def mxnet_network_to_mps_params(net_params):
-    mps_net_params = {}
-    for k in net_params:
-        mps_net_params[k] = mxnet_to_mps(net_params[k].data().asnumpy())
-    return mps_net_params
-
-
 def _prepare_network_parameters(arg_dict):
     items = []
     for name, arr in arg_dict.items():
@@ -485,8 +478,8 @@ class MpsGraphAPI(object):
             sz = n * c_out * h_out * w_out
         self._buf_out_fp16 = (_ctypes.c_float * (sz // 2))()
         self._buf_loss = (_ctypes.c_float * n)()
-        self._ishape = (n, c_in, h_in, w_in)
-        self._oshape = (n, c_out, h_out, w_out)
+        self._ishape = (n, h_in, w_in, c_in)
+        self._oshape = (n, h_out, w_out, c_out)
 
     def train(self, input, label):
         """
@@ -577,8 +570,8 @@ class MpsGraphAPI(object):
         self.handle = _ctypes.c_void_p()
         self._LIB.TCMPSCreateGraphModule(_ctypes.byref(self.handle),
                                  _ctypes.c_int(self._mode))
-        n, c_in, h_in, w_in = self._ishape
-        _, c_out, h_out, w_out = self._oshape
+        n, h_in, w_in, c_in = self._ishape
+        _, h_out, w_out, c_out = self._oshape
         self.init(n, c_in, h_in, w_in, c_out, h_out, w_out,
                   config=self._cur_config, weights=weights)
         # Reload state

--- a/src/unity/toolkits/neural_net/CMakeLists.txt
+++ b/src/unity/toolkits/neural_net/CMakeLists.txt
@@ -7,6 +7,9 @@ project(unity_toolkits)
 
 # When building for macOS, build the MetalPerformanceShaders-based backend.
 if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
+    find_library(ACCELERATE NAMES Accelerate)
+    message("Accelerate found at ${ACCELERATE}.")
+
     find_library(METAL NAMES Metal)
     message("Metal found at ${METAL}.")
 
@@ -30,6 +33,7 @@ if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
         mps_weight.mm
         mps_device_manager.m
       REQUIRES
+        ${ACCELERATE}
         ${METAL}
         ${METAL_PERFORMANCE_SHADERS}
     )

--- a/src/unity/toolkits/neural_net/float_array.hpp
+++ b/src/unity/toolkits/neural_net/float_array.hpp
@@ -50,6 +50,11 @@ public:
   external_float_array(const float* data, size_t size, const size_t* shape,
                        size_t dim);
 
+  explicit external_float_array(const float_array& array)
+    : external_float_array(array.data(), array.size(), array.shape(),
+                           array.dim())
+  {}
+
   const float* data() const override { return data_; }
   size_t size() const override { return size_; }
 

--- a/src/unity/toolkits/neural_net/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/neural_net/mps_graph_cnnmodule.mm
@@ -82,13 +82,13 @@ void mps_graph_cnn_module::init(
       break;
     case kGraphModeTrainReturnGrad:
       // Gradient for input layer
-      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(h_in),
-                       static_cast<size_t>(w_in), static_cast<size_t>(c_in)};
+      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(c_in),
+                       static_cast<size_t>(h_in), static_cast<size_t>(w_in)};
       break;
     case kGraphModeInference:
       // Result image from output layer
-      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(h_out),
-                       static_cast<size_t>(w_out), static_cast<size_t>(c_out)};
+      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(c_out),
+                       static_cast<size_t>(h_out), static_cast<size_t>(w_out)};
       break;
     default:
       break;

--- a/src/unity/toolkits/neural_net/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/neural_net/mps_graph_cnnmodule.mm
@@ -82,13 +82,13 @@ void mps_graph_cnn_module::init(
       break;
     case kGraphModeTrainReturnGrad:
       // Gradient for input layer
-      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(c_in),
-                       static_cast<size_t>(h_in), static_cast<size_t>(w_in)};
+      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(h_in),
+                       static_cast<size_t>(w_in), static_cast<size_t>(c_in)};
       break;
     case kGraphModeInference:
       // Result image from output layer
-      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(c_out),
-                       static_cast<size_t>(h_out), static_cast<size_t>(w_out)};
+      result_shape_ = {static_cast<size_t>(n), static_cast<size_t>(h_out),
+                       static_cast<size_t>(w_out), static_cast<size_t>(c_out)};
       break;
     default:
       break;

--- a/src/unity/toolkits/neural_net/mps_graph_layers.mm
+++ b/src/unity/toolkits/neural_net/mps_graph_layers.mm
@@ -1,4 +1,7 @@
 #include "mps_graph_layers.h"
+
+#include <memory>
+
 #include "mps_utils.h"
 
 
@@ -46,12 +49,14 @@ void ConvGraphLayer::Init(id<MTLDevice> _Nonnull device,
 
   std::string weight_key = name + "_weight";
   std::string bias_key = name + "_bias";
-  float *init_w = NULL;
+  std::unique_ptr<float[]> init_w;
   float *init_b = NULL;
   // TODO: force has key
   if (weights.count(weight_key) > 0) {
     LogStdString("Loading " + weight_key);
-    init_w = const_cast<float*>(weights.at(weight_key).data());
+    const shared_float_array& w = weights.at(weight_key);
+    init_w.reset(new float[w.size()]);
+    convert_image_to_mps(w, init_w.get(), init_w.get() + w.size());
   }
   if (weights.count(bias_key) > 0) {
     LogStdString("Loading " + bias_key);
@@ -70,7 +75,7 @@ void ConvGraphLayer::Init(id<MTLDevice> _Nonnull device,
                 kernelParamsBinaryName:name.c_str()
                                 device:device
                              cmd_queue:cmd_queue
-                       init_weight_ptr:init_w
+                       init_weight_ptr:init_w.get()
                          init_bias_ptr:init_b
                       optimizerOptions:get_array_map_optimizer_options(config)];
 
@@ -104,15 +109,25 @@ float_array_map ConvGraphLayer::Export() const {
   size_t k_w = iparams[1];
   size_t c_in = iparams[2];
   size_t c_out = iparams[3];
+  size_t size = k_h * k_w * c_in * c_out;
   [weight load];
+
+  // Transpose the weights from NHWC to NCHW.
   std::string weight_key = name + "_weight";
-  table[weight_key] = shared_float_array::copy(
-      reinterpret_cast<float*>([weight weights]), {c_out, k_h, k_w, c_in});
+  std::vector<float> weights(size);
+  size_t mps_shape[] = { c_out, k_h, k_w, c_in };
+  const float* mps_weights = reinterpret_cast<float*>([weight weights]);
+  convert_image_from_mps(external_float_array(mps_weights, size, mps_shape, 4),
+                         weights.data(), weights.data() + size);
+  table[weight_key] = shared_float_array::wrap(std::move(weights),
+                                               {c_out, c_in, k_h, k_w});
+
   if (use_bias) {
     std::string bias_key = name + "_bias";
     table[bias_key] = shared_float_array::copy(
         reinterpret_cast<float*>([weight biasTerms]), {c_out});
   }
+
   return table;
 }
 
@@ -319,7 +334,14 @@ MPSCNNLossLabelsBatch *YoloLossGraphLayer::CreateLossState(
   input_size.depth = static_cast<NSUInteger>(oshape[3]);
   NSUInteger stride = input_size.height * input_size.width * input_size.depth;
   for (int i = 0; i < batch_size; ++i) {
-    NSData *label_data = [NSData dataWithBytes:data + i * stride length:stride * sizeof(float)];
+    // Convert NCHW labels_array to NHWC data.
+    NSMutableData *label_data = [NSMutableData dataWithLength:stride * sizeof(float)];
+    float* label_data_raw = reinterpret_cast<float*>(label_data.mutableBytes);
+    convert_image_to_mps(external_float_array(data + i * stride, stride,
+                                              labels_array.shape() + 1, 3),
+                         label_data_raw, label_data_raw + stride);
+
+    // Pass the transposed labels to MPS.
     MPSCNNLossDataDescriptor *desc =
         [MPSCNNLossDataDescriptor cnnLossDataDescriptorWithData:label_data
                                                          layout:MPSDataLayoutHeightxWidthxFeatureChannels

--- a/src/unity/toolkits/neural_net/mps_graph_trainer.h
+++ b/src/unity/toolkits/neural_net/mps_graph_trainer.h
@@ -16,10 +16,8 @@ EXPORT int TCMPSDeleteGraphModule(MPSHandle handle);
 
 EXPORT int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
                      int c_out, int h_out, int w_out,
-                     char **config_names, void **config_arrays,
-                     int64_t *config_sizes, int config_len,
-                     char **weight_names, void **weight_arrays,
-                     int64_t *weight_sizes, int weight_len);
+                     char **config_names, void **config_arrays, int config_len,
+                     char **weight_names, void **weight_arrays, int weight_len);
 
 EXPORT int TCMPSSetLearningRateGraph(MPSHandle handle, float new_lr);
 

--- a/src/unity/toolkits/neural_net/mps_graph_trainer.mm
+++ b/src/unity/toolkits/neural_net/mps_graph_trainer.mm
@@ -99,16 +99,14 @@ int TCMPSTrainReturnGradGraph(
 
 int TCMPSInitGraph(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
               int c_out, int h_out, int w_out,
-              char **config_names, void **config_arrays,
-              int64_t *config_sizes, int config_len,
-              char **weight_names, void **weight_arrays,
-              int64_t *weight_sizes, int weight_len) {
+              char **config_names, void **config_arrays, int config_len,
+              char **weight_names, void **weight_arrays, int weight_len) {
   API_BEGIN();
   
   float_array_map config =
-      make_array_map(config_names, config_arrays, config_sizes, config_len);
+      make_array_map(config_names, config_arrays, config_len);
   float_array_map weights =
-      make_array_map(weight_names, weight_arrays, weight_sizes, weight_len);
+      make_array_map(weight_names, weight_arrays, weight_len);
 
   mps_graph_cnn_module *obj = (mps_graph_cnn_module *)handle;
   obj->init(network_id, n, c_in, h_in, w_in, c_out, h_out, w_out,

--- a/src/unity/toolkits/neural_net/mps_utils.h
+++ b/src/unity/toolkits/neural_net/mps_utils.h
@@ -77,10 +77,10 @@ shared_float_array copy_image_batch_float16(std::vector<size_t> shape,
 API_AVAILABLE(macos(10.14))
 void fill_image_batch(const float_array& data, MPSImageBatch * _Nonnull batch);
 
-void convert_image_to_mps(const float_array& image, float* out_first,
-                          float* out_last);
-void convert_image_from_mps(const float_array& image, float* out_first,
-                            float* out_last);
+void convert_chw_to_hwc(const float_array& image, float* out_first,
+                        float* out_last);
+void convert_hwc_to_chw(const float_array& image, float* out_first,
+                        float* out_last);
 
 float_array_map make_array_map(char **names, void **arrays,
                                int64_t *sizes, int len);

--- a/src/unity/toolkits/neural_net/mps_utils.h
+++ b/src/unity/toolkits/neural_net/mps_utils.h
@@ -77,8 +77,17 @@ shared_float_array copy_image_batch_float16(std::vector<size_t> shape,
 API_AVAILABLE(macos(10.14))
 void fill_image_batch(const float_array& data, MPSImageBatch * _Nonnull batch);
 
+void convert_image_to_mps(const float_array& image, float* out_first,
+                          float* out_last);
+void convert_image_from_mps(const float_array& image, float* out_first,
+                            float* out_last);
+
 float_array_map make_array_map(char **names, void **arrays,
                                int64_t *sizes, int len);
+
+// This version assumes that each void* is actually a float_array*. This casting
+// from plain C should go away once we remove the original Python frontend.
+float_array_map make_array_map(char **names, void **arrays, int len);
 
 float get_array_map_scalar(const float_array_map &config,
                            const std::string &key, float default_value);

--- a/src/unity/toolkits/neural_net/mps_utils.mm
+++ b/src/unity/toolkits/neural_net/mps_utils.mm
@@ -11,58 +11,195 @@
 #include <sys/stat.h>
 #include <memory>
 
+#import <Accelerate/Accelerate.h>
+
 namespace turi {
 namespace neural_net {
 
+// Converts from CHW to HWC
+void convert_image_to_mps(const float_array& image, float* out_first,
+                          float* out_last) {
+  assert(image.dim() >= 3);
+  assert(out_last - out_first == image.size());
+
+  if (image.dim() == 3) {
+    // Use Accelerate framework, interpreting each channel as an image plane.
+
+    const unsigned c = static_cast<unsigned>(image.shape()[0]);
+    const vImagePixelCount h = static_cast<vImagePixelCount>(image.shape()[1]);
+    const vImagePixelCount w = static_cast<vImagePixelCount>(image.shape()[2]);
+
+    std::vector<vImage_Buffer> image_planes(c);
+    std::vector<const vImage_Buffer*> image_plane_ptrs(c);
+    std::vector<void*> output_channels(c);
+    for (size_t i = 0; i < c; ++i) {
+      // Wrap the relevant portion of the float_array data as vImage_Buffer.
+      image_planes[i].data = const_cast<float*>(image.data() + i * h * w);
+      image_planes[i].height = h;
+      image_planes[i].width = w;
+      image_planes[i].rowBytes = w * sizeof(float);
+
+      // The Accelerate API wants an array of pointers to vImage_Buffer...
+      image_plane_ptrs[i] = &image_planes[i];
+
+      // Tell the Accelerate API to write the data into [out_first, out_last).
+      // By setting destStrideBytes and destRowBytes below, the planar data will
+      // be interleaved into HWC format.
+      output_channels[i] = out_first + i;
+    }
+    vImage_Error status;
+    status = vImageConvert_PlanarToChunkyF(
+        /* srcPlanarBuffers */ image_plane_ptrs.data(),
+        /* destChannels */     output_channels.data(),
+        /* channelCount */     c,
+        /* destStrideBytes */  c * sizeof(float),
+        /* destWidth */        w,
+        /* destHeight */       h,
+        /* destRowBytes */     c * w * sizeof(float),
+        /* flags */            kvImageNoFlags);
+    assert(status == kvImageNoError);
+  } else {
+    // Recurse on dimensions
+    const size_t* shape = image.shape();
+    size_t n = shape[0];
+    size_t stride = image.size() / n;
+    float* out = out_first;
+    for (size_t i = 0; i < n; ++i) {
+      external_float_array sub_image(image.data() + i * stride,
+                                     stride, shape + 1, image.dim() - 1);
+      convert_image_to_mps(sub_image, out, out + stride);
+      out += stride;
+    }
+    assert(out == out_last);
+  }
+}
+
+// Converts from HWC to CHW
+void convert_image_from_mps(const float_array& image, float* out_first,
+                            float* out_last) {
+  assert(image.dim() >= 3);
+  assert(out_last - out_first == image.size());
+
+  if (image.dim() == 3) {
+    // Use Accelerate framework, writing each channel to its own image plane.
+
+    const vImagePixelCount h = static_cast<vImagePixelCount>(image.shape()[0]);
+    const vImagePixelCount w = static_cast<vImagePixelCount>(image.shape()[1]);
+    const unsigned c = static_cast<unsigned>(image.shape()[2]);
+
+    std::vector<const void*> input_channels(c);
+    std::vector<vImage_Buffer> output_planes(c);
+    std::vector<const vImage_Buffer*> output_plane_ptrs(c);
+    for (size_t i = 0; i < c; ++i) {
+      // Tell the Accelerate API to read each channel from the input image by
+      // striding from the first value for each channel.
+      input_channels[i] = image.data() + i;
+
+      // Wrap the relevant portion of the output array as vImage_Buffer.
+      output_planes[i].data = out_first + i * h * w;
+      output_planes[i].height = h;
+      output_planes[i].width = w;
+      output_planes[i].rowBytes = w * sizeof(float);
+
+      // The Accelerate API wants an array of pointers to vImage_Buffer...
+      output_plane_ptrs[i] = &output_planes[i];
+    }
+    vImage_Error status;
+    status = vImageConvert_ChunkyToPlanarF(
+        /* srcChannels */       input_channels.data(),
+        /* destPlanarBuffers */ output_plane_ptrs.data(),
+        /* channelCount */      c,
+        /* srcStrideBytes */    c * sizeof(float),
+        /* srcWidth */          w,
+        /* srcHeight */         h,
+        /* srcRowBytes */       c * w * sizeof(float),
+        /* flags */             kvImageNoFlags);
+    assert(status == kvImageNoError);
+  } else {
+    // Recurse on dimensions
+    const size_t* shape = image.shape();
+    size_t n = shape[0];
+    size_t stride = image.size() / n;
+    float* out = out_first;
+    for (size_t i = 0; i < n; ++i) {
+      external_float_array sub_image(image.data() + i * stride,
+                                     stride, shape + 1, image.dim() - 1);
+      convert_image_from_mps(sub_image, out, out + stride);
+      out += stride;
+    }
+    assert(out == out_last);
+  }
+}
+
 shared_float_array copy_image_batch_float16(std::vector<size_t> shape,
                                             MPSImageBatch *batch) {
-  assert(shape.size() == 4);  // NHWC
+  assert(shape.size() == 4);  // NCHW
 
   const size_t n = shape[0];  // N
-  const size_t stride = shape[1] * shape[2] * shape[3];  // H * W * C
+  const size_t stride = shape[1] * shape[2] * shape[3];  // C * H * W
   const size_t size = n * stride;
 
-  // Copy from MPS to a local __fp16 buffer.
+  // Perform allocations.
+  std::unique_ptr<__fp16[]> fp16_buffer(new __fp16[stride]);
+  std::unique_ptr<float[]> image_buffer_hwc(new float[stride]);
+  std::vector<float> batch_buffer_chw(size);
+  float* out_chw = batch_buffer_chw.data();
+
   assert(batch.count >= n);
-  std::unique_ptr<__fp16[]> fp16_buffer(new __fp16[size]);
   for (size_t i = 0; i < n; ++i) {
     MPSImage *img = batch[i];
-
-    assert(img.height == shape[1]);
-    assert(img.width == shape[2]);
-    assert(img.featureChannels == shape[3]);
+    assert(img.featureChannels == shape[1]);
+    assert(img.height == shape[2]);
+    assert(img.width == shape[3]);
     assert(img.pixelFormat == MTLPixelFormatRGBA16Float);
 
-    [img readBytes:fp16_buffer.get() + stride * i
+    // Copy from MPS to local __fp16 buffer.
+    [img readBytes:fp16_buffer.get()
         dataLayout:MPSDataLayoutHeightxWidthxFeatureChannels
         imageIndex:0];
+
+    // Convert from __fp16 to float.
+    std::copy(fp16_buffer.get(), fp16_buffer.get() + stride,
+              image_buffer_hwc.get());
+
+    // Transpose from HWC to CHW.
+    size_t mps_shape[] = { static_cast<size_t>(img.height),
+                           static_cast<size_t>(img.width),
+                           static_cast<size_t>(img.featureChannels) };
+    external_float_array image_hwc(
+        image_buffer_hwc.get(), stride, mps_shape, 3);
+    convert_image_from_mps(image_hwc, out_chw, out_chw + stride);
+    out_chw += stride;
   }
 
-  // Convert from __fp16 to float.
-  std::vector<float> float_buffer(fp16_buffer.get(), fp16_buffer.get() + size);
-
-  return shared_float_array::wrap(std::move(float_buffer), std::move(shape)); 
+  return shared_float_array::wrap(std::move(batch_buffer_chw),
+                                  std::move(shape));
 }
 
 void fill_image_batch(const float_array& blob, MPSImageBatch *batch) {
-  assert(blob.dim() == 4);  // NHWC
+  assert(blob.dim() == 4);  // NCHW
 
-  const float* data = blob.data();
+  const float* data_chw = blob.data();
   const size_t* shape = blob.shape();
-  const size_t stride = shape[1] * shape[2] * shape[3];  // H * W * C
+  const size_t stride = shape[1] * shape[2] * shape[3];  // C * H * W
+
+  std::unique_ptr<float[]> data_hwc(new float[stride]);
 
   assert(batch.count <= shape[0]);
   for (MPSImage *img in batch) {
-    assert(img.height == shape[1]);
-    assert(img.width == shape[2]);
-    assert(img.featureChannels == shape[3]);
+    external_float_array sub_blob(data_chw, stride, shape + 1, 3);
+    convert_image_to_mps(sub_blob, data_hwc.get(), data_hwc.get() + stride);
+
+    assert(img.featureChannels == shape[1]);
+    assert(img.height == shape[2]);
+    assert(img.width == shape[3]);
     assert(img.pixelFormat == MTLPixelFormatRGBA32Float);
 
-    [img writeBytes:data
+    [img writeBytes:data_hwc.get()
          dataLayout:MPSDataLayoutHeightxWidthxFeatureChannels
          imageIndex:0];
 
-    data += stride;
+    data_chw += stride;
   }
 }
 
@@ -74,6 +211,21 @@ float_array_map make_array_map(char **names, void **arrays,
     const float* array = reinterpret_cast<const float*>(arrays[i]);
     const size_t size = static_cast<size_t>(sizes[i]);
     ret[name] = shared_float_array::copy(array, {size});
+  }
+  return ret;
+}
+
+// This version assumes that each void* is actually a float_array*. This casting
+// from plain C should go away once we remove the original Python frontend.
+float_array_map make_array_map(char **names, void **arrays, int len) {
+  float_array_map ret;
+  for (int i = 0; i < len; ++i) {
+    std::string name = names[i];
+    const float_array* array = reinterpret_cast<const float_array*>(arrays[i]);
+
+    // Note that we assume that the provided float arrays will outlive the map.
+    ret[name] = shared_float_array(
+        std::make_shared<external_float_array>(*array));
   }
   return ret;
 }


### PR DESCRIPTION
We can push the MXNet-to-MPS-to-MXNet conversions into TCMPS, where this particular transpose can be implemented as a conversion between planar and "chunky" float images. In this way, we can standardize on the CoreML layouts where possible, for consistency, leaving our MPS usage of NHWC as an implementation detail.