### PR TITLE
Use `com.apple` prefix on os_log subsystem

### DIFF
--- a/src/table_printer/table_printer.cpp
+++ b/src/table_printer/table_printer.cpp
@@ -17,7 +17,7 @@
 #undef MAX
 
 static os_log_t& os_log_object() {
-  static os_log_t log_object = os_log_create("turi", "table_printer");
+  static os_log_t log_object = os_log_create("com.apple.turi", "table_printer");
   return log_object;
 }
 


### PR DESCRIPTION
The os_log subsystem should use a vendor prefix, like `com.apple`.