### PR TITLE
Fix to allow default arguments to extension types to work in python.

### DIFF
--- a/src/unity/python/turicreate/extensions.py
+++ b/src/unity/python/turicreate/extensions.py
@@ -258,8 +258,6 @@ class _ToolkitClass:
         arguments = self._functions[fnname]
         num_args_got = len(args) + len(kwargs)
         num_args_required = len(arguments)
-        if num_args_got != num_args_required:
-            raise TypeError("Expecting " + str(num_args_required) + " arguments, got " + str(num_args_got))
 
         ## fill the dict first with the regular args
         argument_dict = {}


### PR DESCRIPTION
The type and quantity of the extenions arguments is checked rigorously
in the C++ part of the code after the default arguments have been filled
in, so the python check is not needed.  As the python check is not aware
of default arguments, it's better to just let the check happen in the
C++ layer.