### PR TITLE
Fix plot get_data for SFrame summary view

### DIFF
--- a/src/unity/lib/visualization/boxes_and_whiskers.cpp
+++ b/src/unity/lib/visualization/boxes_and_whiskers.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<Plot> turi::visualization::plot_boxes_and_whiskers(
   temp_sf[x_name] = x;
   temp_sf[y_name] = y;
 
-  bw.init(temp_sf);
+  bw.init(temp_sf, 5000000 /* batch_size */);
 
   std::shared_ptr<transformation_base> shared_unity_transformer = std::make_shared<boxes_and_whiskers>(bw);
   return std::make_shared<Plot>(boxes_and_whiskers_specification, shared_unity_transformer, size_array);

--- a/src/unity/lib/visualization/categorical_heatmap.cpp
+++ b/src/unity/lib/visualization/categorical_heatmap.cpp
@@ -89,7 +89,7 @@ std::shared_ptr<Plot> turi::visualization::plot_categorical_heatmap(
     temp_sf["x"] = x;
     temp_sf["y"] = y;
 
-    hm.init(temp_sf);
+    hm.init(temp_sf, 5000000 /* batch_size */);
 
     std::shared_ptr<transformation_base> shared_unity_transformer = std::make_shared<categorical_heatmap>(hm);
     return std::make_shared<Plot>(categorical_heatmap_specification, shared_unity_transformer, size_array);

--- a/src/unity/lib/visualization/categorical_heatmap.hpp
+++ b/src/unity/lib/visualization/categorical_heatmap.hpp
@@ -23,7 +23,7 @@ class categorical_heatmap_result: public transformation_output,
 // expects a gl_sframe of:
 // "x": str,
 // "y": float
-typedef transformation<gl_sframe, categorical_heatmap_result, 5000000> categorical_heatmap_parent;
+typedef transformation<gl_sframe, categorical_heatmap_result> categorical_heatmap_parent;
 
 class categorical_heatmap : public categorical_heatmap_parent {
   public:

--- a/src/unity/lib/visualization/groupby.hpp
+++ b/src/unity/lib/visualization/groupby.hpp
@@ -132,7 +132,7 @@ class groupby_result {
 };
 
 template<typename Result>
-class groupby : public transformation<gl_sframe, Result, 5000000> {
+class groupby : public transformation<gl_sframe, Result> {
   protected:
     virtual void merge_results(std::vector<Result>& transformers) override {
       for (auto& result : transformers) {

--- a/src/unity/lib/visualization/heatmap.cpp
+++ b/src/unity/lib/visualization/heatmap.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<Plot> turi::visualization::plot_heatmap(
   temp_sf[x_name] = x;
   temp_sf[y_name] = y;
 
-  hm.init(temp_sf);
+  hm.init(temp_sf, 5000000 /* batch_size */);
 
   std::shared_ptr<transformation_base> shared_unity_transformer = std::make_shared<heatmap>(hm);
   return std::make_shared<Plot>(heatmap_specification, shared_unity_transformer, size_array);
@@ -70,9 +70,9 @@ void heatmap_result::init(double xMin, double xMax, double yMin, double yMax) {
   extrema.y.update(yMax);
 }
 
-void heatmap::init(const gl_sframe& source) {
+void heatmap::init(const gl_sframe& source, size_t batch_size) {
   // initialize parent class
-  groupby<heatmap_result>::init(source);
+  groupby<heatmap_result>::init(source, batch_size);
 
   // initialize heatmap_result
   const auto& head = source.head(10000); // infer min/max from first 10k rows

--- a/src/unity/lib/visualization/heatmap.hpp
+++ b/src/unity/lib/visualization/heatmap.hpp
@@ -57,7 +57,7 @@ namespace visualization {
    */
   class heatmap : public groupby<heatmap_result> {
     public:
-      virtual void init(const gl_sframe& source) override;
+      virtual void init(const gl_sframe& source, size_t batch_size) override;
       virtual std::vector<heatmap_result> split_input(size_t num_threads) override;
   };
 

--- a/src/unity/lib/visualization/histogram.cpp
+++ b/src/unity/lib/visualization/histogram.cpp
@@ -213,8 +213,8 @@ void histogram_result::add_element_simple(const flexible_type& value) {
   this->bins[bin] += 1;
 }
 
-void histogram::init(const gl_sarray& source) {
-  histogram_parent::init(source);
+void histogram::init(const gl_sarray& source, size_t batch_size) {
+  histogram_parent::init(source, batch_size);
   flex_type_enum dtype = m_source.dtype();
   if (dtype != flex_type_enum::INTEGER &&
       dtype != flex_type_enum::FLOAT) {
@@ -354,7 +354,7 @@ std::shared_ptr<Plot> plot_histogram(
     std::string spec = histogram_spec(title, xlabel, ylabel, self->dtype());
     double size_array = static_cast<double>(self->size());
 
-    hist.init(*self);
+    hist.init(*self, 5000000 /* batch_size */);
 
     std::shared_ptr<transformation_base> shared_unity_transformer = std::make_shared<histogram>(hist);
     return std::make_shared<Plot>(spec, shared_unity_transformer, size_array);

--- a/src/unity/lib/visualization/histogram.hpp
+++ b/src/unity/lib/visualization/histogram.hpp
@@ -111,12 +111,12 @@ struct histogram_result : public sframe_transformation_output {
  *     the histogram (result type, as shown below) representing the current
  *     distribution of values seen so far.
  */
-typedef transformation<gl_sarray, histogram_result, 5000000> histogram_parent;
+typedef transformation<gl_sarray, histogram_result> histogram_parent;
 class histogram : public histogram_parent {
   public:
     virtual std::vector<histogram_result> split_input(size_t num_threads) override;
     virtual void merge_results(std::vector<histogram_result>& transformers) override;
-    virtual void init(const gl_sarray& source) override;
+    virtual void init(const gl_sarray& source, size_t batch_size) override;
 };
 
 std::shared_ptr<Plot> plot_histogram(

--- a/src/unity/lib/visualization/item_frequency.cpp
+++ b/src/unity/lib/visualization/item_frequency.cpp
@@ -151,7 +151,7 @@ namespace turi {
         std::shared_ptr<const gl_sarray> self = std::make_shared<const gl_sarray>(sa);
 
         item_frequency item_freq;
-        item_freq.init(*self);
+        item_freq.init(*self, 5000000 /* batch_size */);
 
         auto transformer = std::dynamic_pointer_cast<item_frequency_result>(item_freq.get());
         auto result = transformer->emit().get<flex_dict>();

--- a/src/unity/lib/visualization/item_frequency.hpp
+++ b/src/unity/lib/visualization/item_frequency.hpp
@@ -31,7 +31,7 @@ class item_frequency_result: public sframe_transformation_output,
     groupby_operators::non_null_count m_non_null_count; // (inverse) num missing
 };
 
-typedef transformation<gl_sarray, item_frequency_result, 5000000> item_frequency_parent;
+typedef transformation<gl_sarray, item_frequency_result> item_frequency_parent;
 
 class item_frequency : public item_frequency_parent {
   public:

--- a/src/unity/lib/visualization/summary_view.hpp
+++ b/src/unity/lib/visualization/summary_view.hpp
@@ -16,23 +16,21 @@ class summary_view_transformation_output : public transformation_output {
     std::vector<std::string> m_column_names;
     std::vector<flex_type_enum> m_column_types;
     size_t m_size;
-    size_t m_index;
 
-    summary_view_transformation_output(const std::vector<std::shared_ptr<transformation_output>> outputs, std::vector<std::string> column_names, std::vector<flex_type_enum> column_types, size_t size, size_t index);
+    summary_view_transformation_output(const std::vector<std::shared_ptr<transformation_output>>& outputs, std::vector<std::string> column_names, std::vector<flex_type_enum> column_types, size_t size);
     virtual std::string vega_column_data(bool sframe = false) const override;
 };
 
 class summary_view_transformation : public transformation_base {
   private:
     std::vector<std::shared_ptr<transformation_base>> m_transformers;
-    size_t m_index = 0;
 
   public:
     std::vector<std::string> m_column_names;
     std::vector<flex_type_enum> m_column_types;
     size_t m_size;
 
-    summary_view_transformation(const std::vector<std::shared_ptr<transformation_base>> transformers, std::vector<std::string> column_names, std::vector<flex_type_enum> column_types, size_t size);
+    summary_view_transformation(const std::vector<std::shared_ptr<transformation_base>>& transformers, std::vector<std::string> column_names, std::vector<flex_type_enum> column_types, size_t size);
 
     virtual std::shared_ptr<transformation_output> get() override;
     virtual bool eof() const override;

--- a/src/unity/lib/visualization/transformation.hpp
+++ b/src/unity/lib/visualization/transformation.hpp
@@ -41,10 +41,10 @@ class transformation_collection : public std::vector<std::shared_ptr<transformat
 };
 
 template<typename InputIterable,
-         typename Output,
-         size_t BATCH_SIZE>
+         typename Output>
 class transformation : public transformation_base {
   protected:
+    size_t m_batch_size;
     InputIterable m_source;
     std::shared_ptr<Output> m_transformer;
     size_t m_currentIdx = 0;
@@ -74,8 +74,9 @@ class transformation : public transformation_base {
     virtual void merge_results(std::vector<Output>& transformers) = 0;
 
   public:
-    virtual void init(const InputIterable& source) {
+    virtual void init(const InputIterable& source, size_t batch_size) {
       check_init("Transformer is already initialized.", false);
+      m_batch_size = batch_size;
       m_source = source;
       m_transformer = std::make_shared<Output>();
       m_currentIdx = 0;
@@ -104,7 +105,7 @@ class transformation : public transformation_base {
 
       const size_t num_threads_reported = thread_pool::get_instance().size();
       const size_t start = m_currentIdx;
-      const size_t input_size = std::min(BATCH_SIZE, m_source.size() - m_currentIdx);
+      const size_t input_size = std::min(m_batch_size, m_source.size() - m_currentIdx);
       const size_t end = start + input_size;
       auto transformers = this->split_input(num_threads_reported);
       const auto& source = this->m_source;
@@ -138,7 +139,7 @@ class transformation : public transformation_base {
     }
 
     virtual size_t get_batch_size() const override {
-      return BATCH_SIZE;
+      return m_batch_size;
     }
 };
 


### PR DESCRIPTION
This change picks up two commits from a branch that were conceptually
necessary for other recent changes, but somehow didn't break the
build, or fail any tests, or break anything in practice except for
issue 1248. The necessary commits were:

https://github.com/znation/turicreate/commit/616de4b641389ce7ccc4e621850996af8d82781
https://github.com/znation/turicreate/commit/3e02db92ed685414f1be25f21bf23a0b9af3d32c

Fixes #1248

TBD: what specific commit went in that broke this? It worked in the 5.1
release.