### PR TITLE
Implement object_detector::export_to_coreml

### DIFF
--- a/src/unity/toolkits/coreml_export/CMakeLists.txt
+++ b/src/unity/toolkits/coreml_export/CMakeLists.txt
@@ -5,6 +5,7 @@ make_library(unity_coreml_model_export
     mldata_exporter.cpp
     xgboost_exporter.cpp
     linear_models_exporter.cpp
+    neural_net_models_exporter.cpp
     coreml_export_utils.cpp
     mlmodel_wrapper.cpp
     MLModel/build/format/ArrayFeatureExtractor.pb.cc

--- a/src/unity/toolkits/coreml_export/mlmodel_wrapper.cpp
+++ b/src/unity/toolkits/coreml_export/mlmodel_wrapper.cpp
@@ -1,5 +1,7 @@
-#include <unity/lib/toolkit_function_macros.hpp>
 #include <unity/toolkits/coreml_export/mlmodel_wrapper.hpp>
+
+#include <unity/toolkits/coreml_export/coreml_export_utils.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
 
 namespace turi {
 namespace coreml {

--- a/src/unity/toolkits/coreml_export/mlmodel_wrapper.hpp
+++ b/src/unity/toolkits/coreml_export/mlmodel_wrapper.hpp
@@ -1,13 +1,16 @@
 #ifndef __TC_ML_MODEL_WRAPPER_HPP_
 #define __TC_ML_MODEL_WRAPPER_HPP_
 
+#include <memory>
+
 #include <unity/lib/extensions/model_base.hpp>
 #include <unity/lib/toolkit_class_macros.hpp>
-#include <unity/lib/toolkit_function_macros.hpp>
 
-#include <unity/toolkits/coreml_export/coreml_export_utils.hpp>
-#include <unity/toolkits/coreml_export/mldata_exporter.hpp>
-#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
+// Forward declare CoreML::Model in lieu of including problematic protocol
+// buffer headers.
+namespace CoreML {
+class Model;
+}
 
 namespace turi {
 namespace coreml { 

--- a/src/unity/toolkits/coreml_export/neural_net_models_exporter.cpp
+++ b/src/unity/toolkits/coreml_export/neural_net_models_exporter.cpp
@@ -1,0 +1,101 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <unity/toolkits/coreml_export/neural_net_models_exporter.hpp>
+
+#include <logger/assertions.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
+
+using CoreML::Specification::ArrayFeatureType;
+using CoreML::Specification::FeatureDescription;
+using CoreML::Specification::ImageFeatureType;
+using CoreML::Specification::ModelDescription;
+using CoreML::Specification::NeuralNetworkLayer;
+using turi::coreml::MLModelWrapper;
+
+namespace turi {
+
+std::shared_ptr<MLModelWrapper> export_object_detector_model(
+    const neural_net::model_spec& nn_spec, size_t image_width,
+    size_t image_height, size_t num_classes, size_t num_predictions,
+    flex_dict user_defined_metadata) {
+
+  CoreML::Specification::Model model_pb;
+
+  // Scale pixel values 0..255 to [0,1]
+  NeuralNetworkLayer* first_layer =
+      model_pb.mutable_neuralnetwork()->add_layers();
+  first_layer->set_name("_divscalar0");
+  first_layer->add_input("image");
+  first_layer->add_output("_divscalar0");
+  first_layer->mutable_scale()->add_shapescale(1);
+  first_layer->mutable_scale()->mutable_scale()->add_floatvalue(1 / 255.f);
+
+  // Copy the NeuralNetwork layers from nn_spec.
+  // TODO: This copies ~60MB at present. Should object_detector be responsible
+  // for _divscalar0, even though this isn't performed by the cnn_module?
+  model_pb.mutable_neuralnetwork()->MergeFrom(nn_spec.get_coreml_spec());
+  ASSERT_GT(model_pb.neuralnetwork().layers_size(), 1);
+
+  // Wire up the input layer from the copied layers to _divscalar0.
+  // TODO: This assumes that the first copied layer is the (only) one to take
+  // the input from "image".
+  NeuralNetworkLayer* second_layer = 
+      model_pb.mutable_neuralnetwork()->mutable_layers(1);
+  ASSERT_EQ(second_layer->input_size(), 1);
+  ASSERT_EQ(second_layer->input(0), "image");
+  second_layer->set_input(0, "_divscalar0");
+
+  // Write the ModelDescription.
+  ModelDescription* model_desc = model_pb.mutable_description();
+
+  // Write FeatureDescription for the image input.
+  FeatureDescription* input_desc = model_desc->add_input();
+  input_desc->set_name("image");
+  input_desc->set_shortdescription("Input image");
+  ImageFeatureType* input_image =
+      input_desc->mutable_type()->mutable_imagetype();
+  input_image->set_width(image_width);
+  input_image->set_height(image_height);
+  input_image->set_colorspace(ImageFeatureType::RGB);
+
+  // Write FeatureDescription for the confidence output.
+  FeatureDescription* confidence_desc = model_desc->add_output();
+  confidence_desc->set_name("confidence");
+  confidence_desc->set_shortdescription(
+      "Boxes × Class confidence (see user-defined metadata \"classes\")");
+  ArrayFeatureType* confidence_array =
+      confidence_desc->mutable_type()->mutable_multiarraytype();
+  confidence_array->add_shape(num_predictions);
+  confidence_array->add_shape(num_classes);
+  confidence_array->set_datatype(ArrayFeatureType::DOUBLE);
+
+  // Write FeatureDescription for the coordinates output.
+  FeatureDescription* coordinates_desc = model_desc->add_output();
+  coordinates_desc->set_name("coordinates");
+  coordinates_desc->set_shortdescription(
+      "Boxes × [x, y, width, height] (relative to image size)");
+  ArrayFeatureType* coordinates_array =
+      coordinates_desc->mutable_type()->mutable_multiarraytype();
+  coordinates_array->add_shape(num_predictions);
+  coordinates_array->add_shape(4);
+  coordinates_array->set_datatype(ArrayFeatureType::DOUBLE);
+
+  // Set CoreML spec version.
+  model_pb.set_specificationversion(1);
+
+  auto model_wrapper = std::make_shared<MLModelWrapper>(
+      std::make_shared<CoreML::Model>(model_pb));
+
+  // Add metadata.
+  model_wrapper->add_metadata({
+      { "user_defined", std::move(user_defined_metadata) }
+  });
+
+  return model_wrapper;
+}
+
+}  // namespace turi

--- a/src/unity/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/unity/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -1,0 +1,39 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef UNITY_TOOLKITS_COREML_EXPORT_NEURAL_NETS_MODELS_EXPORTER_HPP_
+#define UNITY_TOOLKITS_COREML_EXPORT_NEURAL_NETS_MODELS_EXPORTER_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <flexible_type/flexible_type.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_wrapper.hpp>
+#include <unity/toolkits/neural_net/model_spec.hpp>
+
+namespace turi {
+
+/**
+ * Wraps a trained object detector model_spec as a complete MLModel.
+ *
+ * \param nn_spec The NeuralNetwork to wrap, which must accept an input "image"
+ *            with shape (3, image_height, image_width) and values in [0,1],
+ *            output "confidence" with shape (num_predictions, num_classes),
+ *            and "coordinates" with shape (num_predictions, 4).
+ * \param user_defined_metadata Key-value pairs to add as user-defined metadata.
+ *
+ * \todo Should this also initialize non-user-defined metadata?
+ * \todo Should model_spec include Model, not NeuralNetwork, so that the client
+ *       is responsible for populating the inputs and outputs?
+ */
+std::shared_ptr<coreml::MLModelWrapper> export_object_detector_model(
+    const neural_net::model_spec& nn_spec, size_t image_width,
+    size_t image_height, size_t num_classes, size_t num_predictions,
+    flex_dict user_defined_metadata);
+
+}  // namespace turi
+
+#endif  // UNITY_TOOLKITS_COREML_EXPORT_NEURAL_NETS_MODELS_EXPORTER_HPP_

--- a/src/unity/toolkits/neural_net/model_spec.cpp
+++ b/src/unity/toolkits/neural_net/model_spec.cpp
@@ -283,6 +283,10 @@ model_spec::model_spec(const std::string& mlmodel_path)
 
 model_spec::~model_spec() = default;
 
+std::unique_ptr<NeuralNetwork> model_spec::move_coreml_spec() && {
+  return std::move(impl_);
+}
+
 float_array_map model_spec::export_params_view() const {
   float_array_map result;
   wrap_network_params(*impl_, &result);

--- a/src/unity/toolkits/neural_net/model_spec.cpp
+++ b/src/unity/toolkits/neural_net/model_spec.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <fstream>
-#include <initializer_list>
 #include <memory>
 #include <vector>
 
@@ -37,7 +36,7 @@ public:
 
   // Convenience function to help the compiler convert initializer lists to
   // std::vector first, before trying to resolve the std::make_shared template.
-  static shared_float_array create_shared(
+  static shared_float_array create_view(
       std::vector<size_t> shape, const WeightParams& weights) {
 
     return shared_float_array(
@@ -101,12 +100,12 @@ void wrap_network_params(const std::string& name,
   const size_t h = convolution.kernelsize(0);
   const size_t w = convolution.kernelsize(1);
 
-  shared_float_array weights = weight_params_float_array::create_shared(
+  shared_float_array weights = weight_params_float_array::create_view(
       {n, c, h, w}, convolution.weights());
   params_out->emplace(name + "_weight", std::move(weights));
 
   if (convolution.has_bias()) {
-    shared_float_array bias = weight_params_float_array::create_shared(
+    shared_float_array bias = weight_params_float_array::create_view(
         {n}, convolution.bias());
     params_out->emplace(name + "_bias", std::move(bias));
   }
@@ -137,19 +136,19 @@ void wrap_network_params(const std::string& name,
 
   const size_t n = batch_norm.channels();
 
-  shared_float_array gamma = weight_params_float_array::create_shared(
+  shared_float_array gamma = weight_params_float_array::create_view(
       {n}, batch_norm.gamma());
   params_out->emplace(name + "_gamma", std::move(gamma));
 
-  shared_float_array beta = weight_params_float_array::create_shared(
+  shared_float_array beta = weight_params_float_array::create_view(
       {n}, batch_norm.beta());
   params_out->emplace(name + "_beta", std::move(beta));
 
-  shared_float_array mean = weight_params_float_array::create_shared(
+  shared_float_array mean = weight_params_float_array::create_view(
       {n}, batch_norm.mean());
   params_out->emplace(name + "_running_mean", std::move(mean));
 
-  shared_float_array variance = weight_params_float_array::create_shared(
+  shared_float_array variance = weight_params_float_array::create_view(
       {n}, batch_norm.variance());
   params_out->emplace(name + "_running_var", std::move(variance));
 }
@@ -307,6 +306,28 @@ bool model_spec::has_layer_output(const std::string& layer_name) const {
   return false;
 }
 
+void model_spec::add_leakyrelu(const std::string& name,
+                               const std::string& input, float alpha) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  layer->mutable_activation()->mutable_leakyrelu()->set_alpha(alpha);
+}
+
+void model_spec::add_sigmoid(const std::string& name,
+                             const std::string& input) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  layer->mutable_activation()->mutable_sigmoid();
+}
+
 void model_spec::add_convolution(
     const std::string& name, const std::string& input,
     size_t num_output_channels, size_t num_kernel_channels, size_t kernel_size,
@@ -324,7 +345,7 @@ void model_spec::add_convolution(
   params->set_ngroups(1);
   params->add_kernelsize(kernel_size);
   params->add_kernelsize(kernel_size);
-  params->add_stride(1);
+  params->add_stride(1);  // TODO: Parameterize
   params->add_stride(1);
   params->add_dilationfactor(1);
   params->add_dilationfactor(1);
@@ -367,15 +388,151 @@ void model_spec::add_batchnorm(
   params->mutable_variance()->mutable_floatvalue()->Resize(size, 1.f);
 }
 
-void model_spec::add_leakyrelu(const std::string& name,
-                               const std::string& input, float alpha) {
+void model_spec::add_channel_concat(const std::string& name,
+                                    const std::vector<std::string>& inputs) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  for (const std::string& input : inputs) {
+    layer->add_input(input);
+  }
+  layer->add_output(name);
+
+  layer->mutable_concat();
+}
+
+void model_spec::add_softmax(const std::string& name,
+                             const std::string& input) {
 
   NeuralNetworkLayer* layer = impl_->add_layers();
   layer->set_name(name);
   layer->add_input(input);
   layer->add_output(name);
 
-  layer->mutable_activation()->mutable_leakyrelu()->set_alpha(alpha);
+  layer->mutable_softmax();
+}
+
+void model_spec::add_addition(const std::string& name,
+                              const std::vector<std::string>& inputs) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  for (const std::string& input : inputs) {
+    layer->add_input(input);
+  }
+  layer->add_output(name);
+
+  layer->mutable_add();
+}
+
+void model_spec::add_multiplication(const std::string& name,
+                                    const std::vector<std::string>& inputs) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  for (const std::string& input : inputs) {
+    layer->add_input(input);
+  }
+  layer->add_output(name);
+
+  layer->mutable_multiply();
+}
+
+void model_spec::add_exp(const std::string& name, const std::string& input) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  layer->mutable_unary()->set_type(
+      CoreML::Specification::UnaryFunctionLayerParams::EXP);
+}
+
+void model_spec::add_scale(const std::string& name, const std::string& input,
+                           const std::array<size_t, 3>& shape_c_h_w,
+                           weight_initializer scale_initializer_fn) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  CoreML::Specification::ScaleLayerParams* params = layer->mutable_scale();
+  size_t size = 1;
+  for (size_t i = 0; i < 3; ++i) {
+    params->add_shapescale(shape_c_h_w[i]);
+    size *= shape_c_h_w[i];
+  }
+
+  auto* scale = params->mutable_scale()->mutable_floatvalue();
+  scale->Resize(static_cast<int>(size), 0.f);
+  scale_initializer_fn(scale->mutable_data(), scale->mutable_data() + size);
+}
+
+void model_spec::add_constant(const std::string& name,
+                              const std::array<size_t, 3>& shape_c_h_w,
+                              weight_initializer weight_initializer_fn) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_output(name);
+
+  CoreML::Specification::LoadConstantLayerParams* params =
+      layer->mutable_loadconstant();
+  size_t size = 1;
+  for (size_t i = 0; i < 3; ++i) {
+    params->add_shape(shape_c_h_w[i]);
+    size *= shape_c_h_w[i];
+  }
+
+  auto* w = params->mutable_data()->mutable_floatvalue();
+  w->Resize(static_cast<int>(size), 0.f);
+  weight_initializer_fn(w->mutable_data(), w->mutable_data() + size);
+}
+
+void model_spec::add_reshape(const std::string& name, const std::string& input,
+                             const std::array<size_t, 4>& seq_c_h_w) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  CoreML::Specification::ReshapeLayerParams* params = layer->mutable_reshape();
+  for (size_t i = 0; i < 4; ++i) {
+    params->add_targetshape(seq_c_h_w[i]);
+  }
+}
+
+void model_spec::add_permute(const std::string& name, const std::string& input,
+                             const std::array<size_t, 4>& axis_permutation) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  CoreML::Specification::PermuteLayerParams* params = layer->mutable_permute();
+  for (size_t i = 0; i < 4; ++i) {
+    params->add_axis(axis_permutation[i]);
+  }
+}
+
+void model_spec::add_channel_slice(
+    const std::string& name, const std::string& input, int start_index,
+    int end_index, size_t stride) {
+
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  CoreML::Specification::SliceLayerParams* params = layer->mutable_slice();
+  params->set_startindex(start_index);
+  params->set_endindex(end_index);
+  params->set_stride(stride);
+  params->set_axis(CoreML::Specification::SliceLayerParams::CHANNEL_AXIS);
 }
 
 }  // neural_net

--- a/src/unity/toolkits/neural_net/model_spec.hpp
+++ b/src/unity/toolkits/neural_net/model_spec.hpp
@@ -7,9 +7,11 @@
 #ifndef UNITY_TOOLKITS_NEURAL_NET_MODEL_SPEC_HPP_
 #define UNITY_TOOLKITS_NEURAL_NET_MODEL_SPEC_HPP_
 
+#include <array>
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <unity/toolkits/neural_net/float_array.hpp>
 
@@ -68,6 +70,23 @@ public:
   ~model_spec();
 
   /**
+   * Exposes the underlying CoreML proto.
+   */
+  const CoreML::Specification::NeuralNetwork& get_coreml_spec() const {
+    return *impl_;
+  }
+
+  /**
+   * Transfer ownership of the underlying CoreML proto, invalidating the current
+   * instance (leaving it in a "moved-from" state).
+   *
+   * (Note that this method may only be invoked from a model_spec&&)
+   */
+  std::unique_ptr<CoreML::Specification::NeuralNetwork> move_coreml_spec() && {
+    return std::move(impl_);
+  }
+
+  /**
    * Creates a shared_float_array view (weak reference) into the parameters of
    * the model, indexed by layer name.
    *
@@ -107,6 +126,24 @@ public:
   bool has_layer_output(const std::string& layer_name) const;
 
   /**
+   * Appends a leaky ReLU activation layer.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   * \param alpha Multiplied to negative inputs
+   */
+  void add_leakyrelu(const std::string& name, const std::string& input,
+                     float alpha);
+
+  /**
+   * Appends a sigmoid activation layer.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   */
+  void add_sigmoid(const std::string& name, const std::string& input);
+
+  /**
    * Appends a convolution layer.
    *
    * \param name The name of the layer and its output
@@ -130,7 +167,6 @@ public:
    * The beta and mean parameters are initialized to 0.f; the gamma and variance
    * parameters are initialized to 1.f
    *
-   * \param nn_model The NeuralNetwork to which to append a batch norm layer
    * \param name The name of the layer and its output
    * \param input The name of the layer's input
    * \param num_channels The C dimension of the input and output
@@ -140,27 +176,110 @@ public:
                      size_t num_channels, float epsilon);
 
   /**
-   * Appends a leaky ReLU layer.
+   * Appends a layer that concatenates its inputs along the channel axis.
    *
-   * \param nn_model The NeuralNetwork to which to append a leaky ReLU layer
    * \param name The name of the layer and its output
-   * \param input The name of the layer's input
-   * \param alpha Multiplied to negative inputs
+   * \param inputs The names of the layer's inputs
    */
-  void add_leakyrelu(const std::string& name, const std::string& input,
-                     float alpha);
-
-  // TODO: Support additional layers (and further parameterize the above) as
-  // needed.
-
-protected:
+  void add_channel_concat(const std::string& name,
+                          const std::vector<std::string>& inputs);
 
   /**
-   * Exposes the underlying CoreML proto, mostly for testing.
+   * Appends a layer that performs softmax normalization (along channel axis).
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
    */
-  const CoreML::Specification::NeuralNetwork& get_coreml_spec() const {
-    return *impl_;
-  }
+  void add_softmax(const std::string& name, const std::string& input);
+
+  /**
+   * Appends a layer that performs elementwise addition.
+   *
+   * \param name The name of the layer and its output
+   * \param inputs The names of the layer's inputs
+   */
+  void add_addition(const std::string& name,
+                    const std::vector<std::string>& inputs);
+
+  /**
+   * Appends a layer that performs elementwise multiplication.
+   *
+   * \param name The name of the layer and its output
+   * \param inputs The names of the layer's inputs
+   */
+  void add_multiplication(const std::string& name,
+                          const std::vector<std::string>& inputs);
+
+  /**
+   * Appends a layer that applies the unary function f(x) = e^x to its input.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   */
+  void add_exp(const std::string& name, const std::string& input);
+
+
+  /**
+   * Appends a layer that performs elementwise multiplication between its input
+   * and some fixed weights.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   * \param shape_c_h_w The shape of the input and output
+   * \param weight_initializer_fn Callback used to initialize the weights
+   */
+  void add_scale(const std::string& name, const std::string& input,
+                 const std::array<size_t, 3>& shape_c_h_w,
+                 weight_initializer scale_initializer_fn);
+
+  /**
+   * Appends a layer with fixed values.
+   *
+   * \param name The name of the layer and its output
+   * \param shape_c_h_w The shape of the output
+   * \param weight_initializer_fn Callback used to initialize the weights
+   */
+  void add_constant(const std::string& name,
+                    const std::array<size_t, 3>& shape_c_h_w,
+                    weight_initializer weight_initializer_fn);
+
+  /**
+   * Appends a layer that reshapes its input.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   * \param shape_c_h_w The shape of the output
+   */
+  void add_reshape(const std::string& name, const std::string& input,
+                   const std::array<size_t, 4>& seq_c_h_w);
+
+  /**
+   * Appends a layer that transposes the dimensions of its input
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   * \param axis_permutation A permutation of [0, 1, 2, 3], describing how to
+   *            rearrange the [Seq, C, H, W] input.
+   */
+  void add_permute(const std::string& name, const std::string& input,
+                   const std::array<size_t, 4>& axis_permutation);
+
+  /**
+   * Appends a layer that slices the input along the channel axis.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   * \param start_index The first channel to include
+   * \param end_index The first channel to stop including. If negative, then the
+   *            number of channels is added first (so -1 becomes n - 1).
+   * \param stride The interval between channels to include
+   */
+  void add_channel_slice(const std::string& name, const std::string& input,
+                         int start_index, int end_index, size_t stride);
+
+  // TODO: Support additional layers (and further parameterize the above) as
+  // needed. If/when we support the full range of NeuralNetworkLayer values,
+  // this could be shared in some form with coremltools.
 
 private:
 

--- a/src/unity/toolkits/neural_net/model_spec.hpp
+++ b/src/unity/toolkits/neural_net/model_spec.hpp
@@ -15,8 +15,8 @@
 
 #include <unity/toolkits/neural_net/float_array.hpp>
 
-// Forward declare CoreML::Specification::Model in lieu of including problematic
-// protocol buffer headers.
+// Forward declare CoreML::Specification::NeuralNetwork in lieu of including
+// problematic protocol buffer headers.
 namespace CoreML {
 namespace Specification {
 class NeuralNetwork;
@@ -82,9 +82,7 @@ public:
    *
    * (Note that this method may only be invoked from a model_spec&&)
    */
-  std::unique_ptr<CoreML::Specification::NeuralNetwork> move_coreml_spec() && {
-    return std::move(impl_);
-  }
+  std::unique_ptr<CoreML::Specification::NeuralNetwork> move_coreml_spec() &&;
 
   /**
    * Creates a shared_float_array view (weak reference) into the parameters of

--- a/src/unity/toolkits/object_detection/CMakeLists.txt
+++ b/src/unity/toolkits/object_detection/CMakeLists.txt
@@ -5,6 +5,7 @@ make_library(unity_object_detection
     class_registrations.cpp
     object_detector.cpp
     od_data_iterator.cpp
+    od_yolo.cpp
   REQUIRES
     image_io
     random

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -14,6 +14,7 @@
 #include <table_printer/table_printer.hpp>
 #include <unity/lib/extensions/ml_model.hpp>
 #include <unity/lib/gl_sframe.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_wrapper.hpp>
 #include <unity/toolkits/neural_net/cnn_module.hpp>
 #include <unity/toolkits/neural_net/image_augmentation.hpp>
 #include <unity/toolkits/neural_net/model_spec.hpp>
@@ -38,6 +39,8 @@ class EXPORT object_detector: public ml_model_base {
   void train(gl_sframe data, std::string annotations_column_name,
              std::string image_column_name,
              std::map<std::string, flexible_type> options);
+  std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
+      std::string filename);
 
   // Register with Unity server
 
@@ -66,7 +69,9 @@ class EXPORT object_detector: public ml_model_base {
   );
   // TODO: Addition training options: batch_size, max_iterations, etc.
 
-  // TODO: Remainder of interface: predict, export_to_coreml, etc.
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename");
+
+  // TODO: Remainder of interface: predict, etc.
 
   END_CLASS_MEMBER_REGISTRATION
 
@@ -102,6 +107,13 @@ class EXPORT object_detector: public ml_model_base {
                   std::string image_column_name,
                   std::map<std::string, flexible_type> options);
   void perform_training_iteration();
+
+  // Utility code
+
+  template <typename T>
+  T read_state(const std::string& key) const {
+    return variant_get_value<T>(get_state().at(key));
+  }
 
  private:
   neural_net::shared_float_array prepare_label_batch(

--- a/src/unity/toolkits/object_detection/od_yolo.cpp
+++ b/src/unity/toolkits/object_detection/od_yolo.cpp
@@ -1,0 +1,207 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <unity/toolkits/neural_net/model_spec.hpp>
+
+#include <logger/assertions.hpp>
+
+using turi::neural_net::model_spec;
+
+namespace turi {
+namespace object_detection {
+
+void add_yolo(model_spec* nn_spec, const std::string& coordinates_name,
+              const std::string& confidence_name, const std::string& input,
+              const std::vector<std::pair<float, float>>& anchor_boxes,
+              size_t num_classes, size_t output_grid_height,
+              size_t output_grid_width, std::string prefix) {
+
+  // For darknet-yolo, input should be the (B*(5+C), H, W) conv8_fwd output,
+  // where B is the number of anchor boxes, C is the number of classes, and H
+  // is the output grid height, and W is the output grid width.
+
+  // Note that the shapes below conform to the CoreML layout
+  // (Seq_length, C, H, W), although sequence length is always 1 here.
+
+  const size_t num_spatial = output_grid_height * output_grid_width;
+  const size_t num_bounding_boxes = num_spatial * anchor_boxes.size();
+
+  // First, organize the output of the trained model into predictions (bounding
+  // box and one-hot class probabilities), by anchor box, by output-grid cell.
+
+  // (1, B, 5+C, H*W)
+  nn_spec->add_reshape(
+      prefix + "ymap_sp_pre", input,
+      { 1, anchor_boxes.size(), (5 + num_classes), num_spatial });
+
+  // (1, 5+C, B, H*W)
+  nn_spec->add_permute(prefix + "ymap_sp", prefix + "ymap_sp_pre",
+                       { 0, 2, 1, 3 });
+
+  // POSITION: X/Y
+  // Slice out the predicted X/Y offsets and add in the corresponding output
+  // grid cell's location.
+
+  // (1, 2, B, H*W)
+  nn_spec->add_channel_slice(prefix + "raw_rel_xy_sp", prefix + "ymap_sp",
+                             /* start_index */ 0, /* end_index */ 2,
+                             /* stride */ 1);
+
+  // (1, 1, 2, B, H*W)
+  nn_spec->add_sigmoid(prefix + "rel_xy_sp", prefix + "raw_rel_xy_sp");
+
+  // (1, 2, B*H*W, 1)
+  nn_spec->add_reshape(prefix + "rel_xy", prefix + "rel_xy_sp",
+                       { 1, 2, num_bounding_boxes, 1 });
+
+  // (1, 2, B*H*W, 1)
+  auto constant_xy_init = [=](float* out, float* last) {
+    // Write the X coordinate of each output grid cell.
+    for (size_t b = 0; b < anchor_boxes.size(); ++b) {
+      for (size_t y = 0; y < output_grid_height; ++y) {
+        for (size_t x = 0; x < output_grid_width; ++x) {
+          *out++ = static_cast<float>(x);
+        }
+      }
+    }
+    // Write the Y coordinate of each output grid cell.
+    for (size_t b = 0; b < anchor_boxes.size(); ++b) {
+      for (size_t y = 0; y < output_grid_height; ++y) {
+        for (size_t x = 0; x < output_grid_width; ++x) {
+          *out++ = static_cast<float>(y);
+        }
+      }
+    }
+    ASSERT_EQ(out, last);
+  };
+  nn_spec->add_constant(prefix + "constant_xy", { 2, num_bounding_boxes, 1 },
+                        constant_xy_init);
+
+  // (1, 2, B*H*W, 1)
+  nn_spec->add_addition(prefix + "xy",
+                        {prefix + "constant_xy", prefix + "rel_xy"});
+
+  // SHAPE: WIDTH/HEIGHT
+  // Slice out the predicted W/H size adjustment factors and apply them to each
+  // corresponding anchor box size.
+
+  // (1, 2, B, H*W)
+  nn_spec->add_channel_slice(prefix + "raw_rel_wh_sp", prefix + "ymap_sp",
+                             /* start_index */ 2, /* end_index */ 4,
+                             /* stride */ 1);
+
+  // (1, 2, B, H*W)
+  nn_spec->add_exp(prefix + "rel_wh_sp", prefix + "raw_rel_wh_sp");
+
+  // (1, 2*B, H, W)
+  nn_spec->add_reshape(
+      prefix + "rel_wh", prefix + "rel_wh_sp",
+      {1, 2 * anchor_boxes.size(), output_grid_height, output_grid_width});
+
+  // (1, 2*B, H, W)
+  auto c_anchors_init = [&](float* out, float* last) {
+    // Write the widths of each anchor box.
+    for (const std::pair<float,float>& b : anchor_boxes) {
+      for (size_t h = 0; h < output_grid_height; ++h) {
+        for (size_t w = 0; w < output_grid_width; ++w) {
+          *out++ = b.first;
+        }
+      }
+    }
+    // Write the heights of each anchor box.
+    for (const std::pair<float,float>& b : anchor_boxes) {
+      for (size_t h = 0; h < output_grid_height; ++h) {
+        for (size_t w = 0; w < output_grid_width; ++w) {
+          *out++ = b.second;
+        }
+      }
+    }
+    ASSERT_EQ(out, last);
+  };
+  nn_spec->add_constant(
+      prefix + "c_anchors",
+      { 2*anchor_boxes.size(), output_grid_height, output_grid_width },
+      c_anchors_init);
+
+  // (1, 2*B, H, W)
+  nn_spec->add_multiplication(prefix + "wh_pre",
+                              { prefix + "c_anchors", prefix + "rel_wh" });
+
+  // (1, 2, B*H*W, 1)
+  nn_spec->add_reshape(prefix + "wh", prefix + "wh_pre",
+                       { 1, 2, num_bounding_boxes, 1 });
+
+  // BOXES: X/Y/WIDTH/HEIGHT
+  // Concatenate the POSITION and SHAPE results and normalize to [0,1].
+
+  // (1, 4, B*H*W, 1)
+  nn_spec->add_channel_concat(prefix + "boxes_out_transposed",
+                              { prefix + "xy", prefix + "wh" });
+
+  // (1, B*H*W, 4, 1)
+  nn_spec->add_permute(prefix + "boxes_out", prefix + "boxes_out_transposed",
+                       { 0, 2, 1, 3 } );
+
+  // (1, B*H*W, 4, 1)
+  auto boxes_out_init = [&](float* out, float* last) {
+    for (size_t i = 0; i < num_bounding_boxes; ++i) {
+      *out++ = 1.f / output_grid_width;   // x
+      *out++ = 1.f / output_grid_height;  // y
+      *out++ = 1.f / output_grid_width;   // width
+      *out++ = 1.f / output_grid_height;  // height
+    }
+    ASSERT_EQ(out, last);
+  };
+  nn_spec->add_scale(coordinates_name, prefix + "boxes_out",
+                     { num_bounding_boxes, 4, 1 }, boxes_out_init);
+
+  // CLASS PROBABILITIES AND OBJECT CONFIDENCE
+
+  // First, slice out the class-label scores (conditional on the predicted
+  // bounding box) and the object confidence (for the bounding box).
+
+  // (1, C, B, H*W)
+  nn_spec->add_channel_slice(prefix + "scores_sp", prefix + "ymap_sp",
+                             /* start_index */ 5,
+                             /* end_index */ 5 + num_classes, /* stride */ 1);
+
+  // (1, C, B, H*W)
+  nn_spec->add_softmax(prefix + "probs_sp", prefix + "scores_sp");
+
+  // (1, 1, B, H*W)
+  nn_spec->add_channel_slice(prefix + "logit_conf_sp", prefix + "ymap_sp",
+                             /* start_index */ 4, /* end_index */ 5,
+                             /* stride */ 1);
+
+  // (1, 1, B, H*W)
+  nn_spec->add_sigmoid(prefix + "conf_sp", prefix + "logit_conf_sp");
+
+  // Multiply the class scores and the object confidence to obtain the
+  // overall confidence for each class/box pair.
+
+  // (1, C, B, H*W)
+  std::string conf = prefix + "conf_sp";
+  if (num_classes > 1) {
+    nn_spec->add_channel_concat(prefix + "conf_tiled_sp",
+                                std::vector<std::string>(num_classes, conf));
+    conf = prefix + "conf_tiled_sp";
+  }
+
+  // (1, C, B, H*W)
+  nn_spec->add_multiplication(prefix + "confprobs_sp",
+                              { conf, prefix + "probs_sp" });
+
+  // (1, C, B*H*W, 1)
+  nn_spec->add_reshape(prefix + "confprobs_transposed", prefix + "confprobs_sp",
+                       { 1, num_classes, num_bounding_boxes, 1 });
+
+  // (1, B*H*W, C, 1)
+  nn_spec->add_permute(confidence_name, prefix + "confprobs_transposed",
+                       { 0, 2, 1, 3 });
+}
+
+}  // object_detection
+}  // turi

--- a/src/unity/toolkits/object_detection/od_yolo.hpp
+++ b/src/unity/toolkits/object_detection/od_yolo.hpp
@@ -1,0 +1,54 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef TURI_OBJECT_DETECTION_OD_YOLO_H_
+#define TURI_OBJECT_DETECTION_OD_YOLO_H_
+
+#include <unity/toolkits/neural_net/model_spec.hpp>
+
+namespace turi {
+namespace object_detection {
+
+/**
+ * Appends layers to an existing neural net spec, implementing the conversion
+ * from a trained YOLO model to predicted bounding boxes and class labels.
+ *
+ * \param nn_spec Model spec for the trained YOLO model
+ * \param coordinates_name The name to give to the CoreML layer which will
+ *            output the predicted bounding boxes (B*H*W, 4, 1) for each of the
+ *            B anchor boxes and each of the H*W output grid cells, in
+ *            (x,y,width,height) order, normalized to the interval [0,1].
+ * \param confidence_name The name to give to the CoreML layer which will output
+ *            the predicted class label confidences (B*H*W, C, 1) for each of
+ *            the B anchor boxes, each of the H*W output grid cells, and each of
+ *            the C class labels.
+ * \param input The name of the existing CoreML layer that outputs the raw
+ *            (B*(5+C), H, W) predictions of the trained model: for each of B
+ *            anchor boxes, the (x, y, width, height) bounding box, object
+ *            confidence, and C class label confidences, for each of the H*W
+ *            output grid cells.
+ * \param anchor_boxes The B anchor boxes used to train the YOLO model, as a
+ *            vector of (width, height) pairs (in the output grid coordinates).
+ * \param num_classes The number of class labels C used to train the YOLO model.
+ * \param output_grid_height The height H of the output grid used to train the
+ *            YOLO model.
+ * \param output_grid_width The width W of the output grid used to train the
+ *            YOLO model.
+ * \param prefix The prefix to apply to intermediate layers added in service of
+ *            output layers named by `coordinates_name` and `confidence_name`.
+ */
+void add_yolo(neural_net::model_spec* nn_spec,
+              const std::string& coordinates_name,
+              const std::string& confidence_name, const std::string& input,
+              const std::vector<std::pair<float, float>>& anchor_boxes,
+              size_t num_classes, size_t output_grid_height,
+              size_t output_grid_width,
+              std::string prefix = "__tc__internal__");
+
+}  // object_detection
+}  // turi
+
+#endif  // TURI_OBJECT_DETECTION_OD_YOLO_H_

--- a/src/unity/toolkits/recsys/models/itemcf.cpp
+++ b/src/unity/toolkits/recsys/models/itemcf.cpp
@@ -27,6 +27,7 @@
 #include <unity/toolkits/sparse_similarity/sparse_similarity_lookup.hpp>
 #include <unity/toolkits/sparse_similarity/similarities.hpp>
 #include <table_printer/table_printer.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
 
 namespace turi { namespace recsys {
 

--- a/test/unity/toolkits/neural_net/test_model_spec.cxx
+++ b/test/unity/toolkits/neural_net/test_model_spec.cxx
@@ -23,20 +23,10 @@ namespace {
 using CoreML::Specification::NeuralNetwork;
 using CoreML::Specification::NeuralNetworkLayer;
 
-class test_model_spec: public model_spec {
-public:
-
-  test_model_spec() = default;
-  test_model_spec(const NeuralNetwork& nn_model): model_spec(nn_model) {}
-
-  // Expose protected methods intended for testing support.
-  using model_spec::get_coreml_spec;
-};
-
 BOOST_AUTO_TEST_CASE(test_export_empty) {
 
   NeuralNetwork nn_model;
-  test_model_spec nn_spec(nn_model);
+  model_spec nn_spec(nn_model);
   float_array_map params = nn_spec.export_params_view();
   TS_ASSERT(params.empty());
 }
@@ -59,7 +49,7 @@ BOOST_AUTO_TEST_CASE(test_export_conv_params) {
   }
 
   // Extract the parameters from the spec.
-  test_model_spec nn_spec(nn_model);
+  model_spec nn_spec(nn_model);
   float_array_map params = nn_spec.export_params_view();
 
   // The result should have just one float array.
@@ -87,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_export_conv_params_invalid) {
   conv_layer->mutable_convolution();
   // The default ConvolutionLayerParams value is not valid.
 
-  test_model_spec nn_spec(nn_model);
+  model_spec nn_spec(nn_model);
   TS_ASSERT_THROWS_ANYTHING(nn_spec.export_params_view());
 }
 
@@ -105,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_export_batchnorm_params) {
   batchnorm_params->mutable_variance()->add_floatvalue(5.0f);
 
   // Extract the parameters from the spec.
-  test_model_spec nn_spec(nn_model);
+  model_spec nn_spec(nn_model);
   float_array_map params = nn_spec.export_params_view();
 
   // The result should have four float arrays.
@@ -131,7 +121,7 @@ BOOST_AUTO_TEST_CASE(test_export_batchnorm_params) {
 BOOST_AUTO_TEST_CASE(test_add_convolution) {
 
   // Add an arbitrary convolution layer to an empty model spec.
-  test_model_spec nn_spec;
+  model_spec nn_spec;
   int weights_size = 16*8*5*5;
   auto weight_init_fn = [weights_size](float* w, float* w_end) {
     TS_ASSERT_EQUALS(w_end - w, weights_size);
@@ -197,7 +187,7 @@ BOOST_AUTO_TEST_CASE(test_add_convolution) {
 BOOST_AUTO_TEST_CASE(test_add_batchnorm) {
 
   // Add an arbitrary batch layer to an empty model spec.
-  test_model_spec nn_spec;
+  model_spec nn_spec;
   nn_spec.add_batchnorm("test_name", "test_input", 16, 0.125f);
 
   // Verify the resulting NeuralNetworkLayer value.
@@ -248,7 +238,7 @@ BOOST_AUTO_TEST_CASE(test_add_batchnorm) {
 BOOST_AUTO_TEST_CASE(test_add_leakyrelu) {
 
   // Add an arbitrary leaky ReLU layer to an empty model spec.
-  test_model_spec nn_spec;
+  model_spec nn_spec;
   nn_spec.add_leakyrelu("test_name", "test_input", 0.125f);
 
   // Verify the resulting NeuralNetworkLayer value.

--- a/test/unity/toolkits/object_detection/CMakeLists.txt
+++ b/test/unity/toolkits/object_detection/CMakeLists.txt
@@ -4,4 +4,11 @@ make_boost_test(test_object_detector.cxx REQUIRES unity_toolkits)
 
 make_boost_test(test_od_data_iterator.cxx REQUIRES unity_toolkits)
 
-make_boost_test(test_od_yolo.cxx REQUIRES unity_toolkits)
+make_boost_test(test_od_yolo.cxx
+  REQUIRES
+    unity_toolkits
+  COMPILE_FLAGS_EXTRA_GCC
+    -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
+    -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
+)
+

--- a/test/unity/toolkits/object_detection/CMakeLists.txt
+++ b/test/unity/toolkits/object_detection/CMakeLists.txt
@@ -3,3 +3,5 @@ project(unity_test_toolkits)
 make_boost_test(test_object_detector.cxx REQUIRES unity_toolkits)
 
 make_boost_test(test_od_data_iterator.cxx REQUIRES unity_toolkits)
+
+make_boost_test(test_od_yolo.cxx REQUIRES unity_toolkits)

--- a/test/unity/toolkits/object_detection/test_od_yolo.cxx
+++ b/test/unity/toolkits/object_detection/test_od_yolo.cxx
@@ -177,12 +177,12 @@ BOOST_AUTO_TEST_CASE(test_add_tiny_darknet_yolo) {
   TS_ASSERT_EQUALS(c_anchors.loadconstant().shape(2), OUTPUT_GRID_SIZE);
   TS_ASSERT_EQUALS(c_anchors.loadconstant().data().floatvalue_size(),
                    2 * anchor_boxes.size() * OUTPUT_GRID_AREA);
-  for (int i = 0; i < anchor_boxes.size(); ++i) {
-    for (int j = 0; j < OUTPUT_GRID_AREA; ++j) {
-      int idx = i * OUTPUT_GRID_AREA + j;
+  for (size_t i = 0; i < anchor_boxes.size(); ++i) {
+    for (size_t j = 0; j < OUTPUT_GRID_AREA; ++j) {
+      int idx = static_cast<int>(i * OUTPUT_GRID_AREA + j);
       TS_ASSERT_EQUALS(c_anchors.loadconstant().data().floatvalue(idx),
                        anchor_boxes[i].first);
-      idx += anchor_boxes.size() * OUTPUT_GRID_AREA;
+      idx += static_cast<int>(anchor_boxes.size() * OUTPUT_GRID_AREA);
       TS_ASSERT_EQUALS(c_anchors.loadconstant().data().floatvalue(idx),
                        anchor_boxes[i].second);
     }
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(test_add_tiny_darknet_yolo) {
 
   const auto& conf_tiled_sp = nn.layers(20);
   TS_ASSERT_EQUALS(conf_tiled_sp.input_size(), NUM_CLASSES);
-  for (int i = 0; i < NUM_CLASSES; ++i) {
+  for (int i = 0; i < static_cast<int>(NUM_CLASSES); ++i) {
     TS_ASSERT_EQUALS(conf_tiled_sp.input(i), prefix + "conf_sp");
   }
   TS_ASSERT_EQUALS(conf_tiled_sp.output_size(), 1);

--- a/test/unity/toolkits/object_detection/test_od_yolo.cxx
+++ b/test/unity/toolkits/object_detection/test_od_yolo.cxx
@@ -1,0 +1,330 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_od_yolo
+
+#include <unity/toolkits/object_detection/od_yolo.hpp>
+
+#include <algorithm>
+
+#include <boost/test/unit_test.hpp>
+#include <util/test_macros.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
+#include <unity/toolkits/neural_net/model_spec.hpp>
+
+namespace turi {
+namespace object_detection {
+namespace {
+
+using turi::neural_net::model_spec;
+
+BOOST_AUTO_TEST_CASE(test_add_tiny_darknet_yolo) {
+
+  static constexpr char COORDINATES_NAME[] = "test_coordinates";
+  static constexpr char CONFIDENCE_NAME[] = "test_confidence";
+  static constexpr char INPUT_NAME[] = "test_input";
+  static constexpr size_t OUTPUT_GRID_SIZE = 13;
+  static constexpr size_t OUTPUT_GRID_AREA = OUTPUT_GRID_SIZE*OUTPUT_GRID_SIZE;
+  static constexpr size_t NUM_CLASSES = 6;
+  static constexpr size_t NUM_PREDS = NUM_CLASSES + 5;  // 4 for bbox, 1 conf
+
+  const std::string prefix = "__test__";
+  const std::vector<std::pair<float, float>> anchor_boxes = {
+      {1.f, 2.f}, {1.f, 1.f}, {2.f, 1.f},
+      {2.f, 4.f}, {2.f, 2.f}, {4.f, 2.f},
+      {4.f, 8.f}, {4.f, 4.f}, {8.f, 4.f},
+      {8.f, 16.f}, {8.f, 8.f}, {16.f, 8.f},
+      {16.f, 32.f}, {16.f, 16.f}, {32.f, 16.f},
+  };
+
+  model_spec nn_spec;
+  add_yolo(&nn_spec, COORDINATES_NAME, CONFIDENCE_NAME, INPUT_NAME,
+           anchor_boxes, NUM_CLASSES, OUTPUT_GRID_SIZE, OUTPUT_GRID_SIZE,
+           prefix);
+
+  // The add_yolo function simply appends a mostly fixed sequence of 24 layers
+  // to an existing model_spec. Assert that the resulting proto is what we want.
+  // In theory, some of the layers could be reordered or have different names,
+  // but it's much easier to test for exact equality.
+
+  const CoreML::Specification::NeuralNetwork& nn = nn_spec.get_coreml_spec();
+  TS_ASSERT_EQUALS(nn.layers_size(), 24);
+
+  const auto& ymap_sp_pre = nn.layers(0);
+  TS_ASSERT_EQUALS(ymap_sp_pre.input_size(), 1);
+  TS_ASSERT_EQUALS(ymap_sp_pre.input(0), INPUT_NAME);
+  TS_ASSERT_EQUALS(ymap_sp_pre.output_size(), 1);
+  TS_ASSERT_EQUALS(ymap_sp_pre.output(0), prefix + "ymap_sp_pre");
+  TS_ASSERT_EQUALS(ymap_sp_pre.reshape().targetshape_size(), 4);
+  TS_ASSERT_EQUALS(ymap_sp_pre.reshape().targetshape(0), 1);
+  TS_ASSERT_EQUALS(ymap_sp_pre.reshape().targetshape(1), anchor_boxes.size());
+  TS_ASSERT_EQUALS(ymap_sp_pre.reshape().targetshape(2), NUM_PREDS);
+  TS_ASSERT_EQUALS(ymap_sp_pre.reshape().targetshape(3), OUTPUT_GRID_AREA);
+
+  const auto& ymap_sp = nn.layers(1);
+  TS_ASSERT_EQUALS(ymap_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(ymap_sp.input(0), prefix + "ymap_sp_pre");
+  TS_ASSERT_EQUALS(ymap_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(ymap_sp.output(0), prefix + "ymap_sp");
+  TS_ASSERT_EQUALS(ymap_sp.permute().axis_size(), 4);
+  TS_ASSERT_EQUALS(ymap_sp.permute().axis(0), 0);
+  TS_ASSERT_EQUALS(ymap_sp.permute().axis(1), 2);
+  TS_ASSERT_EQUALS(ymap_sp.permute().axis(2), 1);
+  TS_ASSERT_EQUALS(ymap_sp.permute().axis(3), 3);
+
+  const auto& raw_rel_xy_sp = nn.layers(2);
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.input(0), prefix + "ymap_sp");
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.output(0), prefix + "raw_rel_xy_sp");
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.slice().startindex(), 0);
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.slice().endindex(), 2);
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.slice().stride(), 1);
+  TS_ASSERT_EQUALS(raw_rel_xy_sp.slice().axis(),
+                   CoreML::Specification::SliceLayerParams::CHANNEL_AXIS);
+
+  const auto& rel_xy_sp = nn.layers(3);
+  TS_ASSERT_EQUALS(rel_xy_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(rel_xy_sp.input(0), prefix + "raw_rel_xy_sp");
+  TS_ASSERT_EQUALS(rel_xy_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(rel_xy_sp.output(0), prefix + "rel_xy_sp");
+  TS_ASSERT(rel_xy_sp.activation().has_sigmoid());
+
+  const auto& rel_xy = nn.layers(4);
+  TS_ASSERT_EQUALS(rel_xy.input_size(), 1);
+  TS_ASSERT_EQUALS(rel_xy.input(0), prefix + "rel_xy_sp");
+  TS_ASSERT_EQUALS(rel_xy.output_size(), 1);
+  TS_ASSERT_EQUALS(rel_xy.output(0), prefix + "rel_xy");
+  TS_ASSERT_EQUALS(rel_xy.reshape().targetshape_size(), 4);
+  TS_ASSERT_EQUALS(rel_xy.reshape().targetshape(0), 1);
+  TS_ASSERT_EQUALS(rel_xy.reshape().targetshape(1), 2);
+  TS_ASSERT_EQUALS(rel_xy.reshape().targetshape(2),
+                   OUTPUT_GRID_AREA * anchor_boxes.size());
+  TS_ASSERT_EQUALS(rel_xy.reshape().targetshape(3), 1);
+
+  const auto& constant_xy = nn.layers(5);
+  TS_ASSERT_EQUALS(constant_xy.input_size(), 0);
+  TS_ASSERT_EQUALS(constant_xy.output_size(), 1);
+  TS_ASSERT_EQUALS(constant_xy.output(0), prefix + "constant_xy");
+  TS_ASSERT_EQUALS(constant_xy.loadconstant().shape_size(), 3);
+  TS_ASSERT_EQUALS(constant_xy.loadconstant().shape(0), 2);
+  TS_ASSERT_EQUALS(constant_xy.loadconstant().shape(1),
+                   OUTPUT_GRID_AREA * anchor_boxes.size());
+  TS_ASSERT_EQUALS(constant_xy.loadconstant().shape(2), 1);
+  TS_ASSERT_EQUALS(constant_xy.loadconstant().data().floatvalue_size(),
+                   2 * 2535 * 1);
+  for (size_t b = 0; b < anchor_boxes.size(); ++b) {
+    for (size_t y = 0; y < OUTPUT_GRID_SIZE; ++y) {
+      for (size_t x = 0; x < OUTPUT_GRID_SIZE; ++x) {
+        int idx = static_cast<int>(  b * OUTPUT_GRID_AREA
+                                   + y * OUTPUT_GRID_SIZE
+                                   + x);
+        TS_ASSERT_EQUALS(constant_xy.loadconstant().data().floatvalue(idx), x);
+        idx += anchor_boxes.size() * OUTPUT_GRID_AREA;
+        TS_ASSERT_EQUALS(constant_xy.loadconstant().data().floatvalue(idx), y);
+      }
+    }
+  }
+
+  const auto& xy = nn.layers(6);
+  TS_ASSERT_EQUALS(xy.input_size(), 2);
+  TS_ASSERT_EQUALS(xy.input(0), prefix + "constant_xy");
+  TS_ASSERT_EQUALS(xy.input(1), prefix + "rel_xy");
+  TS_ASSERT_EQUALS(xy.output_size(), 1);
+  TS_ASSERT_EQUALS(xy.output(0), prefix + "xy");
+  TS_ASSERT(xy.has_add());
+
+  const auto& raw_rel_wh_sp = nn.layers(7);
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.input(0), prefix + "ymap_sp");
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.output(0), prefix + "raw_rel_wh_sp");
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.slice().startindex(), 2);
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.slice().endindex(), 4);
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.slice().stride(), 1);
+  TS_ASSERT_EQUALS(raw_rel_wh_sp.slice().axis(),
+                   CoreML::Specification::SliceLayerParams::CHANNEL_AXIS);
+
+  const auto& rel_wh_sp = nn.layers(8);
+  TS_ASSERT_EQUALS(rel_wh_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(rel_wh_sp.input(0), prefix + "raw_rel_wh_sp");
+  TS_ASSERT_EQUALS(rel_wh_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(rel_wh_sp.output(0), prefix + "rel_wh_sp");
+  TS_ASSERT_EQUALS(rel_wh_sp.unary().type(),
+                   CoreML::Specification::UnaryFunctionLayerParams::EXP);
+
+  const auto& rel_wh = nn.layers(9);
+  TS_ASSERT_EQUALS(rel_wh.input_size(), 1);
+  TS_ASSERT_EQUALS(rel_wh.input(0), prefix + "rel_wh_sp");
+  TS_ASSERT_EQUALS(rel_wh.output_size(), 1);
+  TS_ASSERT_EQUALS(rel_wh.output(0), prefix + "rel_wh");
+  TS_ASSERT_EQUALS(rel_wh.reshape().targetshape_size(), 4);
+  TS_ASSERT_EQUALS(rel_wh.reshape().targetshape(0), 1);
+  TS_ASSERT_EQUALS(rel_wh.reshape().targetshape(1), 2 * anchor_boxes.size());
+  TS_ASSERT_EQUALS(rel_wh.reshape().targetshape(2), OUTPUT_GRID_SIZE);
+  TS_ASSERT_EQUALS(rel_wh.reshape().targetshape(3), OUTPUT_GRID_SIZE);
+
+  const auto& c_anchors = nn.layers(10);
+  TS_ASSERT_EQUALS(c_anchors.input_size(), 0);
+  TS_ASSERT_EQUALS(c_anchors.output_size(), 1);
+  TS_ASSERT_EQUALS(c_anchors.output(0), prefix + "c_anchors");
+  TS_ASSERT_EQUALS(c_anchors.loadconstant().shape_size(), 3);
+  TS_ASSERT_EQUALS(c_anchors.loadconstant().shape(0), 2 * anchor_boxes.size());
+  TS_ASSERT_EQUALS(c_anchors.loadconstant().shape(1), OUTPUT_GRID_SIZE);
+  TS_ASSERT_EQUALS(c_anchors.loadconstant().shape(2), OUTPUT_GRID_SIZE);
+  TS_ASSERT_EQUALS(c_anchors.loadconstant().data().floatvalue_size(),
+                   2 * anchor_boxes.size() * OUTPUT_GRID_AREA);
+  for (int i = 0; i < anchor_boxes.size(); ++i) {
+    for (int j = 0; j < OUTPUT_GRID_AREA; ++j) {
+      int idx = i * OUTPUT_GRID_AREA + j;
+      TS_ASSERT_EQUALS(c_anchors.loadconstant().data().floatvalue(idx),
+                       anchor_boxes[i].first);
+      idx += anchor_boxes.size() * OUTPUT_GRID_AREA;
+      TS_ASSERT_EQUALS(c_anchors.loadconstant().data().floatvalue(idx),
+                       anchor_boxes[i].second);
+    }
+  }
+
+  const auto& wh_pre = nn.layers(11);
+  TS_ASSERT_EQUALS(wh_pre.input_size(), 2);
+  TS_ASSERT_EQUALS(wh_pre.input(0), prefix + "c_anchors");
+  TS_ASSERT_EQUALS(wh_pre.input(1), prefix + "rel_wh");
+  TS_ASSERT_EQUALS(wh_pre.output_size(), 1);
+  TS_ASSERT_EQUALS(wh_pre.output(0), prefix + "wh_pre");
+  TS_ASSERT(wh_pre.has_multiply());
+
+  const auto& wh = nn.layers(12);
+  TS_ASSERT_EQUALS(wh.input_size(), 1);
+  TS_ASSERT_EQUALS(wh.input(0), prefix + "wh_pre");
+  TS_ASSERT_EQUALS(wh.output_size(), 1);
+  TS_ASSERT_EQUALS(wh.output(0), prefix + "wh");
+  TS_ASSERT_EQUALS(wh.reshape().targetshape_size(), 4);
+  TS_ASSERT_EQUALS(wh.reshape().targetshape(0), 1);
+  TS_ASSERT_EQUALS(wh.reshape().targetshape(1), 2);
+  TS_ASSERT_EQUALS(wh.reshape().targetshape(2),
+                   OUTPUT_GRID_AREA * anchor_boxes.size());
+  TS_ASSERT_EQUALS(wh.reshape().targetshape(3), 1);
+
+  const auto& boxes_out_transposed = nn.layers(13);
+  TS_ASSERT_EQUALS(boxes_out_transposed.input_size(), 2);
+  TS_ASSERT_EQUALS(boxes_out_transposed.input(0), prefix + "xy");
+  TS_ASSERT_EQUALS(boxes_out_transposed.input(1), prefix + "wh");
+  TS_ASSERT_EQUALS(boxes_out_transposed.output_size(), 1);
+  TS_ASSERT_EQUALS(boxes_out_transposed.output(0),
+                   prefix + "boxes_out_transposed");
+  TS_ASSERT(boxes_out_transposed.has_concat());
+  TS_ASSERT(!boxes_out_transposed.concat().sequenceconcat());
+
+  const auto& boxes_out = nn.layers(14);
+  TS_ASSERT_EQUALS(boxes_out.input_size(), 1);
+  TS_ASSERT_EQUALS(boxes_out.input(0), prefix + "boxes_out_transposed");
+  TS_ASSERT_EQUALS(boxes_out.output_size(), 1);
+  TS_ASSERT_EQUALS(boxes_out.output(0), prefix + "boxes_out");
+  TS_ASSERT_EQUALS(boxes_out.permute().axis_size(), 4);
+  TS_ASSERT_EQUALS(boxes_out.permute().axis(0), 0);
+  TS_ASSERT_EQUALS(boxes_out.permute().axis(1), 2);
+  TS_ASSERT_EQUALS(boxes_out.permute().axis(2), 1);
+  TS_ASSERT_EQUALS(boxes_out.permute().axis(3), 3);
+
+  const auto& coordinates = nn.layers(15);
+  TS_ASSERT_EQUALS(coordinates.input_size(), 1);
+  TS_ASSERT_EQUALS(coordinates.input(0), prefix + "boxes_out");
+  TS_ASSERT_EQUALS(coordinates.output_size(), 1);
+  TS_ASSERT_EQUALS(coordinates.output(0), COORDINATES_NAME);
+  TS_ASSERT_EQUALS(coordinates.scale().shapescale_size(), 3);
+  TS_ASSERT_EQUALS(coordinates.scale().shapescale(0),
+                   OUTPUT_GRID_AREA * anchor_boxes.size());
+  TS_ASSERT_EQUALS(coordinates.scale().shapescale(1), 4);
+  TS_ASSERT_EQUALS(coordinates.scale().shapescale(2), 1);
+  TS_ASSERT_EQUALS(coordinates.scale().scale().floatvalue_size(),
+                   OUTPUT_GRID_AREA * anchor_boxes.size() * 4 * 1);
+  for (int i = 0; i < coordinates.scale().scale().floatvalue_size(); ++i) {
+    TS_ASSERT_EQUALS(coordinates.scale().scale().floatvalue(i),
+                     1.f / OUTPUT_GRID_SIZE);
+  }
+
+  const auto& scores_sp = nn.layers(16);
+  TS_ASSERT_EQUALS(scores_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(scores_sp.input(0), prefix + "ymap_sp");
+  TS_ASSERT_EQUALS(scores_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(scores_sp.output(0), prefix + "scores_sp");
+  TS_ASSERT_EQUALS(scores_sp.slice().startindex(), 5);
+  TS_ASSERT_EQUALS(scores_sp.slice().endindex(), NUM_PREDS);
+  TS_ASSERT_EQUALS(scores_sp.slice().stride(), 1);
+  TS_ASSERT_EQUALS(scores_sp.slice().axis(),
+                   CoreML::Specification::SliceLayerParams::CHANNEL_AXIS);
+
+  const auto& probs_sp = nn.layers(17);
+  TS_ASSERT_EQUALS(probs_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(probs_sp.input(0), prefix + "scores_sp");
+  TS_ASSERT_EQUALS(probs_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(probs_sp.output(0), prefix + "probs_sp");
+  TS_ASSERT(probs_sp.has_softmax());
+
+  const auto& logit_conf_sp = nn.layers(18);
+  TS_ASSERT_EQUALS(logit_conf_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(logit_conf_sp.input(0), prefix + "ymap_sp");
+  TS_ASSERT_EQUALS(logit_conf_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(logit_conf_sp.output(0), prefix + "logit_conf_sp");
+  TS_ASSERT_EQUALS(logit_conf_sp.slice().startindex(), 4);
+  TS_ASSERT_EQUALS(logit_conf_sp.slice().endindex(), 5);
+  TS_ASSERT_EQUALS(logit_conf_sp.slice().stride(), 1);
+  TS_ASSERT_EQUALS(logit_conf_sp.slice().axis(),
+                   CoreML::Specification::SliceLayerParams::CHANNEL_AXIS);
+
+  const auto& conf_sp = nn.layers(19);
+  TS_ASSERT_EQUALS(conf_sp.input_size(), 1);
+  TS_ASSERT_EQUALS(conf_sp.input(0), prefix + "logit_conf_sp");
+  TS_ASSERT_EQUALS(conf_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(conf_sp.output(0), prefix + "conf_sp");
+  TS_ASSERT(conf_sp.activation().has_sigmoid());
+
+  const auto& conf_tiled_sp = nn.layers(20);
+  TS_ASSERT_EQUALS(conf_tiled_sp.input_size(), NUM_CLASSES);
+  for (int i = 0; i < NUM_CLASSES; ++i) {
+    TS_ASSERT_EQUALS(conf_tiled_sp.input(i), prefix + "conf_sp");
+  }
+  TS_ASSERT_EQUALS(conf_tiled_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(conf_tiled_sp.output(0), prefix + "conf_tiled_sp");
+  TS_ASSERT(conf_tiled_sp.has_concat());
+  TS_ASSERT(!conf_tiled_sp.concat().sequenceconcat());
+
+  const auto& confprobs_sp = nn.layers(21);
+  TS_ASSERT_EQUALS(confprobs_sp.input_size(), 2);
+  TS_ASSERT_EQUALS(confprobs_sp.input(0), prefix + "conf_tiled_sp");
+  TS_ASSERT_EQUALS(confprobs_sp.input(1), prefix + "probs_sp");
+  TS_ASSERT_EQUALS(confprobs_sp.output_size(), 1);
+  TS_ASSERT_EQUALS(confprobs_sp.output(0), prefix + "confprobs_sp");
+  TS_ASSERT(confprobs_sp.has_multiply());
+
+  const auto& confprobs_transposed = nn.layers(22);
+  TS_ASSERT_EQUALS(confprobs_transposed.input_size(), 1);
+  TS_ASSERT_EQUALS(confprobs_transposed.input(0), prefix + "confprobs_sp");
+  TS_ASSERT_EQUALS(confprobs_transposed.output_size(), 1);
+  TS_ASSERT_EQUALS(confprobs_transposed.output(0),
+                   prefix + "confprobs_transposed");
+  TS_ASSERT_EQUALS(confprobs_transposed.reshape().targetshape_size(), 4);
+  TS_ASSERT_EQUALS(confprobs_transposed.reshape().targetshape(0), 1);
+  TS_ASSERT_EQUALS(confprobs_transposed.reshape().targetshape(1), NUM_CLASSES);
+  TS_ASSERT_EQUALS(confprobs_transposed.reshape().targetshape(2),
+                   OUTPUT_GRID_AREA * anchor_boxes.size());
+  TS_ASSERT_EQUALS(confprobs_transposed.reshape().targetshape(3), 1);
+
+  const auto& confidence = nn.layers(23);
+  TS_ASSERT_EQUALS(confidence.input_size(), 1);
+  TS_ASSERT_EQUALS(confidence.input(0), prefix + "confprobs_transposed");
+  TS_ASSERT_EQUALS(confidence.output_size(), 1);
+  TS_ASSERT_EQUALS(confidence.output(0), CONFIDENCE_NAME);
+  TS_ASSERT_EQUALS(confidence.permute().axis_size(), 4);
+  TS_ASSERT_EQUALS(confidence.permute().axis(0), 0);
+  TS_ASSERT_EQUALS(confidence.permute().axis(1), 2);
+  TS_ASSERT_EQUALS(confidence.permute().axis(2), 1);
+  TS_ASSERT_EQUALS(confidence.permute().axis(3), 3);
+}
+
+}  // namespace
+}  // namespace object_detection
+}  // namespace turi


### PR DESCRIPTION
(Non-maximal suppression still to be implemented)

Note that the logic for the layers appended to the trained NN layers was lifted directly from the [Python implementation](https://github.com/apple/turicreate/blob/7dbe30e53bfb784091f1aff4b93dc59d50584e4d/src/unity/python/turicreate/toolkits/object_detector/object_detector.py#L1234).

When exporting the initial model (without any training), the only differences between the C++ and Python (with NMS disabled) versions are the metadata, the randomly initialized weights, and AFAICT the `alpha`, `epsilon`, and `scale` parameters written here in the Python version are spurious, so I omitted them:
```
  layers {
    name: "__tc__internal__rel_wh_sp"
    input: "__tc__internal__raw_rel_wh_sp"
    output: "__tc__internal__rel_wh_sp"
    unary {
      type: EXP
      alpha: 1.0
      epsilon: 9.99999997475e-07
      scale: 1.0
    }
```