### PR TITLE
Allow visualization server to build without client

### DIFF
--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -34,7 +34,6 @@
 #include <sframe_query_engine/operators/operator_properties.hpp>
 #include <exceptions/error_types.hpp>
 
-#if(TC_BUILD_VISUALIZATION_CLIENT)
 #include <unity/lib/visualization/plot.hpp>
 #include <unity/lib/visualization/process_wrapper.hpp>
 #include <unity/lib/visualization/histogram.hpp>
@@ -46,7 +45,6 @@
 #include <unity/lib/visualization/summary_view.hpp>
 #include <unity/lib/visualization/vega_data.hpp>
 #include <unity/lib/visualization/vega_spec.hpp>
-#endif
 
 #include <unity/lib/image_util.hpp>
 #include <unity/lib/unity_sketch.hpp>
@@ -1617,7 +1615,6 @@ std::string unity_sframe::generate_next_column_name() {
 }
 
 void unity_sframe::show(const std::string& path_to_client) {
-#if(TC_BUILD_VISUALIZATION_CLIENT)
   using namespace turi;
   using namespace turi::visualization;
 
@@ -1626,26 +1623,18 @@ void unity_sframe::show(const std::string& path_to_client) {
   if(plt != nullptr){
     plt->show(path_to_client);
   }
-#else
-  std_log_and_throw(std::runtime_error, "Turi Create compiled with visualizations disabled.");
-#endif
 }
 
 std::shared_ptr<model_base> unity_sframe::plot(){
-#if(TC_BUILD_VISUALIZATION_CLIENT)
   using namespace turi;
   using namespace turi::visualization;
 
   std::shared_ptr<unity_sframe_base> self = this->select_columns(this->column_names());
 
   return plot_columnwise_summary(self);
-#else
-  std_log_and_throw(std::runtime_error, "Turi Create compiled with visualizations disabled.");
-#endif
 }
 
 void unity_sframe::explore(const std::string& path_to_client, const std::string& title) {
-#if(TC_BUILD_VISUALIZATION_CLIENT)
   using namespace turi;
   using namespace turi::visualization;
 
@@ -2018,10 +2007,6 @@ void unity_sframe::explore(const std::string& path_to_client, const std::string&
       }
     }
   });
-#else
-  std_log_and_throw(std::runtime_error, "Turi Create compiled with visualizations disabled.");
-#endif
-
 }
 
 } // namespace turi

--- a/src/unity/server/registration.cpp
+++ b/src/unity/server/registration.cpp
@@ -15,9 +15,7 @@
 
 #include <unity/lib/extensions/ml_model.hpp>
 
-#if(TC_BUILD_VISUALIZATION_CLIENT)
 #include <unity/lib/visualization/show.hpp>
-#endif 
 
 #include <unity/toolkits/activity_classification/class_registrations.hpp>
 #include <unity/toolkits/object_detection/class_registrations.hpp>
@@ -58,9 +56,7 @@ void register_functions(toolkit_function_registry& registry) {
   registry.register_toolkit_function(turi::sdk_model::activity_classification::get_toolkit_function_registration());
 
   registry.register_toolkit_function(image_util::get_toolkit_function_registration());
-#if(TC_BUILD_VISUALIZATION_CLIENT)
   registry.register_toolkit_function(visualization::get_toolkit_function_registration());
-#endif
 
   // Register proprietary toolkits
   registry.register_toolkit_function(turi::kmeans::get_toolkit_function_registration(), "_kmeans");


### PR DESCRIPTION
The macro TC_BUILD_VISUALIZATION_CLIENT should only be used for the
client (tcviz app on macOS or Linux); the C API for visualization
should work regardless as it's purely data structure transformations
and doesn't depend on any client app.