### PR TITLE
Handle resizing of channels of input images 

### DIFF
--- a/src/image/jpeg_io.cpp
+++ b/src/image/jpeg_io.cpp
@@ -83,7 +83,7 @@ void decode_jpeg(const char* data, size_t length, char** out_data, size_t& out_l
     jpeg_start_decompress(&cinfo); // Start decompressor
 
     if (cinfo.out_color_space != JCS_GRAYSCALE && cinfo.out_color_space != JCS_RGB) {
-      log_and_throw(std::string("Image provided is not in supported colorspaces Grayscale or RGB."));
+      log_and_throw(std::string("Unsupported colorspace format. Currently, only RGB and Grayscale are supported."));
     }
 
     size_t width = cinfo.image_width;

--- a/src/image/jpeg_io.cpp
+++ b/src/image/jpeg_io.cpp
@@ -82,6 +82,10 @@ void decode_jpeg(const char* data, size_t length, char** out_data, size_t& out_l
     jpeg_read_header(&cinfo, TRUE); // Read file header, set default decompression parameters
     jpeg_start_decompress(&cinfo); // Start decompressor
 
+    if (cinfo.out_color_space != JCS_GRAYSCALE && cinfo.out_color_space != JCS_RGB) {
+      log_and_throw(std::string("Image provided is not in supported colorspaces Grayscale or RGB."));
+    }
+
     size_t width = cinfo.image_width;
     size_t height = cinfo.image_height;
     size_t channels = cinfo.num_components;

--- a/src/unity/python/turicreate/test/test_image_type.py
+++ b/src/unity/python/turicreate/test/test_image_type.py
@@ -121,7 +121,7 @@ class ImageClassTest(unittest.TestCase):
                         pilimage = pilimage.convert('RGBA')
                     self.__check_raw_image_equals_pilimage(glimage_resized, pilimage)
 
-    def test_color_channels_conversion(self):
+    def test_cmyk_not_supported(self):
         for meta_info in test_image_info:
             input_img = PIL_Image.open(meta_info.url)
             input_img = input_img.convert('CMYK')

--- a/src/unity/python/turicreate/test/test_image_type.py
+++ b/src/unity/python/turicreate/test/test_image_type.py
@@ -14,6 +14,7 @@ import os
 from ..data_structures import image
 from .. import SArray
 from ..toolkits.image_analysis import image_analysis
+from ..toolkits._main import ToolkitError
 
 from ..deps import numpy as _np, HAS_NUMPY
 
@@ -119,6 +120,18 @@ class ImageClassTest(unittest.TestCase):
                     elif (new_channels == 4):
                         pilimage = pilimage.convert('RGBA')
                     self.__check_raw_image_equals_pilimage(glimage_resized, pilimage)
+
+    def test_color_channels_conversion(self):
+        for meta_info in test_image_info:
+            input_img = PIL_Image.open(meta_info.url)
+            input_img = input_img.convert('CMYK')
+
+            import tempfile 
+            with tempfile.NamedTemporaryFile() as t:
+                input_img.save(t, format='jpeg')
+                cmyk_image = image.Image(path=t.name, format='JPG')
+                with self.assertRaises(ToolkitError):
+                    image_analysis.resize(cmyk_image, cmyk_image.width, cmyk_image.height, 3, decode=True)
 
     def test_batch_resize(self):
         image_url_dir = current_file_dir + '/images'

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -81,12 +81,11 @@ class _SFrameDataSource:
 
         # Copy the image data for this row into a NumPy array.
         row = self.sframe[row_index]
-        image_channels = row[self.feature_column].channels
-        
-        if image_channels!=3:
-            image = _convert_image_to_raw(row[self.feature_column]).pixel_data
-        else:
-            image = row[self.feature_column].pixel_data
+
+        turi_image = row[self.feature_column]        
+        if turi_image.channels!=3:
+            turi_image = _convert_image_to_raw(turi_image)
+        image = turi_image.pixel_data
 
         # Copy the annotated bounding boxes for this image, if requested.
         if self.load_labels:

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -17,6 +17,10 @@ from ._detection import yolo_boxes_to_yolo_map as _yolo_boxes_to_yolo_map
 _TMP_COL_RANDOM_ORDER = '_random_order'
 
 
+def _convert_image_to_raw(image):
+    # Decode image and make sure it has 3 channels
+    return _tc.image_analysis.resize(image, image.width, image.height, 3, decode=True)
+
 def _is_rectangle_annotation(ann):
     return 'type' not in ann or ann['type'] == 'rectangle'
 
@@ -78,6 +82,9 @@ class _SFrameDataSource:
         # Copy the image data for this row into a NumPy array.
         row = self.sframe[row_index]
         image = row[self.feature_column].pixel_data
+
+        if image.shape[2]>3:
+            image = _convert_image_to_raw(row[self.feature_column]).pixel_data
 
         # Copy the annotated bounding boxes for this image, if requested.
         if self.load_labels:

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -81,11 +81,12 @@ class _SFrameDataSource:
 
         # Copy the image data for this row into a NumPy array.
         row = self.sframe[row_index]
-        image = row[self.feature_column].pixel_data
         image_channels = row[self.feature_column].channels
         
         if image_channels!=3:
             image = _convert_image_to_raw(row[self.feature_column]).pixel_data
+        else:
+            image = row[self.feature_column].pixel_data
 
         # Copy the annotated bounding boxes for this image, if requested.
         if self.load_labels:

--- a/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/_sframe_loader.py
@@ -82,8 +82,9 @@ class _SFrameDataSource:
         # Copy the image data for this row into a NumPy array.
         row = self.sframe[row_index]
         image = row[self.feature_column].pixel_data
-
-        if image.shape[2]>3:
+        image_channels = row[self.feature_column].channels
+        
+        if image_channels!=3:
             image = _convert_image_to_raw(row[self.feature_column]).pixel_data
 
         # Copy the annotated bounding boxes for this image, if requested.


### PR DESCRIPTION
Fixes #1046. Placed resizing functionality from image_analysis to support conversion of 1-channel (Grayscale) and 4-channel (RGBA) images to 3-channel (RGB) images.

* Currently supported color spaces (and their conversions to RGB) are Grayscale, palette, RGB, and RGBA.
* PNG supports Grayscale, RGB and RGBA. ([LibPng](http://www.libpng.org/pub/png/libpng-1.2.5-manual.html))
* JPEG supports Grayscale and RGB, along with additional colorspaces such as CMYK, YCCK, and YCbCr. [LibJpeg](https://github.com/Windower/libjpeg/blob/master/libjpeg.txt) does not support conversion of YCCK or CMYK to RGB.
* Since we expect image format to be a 3-channel RGB, I added an error check for the jpeg image to be in the acceptable format. (Note: Conversion from CMYK to RGB can still happen using the resizing functionality but since it does so by dropping the K channel it seems wise to inform the user and have them feed the correct image without losing color information.)