### PR TITLE
Disable test_image_classifier.py and test_image_similarity.py in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,9 @@ script:
   # Check whether O_NONBLOCK is set (should print "0"):
   - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print(flags&os.O_NONBLOCK);'
 
-  # Remove object detector and style transfer unit tests
-  - rm src/unity/python/turicreate/test/test_style_transfer.py src/unity/python/turicreate/test/test_object_detector.py
+  # Remove style transfer unit test due to out-of-memory error.
+  # Remove some additional tests temporarily to get under the two-hour timeout.
+  - rm src/unity/python/turicreate/test/test_style_transfer.py src/unity/python/turicreate/test/test_object_detector.py src/unity/python/turicreate/test/test_image_classifier.py src/unity/python/turicreate/test/test_image_similarity.py
 
   # Build the wheel
   - travis_wait 180 bash scripts/make_wheel.sh --build_number=$CI_PIPELINE_ID --num_procs=2 --debug --skip_cpp_test


### PR DESCRIPTION
For more breathing room under the two-hour timeout, pending the upcoming test refactoring