### PR TITLE
WIP: Make the Vega JSON templating more flexible

### DIFF
--- a/src/unity/lib/visualization/vega_spec.hpp
+++ b/src/unity/lib/visualization/vega_spec.hpp
@@ -23,9 +23,10 @@ namespace turi {
     std::string boxes_and_whiskers_spec(const flexible_type& xlabel, const flexible_type& ylabel, const flexible_type& title);
 
     // Utility for escaping JSON string literals. Not concerned with Vega implications of the contents of those strings.
-    std::string escape_string(const std::string& str);
+    std::string escape_string(const std::string& str, bool include_quotes=true);
     std::string replace_all(std::string str, const std::string& from, const std::string& to);
-    std::string extra_label_escape(const std::string& str);
+    std::string extra_label_escape(const std::string& str, bool include_quotes=true);
+    std::string format(const std::string& format_str, const std::unordered_map<std::string, std::string>& format_params);
   }
 }
 

--- a/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
+++ b/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
@@ -27,7 +27,7 @@
     }
   },
   "title": {
-    "text": %1%
+    "text": "{{title}}"
   },
   "height": 550,
   "style": "cell",
@@ -258,7 +258,7 @@
       "scale": "x",
       "labelOverlap": true,
       "orient": "bottom",
-      "title": %2%,
+      "title": "{{xlabel}}",
       "zindex": 1,
       "encode": {
         "labels": {
@@ -277,7 +277,7 @@
       }
     },
     {
-      "title": %3%,
+      "title": "{{ylabel}}",
       "scale": "y",
       "labelOverlap": true,
       "orient": "left",

--- a/src/unity/lib/visualization/vega_spec/categorical.json
+++ b/src/unity/lib/visualization/vega_spec/categorical.json
@@ -19,9 +19,9 @@
     }
   },
   "width": 720,
-  "height": %1%,
+  "height": {{height}},
   "title": {
-    "text": %2%,
+    "text": "{{title}}",
     "offset": 30
   },
   "style": "cell",
@@ -177,7 +177,7 @@
       "tickCount": {
         "signal": "ceil(width/40)"
       },
-      "title": %3%,
+      "title": "{{xlabel}}",
       "zindex": 1
     },
     {
@@ -199,7 +199,7 @@
       "scale": "y",
       "labelOverlap": true,
       "orient": "left",
-      "title": %4%,
+      "title": "{{ylabel}}",
       "zindex": 1
     }
   ],

--- a/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
@@ -4,7 +4,7 @@
   "axes": [
     {
       "scale": "x",
-      "title": %2%,
+      "title": "{{xlabel}}",
       "tickCount": {
         "signal": "min(ceil(width/40), 60)"
       },
@@ -29,7 +29,7 @@
     },
     {
       "scale": "y",
-      "title": %3%,
+      "title": "{{ylabel}}",
       "tickCount": {
         "signal": "min(ceil(height/40), 40)"
       },
@@ -53,7 +53,7 @@
     }
   ],
   "title": {
-    "text": %1%,
+    "text": "{{title}}",
     "frame": "group",
     "fontSize": 16,
     "anchor": "middle",

--- a/src/unity/lib/visualization/vega_spec/heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/heatmap.json
@@ -6,7 +6,7 @@
   "height": 550,
   "style": "cell",
   "title": {
-    "text": %1%
+    "text": "{{title}}"
   },
   "data": [
     {
@@ -108,7 +108,7 @@
       "tickCount": {
         "signal": "min(ceil(width/40), 60)"
       },
-      "title": %2%,
+      "title": "{{xlabel}}",
       "zindex": 1,
       "encode": {
         "labels": {
@@ -133,7 +133,7 @@
       "tickCount": {
         "signal": "min(ceil(height/40), 40)"
       },
-      "title": %3%,
+      "title": "{{ylabel}}",
       "zindex": 1
     }
   ],

--- a/src/unity/lib/visualization/vega_spec/histogram.json
+++ b/src/unity/lib/visualization/vega_spec/histogram.json
@@ -6,7 +6,7 @@
   "height": 550,
   "padding": 5,
   "title": {
-    "text": %1%,
+    "text": "{{title}}",
     "offset": 30
   },
   "style": "cell",
@@ -120,7 +120,7 @@
   ],
   "axes": [
     {
-      "title": %2%,
+      "title": "{{xlabel}}",
       "scale": "x",
       "labelOverlap": true,
       "orient": "bottom",
@@ -145,7 +145,7 @@
       "gridScale": "y"
     },
     {
-      "title": %3%,
+      "title": "{{ylabel}}",
       "scale": "y",
       "labelOverlap": true,
       "orient": "left",

--- a/src/unity/lib/visualization/vega_spec/scatter.json
+++ b/src/unity/lib/visualization/vega_spec/scatter.json
@@ -6,7 +6,7 @@
   "height": 550,
   "style": "cell",
   "title": {
-    "text": %1%,
+    "text": "{{title}}",
     "offset": 30
   },
   "data": [
@@ -95,7 +95,7 @@
       "tickCount": {
         "signal": "ceil(width/40)"
       },
-      "title": %2%,
+      "title": "{{xlabel}}",
       "zindex": 1
     },
     {
@@ -120,7 +120,7 @@
       "tickCount": {
         "signal": "ceil(height/40)"
       },
-      "title": %3%,
+      "title": "{{ylabel}}",
       "zindex": 1
     },
     {

--- a/src/unity/lib/visualization/vega_spec/summary_view.json
+++ b/src/unity/lib/visualization/vega_spec/summary_view.json
@@ -20,7 +20,7 @@
     }
   },
   "width":800,
-  "height":%1%,
+  "height":{{height}},
   "padding":0,
   "data":[
     {


### PR DESCRIPTION
* Uses named instead of position arguments.
* Takes a dictionary of placeholder -> value to apply the template.
* This will allow us to swap in different templated Vega specs for any
  plot type, and the named format parameters can be applied optionally,
  multiple times, and in any order.
* Drops the boost::format dependency (incidentally - since boost::format
  can only handle positional numbered arguments.