### PR TITLE
OD: Make sure setting imageCropAndScaleOption is included in example code

### DIFF
--- a/userguide/object_detection/export-coreml.md
+++ b/userguide/object_detection/export-coreml.md
@@ -30,7 +30,7 @@ let objectRecognition = VNCoreMLRequest(model: visionModel,
         print(bestLabel.identifier, bestLabel.confidence, objectBounds)
     }
 })
-
+objectRecognition.imageCropAndScaleOption = .scaleFill
 ```
 
 For more details on the integration with Core ML and a sample app to get


### PR DESCRIPTION
This is included in our deployment code for iOS 11, but missing from iOS 12. This option is important for correct handling of input.

Fixes #1016 (!!)