### PR TITLE
Fix typo in data-preparation.md

### DIFF
--- a/userguide/object_detection/data-preparation.md
+++ b/userguide/object_detection/data-preparation.md
@@ -171,7 +171,7 @@ del csv_sf['id'], csv_sf['xMin'], csv_sf['xMax'], csv_sf['yMin'], csv_sf['yMax']
 csv_sf = csv_sf.rename({'name': 'label', 'image': 'name'})
 
 # Load all images in random order
-sf_images = tc.image_analysis.load_images(images_directory, recursive=True,
+sf_images = tc.image_analysis.load_images(IMAGES_DIR, recursive=True,
     random_order=True)
 
 # Split path to get filename


### PR DESCRIPTION
```
$ python annotation_to_sframe.py
Finished parsing file /Users/kyo/projects/choose-a-payment/ML/data/eval/out.csv
Parsing completed. Parsed 66 lines in 0.051303 secs.
------------------------------------------------------
Inferred types from first 100 line(s) of file as
column_type_hints=[str,int,str,int,int,int,int]
If parsing fails due to incorrect types, you can correct
the inferred type list above and pass it to read_csv in
the column_type_hints argument
------------------------------------------------------
Finished parsing file /Users/kyo/projects/choose-a-payment/ML/data/eval/out.csv
Parsing completed. Parsed 66 lines in 0.008484 secs.
Traceback (most recent call last):
  File "annotation_to_sframe.py", line 25, in <module>
    sf_images = tc.image_analysis.load_images(images_directory, recursive=True,
NameError: name 'images_directory' is not defined
```
