### PR TITLE
Fix object detector export parameters when set to 0

### DIFF
--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1165,8 +1165,8 @@ class ObjectDetector(_CustomModel):
         import coremltools
         from coremltools.models import datatypes, neural_network
 
-        if not iou_threshold: iou_threshold = self.non_maximum_suppression_threshold
-        if not confidence_threshold: confidence_threshold = 0.25
+        if iou_threshold is None: iou_threshold = self.non_maximum_suppression_threshold
+        if confidence_threshold is None: confidence_threshold = 0.25
 
         preds_per_box = 5 + self.num_classes
         num_anchors = len(self.anchors)


### PR DESCRIPTION
It should be possible to set `confidence_threshold=0.0` and not have it silently fall back to 0.25.