### PR TITLE
More CSV Parsing Improvements

### DIFF
--- a/src/flexible_type/flexible_type_spirit_parser.cpp
+++ b/src/flexible_type/flexible_type_spirit_parser.cpp
@@ -34,7 +34,9 @@ qi::real_parser< double, strict_real_policies<double> > real;
 
 template <typename Iterator, typename SpaceType>
 struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceType> {
-  flexible_type_parser_impl(std::string delimiter = ",", char escape_char = '\\') : 
+  flexible_type_parser_impl(std::string delimiter = ",", 
+                            bool use_escape_char = true, 
+                            char escape_char = '\\') : 
       flexible_type_parser_impl::base_type(root_parser), delimiter(delimiter) {
     using qi::long_long;
     using qi::double_;
@@ -54,6 +56,7 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
      */
     parser_impl::parser_config recursive_element_string_parser;
     recursive_element_string_parser.restrictions = ",{}[]";
+    recursive_element_string_parser.use_escape_char = use_escape_char;
     recursive_element_string_parser.escape_char = escape_char;
     recursive_element_string_parser.double_quote = true;
 
@@ -63,6 +66,7 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
      */
     parser_impl::parser_config dictionary_element_string_parser;
     dictionary_element_string_parser.restrictions = " ,\t{}[]:;";
+    dictionary_element_string_parser.use_escape_char = use_escape_char;
     dictionary_element_string_parser.escape_char = escape_char;
     dictionary_element_string_parser.double_quote = true;
 
@@ -71,6 +75,7 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     if (delimiter.length() <= 1) root_flex_string.restrictions = delimiter;
     else root_flex_string.delimiter = delimiter;
 
+    root_flex_string.use_escape_char = use_escape_char;
     root_flex_string.escape_char = escape_char;
     root_flex_string.double_quote = true;
 
@@ -184,11 +189,13 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
 
 
 
-flexible_type_parser::flexible_type_parser(std::string separator, char escape_char):
+flexible_type_parser::flexible_type_parser(std::string separator, 
+                                           bool use_escape_char, 
+                                           char escape_char):
     parser(new flexible_type_parser_impl<const char*, 
-           decltype(space)>(separator, escape_char)), 
+           decltype(space)>(separator, use_escape_char, escape_char)), 
     non_space_parser(new flexible_type_parser_impl<const char*, 
-                     decltype(qi::eoi)>(separator, escape_char)), 
+                     decltype(qi::eoi)>(separator, use_escape_char, escape_char)), 
     m_delimiter_has_space(delimiter_has_space(parser->delimiter))
     { }
 

--- a/src/flexible_type/flexible_type_spirit_parser.cpp
+++ b/src/flexible_type/flexible_type_spirit_parser.cpp
@@ -36,7 +36,10 @@ template <typename Iterator, typename SpaceType>
 struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceType> {
   flexible_type_parser_impl(std::string delimiter = ",", 
                             bool use_escape_char = true, 
-                            char escape_char = '\\') : 
+                            char escape_char = '\\',
+                            const std::unordered_set<std::string>& na_val = {},
+                            const std::unordered_set<std::string>& true_val = {},
+                            const std::unordered_set<std::string>& false_val = {}) :
       flexible_type_parser_impl::base_type(root_parser), delimiter(delimiter) {
     using qi::long_long;
     using qi::double_;
@@ -59,6 +62,9 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     recursive_element_string_parser.use_escape_char = use_escape_char;
     recursive_element_string_parser.escape_char = escape_char;
     recursive_element_string_parser.double_quote = true;
+    recursive_element_string_parser.na_val = na_val;
+    recursive_element_string_parser.true_val = true_val;
+    recursive_element_string_parser.false_val= false_val;
 
     /*
      * A parser which parses strings, and stops at all unquoted delimiters
@@ -69,6 +75,9 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     dictionary_element_string_parser.use_escape_char = use_escape_char;
     dictionary_element_string_parser.escape_char = escape_char;
     dictionary_element_string_parser.double_quote = true;
+    dictionary_element_string_parser.na_val = na_val;
+    dictionary_element_string_parser.true_val = true_val;
+    dictionary_element_string_parser.false_val = false_val;
 
     parser_impl::parser_config root_flex_string;
     // when the delimiter is just one character, using the restrictions is faster.
@@ -78,6 +87,9 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     root_flex_string.use_escape_char = use_escape_char;
     root_flex_string.escape_char = escape_char;
     root_flex_string.double_quote = true;
+    root_flex_string.na_val = na_val;
+    root_flex_string.true_val = true_val;
+    root_flex_string.false_val = false_val;
 
     string = 
         (parser_impl::restricted_string(root_flex_string)[_val = _1]);
@@ -191,9 +203,12 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
 
 flexible_type_parser::flexible_type_parser(std::string separator, 
                                            bool use_escape_char, 
-                                           char escape_char):
+                                           char escape_char,
+                                           const std::unordered_set<std::string>& na_val,
+                                           const std::unordered_set<std::string>& true_val,
+                                           const std::unordered_set<std::string>& false_val):
     parser(new flexible_type_parser_impl<const char*, 
-           decltype(space)>(separator, use_escape_char, escape_char)), 
+           decltype(space)>(separator, use_escape_char, escape_char, na_val, true_val, false_val)), 
     non_space_parser(new flexible_type_parser_impl<const char*, 
                      decltype(qi::eoi)>(separator, use_escape_char, escape_char)), 
     m_delimiter_has_space(delimiter_has_space(parser->delimiter))

--- a/src/flexible_type/flexible_type_spirit_parser.hpp
+++ b/src/flexible_type/flexible_type_spirit_parser.hpp
@@ -36,7 +36,10 @@ class flexible_type_parser {
  public:
   flexible_type_parser(std::string delimiter = ",", 
                        bool use_escape_char = true, 
-                       char escape_char = '\\');
+                       char escape_char = '\\',
+                       const std::unordered_set<std::string>& na_val = {},
+                       const std::unordered_set<std::string>& true_val = {},
+                       const std::unordered_set<std::string>& false_val = {});
   /**
    * Parses a generalized flexible type from a string. The *str pointer will be
    * updated to point to the character after the last character parsed.

--- a/src/flexible_type/flexible_type_spirit_parser.hpp
+++ b/src/flexible_type/flexible_type_spirit_parser.hpp
@@ -34,7 +34,9 @@ struct flexible_type_parser_impl;
  */
 class flexible_type_parser {
  public:
-  flexible_type_parser(std::string delimiter = ",", char escape_char = '\\');
+  flexible_type_parser(std::string delimiter = ",", 
+                       bool use_escape_char = true, 
+                       char escape_char = '\\');
   /**
    * Parses a generalized flexible type from a string. The *str pointer will be
    * updated to point to the character after the last character parsed.

--- a/src/flexible_type/string_escape.cpp
+++ b/src/flexible_type/string_escape.cpp
@@ -171,8 +171,8 @@ size_t write_utf8(size_t code_point, char* c) {
   return 0;
 }
 
-size_t unescape_string(char* cal, size_t length, char escape_char, 
-                     char quote_char, bool double_quote) {
+size_t unescape_string(char* cal, size_t length, bool use_escape_char, 
+                       char escape_char, char quote_char, bool double_quote) {
   // to avoid allocating a new string, we are do this entirely in-place
   // This works because for all the escapes we have here, the output string
   // is shorter than the input.
@@ -180,7 +180,7 @@ size_t unescape_string(char* cal, size_t length, char escape_char,
   size_t out = 0;
 
   while(in != length) {
-    if (cal[in]  == escape_char && in + 1 < length) {
+    if ((use_escape_char && cal[in] == escape_char) && in + 1 < length) {
       char echar = cal[in + 1];
       switch (echar) {
        case '\'':
@@ -283,10 +283,11 @@ size_t unescape_string(char* cal, size_t length, char escape_char,
 }
 
 
-void unescape_string(std::string& cal, char escape_char, 
+void unescape_string(std::string& cal, bool use_escape_char, char escape_char, 
                      char quote_char, bool double_quote) {
   size_t new_length = unescape_string(&(cal[0]), cal.length(), 
-                                      escape_char, quote_char, double_quote);
+                                      use_escape_char, escape_char, 
+                                      quote_char, double_quote);
   cal.resize(new_length);
 }
 

--- a/src/flexible_type/string_escape.hpp
+++ b/src/flexible_type/string_escape.hpp
@@ -11,14 +11,14 @@ namespace turi {
 /**
  * Unescapes a string inplace
  */
-void unescape_string(std::string& cal, char escape_char, 
+void unescape_string(std::string& cal, bool use_escape_char, char escape_char, 
                      char quote_char, bool double_quote);
 
 /**
  * Unescapes a string inplace, returning the new length
  */
 size_t unescape_string(char* cal, 
-                       size_t length, char escape_char, 
+                       size_t length, bool use_escape_char, char escape_char, 
                        char quote_char, bool double_quote);
 /**
  * Escapes a string from val into output.

--- a/src/flexible_type/string_parser.hpp
+++ b/src/flexible_type/string_parser.hpp
@@ -17,21 +17,23 @@
 
 namespace parser_impl { 
 
-/*
+/**
  * \internal
  * The string parsing configuration.
  *
  */
 struct parser_config {
-  // If any of these character occurs outside of quoted string, 
-  // the string will be terminated
+  /// If any of these character occurs outside of quoted string, 
+  /// the string will be terminated
   std::string restrictions;
-  // If the delimiter string is seen anywhere outside of a quoted string,
-  // the string will be terminated.
+  /// If the delimiter string is seen anywhere outside of a quoted string,
+  /// the string will be terminated.
   std::string delimiter;
-  // The character to use for an escape character
+  /// Whether escape char should be used
+  bool use_escape_char = true;
+  /// The character to use for an escape character
   char escape_char = '\\';
-  /* whether double quotes inside of a quote are treated as a single quote.
+  /** whether double quotes inside of a quote are treated as a single quote.
    * i.e. """hello""" => \"hello\"
    */
   char double_quote = true;
@@ -136,7 +138,7 @@ struct string_parser
     }
     return true;
   }
-#define PUSH_CHAR(c) ret.add_char(c); escape_sequence = (c == config.escape_char);
+#define PUSH_CHAR(c) ret.add_char(c); escape_sequence = config.use_escape_char && (c == config.escape_char);
 
 // insert a character into the field buffer. resizing it if necessary
 
@@ -229,8 +231,9 @@ struct string_parser
       if (!quote_char) boost::algorithm::trim_right(final_str);
       else if (quote_char) {
         // if was quoted field, we unescape the contents
-        turi::unescape_string(final_str, config.escape_char,
-                                  quote_char, config.double_quote);
+        turi::unescape_string(final_str, config.use_escape_char, 
+                              config.escape_char,
+                              quote_char, config.double_quote);
       }
       attr = std::move(final_str);
       first = cur;

--- a/src/flexible_type/string_parser.hpp
+++ b/src/flexible_type/string_parser.hpp
@@ -37,6 +37,10 @@ struct parser_config {
    * i.e. """hello""" => \"hello\"
    */
   char double_quote = true;
+
+  std::unordered_set<std::string> na_val;
+  std::unordered_set<std::string> true_val;
+  std::unordered_set<std::string> false_val;
 };
 
 BOOST_SPIRIT_TERMINAL_EX(restricted_string); 
@@ -235,7 +239,15 @@ struct string_parser
                               config.escape_char,
                               quote_char, config.double_quote);
       }
-      attr = std::move(final_str);
+      if (!config.na_val.empty() && config.na_val.count(final_str)) {
+        attr = turi::flexible_type(turi::flex_type_enum::UNDEFINED);
+      } else if (!config.true_val.empty() && config.true_val.count(final_str)) {
+        attr = 1;
+      } else if (!config.false_val.empty() && config.false_val.count(final_str)) {
+        attr = 0;
+      } else {
+        attr = std::move(final_str);
+      }
       first = cur;
     }
     return true;

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -78,24 +78,6 @@ bool file_logger::set_log_file(std::string file) {
 }
 
 
-
-#define RESET   0
-#define BRIGHT    1
-#define DIM   2
-#define UNDERLINE   3
-#define BLINK   4
-#define REVERSE   7
-#define HIDDEN    8
-
-#define BLACK     0
-#define RED   1
-#define GREEN   2
-#define YELLOW    3
-#define BLUE    4
-#define MAGENTA   5
-#define CYAN    6
-#define WHITE   7
-
 void textcolor(FILE* handle, int attr, int fg)
 {
   char command[13];
@@ -104,12 +86,29 @@ void textcolor(FILE* handle, int attr, int fg)
   fprintf(handle, "%s", command);
 }
 
+std::string textcolor(int attr, int fg)
+{
+  char command[13];
+  /* Command is the control command to the terminal */
+  sprintf(command, "%c[%d;%dm", 0x1B, attr, fg + 30);
+  return command;
+}
+
 void reset_color(FILE* handle)
 {
   char command[20];
   /* Command is the control command to the terminal */
   sprintf(command, "%c[0m", 0x1B);
   fprintf(handle, "%s", command);
+}
+
+
+std::string reset_color()
+{
+  char command[20];
+  /* Command is the control command to the terminal */
+  sprintf(command, "%c[0m", 0x1B);
+  return command;
 }
 
 
@@ -219,19 +218,19 @@ void file_logger::_lograw(int lineloglevel, const char* buf, int len) {
 
     pthread_mutex_lock(&mut);
     if (lineloglevel == LOG_FATAL) {
-      textcolor(stderr, BRIGHT, RED);
+      textcolor(stderr, TEXTCOLOR_BRIGHT, TEXTCOLOR_RED);
     }
     else if (lineloglevel == LOG_ERROR) {
-      textcolor(log_to_stderr ? stderr : stdout, BRIGHT, RED);
+      textcolor(log_to_stderr ? stderr : stdout, TEXTCOLOR_BRIGHT, TEXTCOLOR_RED);
     }
     else if (lineloglevel == LOG_WARNING) {
-      textcolor(log_to_stderr ? stderr : stdout, BRIGHT, MAGENTA);
+      textcolor(log_to_stderr ? stderr : stdout, TEXTCOLOR_BRIGHT, TEXTCOLOR_MAGENTA);
     }
     else if (lineloglevel == LOG_DEBUG) {
-      textcolor(log_to_stderr ? stderr : stdout, BRIGHT, YELLOW);
+      textcolor(log_to_stderr ? stderr : stdout, TEXTCOLOR_BRIGHT, TEXTCOLOR_YELLOW);
     }
     else if (lineloglevel == LOG_EMPH) {
-      textcolor(log_to_stderr ? stderr : stdout, BRIGHT, GREEN);
+      textcolor(log_to_stderr ? stderr : stdout, TEXTCOLOR_BRIGHT, TEXTCOLOR_GREEN);
     }
 #endif
     if(lineloglevel >= LOG_FATAL) {

--- a/src/logger/logger.hpp
+++ b/src/logger/logger.hpp
@@ -689,8 +689,28 @@ struct log_stream_dispatch<false> {
   }
 };
 
+
+#define TEXTCOLOR_RESET   0
+#define TEXTCOLOR_BRIGHT    1
+#define TEXTCOLOR_DIM   2
+#define TEXTCOLOR_UNDERLINE   3
+#define TEXTCOLOR_BLINK   4
+#define TEXTCOLOR_REVERSE   7
+#define TEXTCOLOR_HIDDEN    8
+
+#define TEXTCOLOR_BLACK     0
+#define TEXTCOLOR_RED   1
+#define TEXTCOLOR_GREEN   2
+#define TEXTCOLOR_YELLOW    3
+#define TEXTCOLOR_BLUE    4
+#define TEXTCOLOR_MAGENTA   5
+#define TEXTCOLOR_CYAN    6
+#define TEXTCOLOR_WHITE   7
+
 void textcolor(FILE* handle, int attr, int fg);
+std::string textcolor(int attr, int fg);
 void reset_color(FILE* handle);
+std::string reset_color();
 
 #endif
 

--- a/src/sframe/csv_line_tokenizer.cpp
+++ b/src/sframe/csv_line_tokenizer.cpp
@@ -217,7 +217,7 @@ size_t csv_line_tokenizer::tokenize_line(char* str, size_t len,
   if (!success || ctr < output.size()) {
     std::stringstream strm;
     if (!tokenizer_impl_error.empty()) strm << tokenizer_impl_error << "\n";
-    if (tokenizer_impl_fail_pos >= 0 && tokenizer_impl_fail_pos <= len) {
+    if (tokenizer_impl_fail_pos >= 0 && (size_t)tokenizer_impl_fail_pos <= len) {
       strm << "Parse failed at token ending at: \n";
       std::string line(str, len);
       // colorize the line.

--- a/src/sframe/csv_line_tokenizer.cpp
+++ b/src/sframe/csv_line_tokenizer.cpp
@@ -260,6 +260,26 @@ bool csv_line_tokenizer::parse_as(char** buf, size_t len,
       }
     }
   }
+  if (!true_values.empty() && true_values.count(std::string(*buf, len))) {
+    while(len > 0 && std::isspace((*buf)[len - 1])) len--;
+    if (out.get_type() == flex_type_enum::INTEGER) {
+      out = 1;
+      return true;
+    } else if (out.get_type() == flex_type_enum::FLOAT) {
+      out = 1.0;
+      return true;
+    }
+  }
+  if (!false_values.empty() && false_values.count(std::string(*buf, len))) {
+    while(len > 0 && std::isspace((*buf)[len - 1])) len--;
+    if (out.get_type() == flex_type_enum::INTEGER) {
+      out = 0;
+      return true;
+    } else if (out.get_type() == flex_type_enum::FLOAT) {
+      out = 0.0;
+      return true;
+    }
+  }
   bool parse_success = false;
   // we are trying to parse a non-string, but this actually looks like a string
   // to me.  it might be some other type wrapped inside quote characters
@@ -595,7 +615,9 @@ const std::string& csv_line_tokenizer::get_last_parse_error_diagnosis() const {
 }
 
 void csv_line_tokenizer::init() {
-  parser.reset(new flexible_type_parser(delimiter, use_escape_char, escape_char));
+  parser.reset(new flexible_type_parser(delimiter, use_escape_char, escape_char, 
+                                        std::unordered_set<std::string>(na_values.begin(), na_values.end()),
+                                        true_values, false_values));
   is_regular_line_terminator = line_terminator == "\n";
   if (is_regular_line_terminator) {
     delimiter_is_new_line = delimiter == "\n" || 

--- a/src/sframe/csv_line_tokenizer.cpp
+++ b/src/sframe/csv_line_tokenizer.cpp
@@ -70,7 +70,7 @@ bool csv_line_tokenizer::tokenize_line(const char* str, size_t len,
                          if (len > 0 && buf[len - 1] == quote_char) --len;
                          output.emplace_back(buf, len);
                          if (is_quoted) {
-                           unescape_string(output.back(), escape_char, 
+                           unescape_string(output.back(), use_escape_char, escape_char, 
                                            quote_char, double_quote);
                          }
                          return true;
@@ -102,6 +102,8 @@ size_t csv_line_tokenizer::tokenize_line(char* str, size_t len,
   size_t ctr = 0;
   size_t num_outputs = output.size();
   if (output_order != nullptr) num_outputs = output_order->size();
+  tokenizer_impl_error.clear();
+
   bool success = 
   tokenize_line_impl(str, len,
                      [&](char* buf, size_t len)->bool {
@@ -114,10 +116,16 @@ size_t csv_line_tokenizer::tokenize_line(char* str, size_t len,
                          if (delimiter_is_space_but_not_tab) {
                            if (len == 0) return true;
                            for (size_t i = 0;i < len; ++i) {
-                             if (!std::isspace(buf[i])) return false;
+                             if (!std::isspace(buf[i])) {
+                               tokenizer_impl_error = "Unexpected characters after last column. \"" + 
+                                                 std::string(buf, len) + "\"";
+                               return false;
+                             }
                            }
                            return true;
                          }
+                         tokenizer_impl_error = "Unexpected characters after last column. \"" + 
+                                           std::string(buf, len) + "\"";
                          return false;
                        }
                        // get the output column
@@ -152,8 +160,15 @@ size_t csv_line_tokenizer::tokenize_line(char* str, size_t len,
                            ++buf;
                            --len;
                          }
+                         char* prevbuf = buf;
                          bool success = parse_as(&buf, len, output[output_idx], true);
-                         if (success) ++ctr;
+                         if (success) {
+                           ++ctr;
+                         } else {
+                           tokenizer_impl_error = "Unable to interpret \"" + std::string(prevbuf, len) + 
+                                             "\" as a " + 
+                                             flex_type_enum_to_name(output[output_idx].get_type());
+                         }
                          return success;
                        }
                      },
@@ -199,6 +214,33 @@ size_t csv_line_tokenizer::tokenize_line(char* str, size_t len,
                        --ctr;
                      });
 
+  if (!success || ctr < output.size()) {
+    std::stringstream strm;
+    if (!tokenizer_impl_error.empty()) strm << tokenizer_impl_error << "\n";
+    if (tokenizer_impl_fail_pos >= 0 && tokenizer_impl_fail_pos <= len) {
+      strm << "Parse failed at token ending at: \n";
+      std::string line(str, len);
+      // colorize the line.
+      line.insert(tokenizer_impl_fail_pos, "\033[1m\033[31m^\033[00m");
+      if (line.length() > 256) {
+        // truncate around the fail pos
+        ssize_t start = std::max<ssize_t>(0, tokenizer_impl_fail_pos - 60);
+        ssize_t end = std::min<ssize_t>(len, tokenizer_impl_fail_pos + 60);
+        line = line.substr(start, end - start);
+      }
+      strm << "\t" << line << "\n";
+    }
+    strm <<  "Successfully parsed " << ctr << " tokens: \n";
+    for (size_t i = 0; i < ctr; ++i) {
+      std::string s = std::string(output[i]);
+      if (s.length() > 21) {
+        // too long string. just take first 10, and last 10 chars
+        s = s.substr(0, 10) + " ... " + s.substr(s.length() - 10);
+      }
+      strm << "\t" << i << ": " << s << "\n";
+    }
+    parse_error = strm.str();
+  }
   if (!success) return 0;
   return ctr;
 };
@@ -232,7 +274,7 @@ bool csv_line_tokenizer::parse_as(char** buf, size_t len,
     ++(*buf); 
     if (len > 1) len -= 2;
     size_t new_length = 
-        unescape_string(*buf, len, escape_char, quote_char, double_quote);
+        unescape_string(*buf, len, use_escape_char, escape_char, quote_char, double_quote);
     bool ret = parse_as(buf, new_length, out, false);
     (*buf) = end_of_buf; 
     return ret;
@@ -268,7 +310,7 @@ bool csv_line_tokenizer::parse_as(char** buf, size_t len,
        }
        parse_success = true;
        if (is_quoted) {
-         unescape_string(out.mutable_get<flex_string>(), escape_char, 
+         unescape_string(out.mutable_get<flex_string>(), use_escape_char, escape_char, 
                          quote_char, double_quote);
        }
        break;
@@ -337,7 +379,7 @@ bool csv_line_tokenizer::parse_as(char** buf, size_t len,
 // insert a character into the field buffer. resizing it if necessary
 #define PUSH_CHAR(c) if (field_buffer_len >= field_buffer.size()) field_buffer.resize(field_buffer.size() * 2); \
                      field_buffer[field_buffer_len++] = c;  \
-                     escape_sequence = (c == escape_char);
+                     escape_sequence = use_escape_char && (c == escape_char);
 
 // Finished parsing a field buffer. insert the token and reset the buffer
 #define END_FIELD() if (!add_token(&(field_buffer[0]), field_buffer_len)) { good = false; keep_parsing = false; break; } \
@@ -388,6 +430,7 @@ bool csv_line_tokenizer::tokenize_line_impl(char* str,
   // this is set to true for the character immediately after an escape character
   // and false all other times
   bool escape_sequence = false;
+  tokenizer_impl_fail_pos = -1;
   tokenizer_state state = tokenizer_state::START_FIELD; 
   field_buffer_len = 0;
   if (delimiter_is_new_line) {
@@ -526,15 +569,20 @@ REGULAR_CHARACTER:
     }
     if (reset_escape_sequence) escape_sequence = false;
   }
-  if (!good) return false;
+  if (!good) {
+    tokenizer_impl_fail_pos = (ssize_t)(buf - str);
+    return false;
+  }
   // cleanup 
   if (state != tokenizer_state::START_FIELD) {
     if (!add_token(&(field_buffer[0]), field_buffer_len)) { 
+      tokenizer_impl_fail_pos = (ssize_t)(buf - str);
       return false;
     }
   } else {
     if (start_field_with_delimiter_encountered) {
       if (!add_token(NULL, 0)) { 
+        tokenizer_impl_fail_pos = (ssize_t)(buf - str);
         return false;
       }
     }
@@ -542,8 +590,12 @@ REGULAR_CHARACTER:
   return true;
 }
 
+const std::string& csv_line_tokenizer::get_last_parse_error_diagnosis() const {
+  return parse_error;
+}
+
 void csv_line_tokenizer::init() {
-  parser.reset(new flexible_type_parser(delimiter, escape_char));
+  parser.reset(new flexible_type_parser(delimiter, use_escape_char, escape_char));
   is_regular_line_terminator = line_terminator == "\n";
   if (is_regular_line_terminator) {
     delimiter_is_new_line = delimiter == "\n" || 

--- a/src/sframe/csv_line_tokenizer.cpp
+++ b/src/sframe/csv_line_tokenizer.cpp
@@ -5,12 +5,14 @@
  */
 /**
  * \file
- * CSV Parser as adapted from Pandas
+ * Tokenizes a CSV line.  
+ * Originally modified from Pandas. Now is quite significantly different.
  */
 #include <vector>
 #include <string>
 #include <cstdlib>
 #include <algorithm>
+#include <logger/logger.hpp>
 #include <boost/config/warning_disable.hpp>
 #include <sframe/csv_line_tokenizer.hpp>
 #include <flexible_type/string_escape.hpp>
@@ -221,7 +223,14 @@ size_t csv_line_tokenizer::tokenize_line(char* str, size_t len,
       strm << "Parse failed at token ending at: \n";
       std::string line(str, len);
       // colorize the line.
-      line.insert(tokenizer_impl_fail_pos, "\033[1m\033[31m^\033[00m");
+#ifdef COLOROUTPUT
+      line.insert(tokenizer_impl_fail_pos, 
+                  textcolor(TEXTCOLOR_BRIGHT, TEXTCOLOR_RED) + 
+                  "^" + 
+                  reset_color());
+#else
+      line.insert(tokenizer_impl_fail_pos, "^");
+#endif
       if (line.length() > 256) {
         // truncate around the fail pos
         ssize_t start = std::max<ssize_t>(0, tokenizer_impl_fail_pos - 60);

--- a/src/sframe/csv_line_tokenizer.hpp
+++ b/src/sframe/csv_line_tokenizer.hpp
@@ -47,6 +47,10 @@ struct csv_line_tokenizer {
   bool preserve_quoting = false;
 
   /**
+   * If escape_char is used.
+   */
+  bool use_escape_char = true;
+  /**
    * The character to use to identify the beginning of a C escape sequence 
    * (Defualt '\'). i.e. "\n" will be converted to the '\n' character, "\\"
    * will be converted to "\", etc. Note that only the single character 
@@ -274,12 +278,26 @@ struct csv_line_tokenizer {
   bool parse_as(char** buf, size_t len, 
                 flexible_type& out, bool recursive_parse=false);
 
+  /**
+   * Returns a printable string describing the parse error.
+   * This is only filled when \ref tokenize_line fails.
+   * The string is *not* cleared when tokenize line succeeds so this should
+   * not be used for flagging parse errors.
+   */
+  const std::string& get_last_parse_error_diagnosis() const;
 
  private:
   // internal buffer
   std::string field_buffer;
   // current length of internal buffer
   size_t field_buffer_len = 0;
+
+  // the printable string describing the parse error
+  std::string parse_error;
+  // internal error. filled when tokenizer fails. This is appended to parse_error
+  // when appropriate
+  std::string tokenizer_impl_error;
+  ssize_t tokenizer_impl_fail_pos = -1;
 
   // the state of the tokenizer state machine
   enum class tokenizer_state {
@@ -328,6 +346,7 @@ namespace std {
 static inline ostream& operator<<(ostream& os, const turi::csv_line_tokenizer& t) {
   os << "Tokenizer("
      << "preseve_quoting=" << t.preserve_quoting << ", "
+     << "use_escape_char='" << t.use_escape_char << "', "
      << "escape_char='" << t.escape_char << "', "
      << "skip_initial_space=" << t.skip_initial_space << ", "
      << "delimiter=\"" << t.delimiter << "\", "

--- a/src/sframe/csv_line_tokenizer.hpp
+++ b/src/sframe/csv_line_tokenizer.hpp
@@ -124,6 +124,16 @@ struct csv_line_tokenizer {
   std::vector<std::string> na_values;
 
   /**
+   * string values which map to numeric 1
+   */
+  std::unordered_set<std::string> true_values;
+
+  /**
+   * string values which map to numeric 0
+   */
+  std::unordered_set<std::string> false_values;
+
+  /**
    * Constructor. Does nothing but set up internal buffers.
    */
   csv_line_tokenizer();

--- a/src/sframe/parallel_csv_parser.cpp
+++ b/src/sframe/parallel_csv_parser.cpp
@@ -540,16 +540,26 @@ class parallel_csv_parser {
         if (store_errors) error_buffer[threadid].push_back(badline);
         if (continue_on_failure) {
           if (num_failures.value < 10) {
-            std::string badline = std::string(pstart, pnext - pstart);
-            if (badline.length() > 256) badline=badline.substr(0, 256) + "...";
-            logprogress_stream << std::string("Unable to parse line \"") +
-                               badline + "\"" << std::endl;
+            if (!thread_local_tokenizer[threadid].get_last_parse_error_diagnosis().empty()) {
+              logprogress_stream << thread_local_tokenizer[threadid].get_last_parse_error_diagnosis() 
+                                 << std::endl;
+            } else {
+              std::string badline = std::string(pstart, pnext - pstart);
+              if (badline.length() > 256) badline=badline.substr(0, 256) + "...";
+              logprogress_stream << std::string("Unable to parse line \"") +
+                                 badline + "\"" << std::endl;
+            }
           }
           ++num_failures;
         } else {
+          if (!thread_local_tokenizer[threadid].get_last_parse_error_diagnosis().empty()) {
+            logprogress_stream << thread_local_tokenizer[threadid].get_last_parse_error_diagnosis() 
+                               << std::endl;
+          } 
+          std::string badline = std::string(pstart, pnext - pstart);
+          if (badline.length() > 256) badline=badline.substr(0, 256) + "...";
           log_and_throw(std::string("Unable to parse line \"") +
-                        std::string(pstart, pnext - pstart) + "\"\n" +
-                        "Set error_bad_lines=False to skip bad lines");
+                        badline + "\"\n");
         }
       }
     }

--- a/src/sframe/parallel_csv_parser.cpp
+++ b/src/sframe/parallel_csv_parser.cpp
@@ -497,8 +497,14 @@ class parallel_csv_parser {
     while(c != cend) {
       c = advance_past_newline(c, cend, newline_was_matched);
       bool b = quote_parity.get(c - bufstart - 1);
-      if (newline_was_matched == false || 
-          b == false) return c;
+      // it is not actually a newline if the quote parity is set
+      // continue to continue searching for the next newline
+      if (b && newline_was_matched) {
+        newline_was_matched = false;
+        continue;
+      } else {
+        break;
+      }
     }
     return c;
   }

--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -220,7 +220,7 @@ void unity_sarray::construct_from_json_record_files(std::string url) {
   sarray_ptr->set_type(flex_type_enum::DICT);
   auto output = sarray_ptr->get_output_iterator(0);
 
-  flexible_type_parser parser;
+  flexible_type_parser parser(",", true, '\\', {"null"}, {"true"}, {"false"});
   std::vector<char> buffer;
 
 

--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -164,6 +164,7 @@ std::map<std::string, std::shared_ptr<unity_sarray_base>> unity_sframe::construc
   tokenizer.delimiter = ",";
   tokenizer.has_comment_char = false;
   tokenizer.escape_char = '\\';
+  tokenizer.use_escape_char = true;
   tokenizer.double_quote = true;
   tokenizer.quote_char = '\"';
   tokenizer.skip_initial_space = true;
@@ -196,6 +197,9 @@ std::map<std::string, std::shared_ptr<unity_sarray_base>> unity_sframe::construc
       tokenizer.comment_char= tmp[0];
       tokenizer.has_comment_char = true;
     }
+  }
+  if (csv_parsing_config.count("use_escape_char")) {
+    tokenizer.skip_initial_space = !csv_parsing_config["use_escape_char"].is_zero();
   }
   if (csv_parsing_config["escape_char"].get_type() == flex_type_enum::STRING) {
     std::string tmp = (flex_string)csv_parsing_config["escape_char"];

--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -239,7 +239,27 @@ std::map<std::string, std::shared_ptr<unity_sarray_base>> unity_sframe::construc
       }
     }
   }
+  if (csv_parsing_config["true_values"].get_type() == flex_type_enum::LIST) {
+    flex_list rec = csv_parsing_config["true_values"];
+    std::unordered_set<std::string> true_values;
+    tokenizer.true_values.clear();
+    for (size_t i = 0;i < rec.size(); ++i) {
+      if (rec[i].get_type() == flex_type_enum::STRING) {
+        tokenizer.true_values.insert((std::string)rec[i]);
+      }
+    }
+  }
 
+  if (csv_parsing_config["false_values"].get_type() == flex_type_enum::LIST) {
+    flex_list rec = csv_parsing_config["false_values"];
+    std::unordered_set<std::string> false_values;
+    tokenizer.false_values.clear();
+    for (size_t i = 0;i < rec.size(); ++i) {
+      if (rec[i].get_type() == flex_type_enum::STRING) {
+        tokenizer.false_values.insert((std::string)rec[i]);
+      }
+    }
+  }
   tokenizer.init();
 
   auto sframe_ptr = std::make_shared<sframe>();

--- a/src/unity/python/turicreate/cython/cy_test_utils.pyx
+++ b/src/unity/python/turicreate/cython/cy_test_utils.pyx
@@ -16,3 +16,10 @@ def bad_memory_access_fun():
 
 def force_exit_fun():
   abort()
+
+# Need to put something here to avoid an annoying compile error with
+# some cython versions
+# cy_test_utils.cxx:691:12: error: unused variable '__pyx_clineno' [-Werror,-Wunused-variable]
+cpdef unused():
+    abort()
+

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -882,6 +882,8 @@ class SFrame(object):
                        verbose=True,
                        store_errors=True,
                        nrows_to_infer=100,
+                       true_values=[],
+                       false_values=[],
                        **kwargs):
         """
         Constructs an SFrame from a CSV file or a path to multiple CSVs, and
@@ -932,6 +934,8 @@ class SFrame(object):
         parsing_config["line_terminator"] = line_terminator
         parsing_config["output_columns"] = usecols
         parsing_config["skip_rows"] =skiprows
+        parsing_config["true_values"] = true_values
+        parsing_config["false_values"] = false_values
 
         if type(na_values) is str:
           na_values = [na_values]
@@ -963,7 +967,9 @@ class SFrame(object):
                                  line_terminator=line_terminator,
                                  usecols=usecols,
                                  skiprows=skiprows,
-                                 verbose=verbose)
+                                 verbose=verbose,
+                                 true_values=true_values,
+                                 false_values=false_values)
                 column_type_hints = SFrame._infer_column_types_from_lines(first_rows)
                 typelist = '[' + ','.join(t.__name__ for t in column_type_hints) + ']'
                 if verbose:
@@ -1004,7 +1010,9 @@ class SFrame(object):
                                  line_terminator=line_terminator,
                                  usecols=usecols,
                                  skiprows=skiprows,
-                                 verbose=verbose)
+                                 verbose=verbose,
+                                 true_values=true_values,
+                                 false_values=false_values)
                 inferred_types = SFrame._infer_column_types_from_lines(first_rows)
                 # make a dict of column_name to type
                 inferred_types = dict(list(zip(first_rows.column_names(), inferred_types)))
@@ -1068,6 +1076,8 @@ class SFrame(object):
                              skiprows=0,
                              verbose=True,
                              nrows_to_infer=100,
+                             true_values=[],
+                             false_values=[],
                              **kwargs):
         """
         Constructs an SFrame from a CSV file or a path to multiple CSVs, and
@@ -1127,6 +1137,12 @@ class SFrame(object):
 
         na_values : str | list of str, optional
             A string or list of strings to be interpreted as missing values.
+
+        true_values : str | list of str, optional
+            A string or list of strings to be interpreted as 1
+
+        false_values : str | list of str, optional
+            A string or list of strings to be interpreted as 0
 
         line_terminator : str, optional
             A string to be interpreted as the line terminator. Defaults to "\\n"
@@ -1201,6 +1217,8 @@ class SFrame(object):
                                   skiprows=skiprows,
                                   store_errors=True,
                                   nrows_to_infer=nrows_to_infer,
+                                  true_values=true_values,
+                                  false_values=false_values,
                                   **kwargs)
     @classmethod
     def read_csv(cls,
@@ -1221,6 +1239,8 @@ class SFrame(object):
                  skiprows=0,
                  verbose=True,
                  nrows_to_infer=100,
+                 true_values=[],
+                 false_values=[],
                  **kwargs):
         """
         Constructs an SFrame from a CSV file or a path to multiple CSVs.
@@ -1282,6 +1302,13 @@ class SFrame(object):
 
         na_values : str | list of str, optional
             A string or list of strings to be interpreted as missing values.
+
+        true_values : str | list of str, optional
+            A string or list of strings to be interpreted as 1
+
+        false_values : str | list of str, optional
+            A string or list of strings to be interpreted as 0
+
 
         line_terminator : str, optional
             A string to be interpreted as the line terminator. Defaults to "\n"
@@ -1472,6 +1499,8 @@ class SFrame(object):
                                   verbose=verbose,
                                   store_errors=False,
                                   nrows_to_infer=nrows_to_infer,
+                                  true_values=true_values,
+                                  false_values=false_values,
                                   **kwargs)[0]
 
 
@@ -1568,7 +1597,7 @@ class SFrame(object):
             g = SFrame({'X1':g})
             return g.unpack('X1','')
         elif orient == "lines":
-            g = cls.read_csv(url, header=False)
+            g = cls.read_csv(url, header=False,na_values=['null'],true_values=['true'],false_values=['false'])
             if g.num_rows() == 0:
                 return SFrame()
             if g.num_columns() != 1:

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -923,7 +923,8 @@ class SFrame(object):
         parsing_config["use_header"] = header
         parsing_config["continue_on_failure"] = not error_bad_lines
         parsing_config["comment_char"] = comment_char
-        parsing_config["escape_char"] = escape_char
+        parsing_config["escape_char"] = '\0' if escape_char is None else escape_char
+        parsing_config["use_escape_char"] = escape_char is None
         parsing_config["double_quote"] = double_quote
         parsing_config["quote_char"] = quote_char
         parsing_config["skip_initial_space"] = skip_initial_space
@@ -1091,8 +1092,9 @@ class SFrame(object):
             The character which denotes that the
             remainder of the line is a comment.
 
-        escape_char : string, optional
-            Character which begins a C escape sequence
+        escape_char : string, optional 
+            Character which begins a C escape sequence. Defaults to backslash(\\)
+            Set to None to disable.
 
         double_quote : bool, optional
             If True, two consecutive quotes in a string are parsed to a single
@@ -1245,8 +1247,9 @@ class SFrame(object):
             The character which denotes that the remainder of the line is a
             comment.
 
-        escape_char : string, optional
-            Character which begins a C escape sequence
+        escape_char : string, optional 
+            Character which begins a C escape sequence. Defaults to backslash(\\)
+            Set to None to disable.
 
         double_quote : bool, optional
             If True, two consecutive quotes in a string are parsed to a single

--- a/test/capi/capi_sframe_csv.cxx
+++ b/test/capi/capi_sframe_csv.cxx
@@ -887,30 +887,57 @@ struct sframe_test  {
 
    void test_string_escaping() {
      std::string s = "hello";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "hello");
 
      s = "\\\"world\\\"";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\"world\"");
 
      s = "\\\\world\\\\";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\\world\\");
 
      s = "\\";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\\");
 
      s = "\\\"\"\"a\\\"\"\"";
-     unescape_string(s, '\\', '\"', true);
+     unescape_string(s, true, '\\', '\"', true);
      TS_ASSERT_EQUALS(s, "\"\"a\"\"");
 
      s = "\\\'\\\"\\\\\\/\\b\\r\\n";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\'\"\\/\b\r\n");
-
    }
+
+
+   void test_string_escaping2() {
+     std::string s = "hello";
+     unescape_string(s, false, '\\', '\"', false);
+     TS_ASSERT_EQUALS(s, "hello");
+
+     s = "\\\"world\\\"";
+     unescape_string(s, false, '\\', '\"', false);
+     TS_ASSERT_EQUALS(s, "\\\"world\\\"");
+
+     s = "\\\\world\\\\";
+     unescape_string(s, false, '\\', '\"', false);
+     TS_ASSERT_EQUALS(s, "\\\\world\\\\");
+
+     s = "\\";
+     unescape_string(s, false, '\\', '\"', false);
+     TS_ASSERT_EQUALS(s, "\\");
+
+     s = "\\\"\"\"a\\\"\"\"";
+     unescape_string(s, true, '\\', '\"', true);
+     TS_ASSERT_EQUALS(s, "\\\"\"\"a\\\"\"\"");
+
+     s = "\\\'\\\"\\\\\\/\\b\\r\\n";
+     unescape_string(s, true, '\\', '\"', false);
+     TS_ASSERT_EQUALS(s, "\\\'\\\"\\\\\\/\\b\\r\\n");
+   }
+
    void test_na() {
      //evaluate(test_na_values());
      evaluate(test_na_values2());

--- a/test/sframe/sframe_csv_test.cxx
+++ b/test/sframe/sframe_csv_test.cxx
@@ -795,29 +795,32 @@ struct sframe_test  {
 
    void test_string_escaping() {
      std::string s = "hello";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "hello");
 
      s = "\\\"world\\\"";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\"world\"");
 
      s = "\\\\world\\\\";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\\world\\");
 
      s = "\\";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\\");
 
      s = "\\\"\"\"a\\\"\"\"";
-     unescape_string(s, '\\', '\"', true);
+     unescape_string(s, true, '\\', '\"', true);
      TS_ASSERT_EQUALS(s, "\"\"a\"\"");
 
      s = "\\\'\\\"\\\\\\/\\b\\r\\n";
-     unescape_string(s, '\\', '\"', false);
+     unescape_string(s, true, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\'\"\\/\b\r\n");
 
+     s = "\\world\\";
+     unescape_string(s, false, '\\', '\"', false);
+     TS_ASSERT_EQUALS(s, "\\world\\");
    }
    void test_na() {
      evaluate(test_na_values());


### PR DESCRIPTION
 - Allow escape_char to be optional: push a use_escape_char option all the
  way through all code.
 - Add csv parsing options true_values and false_values which accept a list of strings to interpret as the numeric value 1, and the numeric value 0 respectively.
 - pushed through na_values to the recursive parsers so that missing values inside of dict/lists are handled correctly.
 - Filled in the read_json parsing options to correctly map na_values = ["null"], true_values=["true"] and false_values=["false"]
 - Better parser diagnostics on parser failure. For instance:
```
 Unable to interpret ""hello"" as a integer
Parse failed at token ending at:
	2,"hello"^
Successfully parsed 1 tokens:
	0: 2
```