### PR TITLE
Implement basic training for the new C++ implementation of object detection

### DIFF
--- a/src/unity/toolkits/neural_net/CMakeLists.txt
+++ b/src/unity/toolkits/neural_net/CMakeLists.txt
@@ -49,8 +49,10 @@ make_library(unity_neural_net
   SOURCES
     cnn_module.cpp
     coreml_import.cpp
+    image_augmentation.cpp
     float_array.cpp
   REQUIRES
+    image_type
     logger
     unity_coreml_model_export
     ${additional_unity_neural_net_requirements}

--- a/src/unity/toolkits/neural_net/CMakeLists.txt
+++ b/src/unity/toolkits/neural_net/CMakeLists.txt
@@ -54,6 +54,7 @@ make_library(unity_neural_net
   REQUIRES
     image_type
     logger
+    unity_core
     unity_coreml_model_export
     ${additional_unity_neural_net_requirements}
   COMPILE_FLAGS_EXTRA_GCC

--- a/src/unity/toolkits/neural_net/float_array.hpp
+++ b/src/unity/toolkits/neural_net/float_array.hpp
@@ -80,6 +80,13 @@ public:
   // with the provided `shape`.
   float_buffer(std::vector<float> data, std::vector<size_t> shape);
 
+  // Copies another float_array.
+  float_buffer(const float_array& other)
+    : float_buffer(other.data(),
+                   std::vector<size_t>(other.shape(),
+                                       other.shape() + other.dim()))
+  {}
+
   const float* data() const override { return data_.data(); }
   size_t size() const override { return size_; }
 
@@ -119,6 +126,9 @@ public:
   static shared_float_array copy(const float* data, std::vector<size_t> shape) {
     return shared_float_array(
         std::make_shared<float_buffer>(data, std::move(shape)));
+  }
+  static shared_float_array copy(const float_array& other) {
+    return shared_float_array(std::make_shared<float_buffer>(other));
   }
   static shared_float_array wrap(std::vector<float> data,
                                  std::vector<size_t> shape) {
@@ -167,6 +177,9 @@ public:
   // (known upfront) `shape`.
   deferred_float_array(std::shared_future<shared_float_array> data_future,
                        std::vector<size_t> shape);
+
+  // Wraps an existing (not deferred) float_array
+  deferred_float_array(shared_float_array params);
 
   // Waits for the data future if necessary.
   const float* data() const override;

--- a/src/unity/toolkits/neural_net/image_augmentation.cpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.cpp
@@ -1,0 +1,88 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <unity/toolkits/neural_net/image_augmentation.hpp>
+
+#include <algorithm>
+
+#include <logger/assertions.hpp>
+#include <unity/lib/image_util.hpp>
+
+namespace turi {
+namespace neural_net {
+
+void image_box::scale(float image_width, float image_height) {
+  x /= image_width;
+  width /= image_width;
+
+  y /= image_height;
+  height /= image_height;
+}
+
+void image_box::clip(image_box clip_box) {
+  float x_max = std::min(x + width, clip_box.x + clip_box.width);
+  x = std::max(x, clip_box.x);
+  width = x_max - x;
+
+  float y_max = std::min(y + height, clip_box.y + clip_box.height);
+  y = std::max(y, clip_box.y);
+  height = y_max - y;
+}
+
+// static
+std::unique_ptr<image_augmenter> image_augmenter::create(const options& opts) {
+  // TODO: Implement proper data augmentation.
+  std::unique_ptr<image_augmenter> result;
+  result.reset(new resize_only_image_augmenter(opts));
+  return result;
+}
+
+image_augmenter::result resize_only_image_augmenter::prepare_images(
+    std::vector<labeled_image> source_batch) {
+
+  const size_t n = source_batch.size();
+  const size_t h = opts_.output_height;
+  const size_t w = opts_.output_width;
+  constexpr size_t c = 3;
+
+  result res;
+  res.annotations_batch.reserve(n);
+
+  // Allocate a float vector large enough to contain the entire image batch.
+  std::vector<float> result_array(n * h * w * c);
+
+  // TODO: Parallelize this computation, which is currently the bottleneck in
+  // training!
+  auto out_it = result_array.begin();
+  for (labeled_image& source : source_batch) {
+    // Resize the input image.
+    image_type resized_image = image_util::resize_image(
+        source.image, w, h, c, /* decode */ true, /* resample_method */ 1);
+    ASSERT_EQ(resized_image.m_image_data_size, h * w * c);
+
+    // Copy the resized image into the output buffer, converting to float
+    // (normalized to 1).
+    const unsigned char* src_ptr = resized_image.get_image_data();
+    auto out_end = out_it + h * w * c;
+    while (out_it != out_end) {
+      *out_it = *src_ptr / 255.f;
+      ++src_ptr;
+      ++out_it;
+    }
+
+    // Just move the annotations from the input to the output. Since the
+    // annotations are all in normalized (relative) coordinates, no modification
+    // is required.
+    res.annotations_batch.push_back(std::move(source.annotations));
+  }
+
+  res.image_batch = shared_float_array::wrap(std::move(result_array),
+                                             { n, h, w, c});
+  return res;
+}
+
+}  // neural_net
+}  // turi

--- a/src/unity/toolkits/neural_net/image_augmentation.cpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.cpp
@@ -14,7 +14,7 @@
 namespace turi {
 namespace neural_net {
 
-void image_box::scale(float image_width, float image_height) {
+void image_box::normalize(float image_width, float image_height) {
   x /= image_width;
   width /= image_width;
 
@@ -30,6 +30,23 @@ void image_box::clip(image_box clip_box) {
   float y_max = std::min(y + height, clip_box.y + clip_box.height);
   y = std::max(y, clip_box.y);
   height = y_max - y;
+}
+
+bool operator==(const image_box& a, const image_box& b) {
+  return a.x == b.x && a.y == b.y && a.width == b.width && a.height == b.height;
+}
+
+std::ostream& operator<<(std::ostream& out, const image_box& box) {
+  return out << "(x=" << box.x
+             << ",y=" << box.y
+             << ",w=" << box.width
+             << ",h=" << box.height
+             << ")";
+}
+
+bool operator==(const image_annotation& a, const image_annotation& b) {
+  return a.identifier == b.identifier && a.bounding_box == b.bounding_box &&
+    a.confidence == b.confidence;
 }
 
 // static

--- a/src/unity/toolkits/neural_net/image_augmentation.hpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.hpp
@@ -8,6 +8,7 @@
 #define TURI_NEURAL_NET_IMAGE_AUGMENTATION_HPP_
 
 #include <memory>
+#include <ostream>
 #include <vector>
 
 #include <image/image_type.hpp>
@@ -19,10 +20,8 @@ namespace neural_net {
 /**
  * Represents a rectangular area within an image.
  *
- * The (x,y) coordinates specify the upper-left corner of the box, with the
- * origin (0,0) at the upper-left corner of the image. All coordinates should be
- * normalized to the image size, so each value should line in the closed
- * interval [0,1].
+ * The coordinate system is defined by the user. Any rect without a positive
+ * width and a positive height is an empty or null rect.
  */
 struct image_box {
   image_box() = default;
@@ -36,8 +35,8 @@ struct image_box {
     return width * height;
   }
 
-  // Normalizes this instance to the provided image dimensions.
-  void scale(float image_width, float image_height);
+  // Divides each coordinate and length by the appropriate normalizer.
+  void normalize(float image_width, float image_height);
 
   // Sets this instance to the intersection with the given image_box. If no
   // intersection exists, then the result will have area() of 0.f (and may have
@@ -50,6 +49,9 @@ struct image_box {
   float height = 0.f;
 };
 
+bool operator==(const image_box& a, const image_box& b);
+std::ostream& operator<<(std::ostream& out, const image_box& box);
+
 /**
  * Represents a labelled or predicted entity inside an image.
  */
@@ -58,6 +60,8 @@ struct image_annotation {
   image_box bounding_box;
   float confidence = 0.f;  // Typically 1 for training data
 };
+
+bool operator==(const image_annotation& a, const image_annotation& b);
 
 /**
  * Contains one image and its associated annotations.

--- a/src/unity/toolkits/neural_net/image_augmentation.hpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.hpp
@@ -1,0 +1,133 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef TURI_NEURAL_NET_IMAGE_AUGMENTATION_HPP_
+#define TURI_NEURAL_NET_IMAGE_AUGMENTATION_HPP_
+
+#include <memory>
+#include <vector>
+
+#include <image/image_type.hpp>
+#include <unity/toolkits/neural_net/float_array.hpp>
+
+namespace turi {
+namespace neural_net {
+
+/**
+ * Represents a rectangular area within an image.
+ *
+ * The (x,y) coordinates specify the upper-left corner of the box, with the
+ * origin (0,0) at the upper-left corner of the image. All coordinates should be
+ * normalized to the image size, so each value should line in the closed
+ * interval [0,1].
+ */
+struct image_box {
+  image_box() = default;
+  image_box(float x, float y, float width, float height)
+    : x(x), y(y), width(width), height(height)
+  {}
+
+  // Computes the area if the width and height are positive, otherwise returns 0
+  float area() const {
+    if (width < 0.f || height < 0.f) return 0.f;
+    return width * height;
+  }
+
+  // Normalizes this instance to the provided image dimensions.
+  void scale(float image_width, float image_height);
+
+  // Sets this instance to the intersection with the given image_box. If no
+  // intersection exists, then the result will have area() of 0.f (and may have
+  // negative width or height).
+  void clip(image_box clip_box = image_box(0.f, 0.f, 1.f, 1.f));
+
+  float x = 0.f;
+  float y = 0.f;
+  float width = 0.f;
+  float height = 0.f;
+};
+
+/**
+ * Represents a labelled or predicted entity inside an image.
+ */
+struct image_annotation {
+  int identifier = 0;
+  image_box bounding_box;
+  float confidence = 0.f;  // Typically 1 for training data
+};
+
+/**
+ * Contains one image and its associated annotations.
+ */
+struct labeled_image {
+  image_type image;
+  std::vector<image_annotation> annotations;
+};
+
+/**
+ * Pure virtual interface for objects that process/augment/mutate images and
+ * their associated annotations.
+ */
+class image_augmenter {
+public:
+  /** Parameters for constructing new image_augmenter instances. */
+  struct options {
+    /** The W dimension of the resulting float array. */
+    size_t output_width = 0;
+
+    /** The H dimension of the resulting float array. */
+    size_t output_height = 0;
+  };
+
+  /** The output of an image_augmenter. */
+  struct result {
+    /** The augmented images, represented as a single NHWC array (RGB). */
+    shared_float_array image_batch;
+
+    /**
+     * The transformed annotations for each augmented image. This vector's size
+     * should equal the size of the N dimension in the image_batch above, and
+     * each inner vector should have the same length as the corresponding input
+     * image's annotations vector. */
+    std::vector<std::vector<image_annotation>> annotations_batch;
+  };
+
+  /**
+   * Constructs an image_augmenter. The implementation may depend on platform
+   * and hardware resources. */
+  static std::unique_ptr<image_augmenter> create(const options& opts);
+
+  virtual ~image_augmenter() = default;
+
+  /** Returns the options parameterizing this instance. */
+  virtual const options& get_options() const = 0;
+
+  /**
+   * Performs augmentation on a batch of images (and their annotations).
+   */
+  virtual result prepare_images(std::vector<labeled_image> source_batch) = 0;
+};
+
+/**
+ * An image_augmenter implementation that only resizes the input images to the
+ * desired output shape.
+ */
+class resize_only_image_augmenter final: public image_augmenter {
+public:
+  resize_only_image_augmenter(const options& opts): opts_(opts) {}
+
+  const options& get_options() const override { return opts_; }
+
+  result prepare_images(std::vector<labeled_image> source_batch) override;
+
+private:
+  options opts_;
+};
+
+}  // neural_net
+}  // turi
+
+#endif  // TURI_NEURAL_NET_IMAGE_AUGMENTATION_HPP_

--- a/src/unity/toolkits/object_detection/CMakeLists.txt
+++ b/src/unity/toolkits/object_detection/CMakeLists.txt
@@ -2,9 +2,12 @@ project(unity_toolkits)
 
 make_library(unity_object_detection
 SOURCES
-    object_detector.cpp
     class_registrations.cpp
+    object_detector.cpp
+    od_data_iterator.cpp
 REQUIRES
+    image_io
+    table_printer
     unity_core
     unity_neural_net
 )

--- a/src/unity/toolkits/object_detection/object_detector.cpp
+++ b/src/unity/toolkits/object_detection/object_detector.cpp
@@ -6,11 +6,24 @@
 
 #include <unity/toolkits/object_detection/object_detector.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <limits>
+#include <numeric>
+
+#include <logger/assertions.hpp>
 #include <logger/logger.hpp>
 #include <unity/toolkits/neural_net/coreml_import.hpp>
 
 using turi::neural_net::cnn_module;
+using turi::neural_net::deferred_float_array;
 using turi::neural_net::float_array_map;
+using turi::neural_net::image_annotation;
+using turi::neural_net::image_augmenter;
+using turi::neural_net::labeled_image;
 using turi::neural_net::load_network_params;
 using turi::neural_net::shared_float_array;
 
@@ -21,25 +34,32 @@ namespace {
 
 constexpr size_t OBJECT_DETECTOR_VERSION = 1;
 
-// TODO: Batch size should be a user-configurable parameter.
-constexpr int BATCH_SIZE = 32;
+constexpr int DEFAULT_BATCH_SIZE = 32;
 
 // We assume RGB input.
 constexpr int NUM_INPUT_CHANNELS = 3;
-
-// TODO: This should be computed dynamically from the number of class labels and
-// the number of anchor boxes. The current value assumes 15 anchor boxes and
-// 11 outputs per anchor (4 bounding-box coordinates + 1 confidence + 6 labels).
-constexpr int NUM_OUTPUT_CHANNELS = 165;
 
 // Annotated and predicted bounding boxes are defined relative to a
 // GRID_SIZE x GRID_SIZE grid laid over the image.
 constexpr int GRID_SIZE = 13;
 
+// Each bounding box is evaluated relative to a list of pre-defined sizes.
+constexpr int NUM_ANCHOR_BOXES = 15;
+
 // The spatial reduction depends on the input size of the pre-trained model
 // (relative to the grid size).
 // TODO: When we support alternative base models, we will have to generalize.
 constexpr int SPATIAL_REDUCTION = 32;
+
+// For the MPS implementation of the darknet-yolo model, the loss must be scaled
+// up to avoid underflow in the fp16 gradient images. The learning rate is
+// correspondingly divided by the same multiple to make training mathematically
+// equivalent. The update is done in fp32, which is why this trick works. The
+// loss presented to the user is presented in the original scale.
+// TODO: Only apply this for MPS, once this code also supports MXNet.
+constexpr float MPS_LOSS_MULTIPLIER = 8;
+
+constexpr float BASE_LEARNING_RATE = 0.001f / MPS_LOSS_MULTIPLIER;
 
 // These are the fixed values that the Python implementation currently passes
 // into TCMPS.
@@ -47,38 +67,112 @@ constexpr int SPATIAL_REDUCTION = 32;
 // TODO: A struct instead of a map would be nice, too.
 float_array_map get_training_config() {
   float_array_map config;
-  config["gradient_clipping"]        = shared_float_array::wrap(0.2f);
-  config["learning_rate"]            = shared_float_array::wrap(0.000125f);
+  config["gradient_clipping"]        =
+      shared_float_array::wrap(0.025f * MPS_LOSS_MULTIPLIER);
+  config["learning_rate"]            =
+      shared_float_array::wrap(BASE_LEARNING_RATE);
   config["mode"]                     = shared_float_array::wrap(0.f);
   config["od_include_loss"]          = shared_float_array::wrap(1.0f);
   config["od_include_network"]       = shared_float_array::wrap(1.0f);
   config["od_max_iou_for_no_object"] = shared_float_array::wrap(0.3f);
   config["od_min_iou_for_object"]    = shared_float_array::wrap(0.7f);
   config["od_rescore"]               = shared_float_array::wrap(1.0f);
-  config["od_scale_class"]           = shared_float_array::wrap(16.0f);
-  config["od_scale_no_object"]       = shared_float_array::wrap(40.0f);
-  config["od_scale_object"]          = shared_float_array::wrap(800.0f);
-  config["od_scale_wh"]              = shared_float_array::wrap(80.0f);
-  config["od_scale_xy"]              = shared_float_array::wrap(80.0f);
+  config["od_scale_class"]           =
+      shared_float_array::wrap(2.0f * MPS_LOSS_MULTIPLIER);
+  config["od_scale_no_object"]       =
+      shared_float_array::wrap(5.0f * MPS_LOSS_MULTIPLIER);
+  config["od_scale_object"]          =
+      shared_float_array::wrap(100.0f * MPS_LOSS_MULTIPLIER);
+  config["od_scale_wh"]              =
+      shared_float_array::wrap(10.0f * MPS_LOSS_MULTIPLIER);
+  config["od_scale_xy"]              =
+      shared_float_array::wrap(10.0f * MPS_LOSS_MULTIPLIER);
   config["use_sgd"]                  = shared_float_array::wrap(1.0f);
   config["weight_decay"]             = shared_float_array::wrap(0.0005f);
   return config;
 }
 
+flex_int estimate_max_iterations(flex_int num_instances, flex_int batch_size) {
+
+  // Scale with square root of number of labeled instances.
+  float num_images = 5000.f * std::sqrt(static_cast<float>(num_instances));
+
+  // Normalize by batch size.
+  float num_iter_raw = num_images / batch_size;
+
+  // Round to the nearest multiple of 1000.
+  float num_iter_rounded = 1000.f * std::round(num_iter_raw / 1000.f);
+
+  // Always return a positive number.
+  return std::max(1000, static_cast<int>(num_iter_rounded));
+}
+
 }  // namespace
 
 object_detector::object_detector()
-  : object_detector(&load_network_params, &cnn_module::create_object_detector)
+  : object_detector([this](const std::string& path) {
+                      return this->init_model_params(path);
+                    },
+                    &image_augmenter::create,
+                    &cnn_module::create_object_detector)
 {}
 
 object_detector::object_detector(coreml_importer coreml_importer_fn,
+                                 augmenter_factory augmenter_factory_fn,
                                  module_factory module_factory_fn)
   : coreml_importer_fn_(std::move(coreml_importer_fn)),
+    augmenter_factory_fn_(std::move(augmenter_factory_fn)),
     module_factory_fn_(std::move(module_factory_fn))
 {}
 
-void object_detector::init_options(const std::map<std::string,
-                                   flexible_type>& options) {}
+void object_detector::init_options(
+    const std::map<std::string, flexible_type>& opts) {
+
+  // The default values for some options request automatic configuration from
+  // the training data.
+  ASSERT_TRUE(training_data_iterator_ != nullptr);
+
+  // Define options.
+  options.create_integer_option(
+      "batch_size",
+      "The number of images to process for each training iteration",
+      FLEX_UNDEFINED,
+      1,
+      std::numeric_limits<int>::max());
+  options.create_integer_option(
+      "max_iterations",
+      "Maximum number of iterations to perform during training",
+      FLEX_UNDEFINED,
+      1,
+      std::numeric_limits<int>::max());
+
+  // Validate user-provided options.
+  options.set_options(opts);
+
+  // Configure the batch size automatically if not set.
+  if (options.value("batch_size") == FLEX_UNDEFINED) {
+    // TODO: Reduce batch size when training on GPU with less than 4GB RAM.
+    flex_int batch_size = DEFAULT_BATCH_SIZE;
+
+    logprogress_stream << "Setting 'batch_size' to " << batch_size;
+
+    options.set_option("batch_size", batch_size);
+  }
+
+  // Configure targeted number of iterations automatically if not set.
+  if (options.value("max_iterations") == FLEX_UNDEFINED) {
+    flex_int max_iterations = estimate_max_iterations(
+        static_cast<flex_int>(training_data_iterator_->num_instances()),
+        options.value("batch_size"));
+
+    logprogress_stream << "Setting 'max_iterations' to " << max_iterations;
+
+    options.set_option("max_iterations", max_iterations);
+  }
+
+  // Write model fields.
+  add_or_update_state(flexmap_to_varmap(options.current_option_values()));
+}
 
 size_t object_detector::get_version() const {
   return OBJECT_DETECTOR_VERSION;
@@ -92,20 +186,307 @@ void object_detector::train(gl_sframe data,
                             std::string annotations_column_name,
                             std::string image_column_name,
                             std::map<std::string, flexible_type> options) {
-  auto options_iter = options.find("model_params_path");
-  if (options_iter == options.end()) {
-    log_and_throw("Expected option \"model_params_path\" not found.");
-  }
-  const std::string model_params_path = options_iter->second;
-  float_array_map model_params = coreml_importer_fn_(model_params_path);
 
+  // Begin printing progress.
+  // TODO: Make progress printing optional.
+  training_table_printer_.reset(new table_printer(
+      {{ "Iteration", 12}, {"Loss", 12}, {"Elapsed Time", 12}}));
+  training_table_printer_->print_header();
+
+  // Instantiate the training dependencies: data iterator, image augmenter,
+  // backend NN module.
+  init_train(std::move(data), std::move(annotations_column_name),
+             std::move(image_column_name), std::move(options));
+
+  // Perform all the iterations at once.
+  while (get_training_iterations() < get_max_iterations()) {
+    perform_training_iteration();
+  }
+
+  // Wait for any outstanding batches to finish.
+  wait_for_training_batches();
+
+  // Finish printing progress.
+  training_table_printer_->print_footer();
+  training_table_printer_.reset();
+}
+
+void object_detector::init_train(gl_sframe data,
+                                 std::string annotations_column_name,
+                                 std::string image_column_name,
+                                 std::map<std::string, flexible_type> opts) {
+
+  // Bind the data to a data iterator.
+  training_data_iterator_.reset(new data_iterator(
+      data, annotations_column_name, image_column_name));
+
+  // Instantiate the data augmenter.
+  image_augmenter::options aug_opts;
+  aug_opts.output_width = GRID_SIZE * SPATIAL_REDUCTION;
+  aug_opts.output_height = GRID_SIZE * SPATIAL_REDUCTION;
+  training_data_augmenter_ = augmenter_factory_fn_(aug_opts);
+
+  // Load the pre-trained model from the provided path.
+  auto mlmodel_path_iter = opts.find("mlmodel_path");
+  if (mlmodel_path_iter == opts.end()) {
+    log_and_throw("Expected option \"mlmodel_path\" not found.");
+  }
+  const std::string mlmodel_path = mlmodel_path_iter->second;
+  float_array_map model_params = coreml_importer_fn_(mlmodel_path);
+
+  // Remove 'mlmodel_path' to avoid storing it as a model field.
+  opts.erase(mlmodel_path_iter);
+
+  // Validate options, and infer values for unspecified options. Note that this
+  // depends on training data statistics in the general case.
+  init_options(opts);
+
+  // Set additional model fields.
+  const std::vector<std::string>& classes =
+      training_data_iterator_->class_labels();
+  std::array<flex_int, 3> input_image_shape =  // Using CoreML CHW format.
+      {3, GRID_SIZE * SPATIAL_REDUCTION, GRID_SIZE * SPATIAL_REDUCTION};
+  add_or_update_state({
+      { "annotations", annotations_column_name },
+      { "classes", flex_list(classes.begin(), classes.end()) },
+      { "feature", image_column_name },
+      { "input_image_shape", flex_list(input_image_shape.begin(),
+                                       input_image_shape.end()) },
+      { "model", "darknet-yolo" },
+      { "num_bounding_boxes", training_data_iterator_->num_instances() },
+      { "num_classes", training_data_iterator_->class_labels().size() },
+      { "num_examples", data.size() },
+      { "training_epochs", 0 },
+      { "training_iterations", 0 },
+  });
+  // TODO: The original Python implementation also exposed "anchors",
+  // "non_maximum_suppression_threshold", and "training_time".
+
+  // Instantiate the NN backend.
+  int num_outputs_per_anchor =  // 4 bbox coords + 1 conf + one-hot class labels
+      5 + static_cast<int>(training_data_iterator_->class_labels().size());
+  int num_output_channels = num_outputs_per_anchor * NUM_ANCHOR_BOXES;
   training_module_ = module_factory_fn_(
-      BATCH_SIZE, NUM_INPUT_CHANNELS, /* h_in */ GRID_SIZE * SPATIAL_REDUCTION,
-      /* w_in */ GRID_SIZE * SPATIAL_REDUCTION, NUM_OUTPUT_CHANNELS,
-      /* h_out */ GRID_SIZE, /* w_out */ GRID_SIZE, get_training_config(),
+      /* n */     options.value("batch_size"),
+      /* c_in */  NUM_INPUT_CHANNELS,
+      /* h_in */  GRID_SIZE * SPATIAL_REDUCTION,
+      /* w_in */  GRID_SIZE * SPATIAL_REDUCTION,
+      /* c_out */ num_output_channels,
+      /* h_out */ GRID_SIZE,
+      /* w_out */ GRID_SIZE,
+      get_training_config(),
       std::move(model_params));
+}
+
+void object_detector::perform_training_iteration() {
+  // Training must have been initialized.
+  ASSERT_TRUE(training_data_iterator_ != nullptr);
+  ASSERT_TRUE(training_data_augmenter_ != nullptr);
+  ASSERT_TRUE(training_module_ != nullptr);
+
+  // We want to have no more than two pending batches at a time (double
+  // buffering). We're about to add a new one, so wait until we only have one.
+  wait_for_training_batches(1);
+
+  // Update iteration count and check learning rate schedule.
+  // TODO: Abstract out the learning rate schedule.
+  flex_int iteration_idx = get_training_iterations();
+  flex_int max_iterations = get_max_iterations();
+  if (iteration_idx == max_iterations / 2) {
+
+    training_module_->set_learning_rate(BASE_LEARNING_RATE / 10.f);
+
+  } else if (iteration_idx == max_iterations * 3 / 4) {
+
+    training_module_->set_learning_rate(BASE_LEARNING_RATE / 100.f);
+
+  } else if (iteration_idx == max_iterations) {
+
+    // Handle any manually triggered iterations after the last planned one.
+    training_module_->set_learning_rate(BASE_LEARNING_RATE / 1000.f);
+  }
+
+  // Update the model fields tracking how much training we've done.
+  flex_int batch_size =
+      variant_get_value<flex_int>(get_value_from_state("batch_size"));
+  flex_int num_examples =
+      variant_get_value<flex_int>(get_value_from_state("num_examples"));
+  add_or_update_state({
+      { "training_iterations", iteration_idx + 1 },
+      { "training_epochs", (iteration_idx + 1) * batch_size / num_examples },
+  });
+
+  // Fetch the next batch of raw images and annotations.
+  std::vector<labeled_image> image_batch =
+      training_data_iterator_->next_batch(static_cast<size_t>(batch_size));
+
+  // Perform data augmentation.
+  image_augmenter::result augmenter_result =
+      training_data_augmenter_->prepare_images(std::move(image_batch));
+
+  // Encode the labels.
+  shared_float_array label_batch =
+      prepare_label_batch(augmenter_result.annotations_batch);
+
+  // Submit the batch to the neural net module.
+  deferred_float_array loss_batch = training_module_->train(
+      augmenter_result.image_batch, label_batch);
+
+  // Save the result, which is a future that can synchronize with the
+  // completion of this batch.
+  pending_training_batches_.emplace(iteration_idx, std::move(loss_batch));
+}
+
+float_array_map object_detector::init_model_params(
+    const std::string& pretrained_mlmodel_path) const {
+
+  // All of this presumes that the pre-trained model is the darknet model from
+  // our first object detector implementation....
+
+  // TODO: Make this more generalizable.
+  // TODO: Extract some of the pieces here into utility code.
+
+  static constexpr size_t BUFFER_SIZE = 32;
+  char name[BUFFER_SIZE];
+
+  // Start with parameters from the pre-trained model.
+  float_array_map model_params = load_network_params(pretrained_mlmodel_path);
+
+  // Fill out the parameters for the batch-norm layers.
+  std::array<size_t, 8> batchnorm_sizes =
+      {16, 32, 64, 128, 256, 512, 1024, 1024};
+  for (unsigned i = 0; i < batchnorm_sizes.size(); ++i) {
+    size_t size = batchnorm_sizes[i];
+
+    // The last layer does not come from the pre-trained model and must be
+    // initialized from scratch.
+    if (i == 7) {
+      std::snprintf(name, BUFFER_SIZE, "batchnorm%u_beta", i);
+      model_params[name] =
+          shared_float_array::wrap(std::vector<float>(size, 0.f), {size});
+
+      std::snprintf(name, BUFFER_SIZE, "batchnorm%u_gamma", i);
+      model_params[name] =
+          shared_float_array::wrap(std::vector<float>(size, 1.f), {size});
+    }
+
+    std::snprintf(name, BUFFER_SIZE, "batchnorm%u_running_mean", i);
+    model_params[name] =
+        shared_float_array::wrap(std::vector<float>(size, 0.f), {size});
+
+    std::snprintf(name, BUFFER_SIZE, "batchnorm%u_running_var", i);
+    model_params[name] =
+        shared_float_array::wrap(std::vector<float>(size, 1.f), {size});
+  }
+
+  // Initialize conv7 using the Xavier method (with base magnitude 3).
+  // The conv7 weights have shape [1024, 1024, 3, 3], so fan in and fan out are
+  // both 1024*3*3.
+  static constexpr size_t CONV7_FAN_IN = 1024 * 3 * 3;
+  float conv7_magnitude = std::sqrt(3.f / CONV7_FAN_IN);
+  std::vector<float> conv7_weights(1024*1024*3*3);
+  for (float& w : conv7_weights) {
+    w = random::fast_uniform(-conv7_magnitude, conv7_magnitude);
+  }
+  std::snprintf(name, BUFFER_SIZE, "conv%u_weight", 7);
+  model_params[name] = shared_float_array::wrap(std::move(conv7_weights),
+                                                { 1024, 1024, 3, 3});
+
+  // Initialize conv8.
+
+  static constexpr float CONV8_MAGNITUDE = 0.00005f;
+  size_t num_classes = training_data_iterator_->class_labels().size();
+  size_t num_predictions = 5 + num_classes;  // Per anchor box
+  size_t c_out = NUM_ANCHOR_BOXES * num_predictions;
+  std::vector<float> conv8_weights(c_out*1024*1*1);
+  for (float& w : conv8_weights) {
+    w = random::fast_uniform(-CONV8_MAGNITUDE, CONV8_MAGNITUDE);
+  }
+  std::snprintf(name, BUFFER_SIZE, "conv%u_weight", 8);
+  model_params[name] = shared_float_array::wrap(std::move(conv8_weights),
+                                                { c_out, 1024, 1, 1});
+
+  // Initialize object confidence low, preventing an unnecessary adjustment
+  // period toward conservative estimates
+  std::vector<float> conv8_bias(c_out);  // Zero-initialized.
+  for (size_t i = 0; i < NUM_ANCHOR_BOXES; ++i) {
+    conv8_bias[i * num_predictions + 4] = -6.f;
+  }
+  std::snprintf(name, BUFFER_SIZE, "conv%u_bias", 8);
+  model_params[name] = shared_float_array::wrap(std::move(conv8_bias),
+                                                { c_out });
+
+  return model_params;
+}
+
+shared_float_array object_detector::prepare_label_batch(
+    std::vector<std::vector<image_annotation>> annotations_batch) const {
+
+  // Allocate a float buffer of sufficient size.
+  size_t num_classes = training_data_iterator_->class_labels().size();
+  size_t num_channels = NUM_ANCHOR_BOXES * (5 + num_classes);  // C
+  size_t batch_stride = GRID_SIZE * GRID_SIZE * num_channels;  // H * W * C
+  std::vector<float> result(annotations_batch.size() * batch_stride);  // NHWC
+
+  // Write the structured annotations into the float buffer.
+  float* result_out = result.data();
+  for (const std::vector<image_annotation>& annotations : annotations_batch) {
+
+    data_iterator::convert_annotations_to_yolo(
+        annotations, GRID_SIZE, GRID_SIZE, NUM_ANCHOR_BOXES, num_classes,
+        result_out);
+
+    result_out += batch_stride;
+  }
+
+  // Wrap the resulting buffer and return it.
+  return shared_float_array::wrap(
+      std::move(result),
+      { annotations_batch.size(), GRID_SIZE, GRID_SIZE, num_channels });
+}
+
+flex_int object_detector::get_max_iterations() const {
+  return variant_get_value<flex_int>(state.at("max_iterations"));
+}
+
+flex_int object_detector::get_training_iterations() const {
+  return variant_get_value<flex_int>(state.at("training_iterations"));
+}
+
+void object_detector::wait_for_training_batches(size_t max_pending) {
+
+  while (pending_training_batches_.size() > max_pending) {
+
+    // Pop the first pending batch from the queue.
+    auto batch_it = pending_training_batches_.begin();
+    size_t iteration_idx = batch_it->first;
+    deferred_float_array loss_batch = std::move(batch_it->second);
+    pending_training_batches_.erase(batch_it);
+
+    // Compute the loss for this batch.
+    float batch_loss = std::accumulate(
+        loss_batch.data(), loss_batch.data() + loss_batch.size(), 0.f,
+        [](float a, float b) { return a + b; });
+    batch_loss /= MPS_LOSS_MULTIPLIER;
+
+    // Update our rolling average (smoothed) loss.
+    auto loss_it = state.find("training_loss");
+    if (loss_it == state.end()) {
+      loss_it = state.emplace("training_loss", variant_type(batch_loss)).first;
+    } else {
+      float smoothed_loss = variant_get_value<flex_float>(loss_it->second);
+      smoothed_loss = 0.9f * smoothed_loss + 0.1f * batch_loss;
+      loss_it->second = smoothed_loss;
+    }
+
+    // Report progress if we have an active table printer.
+    if (training_table_printer_) {
+      flex_float loss = variant_get_value<flex_float>(loss_it->second);
+      training_table_printer_->print_progress_row(
+          iteration_idx, iteration_idx + 1, loss, progress_time());
+    }
+  }
 }
 
 }  // object_detection
 }  // turi 
-

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -8,11 +8,15 @@
 #define TURI_OBJECT_DETECTION_OBJECT_DETECTOR_H_
 
 #include <functional>
+#include <map>
 #include <memory>
 
+#include <table_printer/table_printer.hpp>
 #include <unity/lib/extensions/ml_model.hpp>
 #include <unity/lib/gl_sframe.hpp>
 #include <unity/toolkits/neural_net/cnn_module.hpp>
+#include <unity/toolkits/neural_net/image_augmentation.hpp>
+#include <unity/toolkits/object_detection/od_data_iterator.hpp>
 
 namespace turi {
 namespace object_detection {
@@ -40,6 +44,8 @@ class EXPORT object_detector: public ml_model_base {
   BEGIN_CLASS_MEMBER_REGISTRATION("object_detector")
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::list_fields);
+  REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
+      "get_value", object_detector::get_value_from_state, "field");
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::train, "data",
                                  "annotations_column_name",
@@ -49,8 +55,14 @@ class EXPORT object_detector: public ml_model_base {
       "\n"
       "Options\n"
       "-------\n"
-      "model_params_path : string\n"
+      "mlmodel_path : string\n"
       "    Path to the CoreML specification with the pre-trained model parameters.\n"
+      "batch_size: int\n"
+      "    The number of images per training iteration. If 0, then it will be\n"
+      "    automatically determined based on resource availability.\n"
+      "max_iterations : int\n"
+      "    The number of training iterations. If 0, then it will be automatically\n"
+      "    be determined based on the amount of data you provide.\n"
   );
   // TODO: Addition training options: batch_size, max_iterations, etc.
 
@@ -62,20 +74,51 @@ class EXPORT object_detector: public ml_model_base {
   // Support for dependency injection, for testing purposes.
   using coreml_importer =
       std::function<neural_net::float_array_map(const std::string&)>;
+  using augmenter_factory =
+      std::function<std::unique_ptr<neural_net::image_augmenter>(
+          const neural_net::image_augmenter::options&)>;
   using module_factory =
       std::function<std::unique_ptr<neural_net::cnn_module>(
           int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
           const neural_net::float_array_map& config,
           const neural_net::float_array_map& weights)>;
+
   object_detector(coreml_importer coreml_importer_fn,
+                  augmenter_factory augmenter_factory_fn,
                   module_factory module_factory_fn);
 
+  // Support for iterative training.
+  // TODO: Expose via forthcoming C-API checkpointing mechanism?
+  void init_train(gl_sframe data, std::string annotations_column_name,
+                  std::string image_column_name,
+                  std::map<std::string, flexible_type> options);
+  void perform_training_iteration();
+
  private:
+  neural_net::float_array_map init_model_params(
+      const std::string& pretrained_mlmodel_path) const;
+  neural_net::shared_float_array prepare_label_batch(
+      std::vector<std::vector<neural_net::image_annotation>> annotations_batch)
+      const;
+  flex_int get_max_iterations() const;
+  flex_int get_training_iterations() const;
+
+  // Waits until the number of pending patches is at most `max_pending`.
+  void wait_for_training_batches(size_t max_pending = 0);
+
   // Injected dependencies
   coreml_importer coreml_importer_fn_;
+  augmenter_factory augmenter_factory_fn_;
   module_factory module_factory_fn_;
 
+  std::unique_ptr<data_iterator> training_data_iterator_;
+  std::unique_ptr<neural_net::image_augmenter> training_data_augmenter_;
   std::unique_ptr<neural_net::cnn_module> training_module_;
+
+  std::unique_ptr<table_printer> training_table_printer_;
+
+  // Map from iteration index to the loss future.
+  std::map<size_t, neural_net::deferred_float_array> pending_training_batches_;
 };
 
 }  // object_detection

--- a/src/unity/toolkits/object_detection/od_data_iterator.cpp
+++ b/src/unity/toolkits/object_detection/od_data_iterator.cpp
@@ -1,0 +1,277 @@
+#include <unity/toolkits/object_detection/od_data_iterator.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+#include <image/io.hpp>
+
+namespace turi {
+namespace object_detection {
+
+namespace {
+
+using neural_net::image_annotation;
+using neural_net::image_box;
+using neural_net::labeled_image;
+using neural_net::shared_float_array;
+
+flex_image get_image(const flexible_type& image_feature) {
+  if (image_feature.get_type() == flex_type_enum::STRING) {
+    return read_image(image_feature, /* format_hint */ "");
+  } else {
+    return image_feature;
+  }
+}
+
+std::vector<image_annotation> parse_annotations(
+    const flex_list& flex_annotations,
+    size_t image_width, size_t image_height,
+    const std::unordered_map<std::string, int>& class_to_index_map) {
+
+  std::vector<image_annotation> result;
+  result.reserve(flex_annotations.size());
+
+  for (const flexible_type& flex_annotation : flex_annotations) {
+    image_annotation annotation;
+
+    // Scan through the flexible_type representation, populating each field.
+    bool has_label = false;
+    bool has_x = false;
+    bool has_y = false;
+    for (const auto& kv : flex_annotation.get<flex_dict>()) {
+
+      const flex_string& key = kv.first.get<flex_string>();
+
+      if (key == "label") {
+
+        annotation.identifier =
+            class_to_index_map.at(kv.second.get<flex_string>());
+        has_label = true;
+
+      } else if (key == "coordinates") {
+
+        // Scan through the nested "coordinates" keys, populating the bounding
+        // box.
+        const flex_dict& coordinates = kv.second.get<flex_dict>();
+        for (const auto& coord_kv : coordinates) {
+
+          const flex_string& coord_key = coord_kv.first.get<flex_string>();
+          float coord_val = coord_kv.second;
+
+          if (coord_key == "x") {
+
+            annotation.bounding_box.x = coord_val;
+            has_x = true;
+
+          } else if (coord_key == "y") {
+
+            annotation.bounding_box.y = coord_val;
+            has_y = true;
+
+          } if (coord_key == "width") {
+
+            annotation.bounding_box.width = coord_val;
+
+          } if (coord_key == "height") {
+
+            annotation.bounding_box.height = coord_val;
+          }
+        }
+      }
+    }
+
+    // Verify that all the fields were populated.
+    // TODO: Validate the dictionary keys in compute_properties. Let downstream
+    // code worry about semantics such as non-empty boxes. Then the number of
+    // instances we report will actually equal the number of image_annotation
+    // values.
+    if (has_label && has_x && has_y && annotation.bounding_box.area() > 0.f) {
+
+      // Use x and y fields to store upper-left corner, not center.
+      annotation.bounding_box.x -= annotation.bounding_box.width / 2.f;
+      annotation.bounding_box.y -= annotation.bounding_box.height / 2.f;
+
+      // Translate to normalized coordinates.
+      annotation.bounding_box.scale(image_width, image_height);
+
+      // Add this annotation if we still have a valid bounding box.
+      if (annotation.bounding_box.area() > 0.f) {
+
+        annotation.confidence = 1.0f;
+        result.push_back(std::move(annotation));
+      }
+    }
+  }
+
+  return result;
+}
+
+}  // namespace
+
+// static
+void data_iterator::convert_annotations_to_yolo(
+    const std::vector<image_annotation>& annotations, size_t output_height,
+    size_t output_width, size_t num_anchors, size_t num_classes, float* out) {
+
+  // Number of floats to represent bbox (4), confidence (1), and a one-hot
+  // encoding of the class (num_classes).
+  size_t label_size = 5 + num_classes;
+
+  // Initialize the output buffer. We can iterate by "label", which is
+  // conceptually the lowest-order dimension of the (H,W,num_anchors,label_size)
+  // array.
+  // TODO: Add a mutable float_array interface so we can validate size.
+  float* out_end =
+      out + output_height * output_width * num_anchors * label_size;
+  for (float* ptr = out; ptr < out_end; ptr += label_size) {
+
+    // Initialize the bounding boxes and confidences to 0.
+    std::fill(ptr, ptr + 5, 0.f);
+
+    // Initialize the class probabilities for each output-grid cell and anchor
+    // box to 1/num_classes.
+    std::fill(ptr + 5, ptr + label_size, 1.0f / num_classes);
+  }
+
+  // Iterate through all the annotations for one image.
+  for (const image_annotation& annotation : annotations) {
+
+    // Scale the bounding box to the output grid, converting to the YOLO
+    // representation, defining each box by its center.
+    const image_box& bbox = annotation.bounding_box;
+    float center_x = output_width * (bbox.x + (bbox.width / 2.f));
+    float center_y = output_height * (bbox.y + (bbox.height / 2.f));
+    float width = output_width * bbox.width;
+    float height = output_height * bbox.height;
+
+    // Skip bounding boxes with trivial area, to guard against issues in
+    // augmentation.
+    if (width * height < 0.001f) continue;
+
+    // Write the label into the output grid cell containing the bounding box
+    // center.
+    float icenter_x = std::floor(center_x);
+    float icenter_y = std::floor(center_y);
+    if (0.f <= icenter_x && icenter_x < output_width &&
+        0.f <= icenter_y && icenter_y < output_height) {
+
+      size_t output_grid_stride = num_anchors * label_size;
+      size_t output_grid_offset = static_cast<size_t>(icenter_x) +
+          static_cast<size_t>(icenter_y) * output_width;
+
+      // Write the label once for each anchor box.
+      float* anchor_out = out + output_grid_offset * output_grid_stride;
+      for (size_t anchor_idx = 0; anchor_idx < num_anchors; ++anchor_idx) {
+
+        // Write YOLO-formatted bounding box. YOLO uses (x, y)/(w, h) order.
+        anchor_out[0] = center_x - icenter_x;
+        anchor_out[1] = center_y - icenter_y;
+        anchor_out[2] = width;
+        anchor_out[3] = height;
+
+        // Set confidence to 1.
+        anchor_out[4] = 1.f;
+
+        // One-hot encoding of the class label.
+        std::fill(anchor_out + 5, anchor_out + label_size, 0.f);
+        anchor_out[5 + annotation.identifier] = 1.f;
+
+        // Advance the output iterator to the next anchor.
+        anchor_out += label_size;
+      }
+    }
+  }
+}
+
+data_iterator::annotation_properties data_iterator::compute_properties(
+    const gl_sarray& annotations) {
+
+  annotation_properties result;
+
+  // Construct an SFrame with one row per bounding box.
+  gl_sframe instances;
+  if (annotations.dtype() == flex_type_enum::LIST) {
+    gl_sframe unstacked_instances({{"annotations", annotations}});
+    instances = unstacked_instances.stack("annotations", "bbox",
+                                          /* drop_na */ true);
+  } else {
+    instances["bbox"] = annotations;
+  }
+
+  // Extract the label for each bounding box.
+  instances = instances.unpack("bbox", /* column_name_prefix */ "",
+                               { flex_type_enum::STRING },
+                               /* na_value */ FLEX_UNDEFINED, { "label" });
+
+  // Determine the list of unique class labels and construct the class-to-index
+  // map.
+  gl_sarray classes = instances["label"].unique().sort();
+  result.classes.reserve(classes.size());
+  int i = 0;
+  for (const flexible_type& label : classes.range_iterator()) {
+    result.classes.push_back(label);
+    result.class_to_index_map[label] = i++;
+  }
+
+  // Record the number of labeled bounding boxes.
+  result.num_instances = instances.size();
+
+  return result;
+}
+
+data_iterator::data_iterator(const gl_sframe& data,
+                             const std::string& annotations_column_name,
+                             const std::string& image_column_name)
+
+    // Reduce SFrame to the two columns we care about.
+  : data_(data[{annotations_column_name, image_column_name}]),
+
+    // Determine which column is which within each (ordered) row.
+    annotations_index_(data_.column_index(annotations_column_name)),
+    image_index_(data_.column_index(image_column_name)),
+
+    // Identify the class labels and other annotation properties.
+    annotation_properties_(compute_properties(data_[annotations_column_name])),
+
+    // Start an iteration through the entire SFrame.
+    range_iterator_(data_.range_iterator()),
+    next_row_(range_iterator_.begin())
+{}
+
+std::vector<labeled_image> data_iterator::next_batch(size_t batch_size) {
+
+  // For now, only return empty if we literally have no data at all.
+  if (data_.empty()) return {};
+
+  std::vector<std::pair<flexible_type, flexible_type>> raw_batch;
+  raw_batch.reserve(batch_size);
+  while (raw_batch.size() < batch_size) {
+
+    const sframe_rows::row& row = *next_row_;
+    raw_batch.emplace_back(row[image_index_], row[annotations_index_]);
+
+    if (++next_row_ == range_iterator_.end()) {
+
+      // TODO: Shuffle if desired.
+      range_iterator_ = data_.range_iterator();
+      next_row_ = range_iterator_.begin();
+    }
+  }
+
+  std::vector<labeled_image> result(batch_size);
+  for (size_t i = 0; i < batch_size; ++i) {
+
+    // Reads the undecoded image data from disk, if necessary.
+    // TODO: Investigate parallelizing this file I/O.
+    result[i].image = get_image(raw_batch[i].first);
+
+    result[i].annotations = parse_annotations(
+        raw_batch[i].second, result[i].image.m_width, result[i].image.m_height,
+        annotation_properties_.class_to_index_map);
+  }
+
+  return result;
+}
+
+}  // object_detection
+}  // turi

--- a/src/unity/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/unity/toolkits/object_detection/od_data_iterator.hpp
@@ -1,0 +1,113 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef TURI_OBJECT_DETECTION_OD_DATA_ITERATOR_HPP_
+#define TURI_OBJECT_DETECTION_OD_DATA_ITERATOR_HPP_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <unity/lib/gl_sframe.hpp>
+#include <unity/toolkits/neural_net/float_array.hpp>
+#include <unity/toolkits/neural_net/image_augmentation.hpp>
+
+namespace turi {
+namespace object_detection {
+
+/**
+ * Helper class for producing batches of data (pre-augmentation) from a raw
+ * SFrame.
+ */
+class data_iterator {
+public:
+  /**
+   * Writes a list of image_annotation values into an output float buffer.
+   *
+   * \param annotations The list of annotations (for one image) to write
+   * \param output_height The height of the YOLO output grid
+   * \param output_width The width of the YOLO output grid
+   * \param num_anchors The number of YOLO anchors
+   * \param num_classes The number of classes in the output one-hot encoding
+   * \param out Address to a float buffer of size output_height * output_width *
+   *            num_anchors * (5 + num_classes)
+   * \todo Add a mutable_float_array or shared_float_buffer type for functions
+   *       like this one to write into.
+   */
+  static void convert_annotations_to_yolo(
+      const std::vector<neural_net::image_annotation>& annotations,
+      size_t output_height, size_t output_width, size_t num_anchors,
+      size_t num_classes, float* out);
+
+  /**
+   * Constructs a data_iterator wrapping a given SFrame.
+   *
+   * \param data The SFrame to wrap.
+   * \param annotations_column_name The name of the column containing the
+   *            annotations. The values must either be dictionaries containing
+   *            an annotation, or a list of such dictionaries. An annotation
+   *            dictionary has a "label" key whose value is a string, and a
+   *            "coordinates" key whose value is another dictionary containing
+   *            "x", "y", "width", and "height", describing the position of the
+   *            center and the size of the bounding box (in the image's
+   *            coordinates, with the origin at the top left).
+   * \param image_column_name The name of the column containing the images. Each
+   *            value is either an image or a path to an image file on disk.
+   *
+   * \todo Add a parameter to enable shuffling after each epoch.
+   */
+  data_iterator(const gl_sframe& data,
+                const std::string& annotations_column_name,
+                const std::string& image_column_name);
+
+  // Not copyable or movable.
+  data_iterator(const data_iterator&) = delete;
+  data_iterator& operator=(const data_iterator&) = delete;
+
+  /**
+   * Returns a vector whose size is equal to `batch_size`. Note that the
+   * iterator will cycle indefinitely through the SFrame over and over.
+   */
+  std::vector<neural_net::labeled_image> next_batch(size_t batch_size);
+
+  /**
+   * Returns a sorted list of the unique "label" values found in the
+   * annotations.
+   */
+  const std::vector<std::string>& class_labels() const {
+    return annotation_properties_.classes;
+  }
+
+  /**
+   * Returns the number of annotations (bounding boxes) found across all rows.
+   */
+  size_t num_instances() const {
+    return annotation_properties_.num_instances;
+  }
+
+private:
+  struct annotation_properties {
+    std::vector<std::string> classes;
+    std::unordered_map<std::string, int> class_to_index_map;
+    size_t num_instances;
+  };
+
+  annotation_properties compute_properties(const gl_sarray& annotations);
+
+  const gl_sframe data_;
+  const size_t annotations_index_;
+  const size_t image_index_;
+
+  const annotation_properties annotation_properties_;
+
+  gl_sframe_range range_iterator_;
+  gl_sframe_range::iterator next_row_;
+};
+
+}  // object_detection
+}  // turi
+
+#endif  // TURI_OBJECT_DETECTION_OD_DATA_ITERATOR_HPP_

--- a/test/unity/toolkits/neural_net/CMakeLists.txt
+++ b/test/unity/toolkits/neural_net/CMakeLists.txt
@@ -7,3 +7,5 @@ make_boost_test(test_coreml_import.cxx
     -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
     -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
 )
+
+make_boost_test(test_image_augmentation.cxx REQUIRES unity_neural_net)

--- a/test/unity/toolkits/neural_net/test_image_augmentation.cxx
+++ b/test/unity/toolkits/neural_net/test_image_augmentation.cxx
@@ -1,0 +1,146 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_image_augmentation
+
+#include <unity/toolkits/neural_net/image_augmentation.hpp>
+
+#include <algorithm>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <image/image_type.hpp>
+#include <util/test_macros.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+BOOST_AUTO_TEST_CASE(test_image_box_constructor) {
+  // Default boxes are zero-initialized.
+  image_box box;
+  TS_ASSERT_EQUALS(box.x, 0.f);
+  TS_ASSERT_EQUALS(box.y, 0.f);
+  TS_ASSERT_EQUALS(box.width, 0.f);
+  TS_ASSERT_EQUALS(box.height, 0.f);
+
+  // The constructor takes arguments in x,y,width,height order.
+  box = image_box(1.f, 2.f, 3.f, 4.f);  
+  TS_ASSERT_EQUALS(box.x, 1.f);
+  TS_ASSERT_EQUALS(box.y, 2.f);
+  TS_ASSERT_EQUALS(box.width, 3.f);
+  TS_ASSERT_EQUALS(box.height, 4.f);
+}
+
+BOOST_AUTO_TEST_CASE(test_image_box_area) {
+  // Typical case
+  image_box box(0.f, 0.f, 0.4f, 0.5f);
+  TS_ASSERT_EQUALS(box.area(), 0.2f);
+
+  // Any negative width or height yields zero area.
+  box = image_box(1.f, 1.f, -0.5f, 0.5f);
+  TS_ASSERT_EQUALS(box.area(), 0.f);
+  box = image_box(1.f, 1.f, 0.5f, -0.5f);
+  TS_ASSERT_EQUALS(box.area(), 0.f);
+}
+
+BOOST_AUTO_TEST_CASE(test_image_box_normalize) {
+  // Typical case
+  image_box box(10.f, 20.f, 30.f, 40.f);
+  box.normalize(100.f, 50.f);
+  TS_ASSERT_EQUALS(box, image_box(0.1f, 0.4f, 0.3f, 0.8f));
+}
+
+BOOST_AUTO_TEST_CASE(test_image_box_clip) {
+  image_box box;
+
+  // Clipping to a larger box is a no-op.
+  box = image_box(10.f, 20.f, 30.f, 40.f);
+  box.clip(image_box(0.f, 0.f, 100.f, 100.f));
+  TS_ASSERT_EQUALS(box, image_box(10.f, 20.f, 30.f, 40.f));
+
+  // Clipping to a strictly contained box results in the contained box.
+  box = image_box(10.f, 20.f, 30.f, 40.f);
+  box.clip(image_box(15.f, 25.f, 10.f, 10.f));
+  TS_ASSERT_EQUALS(box, image_box(15.f, 25.f, 10.f, 10.f));
+
+  // Clipping to an overlapping box returns the intersection.
+  box = image_box(10.f, 20.f, 30.f, 40.f);
+  box.clip(image_box(20.f, 0.f, 10.f, 80.f));
+  TS_ASSERT_EQUALS(box, image_box(20.f, 20.f, 10.f, 40.f));
+
+  // Clipping to a non-overlapping box return an empty box.
+  // Clipping to a strictly contained box results in the contained box.
+  box = image_box(10.f, 20.f, 30.f, 40.f);
+  box.clip(image_box(70.f, 70.f, 100.f, 100.f));
+  TS_ASSERT_EQUALS(box.area(), 0.f);
+}
+
+image_type create_black_image(size_t width, size_t height) {
+  std::vector<char> buffer(height*width*3, 0);
+  return image_type(buffer.data(), height, width, 3, buffer.size(),
+                    IMAGE_TYPE_CURRENT_VERSION,
+                    static_cast<int>(Format::RAW_ARRAY));
+}
+
+BOOST_AUTO_TEST_CASE(test_resize_only_image_augmenter) {
+
+  // Create some arbitrary-size images.
+  std::vector<labeled_image> source_batch(4);
+  source_batch[0].image = create_black_image(100, 200);
+  source_batch[1].image = create_black_image(200, 100);
+  source_batch[2].image = create_black_image(400, 400);
+  source_batch[3].image = create_black_image(100, 500);
+
+  // Add some arbitrary annotations.
+  source_batch[0].annotations.resize(1);
+  source_batch[0].annotations[0].identifier = 1;
+  source_batch[0].annotations[0].bounding_box =
+      image_box(10.f, 10.f, 20.f, 20.f);
+  source_batch[2].annotations.resize(2);
+  source_batch[2].annotations[0].identifier = 2;
+  source_batch[2].annotations[0].bounding_box =
+      image_box(20.f, 20.f, 20.f, 20.f);
+  source_batch[2].annotations[1].identifier = 3;
+  source_batch[2].annotations[1].bounding_box =
+      image_box(30.f, 30.f, 20.f, 20.f);
+
+  // Configure an augmenter to resize to 400x300.
+  image_augmenter::options options;
+  options.output_width = 400;
+  options.output_height = 300;
+
+  // Create the augmenter.
+  resize_only_image_augmenter augmenter(options);
+  TS_ASSERT_EQUALS(augmenter.get_options().output_width, options.output_width);
+  TS_ASSERT_EQUALS(augmenter.get_options().output_height,
+                   options.output_height);
+
+  // Invoke the augmenter.
+  image_augmenter::result result = augmenter.prepare_images(source_batch);
+
+  // Validate the shape of the float array.
+  TS_ASSERT_EQUALS(result.image_batch.dim(), 4);
+  TS_ASSERT_EQUALS(result.image_batch.shape()[0], 4);    // N
+  TS_ASSERT_EQUALS(result.image_batch.shape()[1], 300);  // H
+  TS_ASSERT_EQUALS(result.image_batch.shape()[2], 400);  // W
+  TS_ASSERT_EQUALS(result.image_batch.shape()[3], 3);    // C
+
+  // Validate that each image is still black
+  const float* data = result.image_batch.data();
+  size_t size = result.image_batch.size();
+  auto is_zero = [](float x) { return x == 0.f; };
+  TS_ASSERT(std::all_of(data, data + size, is_zero));
+
+  // Validate that the annotations were copied.
+  for (int i = 0; i < 4; ++i) {
+    TS_ASSERT_EQUALS(source_batch[i].annotations, result.annotations_batch[i]);
+  }
+}
+
+}  // namespace
+}  // neural_net
+}  // turi

--- a/test/unity/toolkits/object_detection/CMakeLists.txt
+++ b/test/unity/toolkits/object_detection/CMakeLists.txt
@@ -1,3 +1,5 @@
 project(unity_test_toolkits)
 
 make_boost_test(test_object_detector.cxx REQUIRES unity_toolkits)
+
+make_boost_test(test_od_data_iterator.cxx REQUIRES unity_toolkits)

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -1,0 +1,120 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_od_data_iterator
+
+#include <unity/toolkits/object_detection/od_data_iterator.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <util/test_macros.hpp>
+
+namespace turi {
+namespace object_detection {
+namespace {
+
+using neural_net::image_box;
+using neural_net::labeled_image;
+
+constexpr size_t IMAGE_HEIGHT = 64;
+constexpr size_t IMAGE_WIDTH = 128;
+
+// Returns an SFrame with columns "test_image" and "test_annotations".
+data_iterator::parameters create_data(size_t num_rows) {
+
+  data_iterator::parameters result;
+
+  flex_list images(num_rows);
+  flex_list annotations(num_rows);
+
+  std::vector<unsigned char> buffer(IMAGE_HEIGHT * IMAGE_WIDTH * 3);
+  for (size_t i = 0; i < num_rows; ++i) {
+
+    // Each pixel has R, G, and B value qual to the row index (modulo 256).
+    std::fill(buffer.begin(), buffer.end(),
+              static_cast<unsigned char>(i % 256));
+    images[i] = flex_image(reinterpret_cast<char*>(buffer.data()), IMAGE_HEIGHT,
+                           IMAGE_WIDTH, 3, buffer.size(),
+                           IMAGE_TYPE_CURRENT_VERSION,
+                           static_cast<int>(Format::RAW_ARRAY));
+
+    // Each image has one annotation, with the label "foo" and a bounding box
+    // with height and width 16. As the row index increases, the box moves to
+    // the right until eventually resetting to the left and moving down.
+    annotations[i] = flex_list();
+    annotations[i].push_back(flex_dict({
+          {"label", "foo"},
+          {"coordinates", flex_dict({ {"x", 8 + i % 112},
+                                      {"y", 8 + i / 112},
+                                      {"width", 16},
+                                      {"height", 16}      })},
+        }));
+  }
+
+  result.annotations_column_name = "test_annotations";
+  result.image_column_name = "test_image";
+  result.data =  gl_sframe({
+      {"test_image", gl_sarray(images)},
+      {"test_annotations", gl_sarray(annotations)},
+  });
+
+  return result;
+}
+
+// TODO: Directly test data_iterator::convert_annotations_to_yolo, checking for
+// corner cases.
+
+BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
+
+  static constexpr size_t NUM_ROWS = 4;
+  static constexpr size_t BATCH_SIZE = 4;
+
+  data_iterator::parameters params = create_data(NUM_ROWS);
+
+  std::vector<std::string> class_labels = { "foo" };
+
+  simple_data_iterator data_source(params);
+  TS_ASSERT_EQUALS(data_source.class_labels(), class_labels);
+  TS_ASSERT_EQUALS(data_source.num_instances(), 4);
+
+  auto assert_batch = [](const std::vector<labeled_image>& batch,
+                         size_t row_offset) {
+    for (size_t i = 0; i < batch.size(); ++i) {
+
+      const labeled_image& example = batch[i];
+      size_t row = (row_offset + i) % NUM_ROWS;
+
+      TS_ASSERT_EQUALS(example.image.m_height, IMAGE_HEIGHT);
+      TS_ASSERT_EQUALS(example.image.m_width, IMAGE_WIDTH);
+      TS_ASSERT_EQUALS(example.image.m_channels, 3);
+
+      TS_ASSERT_EQUALS(static_cast<size_t>(*example.image.get_image_data()),
+                       row % 256);
+
+      TS_ASSERT_EQUALS(example.annotations.size(), 1);
+      TS_ASSERT_EQUALS(example.annotations[0].identifier, 0);
+      TS_ASSERT_EQUALS(example.annotations[0].confidence, 1.f);
+      TS_ASSERT_EQUALS(example.annotations[0].bounding_box,
+                       image_box(static_cast<float>(row % 112) / IMAGE_WIDTH,
+                                 static_cast<float>(row / 112) / IMAGE_HEIGHT,
+                                 16.f / IMAGE_WIDTH,
+                                 16.f / IMAGE_HEIGHT));
+    }
+  };
+
+  size_t row_offset = 0;
+  std::vector<labeled_image> batch = data_source.next_batch(BATCH_SIZE);
+  TS_ASSERT_EQUALS(batch.size(), BATCH_SIZE);
+  assert_batch(batch, row_offset);
+
+  row_offset += BATCH_SIZE;
+  batch = data_source.next_batch(BATCH_SIZE);
+  TS_ASSERT_EQUALS(batch.size(), BATCH_SIZE);
+  assert_batch(batch, 0);
+}
+
+}  // namespace
+}  // namespace object_detection
+}  // namespace turi


### PR DESCRIPTION
With these changes, I can now train a model on the data from our "breakfast" demo:
```
import turicreate as tc

data = tc.SFrame('breakfast-data.sframe')
m = tc.extensions.object_detector()
m.train(data, 'annotation', 'image', {'mlmodel_path':'/Users/jong/Desktop/od-init.mlmodel', 'max_iterations' : 1000})
```

I get output like:
```
+--------------+--------------+--------------+
| Iteration    | Loss         | Elapsed Time |
+--------------+--------------+--------------+
| 1            | 7.98467      | 10.86s       |
| 2            | 7.9668       | 14.37s       |
| 3            | 7.96799      | 17.87s       |
...
| 999          | 0.560803     | 1h 1m        |
| 1000         | 0.630218     | 1h 1m        |
+--------------+--------------+--------------+
```

I can't actually export the model yet or run prediction, but it's clearly learning something, right? Well, there's no data augmentation, so it's probably overfitting. And all the image resizing is happening on a single thread (the same one feeding MPS), so it's slow.