### PR TITLE
Fix iOS flag passed from build_capi.sh

### DIFF
--- a/build_capi.sh
+++ b/build_capi.sh
@@ -120,7 +120,7 @@ if [[ ${cleanup} -eq 1 ]]; then
 fi
 
 if [[ "$cross_compile" == "iOS" ]]; then
-  ios_flag=--with-ios
+  ios_flag=--target-ios
 fi
 
 function build_capi {


### PR DESCRIPTION
It was trying to pass `--with-ios` to `./configure`, but the correct
flag is actually `--target-ios`.