### PR TITLE
image similarity README fix save model syntax highlight

### DIFF
--- a/userguide/image_similarity/README.md
+++ b/userguide/image_similarity/README.md
@@ -123,7 +123,7 @@ similar_images = similarity_graph.edges
 
 Once you have created a model, you can save it and load it back later for use.
 
-```
+```python
 model.save('./myModel.model')
 loaded_model = turicreate.load_model('./myModel.model')
 ```


### PR DESCRIPTION
Fixing a syntax highlight issue in the README of the image similarity when saving the model

Issue https://github.com/apple/turicreate/issues/1172