### PR TITLE
Fix link error in metrics.cpp

### DIFF
--- a/src/unity/toolkits/evaluation/CMakeLists.txt
+++ b/src/unity/toolkits/evaluation/CMakeLists.txt
@@ -5,6 +5,7 @@ make_library(unity_evaluation
     metrics.cpp 
     unity_evaluation.cpp
   REQUIRES
+    ml_data
     unity_core 
     unity_recsys
   )


### PR DESCRIPTION
This fixes a linker error (missing symbols) from metrics.cpp in
unity_evaluation. It seems to have been introduced by #1262.