### PR TITLE
Call os_log from table_printer

### DIFF
--- a/src/table_printer/table_printer.cpp
+++ b/src/table_printer/table_printer.cpp
@@ -323,8 +323,9 @@ void table_printer::_os_log_value(size_t column_index, float value) {
 }
 
 void table_printer::_os_log_value(size_t column_index, const progress_time& value) const {
-  double t = (value.elapsed_seconds < 0) ? tt.current_time() : value.elapsed_seconds;
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %f seconds", column_index, t);
+  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %f seconds",
+    column_index,
+    (value.elapsed_seconds < 0) ? tt.current_time() : value.elapsed_seconds);
 }
 
 void table_printer::_os_log_value(size_t column_index, const char* value) {

--- a/src/table_printer/table_printer.cpp
+++ b/src/table_printer/table_printer.cpp
@@ -16,18 +16,21 @@
 #undef MIN
 #undef MAX
 
+static os_log_t& os_log_object() {
+  static os_log_t log_object = os_log_create("turi", "table_printer");
+  return log_object;
+}
+
 #define _os_log_event_impl(event)                                         \
   os_log_info(                                                            \
-    OS_LOG_DEFAULT,                                                       \
-    "source: %lu, event: %lu",                                            \
-    1ul, /* source: table printer */                                      \
+    os_log_object(),                                                      \
+    "event: %lu",                                                         \
     event)
 
 #define _os_log_event_with_value_impl(format, event, column_index, value) \
   os_log_info(                                                            \
-    OS_LOG_DEFAULT,                                                       \
+    os_log_object(),                                                      \
     format,                                                               \
-    1ul, /* source: table printer */                                      \
     event,                                                                \
     column_index,                                                         \
     value)
@@ -122,7 +125,7 @@ void table_printer::print_header() const {
     ss << ' ' << '|';
 
     _os_log_header_impl(
-      "source: %lu, event: %lu, column: %lu, value: %{public}s",
+      "event: %lu, column: %lu, value: %{public}s",
       i, /* column_index */
       p.first.c_str());
 
@@ -231,7 +234,7 @@ void table_printer::print_track_row_if_necessary() const {
   ss << '|';
   for (size_t i = 0; i < track_row_values_.size(); ++i) {
     const flexible_type& value = track_row_values_[i];
-    _os_log_value(i, value);
+    os_log_value(i, value);
     const size_t width = format[i].second;
 
     // Use track_row_styles_ to recover any type information lost when stuffing
@@ -289,84 +292,81 @@ size_t table_printer::set_up_time_printing_interval(size_t tick) {
   return _tick_interval; 
 }
 
-
-void table_printer::_os_log_value(size_t column_index, unsigned long long value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %llu", column_index, value);
+void table_printer::os_log_value(size_t column_index, unsigned long long value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %llu", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, unsigned long value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %lu", column_index, value);
+void table_printer::os_log_value(size_t column_index, unsigned long value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %lu", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, unsigned int value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %u", column_index, value);
+void table_printer::os_log_value(size_t column_index, unsigned int value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %u", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, long long value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %lld", column_index, value);
+void table_printer::os_log_value(size_t column_index, long long value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %lld", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, long value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %ld", column_index, value);
+void table_printer::os_log_value(size_t column_index, long value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %ld", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, int value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %d", column_index, value);
+void table_printer::os_log_value(size_t column_index, int value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %d", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, double value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %f", column_index, value);
+void table_printer::os_log_value(size_t column_index, double value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %f", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, float value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %f", column_index, value);
+void table_printer::os_log_value(size_t column_index, float value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %f", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, const progress_time& value) const {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %f seconds",
+void table_printer::os_log_value(size_t column_index, const progress_time& value) const {
+  _os_log_value_impl("event: %lu, column: %lu, value: %f seconds",
     column_index,
     (value.elapsed_seconds < 0) ? tt.current_time() : value.elapsed_seconds);
 }
 
-void table_printer::_os_log_value(size_t column_index, const char* value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %{public}s", column_index, value);
+void table_printer::os_log_value(size_t column_index, const char* value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %{public}s", column_index, value);
 }
 
-void table_printer::_os_log_value(size_t column_index, bool value) {
-  _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %hhud", column_index, static_cast<unsigned char>(value));
+void table_printer::os_log_value(size_t column_index, bool value) {
+  _os_log_value_impl("event: %lu, column: %lu, value: %hhu", column_index, static_cast<unsigned char>(value));
 }
 
-void table_printer::_os_log_value(size_t column_index, const flexible_type& value) {
-  #ifdef __APPLE__
-      switch (value.get_type()) {
-        case flex_type_enum::INTEGER:
-          _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %lld", column_index, value.get<flex_int>());
-          break;
-        case flex_type_enum::DATETIME:
-        {
-          int64_t timestamp = value.get<flex_date_time>().posix_timestamp();
-          _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %{time}lld", column_index, timestamp);
-          break;
-        }
-        case flex_type_enum::FLOAT:
-          _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %f", column_index, value.get<flex_float>());
-          break;
-        case flex_type_enum::STRING:
-        {
-          std::string str_value = value.get<flex_string>();
-          _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: %{public}s", column_index, str_value.c_str());
-          break;
-        }
-        case flex_type_enum::VECTOR:
-        case flex_type_enum::ND_VECTOR:
-        case flex_type_enum::LIST:
-        case flex_type_enum::DICT:
-        case flex_type_enum::IMAGE:
-        default:
-          _os_log_value_impl("source: %lu, event: %lu, column: %lu, value: instance of complex type %{public}s", column_index, flex_type_enum_to_name(value.get_type()));
-          break;
-      }
-  #endif
+void table_printer::os_log_value(size_t column_index, const flexible_type& value) {
+  switch (value.get_type()) {
+    case flex_type_enum::INTEGER:
+      _os_log_value_impl("event: %lu, column: %lu, value: %lld", column_index, value.get<flex_int>());
+      break;
+    case flex_type_enum::DATETIME:
+    {
+      int64_t timestamp = value.get<flex_date_time>().posix_timestamp();
+      _os_log_value_impl("event: %lu, column: %lu, value: %{time_t}lld", column_index, timestamp);
+      break;
+    }
+    case flex_type_enum::FLOAT:
+      _os_log_value_impl("event: %lu, column: %lu, value: %f", column_index, value.get<flex_float>());
+      break;
+    case flex_type_enum::STRING:
+    {
+      std::string str_value = value.get<flex_string>();
+      _os_log_value_impl("event: %lu, column: %lu, value: %{public}s", column_index, str_value.c_str());
+      break;
+    }
+    case flex_type_enum::VECTOR:
+    case flex_type_enum::ND_VECTOR:
+    case flex_type_enum::LIST:
+    case flex_type_enum::DICT:
+    case flex_type_enum::IMAGE:
+    default:
+      _os_log_value_impl("event: %lu, column: %lu, value: instance of complex type %{public}s", column_index, flex_type_enum_to_name(value.get_type()));
+      break;
+  }
 }
 
 }

--- a/src/table_printer/table_printer.cpp
+++ b/src/table_printer/table_printer.cpp
@@ -344,20 +344,14 @@ void table_printer::os_log_value(size_t column_index, const flexible_type& value
       _os_log_value_impl("event: %lu, column: %lu, value: %lld", column_index, value.get<flex_int>());
       break;
     case flex_type_enum::DATETIME:
-    {
-      int64_t timestamp = value.get<flex_date_time>().posix_timestamp();
-      _os_log_value_impl("event: %lu, column: %lu, value: %{time_t}lld", column_index, timestamp);
+      _os_log_value_impl("event: %lu, column: %lu, value: %{time_t}lld", column_index, value.get<flex_date_time>().posix_timestamp());
       break;
-    }
     case flex_type_enum::FLOAT:
       _os_log_value_impl("event: %lu, column: %lu, value: %f", column_index, value.get<flex_float>());
       break;
     case flex_type_enum::STRING:
-    {
-      std::string str_value = value.get<flex_string>();
-      _os_log_value_impl("event: %lu, column: %lu, value: %{public}s", column_index, str_value.c_str());
+      _os_log_value_impl("event: %lu, column: %lu, value: %{public}s", column_index, value.get<flex_string>().c_str());
       break;
-    }
     case flex_type_enum::VECTOR:
     case flex_type_enum::ND_VECTOR:
     case flex_type_enum::LIST:

--- a/src/table_printer/table_printer.hpp
+++ b/src/table_printer/table_printer.hpp
@@ -18,12 +18,6 @@
 #include <util/code_optimization.hpp>
 #include <table_printer/table_element_printers.hpp>
 
-#ifdef __APPLE__
-#include <os/log.h>
-#undef MIN
-#undef MAX
-#endif
-
 namespace turi {
 
 extern double MIN_SECONDS_BETWEEN_TICK_PRINTS;
@@ -245,7 +239,6 @@ class table_printer {
   static void _os_log_value(size_t column_index, double value);
   static void _os_log_value(size_t column_index, float value);
   void _os_log_value(size_t column_index, const progress_time& value) const;
-  static void _os_log_value(size_t column_index, char* value);
   static void _os_log_value(size_t column_index, const char* value);
   static void _os_log_value(size_t column_index, bool value);
   static void _os_log_value(size_t column_index, const flexible_type& value);

--- a/src/table_printer/table_printer.hpp
+++ b/src/table_printer/table_printer.hpp
@@ -18,6 +18,12 @@
 #include <util/code_optimization.hpp>
 #include <table_printer/table_element_printers.hpp>
 
+#ifdef __APPLE__
+#include <os/log.h>
+#undef MIN
+#undef MAX
+#endif
+
 namespace turi {
 
 extern double MIN_SECONDS_BETWEEN_TICK_PRINTS;
@@ -228,8 +234,22 @@ class table_printer {
    */
   void set_output_stream(std::ostream& out_stream) {
     alt_output_stream = &out_stream;
-  }  
-  
+  }
+
+  static void _os_log_value(size_t column_index, unsigned long long value);
+  static void _os_log_value(size_t column_index, unsigned long value);
+  static void _os_log_value(size_t column_index, unsigned int value);
+  static void _os_log_value(size_t column_index, long long value);
+  static void _os_log_value(size_t column_index, long value);
+  static void _os_log_value(size_t column_index, int value);
+  static void _os_log_value(size_t column_index, double value);
+  static void _os_log_value(size_t column_index, float value);
+  void _os_log_value(size_t column_index, const progress_time& value) const;
+  static void _os_log_value(size_t column_index, char* value);
+  static void _os_log_value(size_t column_index, const char* value);
+  static void _os_log_value(size_t column_index, bool value);
+  static void _os_log_value(size_t column_index, const flexible_type& value);
+
   /** Prints the header.
    *
    *  Example output:
@@ -290,8 +310,10 @@ class table_printer {
 
     ss << '|';
 
-    for (size_t i = 0; i < row_string.size(); ++i)
+    for (size_t i = 0; i < row_string.size(); ++i) {
+      _os_log_value(i, row_string[i]);
       _get_table_printer(row_string[i]).print(ss, format[i].second);
+    }
 
     _p(ss);
   }
@@ -463,6 +485,7 @@ private:
   GL_HOT_INLINE_FLATTEN void _add_values_in_row(std::ostringstream& ss, size_t column_index,
                                                 const T& t, const Args&... columns) const {
 
+    _os_log_value(column_index, t);
     _get_table_printer(t).print(ss, format[column_index].second);
     _add_values_in_row(ss, column_index + 1, columns...);
   }
@@ -471,6 +494,7 @@ private:
    */
   template <typename T, typename... Args>
   GL_HOT_INLINE_FLATTEN void _add_values_in_row(std::ostringstream& ss, size_t column_index, const T& t) const {
+    _os_log_value(column_index, t);
     _get_table_printer(t).print(ss, format[column_index].second);
   }
 

--- a/src/table_printer/table_printer.hpp
+++ b/src/table_printer/table_printer.hpp
@@ -230,19 +230,7 @@ class table_printer {
     alt_output_stream = &out_stream;
   }
 
-  static void _os_log_value(size_t column_index, unsigned long long value);
-  static void _os_log_value(size_t column_index, unsigned long value);
-  static void _os_log_value(size_t column_index, unsigned int value);
-  static void _os_log_value(size_t column_index, long long value);
-  static void _os_log_value(size_t column_index, long value);
-  static void _os_log_value(size_t column_index, int value);
-  static void _os_log_value(size_t column_index, double value);
-  static void _os_log_value(size_t column_index, float value);
-  void _os_log_value(size_t column_index, const progress_time& value) const;
-  static void _os_log_value(size_t column_index, const char* value);
-  static void _os_log_value(size_t column_index, bool value);
-  static void _os_log_value(size_t column_index, const flexible_type& value);
-
+  
   /** Prints the header.
    *
    *  Example output:
@@ -304,7 +292,7 @@ class table_printer {
     ss << '|';
 
     for (size_t i = 0; i < row_string.size(); ++i) {
-      _os_log_value(i, row_string[i]);
+      os_log_value(i, row_string[i]);
       _get_table_printer(row_string[i]).print(ss, format[i].second);
     }
 
@@ -441,6 +429,23 @@ class table_printer {
   sframe get_tracked_table();
 
 private:
+  
+  /**
+   * Methods to log specific value types
+   */
+  static void os_log_value(size_t column_index, unsigned long long value);
+  static void os_log_value(size_t column_index, unsigned long value);
+  static void os_log_value(size_t column_index, unsigned int value);
+  static void os_log_value(size_t column_index, long long value);
+  static void os_log_value(size_t column_index, long value);
+  static void os_log_value(size_t column_index, int value);
+  static void os_log_value(size_t column_index, double value);
+  static void os_log_value(size_t column_index, float value);
+  void os_log_value(size_t column_index, const progress_time& value) const;
+  static void os_log_value(size_t column_index, const char* value);
+  static void os_log_value(size_t column_index, bool value);
+  static void os_log_value(size_t column_index, const flexible_type& value);
+
 
   /** Returns the table_printer::style_type for a given value
    */
@@ -478,7 +483,7 @@ private:
   GL_HOT_INLINE_FLATTEN void _add_values_in_row(std::ostringstream& ss, size_t column_index,
                                                 const T& t, const Args&... columns) const {
 
-    _os_log_value(column_index, t);
+    os_log_value(column_index, t);
     _get_table_printer(t).print(ss, format[column_index].second);
     _add_values_in_row(ss, column_index + 1, columns...);
   }
@@ -487,7 +492,7 @@ private:
    */
   template <typename T, typename... Args>
   GL_HOT_INLINE_FLATTEN void _add_values_in_row(std::ostringstream& ss, size_t column_index, const T& t) const {
-    _os_log_value(column_index, t);
+    os_log_value(column_index, t);
     _get_table_printer(t).print(ss, format[column_index].second);
   }
 


### PR DESCRIPTION
* All types that are passed into table printer are handled.
* Logs start, header, values, and end.
* Apple-platform only; on others, this will no-op.