### PR TITLE
Fix logger output in debug builds

### DIFF
--- a/src/logger/logger.hpp
+++ b/src/logger/logger.hpp
@@ -498,7 +498,9 @@ class file_logger{
       std::stringstream& streambuffer = streambufentry->streambuffer;
       bool& streamactive = streambufentry->streamactive;
 
-      if (streamactive) streambuffer << a;
+      if (streamactive) {
+        streambuffer << a;
+      }
     }
     return *this;
   }
@@ -536,15 +538,12 @@ class file_logger{
       std::stringstream& streambuffer = streambufentry->streambuffer;
       bool& streamactive = streambufentry->streamactive;
 
-      typedef std::ostream& (*endltype)(std::ostream&);
       if (streamactive) {
-        if (endltype(f) == endltype(std::endl)) {
-          streambuffer << "\n";
-          stream_flush();
-          if(streamloglevel == LOG_FATAL) {
-            __print_back_trace();
-            TURI_LOGGER_FAIL_METHOD("LOG_FATAL encountered");
-          }
+        streambuffer << f;
+        stream_flush();
+        if(streamloglevel == LOG_FATAL) {
+          __print_back_trace();
+          TURI_LOGGER_FAIL_METHOD("LOG_FATAL encountered");
         }
       }
     }

--- a/src/logger/logger.hpp
+++ b/src/logger/logger.hpp
@@ -539,6 +539,12 @@ class file_logger{
       bool& streamactive = streambufentry->streamactive;
 
       if (streamactive) {
+        // TODO: previously, we had a check for if (endltype(f) == endltype(std::endl))
+        // and only flushed the stream on endl (ignoring all other stream modifiers).
+        // On recent clang compilers, this check seems to always return false in debug.
+        // (tested with Apple LLVM version 10.0.0 (clang-1000.11.45.5))
+        // As a workaround, let's just flush the stream on all modifiers.
+        // In practice they're usually endl anyway, so the perf hit should not be too bad.
         streambuffer << f;
         stream_flush();
         if(streamloglevel == LOG_FATAL) {


### PR DESCRIPTION
Seems that perhaps we were relying on undefined behavior, and the
behavior has changed in newer compilers. (Unclear cause.)

The result is that in debug mode, the expression
`endltype(f) == endltype(std::endl)` always returns false,
even when the modifier passed in is in fact std::endl.
As a result, in debug mode, we never flush the stream.

This fix is to ignore which modifier is being passed in, and
always flush the stream as though it's std::endl. In practice,
it's likely to be endl most of the time, so the performance hit
from flushing more often should not be too bad.