### PR TITLE
WIP: Indexed sframe

### DIFF
--- a/src/sframe/CMakeLists.txt
+++ b/src/sframe/CMakeLists.txt
@@ -33,6 +33,8 @@ project(sframe)
      sframe_saving_impl.cpp
      sframe_compact.cpp
      rolling_aggregate.cpp
+     sframe_random_access_impl.cpp
+     sframe_random_access_buffers_impl.cpp
    REQUIRES
      random flexible_type fileio parallel lz4 
      cancel_serverside_ops serialization libjson globals 

--- a/src/sframe/sframe_random_access.hpp
+++ b/src/sframe/sframe_random_access.hpp
@@ -1,0 +1,359 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_SFRAME_RANDOM_ACCESS_H_
+#define TURI_SFRAME_RANDOM_ACCESS_H_
+
+#include <flexible_type/flexible_type_base_types.hpp>
+#include <flexible_type/flexible_type.hpp>
+#include <unity/lib/gl_sarray.hpp>
+#include <unity/lib/gl_sframe.hpp>
+#include <util/basic_types.hpp>
+
+using turi::flex_type_enum;
+using turi::flexible_type;
+using turi::gl_sarray;
+using turi::gl_sframe;
+
+#include <map>
+#include <mutex>
+
+using std::enable_shared_from_this;
+using std::istream;
+using std::make_shared;
+using std::lock_guard;
+using std::ostream;
+using std::pair;
+using std::recursive_mutex;
+using std::shared_ptr;
+using std::unique_lock;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
+using std::weak_ptr;
+
+namespace turi { namespace sframe_random_access {
+
+/**
+ * \ingroup sframe_physical
+ * \addtogroup sframe_random_access SFrame Random Access Backend
+ *
+ * This module provides an alternate binary representation of (strongly-typed)
+ * SArray and SFrame values, which supports fast random access and indirect
+ * references, as well as some basic indexing utilities over this alternate
+ * representation.
+ * \{
+ */
+
+/*! \cond internal */
+DECL_STRUCT(ref_context);
+DECL_STRUCT(url);
+DECL_STRUCT(value);
+DECL_STRUCT(value_column);
+DECL_STRUCT(value_either);
+DECL_STRUCT(value_index);
+DECL_STRUCT(value_nd_vector);
+DECL_STRUCT(value_record);
+DECL_STRUCT(value_ref);
+DECL_STRUCT(value_type);
+
+typedef typename boost::make_recursive_variant<
+  value_column_p,
+  value_nd_vector_p,
+  value_record_p,
+  value_either_p,
+  value_ref_p,
+  value_index_p
+>::type value_v;
+
+using value_id_map_shared_ptr_type = unordered_map<
+  pair<int64_t, int64_t>,
+  shared_ptr<value>,
+  std_pair_hash<int64_t, int64_t>>;
+
+using value_id_map_weak_ptr_type = unordered_map<
+  pair<int64_t, int64_t>,
+  weak_ptr<value>,
+  std_pair_hash<int64_t, int64_t>>;
+/*! \endcond */
+
+/**
+ * The \ref value struct is a tagged union of the following cases.
+ */
+enum class value_enum {
+  /**
+   * Column data (random-access variant of SArray).
+   */
+  COLUMN,
+  /**
+   * Multidimensional array data (also used to hold strings as 1-dimensional
+   * character arrays).
+   */
+  ND_VECTOR,
+  /**
+   * Record mapping field names to values.
+   * An SFrame is stored as a record mapping column names to column values.
+   */
+  RECORD,
+  /**
+   * Variant type storing one of multiple cases.
+   */
+  EITHER,
+  /**
+   * Indirect reference to another value or column subset.
+   */
+  REF,
+  /**
+   * Index structure providing fast lookups over a column (internal use only).
+   */
+  INDEX,
+};
+
+/**
+ * Indexing modes for column data. Currently this is limited to equality-based
+ * indexing (i.e., hash of each value in the column, but in the future we would
+ * like to also support ordering-based indexing for numeric data.
+ */
+enum class index_mode_enum {
+  /**
+   * Index based on equality (i.e., hash of each value in the column).
+   */
+  EQUALS,
+};
+
+/**
+ * Index lookup modes for column data. For equality-based indices this is
+ * trivial, but for ordering-based indices we can look up based on, e.g.,
+ * less-than or greater-than relations.
+ */
+enum class index_lookup_mode_enum {
+  /**
+   * Index based on equality (i.e., hash of each value in the column).
+   */
+  EQUALS,
+};
+
+/**
+ * A simple convenience structure containing multiple hash maps, one for each
+ * of our K worker threads. The space of valid hashes (0..2^128) is divided into
+ * K equal sized chunks, and each thread writes to its own chunk, so that there
+ * is no collision.
+ */
+template<typename T>
+struct parallel_hash_map {
+  /**
+   * Insert a pair (k, v) into the hash map.
+   */
+  void put(uint128_t k, const T& v);
+
+  /**
+   * Get a reference to the value mapped at hash k.
+   */
+  T& operator[](uint128_t k);
+
+  /**
+   * Get an iterator corresponding to the value mapped at hash k.
+   */
+  typename unordered_map<uint128_t, T>::iterator find(uint128_t k);
+
+  /**
+   * Return the end iterator of the sub-map that corresponds to key k's chunk of
+   * the hash space.
+   */
+  typename unordered_map<uint128_t, T>::iterator end(uint128_t k);
+
+  /**
+   * Return the number of occurrences of key k in the hash map.
+   */
+  int64_t count(uint128_t k);
+
+  /**
+   * Clear the hash map.
+   */
+  void clear();
+
+  /**
+   * Construct an empty hash map.
+   */
+  parallel_hash_map();
+
+  /* \cond internal */
+  vector<unordered_map<uint128_t, T>> maps_;
+  /*! \endcond */
+};
+
+/**
+ * Creates a random-access SFrame object from a standard \ref gl_sframe.
+ */
+value_p from_sframe(const gl_sframe& sf);
+
+/**
+ * Converts a random-access SFrame object to a standard \ref gl_sframe.
+ */
+gl_sframe to_sframe(value_p v);
+
+/**
+ * The \ref value struct stores an arbitary value in our random access backend
+ * (including random-access variants of SFrame, SArray, and simple cases of
+ * flexible_type). Specifically, a \ref value instance is a tagged union of the
+ * cases described in \ref value_enum, together with several utility methods for
+ * creating \ref value objects and performing relational operations on them.
+ */
+struct value : public enable_shared_from_this<value> {
+  /**
+   * Saves the contents of a random access SFrame value to disk.
+   */
+  void save(const string& output_path);
+
+  /**
+   * Loads the contents of a random access SFrame value from disk.
+   */
+  static value_p load_from_path(const string& input_path);
+
+  /**
+   * Creates a value corresponding to the empty record (e.g., a table with
+   * zero columns).
+   */
+  static value_p create_empty_record();
+
+  /**
+   * Creates a scalar of type int64, with the value provided.
+   */
+  static value_p create_scalar_int64(int64_t x);
+
+  /**
+   * Creates a string with the value provided.
+   */
+  static value_p create_string(string s);
+
+  /**
+   * Creates a table value with the column names and values provided.
+   */
+  static value_p create_table(
+    vector<string> column_names, vector<value_p> column_values);
+
+  /**
+   * Creates an integer column from the vector of int64 values provided.
+   * The unique flag may be provided as an optimization to indicate that
+   * the values in the vector are unique (no duplicates).
+   */
+  static value_p create_column_from_integers(vector<int64_t>& values, bool unique);
+
+  /**
+   * Returns the number of rows of a given column. It is invalid to call this
+   * method on a value that is not a column.
+   */
+  int64_t get_column_length();
+
+  /**
+   * Returns the value corresponding to a given field of a record (e.g.,
+   * retrieves the column from a table with the given column name).
+   */
+  value_p get_record_at_field_name(const string& field_name);
+
+  /**
+   * Returns the contents of this value as a raw string. It is invalid to call
+   * this method on a value that is not a string.
+   */
+  string get_value_string();
+
+  /**
+   * Returns the contents of this value as a raw int64. It is invalid to call
+   * this method on a value that is not an int64 scalar.
+   */
+  int64_t get_value_scalar_int64();
+
+  /**
+   * Returns the contents of this value as a raw float64. It is invalid to call
+   * this method on a value that is not a float64 scalar.
+   */
+  double get_value_scalar_float64();
+
+  /**
+   * Returns the contents of this value as a raw integer. It is invalid to call
+   * this method on a value that is not a scalar of some integer type.
+   */
+  uint64_t get_integral_value();
+
+  /**
+   * Build a hash-based index of the indicated source columns.
+   */
+  static value_p build_index(
+    vector<value_p> source_columns, index_mode_enum index_mode);
+
+  /**
+   * Look up a given hash in an index built by \ref value::build_index.
+   */
+  static value_p index_lookup_by_hash(
+    value_p index, uint128_t hash, index_lookup_mode_enum mode);
+
+  /**
+   * Look up a given set of values in an index built by \ref value::build_index.
+   */
+  static value_p index_lookup(
+    value_p index, vector<value_p> keys, index_lookup_mode_enum mode);
+
+  //////////////////// Implementation-internal APIs /////////////////////
+  /*! \cond internal */
+  static const char* object_id_;
+
+  optional<string> struct_hash_cached_;
+
+  value_v v_;
+  value_type_p ty_;
+
+  optional<url_p> url_context_;
+  optional<int64_t> value_id_;
+  optional<ref_context_p> ref_context_;
+
+  value_enum which();
+  template<typename T> T& as();
+  template<typename T> const T& as() const;
+
+  value_type_p get_type();
+
+  static value_p create_record(value_type_p type, vector<value_p> fields);
+
+  static value_p create_optional_none(value_type_p ty);
+  static value_p create_optional_some(value_type_p ty, value_p v);
+
+  static value_p create_index(
+    value_p index_keys,
+    value_p index_values_flat,
+    value_p index_values_grouped,
+    vector<uint128_t> index_hashes,
+    parallel_hash_map<int64_t> index_map_singleton,
+    parallel_hash_map<pair<int64_t, int64_t>> index_map_range,
+    vector<value_type_p> source_column_types,
+    index_mode_enum index_mode);
+
+  optional<value_column*> get_as_direct_column();
+
+  template<typename T> static value_p create(
+    T v, value_type_p ty, optional<ref_context_p> accum_refs,
+    optional<url_p> url_context, optional<int64_t> id);
+
+  value(value_v v, value_type_p ty, optional<ref_context_p> accum_refs,
+        optional<url_p> url_context, optional<int64_t> id);
+
+  void save_raw(
+    ostream& os, optional<ref_context_p> context,
+    optional<unordered_set<int64_t>*> local_refs_acc);
+
+  static value_p load_raw(
+    istream& is, value_type_p type, optional<url_p> url_context);
+
+  int64_t get_value_id();
+  static value_p get_value_by_id(optional<url_p> url_context, int64_t value_id);
+
+  // Note: should only access while holding lock
+  static value_id_map_weak_ptr_type& get_value_id_map();
+  static recursive_mutex& get_value_id_map_lock();
+  /*! \endcond */
+};
+
+}}
+
+#endif

--- a/src/sframe/sframe_random_access_buffers_impl.cpp
+++ b/src/sframe/sframe_random_access_buffers_impl.cpp
@@ -1,0 +1,194 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <sframe/sframe_random_access_buffers_impl.hpp>
+
+#include <sframe/sframe_random_access_impl.hpp>
+#include <util/fs_util.hpp>
+
+using turi::fs_util::list_directory;
+using turi::fs_util::make_directories_strict;
+
+using std::ifstream;
+using std::max;
+using std::min;
+using std::ofstream;
+using std::set;
+
+namespace turi { namespace sframe_random_access {
+
+/**
+ * \internal
+ * \ingroup sframe_physical
+ * \addtogroup sframe_random_access SFrame Random Access Backend
+ * \{
+ */
+
+block_manager* block_manager::get() {
+  static block_manager_p block_manager_singleton =
+    make_shared<block_manager>();
+  return block_manager_singleton.get();
+}
+
+block_manager::handle_p block_manager::create_block() {
+  return make_shared<block_manager::handle>(make_shared<block_in_memory>());
+}
+
+void block_manager::block_in_memory::reserve_length(int64_t new_length) {
+  if (new_length <= capacity_) {
+    length_ = new_length;
+    return;
+  }
+
+  int64_t new_capacity_round = capacity_;
+  while (new_capacity_round < new_length) {
+    new_capacity_round *= 2;
+  }
+
+  addr_ = reinterpret_cast<char*>(realloc(addr_, new_capacity_round));
+  ASSERT_TRUE(!!addr_);
+  length_ = new_length;
+  capacity_ = new_capacity_round;
+}
+
+block_manager::block_in_memory::~block_in_memory() {
+  free(addr_);
+}
+
+void block_manager::handle::save_bin_dir(string base_path) {
+  make_directories_strict(base_path);
+  auto view = this->get_in_memory_view();
+  ofstream os { generate_bin_file_path(base_path, 0) };
+  if (view->length_ > 0) {
+    os.write(view->addr_, view->length_);
+  }
+}
+
+block_manager::handle_p block_manager::load_bin_dir(string base_path) {
+  auto num_files = list_directory(base_path).size();
+  ASSERT_EQ(num_files, 1);
+  auto path = generate_bin_file_path(base_path, 0);
+  ifstream fin(path);
+  fin.seekg(0, ios_base::end);
+  int64_t file_len = fin.tellg();
+  fin.seekg(0, ios_base::beg);
+
+  auto ret = block_manager::get()->create_block();
+  auto ret_view = ret->get_in_memory_view();
+  ret_view->reserve_length(file_len);
+
+  fin.read(ret_view->addr_, file_len);
+  fin.close();
+  return ret;
+}
+
+int64_t binary_data_directory_get_file_count(
+  const string& base_path, bool is_variable) {
+
+  auto paths = list_directory(base_path);
+
+  if (!is_variable) {
+    ASSERT_EQ(paths.size(), 1);
+    return 1;
+  }
+
+  set<int64_t> bin_indices;
+
+  for (auto path : paths) {
+    auto path_list = list_directory(
+      cc_sprintf("%s/%s", base_path.c_str(), path.c_str()));
+    if (path_list.size() == 0) {
+      continue;
+    } else if (path_list.size() == 1) {
+      auto path_sub = cc_sprintf(
+        "%s/%s/00000.bin", base_path.c_str(), path.c_str());
+      auto bin_index = string_to_int_check<int64_t>(path);
+      bin_indices.insert(bin_index);
+    } else {
+      // TODO: allow multiple entries to avoid large bin files
+      AU();
+    }
+  }
+
+  int64_t num_files = len(bin_indices);
+  if (num_files != 0) {
+    ASSERT_EQ(*bin_indices.rbegin() + 1, num_files);
+  }
+
+  return num_files;
+}
+
+string generate_bin_file_path(const string& base_path, int64_t file_index) {
+  return base_path + "/" + cc_sprintf("%05d.bin", file_index);
+}
+
+binary_data_view_fixed::binary_data_view_fixed(string base_path)
+  : len_total_(0) {
+
+  auto num_files = binary_data_directory_get_file_count(base_path, false);
+  ASSERT_EQ(num_files, 1);
+
+  block_handle_ =
+    block_manager::get()->load_bin_dir(base_path);
+
+  len_total_ = block_handle_->get_in_memory_view()->length_;
+}
+
+binary_data_view_fixed::binary_data_view_fixed(
+  block_manager::handle_p block_handle)
+  : len_total_(0), block_handle_(block_handle) {
+
+  len_total_ = block_handle_->get_in_memory_view()->length_;
+}
+
+string binary_data_view_fixed::get_data_string(int64_t offset, int64_t len) {
+  return binary_data_view_fixed_get_data_string(
+    offset, len, block_handle_);
+}
+
+streamsize binary_data_view_fixed::istream_reader::read(
+  char* dst, streamsize len) {
+
+  if (curr_offset_ == src_->len_total_) {
+    return -1;
+  }
+  len = min<int64_t>(len, src_->len_total_ - curr_offset_);
+  binary_data_view_fixed_get_data(
+    dst, curr_offset_, len, src_->block_handle_);
+  curr_offset_ += len;
+  return len;
+}
+
+streampos binary_data_view_fixed::istream_reader::seek(
+  boost::iostreams::stream_offset off, ios_base::seekdir way) {
+
+  if (way == ios_base::cur) {
+    curr_offset_ += off;
+  } else if (way == ios_base::beg) {
+    curr_offset_ = off;
+  } else if (way == ios_base::end) {
+    curr_offset_ = src_->len_total_ - off;
+  } else {
+    AU();
+  }
+  curr_offset_ = max<int64_t>(0, min<int64_t>(src_->len_total_, curr_offset_));
+  return curr_offset_;
+}
+
+binary_data_view_fixed::istream_type_p binary_data_view_fixed::get_istream() {
+  return make_shared<binary_data_view_fixed::istream_type>(shared_from_this());
+}
+
+binary_data_view_variable::binary_data_view_variable(string base_path) {
+  auto num_files = binary_data_directory_get_file_count(base_path, true);
+  for (int64_t i = 0; i < num_files; i++) {
+    block_handles_.push_back(
+      block_manager::get()->load_bin_dir(
+        cc_sprintf("%s/%05d", base_path.c_str(), i)));
+  }
+}
+
+}}

--- a/src/sframe/sframe_random_access_buffers_impl.hpp
+++ b/src/sframe/sframe_random_access_buffers_impl.hpp
@@ -1,0 +1,758 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_SFRAME_RANDOM_ACCESS_BUFFERS_H_
+#define TURI_SFRAME_RANDOM_ACCESS_BUFFERS_H_
+
+#include <platform/parallel/lambda_omp.hpp>
+#include <util/basic_types.hpp>
+#include <util/cityhash_tc.hpp>
+#include <util/md5.hpp>
+#include <util/string_util.hpp>
+
+using std::enable_shared_from_this;
+using std::ios_base;
+using std::istream;
+using std::make_shared;
+using std::map;
+using std::pair;
+using std::shared_ptr;
+using std::streampos;
+using std::streamsize;
+
+namespace turi { namespace sframe_random_access {
+
+/**
+ * \internal
+ * \ingroup sframe_physical
+ * \addtogroup sframe_random_access SFrame Random Access Backend
+ * \{
+ */
+
+inline void write_string_raw(ostream& os, const string& s) {
+  os.write(&s[0], s.length());
+}
+
+inline string read_string_raw(istream& is, int64_t len) {
+  vector<char> buf(len);
+  is.read(buf.data(), len);
+  return string(buf.data(), len);
+}
+
+inline void read_buffer_check(istream& is, const void* data_check, int64_t len) {
+  vector<char> buf(len);
+  is.read(buf.data(), len);
+  bool ok = !memcmp(buf.data(), data_check, len);
+  if (!ok) {
+    cerr << "read_buffer_check:" << endl;
+    cerr << "Expected: " << format_hex(
+      string(reinterpret_cast<const char*>(data_check), len)) << endl;
+    cerr << "Received: " << format_hex(string(&buf[0], len)) << endl;
+    AU();
+  }
+}
+
+inline void read_string_raw_check(istream& is, const string& s) {
+  read_buffer_check(is, &s[0], s.length());
+}
+
+template<typename T> struct type_specializer { };
+
+template<typename T> void write_bin(ostream& os, T x);
+
+template<typename T> void write_bin(ostream& os, T x) {
+  write_bin(os, x, type_specializer<T>());
+}
+
+template<typename T> T read_bin(istream& is);
+
+template<typename T> T read_bin(istream& is) {
+  return read_bin(is, type_specializer<T>());
+}
+
+template<typename T> void write_bin_pod(ostream& os, T x) {
+  os.write(reinterpret_cast<char*>(&x), sizeof(T));
+}
+
+template<typename T> T read_bin_pod(istream& is) {
+  T ret;
+  is.read(reinterpret_cast<char*>(&ret), sizeof(T));
+  return ret;
+}
+
+#define SERIALIZE_POD(Type) \
+  inline void write_bin(ostream& os, Type t, type_specializer<Type>) { \
+    write_bin_pod(os, t); \
+  } \
+  inline Type read_bin(istream& is, type_specializer<Type>) { \
+    return read_bin_pod<Type>(is); \
+  } \
+
+#define SERIALIZE_DECL(Type) \
+  void write_bin(ostream& os, Type t, type_specializer<Type>); \
+  Type read_bin(istream& is, type_specializer<Type>);
+
+SERIALIZE_POD(int8_t);
+SERIALIZE_POD(char);
+SERIALIZE_POD(bool);
+SERIALIZE_POD(int32_t);
+SERIALIZE_POD(int64_t);
+
+struct object_ids_builtin {
+  static const char* pair_;
+  static const char* vector_;
+};
+
+const uint32_t SFR_VERSION = 0xff010000U; // format version 1 (development)
+
+template<class T> void write_object_header(ostream& os, T*) {
+  write_string_raw(os, "SF");
+  os.write(reinterpret_cast<const char*>(&SFR_VERSION), sizeof(SFR_VERSION));
+  os.write(T::object_id_, strlen(T::object_id_));
+}
+
+template<class T> void read_object_header_check(istream& is) {
+  read_string_raw_check(is, "SF");
+  read_buffer_check(
+    is, reinterpret_cast<const char*>(&SFR_VERSION), sizeof(SFR_VERSION));
+  read_buffer_check(is, T::object_id_, strlen(T::object_id_));
+}
+
+template<typename T> void write_bin(
+  ostream& os, optional<T> x, type_specializer<optional<T>>) {
+
+  if (!!x) {
+    write_bin(os, int8_t(1));
+    write_bin(os, *x);
+  } else {
+    write_bin(os, int8_t(0));
+  }
+}
+
+template<typename T> optional<T> read_bin(
+  istream& is, type_specializer<optional<T>>) {
+
+  auto b = read_bin<int8_t>(is);
+  if (b == 0) {
+    return NONE<T>();
+  } else {
+    auto ret = read_bin<T>(is);
+    return SOME<T>(ret);
+  }
+}
+
+template<typename T, typename U> void write_bin(
+  ostream& os, pair<T, U> x, type_specializer<pair<T, U>>) {
+
+  write_bin(os, x.first);
+  write_bin(os, x.second);
+}
+
+template<typename T, typename U> pair<T, U> read_bin(
+  istream& is, type_specializer<pair<T, U>>) {
+
+  auto t = read_bin<T>(is);
+  auto u = read_bin<U>(is);
+  return make_pair(t, u);
+}
+
+template<typename T> void write_bin(
+  ostream& os, vector<T> x, type_specializer<vector<T>>) {
+  write_bin<int64_t>(os, int64_t(x.size()));
+  for (int64_t i = 0; i < len(x); i++) {
+    write_bin<T>(os, x[i]);
+  }
+}
+
+template<typename T> vector<T> read_bin(
+  istream& is, type_specializer<vector<T>>) {
+
+  auto n = read_bin<int64_t>(is);
+  vector<T> ret;
+  for (int64_t i = 0; i < n; i++) {
+    ret.push_back(read_bin<T>(is));
+  }
+  return ret;
+}
+
+template<typename T, typename U> void write_bin(
+  ostream& os, map<T, U> x, type_specializer<map<T, U>>) {
+
+  write_bin<int64_t>(os, int64_t(x.size()));
+  for (auto p : x) {
+    write_bin<T>(os, p.first);
+    write_bin<U>(os, p.second);
+  }
+}
+
+template<typename T, typename U> map<T, U> read_bin(
+  istream& is, type_specializer<map<T, U>>) {
+
+  auto n = read_bin<int64_t>(is);
+  map<T, U> ret;
+  for (int64_t i = 0; i < n; i++) {
+    auto key = read_bin<T>(is);
+    ret[key] = read_bin<U>(is);
+  }
+  return ret;
+}
+
+inline void write_bin(
+  ostream& os, string x, type_specializer<string>) {
+
+  write_bin(os, int64_t(x.length()));
+  os.write(&x[0], x.length());
+}
+
+inline string read_bin(istream& is, type_specializer<string>) {
+  auto n = read_bin<int64_t>(is);
+  vector<char> ret(n);
+  is.read(&ret[0], n);
+  return string(&ret[0], n);
+}
+
+enum class dtype_enum {
+  BOOL,
+  I8,
+  I16,
+  I32,
+  I64,
+  U8,
+  U16,
+  U32,
+  U64,
+  F16,
+  F32,
+  F64,
+};
+
+SERIALIZE_POD(dtype_enum);
+
+inline string dtype_to_string(dtype_enum dtype) {
+  switch (dtype) {
+  case dtype_enum::BOOL:  return "bool";
+  case dtype_enum::I8:    return "int8_t";
+  case dtype_enum::U8:    return "uint8_t";
+  case dtype_enum::I64:   return "int64_t";
+  case dtype_enum::F64:   return "double";
+  default:
+    cerr << static_cast<int64_t>(dtype) << endl;
+    AU();
+    return 0;
+  }
+}
+
+inline ostream& operator<<(ostream& os, dtype_enum dtype) {
+  os << dtype_to_string(dtype);
+  return os;
+}
+
+inline int64_t dtype_size_bytes(dtype_enum dtype) {
+  switch (dtype) {
+  case dtype_enum::BOOL:  return 1;
+  case dtype_enum::I8:    return 1;
+  case dtype_enum::U8:    return 1;
+  case dtype_enum::I64:   return 8;
+  case dtype_enum::F64:   return 8;
+  default:
+    cerr << dtype << endl;
+    AU();
+    return 0;
+  }
+}
+
+inline char dtype_to_char(dtype_enum dtype) {
+  switch (dtype) {
+  case dtype_enum::BOOL: return 'b';
+  case dtype_enum::I8:   return 'c';
+  case dtype_enum::U8:   return 'C';
+  case dtype_enum::I64:  return 'I';
+  case dtype_enum::F64:  return 'd';
+  default:
+    AU();
+    return 0;
+  }
+}
+
+inline dtype_enum dtype_from_char(char c) {
+  switch (c) {
+  case 'b': return dtype_enum::BOOL;
+  case 'c': return dtype_enum::I8;
+  case 'C': return dtype_enum::U8;
+  case 'I': return dtype_enum::I64;
+  case 'd': return dtype_enum::F64;
+  default:
+    cerr << "Dtype character not supported: " << c << endl;
+    AU();
+    return dtype_enum::I8;
+  }
+}
+
+inline dtype_enum dtype_from_char(const string& s) {
+  ASSERT_EQ(s.length(), 1);
+  return dtype_from_char(s[0]);
+}
+
+inline bool dtype_is_discrete(dtype_enum dtype) {
+  switch (dtype) {
+  case dtype_enum::BOOL:
+  case dtype_enum::I8:
+  case dtype_enum::U8:
+  case dtype_enum::I16:
+  case dtype_enum::U16:
+  case dtype_enum::I32:
+  case dtype_enum::U32:
+  case dtype_enum::I64:
+  case dtype_enum::U64:
+    return true;
+  case dtype_enum::F16:
+  case dtype_enum::F32:
+  case dtype_enum::F64:
+    return false;
+  default:
+    AU();
+    return 0;
+  }
+}
+
+/**
+ * Length of an MD5 hash. Note that we use MD5 as the default for hashing
+ * structures in general, but for hashing elements to build column indices, we
+ * prefer cityhash due to its significantly faster speed.
+ */
+constexpr int64_t VALUE_HASH_SIZE_BYTES = 16;
+
+inline string hash_string_value(const char* src, int64_t len) {
+  string s(src, len);
+  return turi::md5_raw(s);
+}
+
+inline string hash_string_value(const string& src) {
+  return hash_string_value(src.c_str(), src.length());
+}
+
+/**
+ * Hashes a given structure recursively (first computing a hash for each of its
+ * hashable contents if not already cached).
+ */
+template<typename T> inline string struct_hash(shared_ptr<T>& x) {
+  if (!!x->struct_hash_cached_) {
+    string ret = *(x->struct_hash_cached_);
+    return ret;
+  }
+
+  ostringstream os;
+  write_struct_hash_data(os, x);
+  string ret = hash_string_value(os.str());
+  x->struct_hash_cached_ = SOME(ret);
+  return ret;
+}
+
+template<typename T> inline string struct_hash(T x) {
+  ostringstream os;
+  write_struct_hash_data(os, x);
+  string ret = hash_string_value(os.str());
+  return ret;
+}
+
+template<typename T, typename U> inline void write_struct_hash_data(
+  ostream& os, pair<T, U> x) {
+
+  write_bin<string>(os, string(object_ids_builtin::pair_));
+  write_struct_hash_data(os, x.first);
+  write_struct_hash_data(os, x.second);
+}
+
+template<typename T> inline void write_struct_hash_data(
+  ostream& os, vector<T> x) {
+
+  write_bin<string>(os, string(object_ids_builtin::vector_));
+  write_bin<int64_t>(os, x.size());
+  for (auto xi : x) {
+    write_struct_hash_data(os, xi);
+  }
+}
+
+inline string format_hex_hash(uint128_t x) {
+  auto xs = string(reinterpret_cast<char*>(&x), sizeof(uint128_t));
+  return format_hex(xs);
+}
+
+/**
+ * The number of worker threads, and hence the number of chunks that our 128-bit
+ * hash space is divided into (see \ref parallel_hash_map).
+ */
+inline int64_t get_num_hash_chunks() {
+  return turi::thread_pool::get_instance().size();
+}
+
+/**
+ * The size of a given chunk of the 128-bit hash space (see \ref
+ * parallel_hash_map).
+ */
+inline uint128_t get_hash_chunk_size() {
+  thread_local uint128_t ret_cached { 0 };
+  thread_local bool ret_is_cached { false };
+  if (ret_is_cached) {
+    return ret_cached;
+  }
+
+  int64_t nt = get_num_hash_chunks();
+  uint128_t hash_round = uint128_t(1) << 127;
+  uint128_t hash_max = hash_round + (hash_round - 1);
+  uint128_t hash_chunk_size = (hash_max / nt) + 1;
+  if (nt == 1) {
+    hash_chunk_size = hash_max;
+  }
+  ret_cached = hash_chunk_size;
+  ret_is_cached = true;
+  return ret_cached;
+}
+
+struct bin_handle {
+  int64_t index_;
+  int64_t offset_;
+  int64_t len_;
+  bin_handle() : index_(0), offset_(0), len_(0) { }
+  bin_handle(int64_t index, int64_t offset, int64_t len)
+    : index_(index), offset_(offset), len_(len) { }
+};
+
+struct buffer {
+  char* addr_;
+  int64_t length_;
+
+  buffer(char* addr, int64_t length) : addr_(addr), length_(length) { }
+};
+
+DECL_STRUCT(block_manager);
+
+/**
+ * Stores, allocates, and reallocates raw binary buffers in memory.
+ */
+struct block_manager {
+  struct block_in_memory {
+    char* addr_;
+    int64_t length_;
+    int64_t capacity_;
+
+    void reserve_length(int64_t new_length);
+
+    block_in_memory() {
+      int64_t init_length = 0;
+      int64_t init_capacity = (1 << 8);
+      length_ = init_length;
+      capacity_ = init_capacity;
+      addr_ = reinterpret_cast<char*>(malloc(capacity_));
+    }
+
+    ~block_in_memory();
+  };
+
+  using block_in_memory_p = shared_ptr<block_in_memory>;
+
+  struct handle {
+    // TODO: optional (may be paged out to disk/compressed)
+    block_in_memory_p block_;
+
+    inline const block_in_memory_p& get_in_memory_view() {
+      return block_;
+    }
+
+    inline uint128_t get_data_hash(int64_t offset, int64_t len) {
+      return turi::hash128(this->get_in_memory_view()->addr_ + offset, len);
+    }
+
+    void save_bin_dir(string base_path);
+
+    handle(block_in_memory_p block) : block_(block) { }
+  };
+
+  using handle_p = shared_ptr<handle>;
+
+  handle_p load_bin_dir(string base_path);
+  handle_p create_block();
+
+  static block_manager* get();
+};
+
+bool operator==(
+  block_manager::block_in_memory_p, block_manager::block_in_memory_p);
+bool operator==(block_manager::handle_p, block_manager::handle_p);
+
+inline buffer binary_data_view_get_data_raw(
+  bin_handle h, vector<block_manager::handle_p>& block_handles) {
+
+  return buffer(
+    block_handles[h.index_]->get_in_memory_view()->addr_ + h.offset_, h.len_);
+}
+
+inline uint128_t binary_data_view_get_data_hash(
+  bin_handle h, vector<block_manager::handle_p>& block_handles) {
+
+  return block_handles[h.index_]->get_data_hash(h.offset_, h.len_);
+}
+
+inline void binary_data_view_get_data(
+  void* dst_addr, bin_handle h,
+  vector<block_manager::handle_p>& block_handles) {
+
+  memcpy(
+    dst_addr,
+    block_handles[h.index_]->get_in_memory_view()->addr_ + h.offset_,
+    h.len_);
+}
+
+inline void binary_data_view_fixed_get_data(
+  void* dst_addr, int64_t offset, int64_t len,
+  block_manager::handle_p& block_handle) {
+
+  memcpy(dst_addr, block_handle->block_->addr_ + offset, len);
+}
+
+inline string binary_data_view_fixed_get_data_string(
+  int64_t offset, int64_t len, block_manager::handle_p block_handle) {
+
+  vector<char> dst(len);
+  binary_data_view_fixed_get_data(dst.data(), offset, len, block_handle);
+  return string(dst.data(), len);
+}
+
+int64_t binary_data_directory_get_file_count(
+  const string& base_path, bool is_variable);
+
+string generate_bin_file_path(const string& base_path, int64_t file_index);
+
+/**
+ * Provides the basic abstraction of a binary data blob, supporting random
+ * access, append operations, and efficient serialization. Note that this
+ * version is "fixed"-length, meaning it is backed by a single buffer and does
+ * not support multiple concurrent appends.
+ */
+struct binary_data_builder_fixed {
+  int64_t curr_offset_;
+  int64_t curr_length_;
+  block_manager::handle_p block_handle_;
+
+  inline int64_t get_current_offset() {
+    return curr_offset_;
+  }
+
+  binary_data_builder_fixed()
+    : curr_offset_(0), curr_length_(0),
+      block_handle_(block_manager::get()->create_block()) { }
+
+  inline void reserve_length(int64_t new_length) {
+    if (new_length <= curr_length_) {
+      return;
+    }
+
+    auto view = block_handle_->get_in_memory_view();
+    view->reserve_length(new_length);
+    curr_length_ = new_length;
+  }
+
+  inline void put_data_unchecked(int64_t offset, const void* src_addr, int64_t len) {
+    memcpy(block_handle_->block_->addr_ + offset, src_addr, len);
+  }
+
+  inline void put_data(int64_t offset, const void* src_addr, int64_t len) {
+    reserve_length(offset + len);
+    put_data_unchecked(offset, src_addr, len);
+  }
+
+  inline void get_data_unchecked(void* dst_addr, int64_t offset, int64_t len) {
+    memcpy(dst_addr, block_handle_->block_->addr_ + offset, len);
+  }
+
+  inline void get_data(void* dst_addr, int64_t offset, int64_t len) {
+    ASSERT_LE(offset + len, curr_length_);
+    get_data_unchecked(dst_addr, offset, len);
+  }
+
+  inline string get_data_string(int64_t offset, int64_t len) {
+    vector<char> dst(len);
+    get_data(dst.data(), offset, len);
+    return string(dst.data(), len);
+  }
+
+  inline void append(const void* src_addr, int64_t len) {
+    put_data(curr_offset_, src_addr, len);
+    curr_offset_ += len;
+  }
+
+  inline void append(const string& s) {
+    append(&s[0], s.length());
+  }
+
+  inline void append_skip(int64_t len) {
+    reserve_length(curr_offset_ + len);
+    curr_offset_ += len;
+  }
+
+  template<typename T> void append_object_header(T*) {
+    ostringstream os;
+    write_object_header<T>(os, nullptr);
+    append(os.str());
+  }
+
+  template<typename T> void append_value(const T& val) {
+    ostringstream os;
+    write_bin(os, val);
+    append(os.str());
+  }
+
+  inline void save(string base_path) {
+    block_handle_->save_bin_dir(base_path);
+  }
+
+  binary_data_builder_fixed(const binary_data_builder_fixed&) = delete;
+  binary_data_builder_fixed operator=(
+    const binary_data_builder_fixed&) = delete;
+};
+
+DECL_STRUCT(binary_data_view_fixed);
+
+/**
+ * Provides an efficient random-access view on a fully-serialized binary data
+ * blob (see \ref binary_data_builder_fixed).
+ */
+struct binary_data_view_fixed
+  : public enable_shared_from_this<binary_data_view_fixed> {
+
+  string base_path_;
+  int64_t len_total_;
+
+  block_manager::handle_p block_handle_;
+
+  binary_data_view_fixed(block_manager::handle_p block_handle);
+  binary_data_view_fixed(string base_path);
+
+  inline void get_data(void* dst_addr, int64_t offset, int64_t len) {
+    binary_data_view_fixed_get_data(
+      dst_addr, offset, len, block_handle_);
+  }
+
+  string get_data_string(int64_t offset, int64_t len);
+
+  inline void save(string base_path) {
+    block_handle_->save_bin_dir(base_path);
+  }
+
+  struct istream_reader
+    : public boost::iostreams::device<boost::iostreams::input_seekable> {
+
+    binary_data_view_fixed_p src_;
+    int64_t curr_offset_;
+
+    istream_reader(binary_data_view_fixed_p src)
+      : src_(src), curr_offset_(0) { }
+
+    streamsize read(char* dst, streamsize len);
+    streampos seek(boost::iostreams::stream_offset off, ios_base::seekdir way);
+  };
+
+  using istream_type = boost::iostreams::stream<istream_reader>;
+  using istream_type_p = shared_ptr<istream_type>;
+
+  istream_type_p get_istream();
+};
+
+DECL_STRUCT(binary_data_view_variable);
+
+/**
+ * Provides an efficient random-access view on a fully-serialized binary data
+ * blob (see \ref binary_data_builder_variable).
+ */
+struct binary_data_view_variable {
+  vector<block_manager::handle_p> block_handles_;
+
+  binary_data_view_variable(vector<block_manager::handle_p> block_handles)
+    : block_handles_(block_handles) { }
+  binary_data_view_variable(string base_path);
+
+  inline void get_data(void* dst_addr, bin_handle h) {
+    binary_data_view_get_data(dst_addr, h, block_handles_);
+  }
+
+  inline buffer get_data_raw(bin_handle h) {
+    return binary_data_view_get_data_raw(h, block_handles_);
+  }
+
+  inline uint128_t get_data_hash(bin_handle h) {
+    return binary_data_view_get_data_hash(h, block_handles_);
+  }
+
+  inline string get_data_string(bin_handle h) {
+    vector<char> dst(h.len_);
+    get_data(dst.data(), h);
+    return string(dst.data(), h.len_);
+  }
+
+  inline void save(string base_path) {
+    for (int64_t i = 0; i < len(block_handles_); i++) {
+      auto dst_path_i = cc_sprintf("%s/%05lld", base_path.c_str(), i);
+      at(block_handles_, i)->save_bin_dir(dst_path_i);
+    }
+  }
+};
+
+/**
+ * Provides the basic abstraction of a binary data blob, supporting random
+ * access, append operations, and efficient serialization. Note that this
+ * version is "variable"-length, meaning it is backed by a separate buffer for
+ * each worker thread and can support multiple concurrent appends.
+ */
+struct binary_data_builder_variable {
+  int64_t num_workers_max_;
+  vector<int64_t> curr_offsets_;
+  vector<block_manager::handle_p> block_handles_;
+
+  binary_data_builder_variable(int64_t num_workers_max)
+    : num_workers_max_(num_workers_max), curr_offsets_(num_workers_max, 0) {
+
+    for (int64_t i = 0; i < num_workers_max; i++) {
+      block_handles_.push_back(block_manager::get()->create_block());
+    }
+  }
+
+  inline void put_data_unchecked(
+    int64_t offset, const void* src_addr, int64_t len, int64_t worker_index) {
+    memcpy(
+      block_handles_[worker_index]->block_->addr_ + offset, src_addr, len);
+  }
+
+  inline void put_data(
+    int64_t offset, const void* src_addr, int64_t len, int64_t worker_index) {
+    block_handles_[worker_index]->block_->reserve_length(offset + len);
+    put_data_unchecked(offset, src_addr, len, worker_index);
+  }
+
+  inline bin_handle append(const void* src_addr, int64_t len, int64_t worker_index) {
+    auto curr_offset = curr_offsets_[worker_index];
+    put_data(curr_offset, src_addr, len, worker_index);
+    auto ret = bin_handle(worker_index, curr_offset, len);
+    curr_offsets_[worker_index] = curr_offset + len;
+    return ret;
+  }
+
+  inline void get_data(void* dst_addr, bin_handle h) {
+    binary_data_view_get_data(dst_addr, h, block_handles_);
+  }
+
+  inline string get_data_string(bin_handle h) {
+    vector<char> dst(h.len_);
+    get_data(dst.data(), h);
+    return string(dst.data(), h.len_);
+  }
+
+  binary_data_builder_variable(const binary_data_builder_variable&) = delete;
+  binary_data_builder_variable operator=(
+    const binary_data_builder_variable&) = delete;
+};
+
+}}
+
+#endif

--- a/src/sframe/sframe_random_access_impl.cpp
+++ b/src/sframe/sframe_random_access_impl.cpp
@@ -1,0 +1,2185 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <sframe/sframe_random_access.hpp>
+
+#include <sframe/sarray.hpp>
+#include <sframe/sframe_random_access_impl.hpp>
+#include <unity/toolkits/util/random_sframe_generation.hpp>
+#include <util/basic_types.hpp>
+#include <util/fs_util.hpp>
+
+using turi::fs_util::copy_directory_recursive;
+using turi::fs_util::make_directories_strict;
+
+using std::istringstream;
+using std::make_pair;
+using std::max;
+using std::min;
+using std::set;
+
+namespace turi { namespace sframe_random_access {
+
+value_type_p value_type::create_column(
+  value_type_p element_type, optional<int64_t> length, bool known_unique) {
+
+  return value_type::create(
+    value_type_column_create(element_type, length, known_unique));
+}
+
+value_type_p value_type::create_bool_column() {
+  return value_type::create_column(
+    value_type::create_scalar(dtype_enum::BOOL), NONE<int64_t>(), false);
+}
+
+value_type_p value_type::create_nd_vector(int64_t ndim, dtype_enum dtype) {
+  return value_type::create(value_type_nd_vector::create(ndim, dtype));
+}
+
+value_type_p value_type::create_string() {
+  return value_type::create(
+    value_type_nd_vector::create(1, dtype_enum::I8),
+    value_type_tag_enum::STRING);
+}
+
+value_type_p value_type::create_image() {
+  return value_type::create(
+    value_type_nd_vector::create(1, dtype_enum::I8),
+    value_type_tag_enum::IMAGE);
+}
+
+value_type_p value_type::create_scalar(dtype_enum dtype) {
+  return value_type::create_nd_vector(0, dtype);
+}
+
+value_type_p value_type::create_record(
+  vector<pair<string, value_type_p>> field_types) {
+  return value_type::create(
+    make_shared<value_type_record>(field_types));
+}
+
+value_type_p value_type::create_data_table(
+  vector<pair<string, value_type_p>> field_types) {
+  return value_type::create(
+    make_shared<value_type_record>(field_types));
+}
+
+value_type_p value_type::create_empty_record() {
+  return value_type::create_record(vector<pair<string, value_type_p>>());
+}
+
+value_type_p value_type::create_optional(value_type_p some_ty) {
+  vector<pair<string, value_type_p>> case_types;
+
+  case_types.push_back(
+    make_pair(string("None"), value_type::create_empty_record()));
+  case_types.push_back(
+    make_pair(string("Some"), some_ty));
+
+  return value_type::create(
+    make_shared<value_type_either>(case_types),
+    value_type_tag_enum::OPTIONAL);
+}
+
+value_type_p value_type::create_function(
+  value_type_p left, value_type_p right) {
+  return value_type::create(make_shared<value_type_function>(left, right));
+}
+
+value_type_p value_type::create_index(
+  vector<value_type_p> source_column_types, index_mode_enum index_mode) {
+
+  return value_type::create(
+    make_shared<value_type_index>(source_column_types, index_mode));
+}
+
+value_type_enum value_type::which() {
+  return static_cast<value_type_enum>(v_.which());
+}
+
+string value_type::which_str() {
+  ostringstream os;
+  os << this->which();
+  return os.str();
+}
+
+optional<value_type_p> value_type::unpack_optional_ext() {
+  if (!tag_ || *tag_ != value_type_tag_enum::OPTIONAL) {
+    return NONE<value_type_p>();
+  }
+
+  auto cc = this->as<value_type_either_p>();
+  return SOME(cc->case_types_[1].second);
+}
+
+bool value_type::is_optional() {
+  return !!unpack_optional_ext();
+}
+
+value_type_p value_type::unpack_optional() {
+  return *unpack_optional_ext();
+}
+
+vector<pair<string, value_type_p>> value_type::as_record_items() const {
+  auto cc = this->as<value_type_record_p>();
+  return cc->field_types_;
+}
+
+pair<int64_t, dtype_enum> value_type::as_nd_vector_items() const {
+  auto cc = this->as<value_type_nd_vector_p>();
+  return make_pair(cc->ndim_, cc->dtype_);
+}
+
+string value_type::struct_hash() {
+  ostringstream os;
+  write_bin(os, shared_from_this());
+  return hash_string_value(os.str());
+}
+
+bool struct_eq(value_type_p x, value_type_p y) {
+  return x->struct_hash() == y->struct_hash();
+}
+
+void write_bin(ostream& os, value_type_p x, type_specializer<value_type_p>) {
+  write_object_header(os, x.get());
+  auto which = static_cast<value_type_enum>(x->v_.which());
+  write_bin(os, which);
+  write_bin(os, x->tag_);
+
+  switch (which) {
+  case value_type_enum::COLUMN:
+    x->as<value_type_column_p>()->save_sub(os);
+    break;
+  case value_type_enum::ND_VECTOR:
+    x->as<value_type_nd_vector_p>()->save_sub(os);
+    break;
+  case value_type_enum::RECORD:
+    x->as<value_type_record_p>()->save_sub(os);
+    break;
+  case value_type_enum::EITHER:
+    x->as<value_type_either_p>()->save_sub(os);
+    break;
+  case value_type_enum::FUNCTION:
+    x->as<value_type_function_p>()->save_sub(os);
+    break;
+  case value_type_enum::INDEX:
+    x->as<value_type_index_p>()->save_sub(os);
+    break;
+  default:
+    cerr << "Unrecognized value_type_enum: " << int64_t(x->v_.which()) << endl;
+    AU();
+  }
+}
+
+value_type_p read_bin(istream& is, type_specializer<value_type_p>) {
+  read_object_header_check<value_type>(is);
+  auto which = read_bin<value_type_enum>(is);
+  auto tag = read_bin<optional<value_type_tag_enum>>(is);
+
+  switch (which) {
+  case value_type_enum::COLUMN:
+    return value_type::create(value_type_column::load_sub(is), tag);
+  case value_type_enum::ND_VECTOR:
+    return value_type::create(value_type_nd_vector::load_sub(is), tag);
+  case value_type_enum::RECORD:
+    return value_type::create(value_type_record::load_sub(is), tag);
+  case value_type_enum::EITHER:
+    return value_type::create(value_type_either::load_sub(is), tag);
+  case value_type_enum::FUNCTION:
+    return value_type::create(value_type_function::load_sub(is), tag);
+  case value_type_enum::INDEX:
+    return value_type::create(value_type_index::load_sub(is), tag);
+  default:
+    cerr << "Unrecognized value_type_enum: " << int64_t(which) << endl;
+    AU();
+  }
+}
+
+ostream& operator<<(ostream& os, value_type_p x) {
+  switch (x->which()) {
+  case value_type_enum::COLUMN: {
+    auto cc = x->as<value_type_column_p>();
+    os << "[" << cc->element_type_;
+    if (!!cc->length_) {
+      os << ":" << (*cc->length_);
+    }
+    if (cc->known_unique_) {
+      os << "!";
+    }
+    os << "]";
+    break;
+  }
+
+  case value_type_enum::ND_VECTOR: {
+    auto cc = x->as<value_type_nd_vector_p>();
+
+    if (!!x->tag_) {
+      if (*(x->tag_) == value_type_tag_enum::STRING) {
+        ASSERT_EQ(cc->ndim_, 1);
+        ASSERT_EQ(cc->dtype_, dtype_enum::I8);
+        os << "str";
+      } else if (*(x->tag_) == value_type_tag_enum::IMAGE) {
+        ASSERT_EQ(cc->ndim_, 1);
+        ASSERT_EQ(cc->dtype_, dtype_enum::I8);
+        os << "image";
+      } else {
+        AU();
+      }
+    } else {
+      if (cc->ndim_ == 0 && cc->dtype_ == dtype_enum::I64) {
+        os << "int";
+      } else {
+        os << dtype_to_char(cc->dtype_) << cc->ndim_;
+      }
+    }
+    break;
+  }
+
+  case value_type_enum::RECORD: {
+    auto cc = x->as<value_type_record_p>();
+
+    if (!!x->tag_) {
+      if (*(x->tag_) == value_type_tag_enum::DATA_TABLE) {
+        os << "Table ";
+      } else {
+        AU();
+      }
+    }
+
+    os << "{";
+    for (int64_t i = 0; i < len(cc->field_types_); i++) {
+      auto p = cc->field_types_[i];
+      if (i > 0) {
+        os << ", ";
+      }
+      os << p.first << ": " << p.second;
+    }
+    os << "}";
+    break;
+  }
+
+  case value_type_enum::EITHER: {
+    if (x->is_optional()) {
+      os << x->unpack_optional() << "?";
+    } else {
+      fmt(cerr, "General sum types not yet supported\n");
+      AU();
+    }
+    break;
+  }
+
+  case value_type_enum::FUNCTION: {
+    auto cc = x->as<value_type_function_p>();
+    os << cc->left_ << " -> " << cc->right_;
+    break;
+  }
+
+  case value_type_enum::INDEX: {
+    os << "<index>";
+    break;
+  }
+
+  default:
+    cerr << x->which() << endl;
+    AU();
+    break;
+  }
+
+  return os;
+}
+
+/**
+ * Returns true if a given \ref value_type is valid for a target \ref
+ * value_type, i.e., if it is a subtype of the target type.
+ */
+bool type_valid(value_type_p target, value_type_p sub) {
+  if (target->which() != sub->which()) {
+    return false;
+  }
+
+  if (!!target->tag_ && (!sub->tag_ || (*target->tag_ != *sub->tag_))) {
+    return false;
+  }
+
+  switch (target->which()) {
+  case value_type_enum::COLUMN: {
+    auto ct = target->as<value_type_column_p>();
+    auto cs = sub->as<value_type_column_p>();
+
+    if (!type_valid(ct->element_type_, cs->element_type_)) {
+      return false;
+    }
+
+    if (!!ct->length_ && (!cs->length_ || (*cs->length_ != *ct->length_))) {
+      return false;
+    }
+
+    if (ct->known_unique_ && !cs->known_unique_) {
+      return false;
+    }
+
+    return true;
+    break;
+  }
+
+  case value_type_enum::ND_VECTOR: {
+    auto ct = target->as<value_type_nd_vector_p>();
+    auto cs = sub->as<value_type_nd_vector_p>();
+    return ((ct->ndim_ == cs->ndim_) && (ct->dtype_ == cs->dtype_));
+    break;
+  }
+
+  case value_type_enum::RECORD: {
+    auto ct = target->as<value_type_record_p>();
+    auto cs = sub->as<value_type_record_p>();
+
+    int64_t n = len(ct->field_types_);
+    if (len(cs->field_types_) != n) {
+      return false;
+    }
+
+    for (int64_t i = 0; i < n; i++) {
+      if (ct->field_types_[i].first != cs->field_types_[i].first) {
+        return false;
+      }
+
+      if (!type_valid(
+            ct->field_types_[i].second, cs->field_types_[i].second)) {
+        return false;
+      }
+    }
+
+    return true;
+    break;
+  }
+
+  case value_type_enum::EITHER: {
+    if (target->is_optional() && sub->is_optional()) {
+      return type_valid(target->unpack_optional(), sub->unpack_optional());
+    } else {
+      fmt(cerr, "Non-optional sum types not yet supported\n");
+      AU();
+    }
+    break;
+  }
+
+  case value_type_enum::FUNCTION: {
+    AU();
+    break;
+  }
+
+  default:
+    cerr << target->which() << endl;
+    AU();
+    break;
+  }
+}
+
+void assert_type_valid(value_type_p target, value_type_p sub) {
+  bool is_valid = type_valid(target, sub);
+  if (!is_valid) {
+    fmt(
+      cerr,
+      " *** Type mismatch\n"
+      "     Expected: %v\n"
+      "     Received: %v\n", target, sub);
+    AU();
+  }
+}
+
+value_type_p value_type_create_nd_vector(int64_t ndim, const string& dtype_str) {
+  return value_type::create_nd_vector(ndim, dtype_from_char(dtype_str));
+}
+
+ostream& operator<<(ostream& os, value_enum x) {
+  switch (x) {
+  case value_enum::COLUMN: os << "COLUMN"; break;
+  case value_enum::ND_VECTOR: os << "ND_VECTOR"; break;
+  case value_enum::RECORD: os << "RECORD"; break;
+  case value_enum::EITHER: os << "EITHER"; break;
+  case value_enum::REF: os << "REF"; break;
+  case value_enum::INDEX: os << "INDEX"; break;
+  default:
+    cerr << static_cast<int64_t>(x) << endl;
+    AU();
+  }
+
+  return os;
+}
+
+ostream& operator<<(ostream& os, value_ref_enum x) {
+  switch (x) {
+  case value_ref_enum::VALUE: os << "VALUE"; break;
+  case value_ref_enum::COLUMN_ELEMENT: os << "COLUMN_ELEMENT"; break;
+  case value_ref_enum::COLUMN_RANGE: os << "COLUMN_RANGE"; break;
+  case value_ref_enum::COLUMN_SUBSET: os << "COLUMN_SUBSET"; break;
+  default:
+    cerr << static_cast<int64_t>(x) << endl;
+    AU();
+  }
+
+  return os;
+}
+
+ref_context_p ref_context::create() {
+  return make_shared<ref_context>();
+}
+
+ostream& operator<<(ostream& os, column_format_enum x) {
+  switch (x) {
+  case column_format_enum::VARIABLE:  os << "VARIABLE"; break;
+  default:
+    os << static_cast<int64_t>(x) << endl;
+    AU();
+  }
+  return os;
+}
+
+column_builder::column_builder(
+  value_type_p entry_type, column_format_enum format) {
+
+  entry_type_ = entry_type;
+  top_acc_ = make_shared<binary_data_builder_fixed>();
+  entries_acc_ = make_shared<binary_data_builder_variable>(
+    turi::thread_pool::get_instance().size());
+  format_ = format;
+  ref_context_ = ref_context::create();
+  is_finalized_ = false;
+
+  ASSERT_TRUE(format_ == column_format_enum::VARIABLE);
+
+  num_entries_current_ = 0;
+}
+
+void column_builder::put(const value_p& entry, int64_t i, int64_t worker_index) {
+  string entry_str;
+  {
+    ostringstream os;
+    entry->save_raw(os, SOME(ref_context_), NONE<unordered_set<int64_t>*>());
+    entry_str = os.str();
+  }
+
+  this->put_raw(buffer(&entry_str[0], entry_str.length()), i, worker_index);
+}
+
+void column_builder::append_raw(buffer src) {
+  ASSERT_TRUE(!is_finalized_);
+  int64_t start_index = num_entries_current_;
+  this->extend_length_raw(start_index + 1);
+  this->put_raw(src, start_index, 0);
+}
+
+void column_builder::append(const value_p& entry) {
+  ASSERT_TRUE(!is_finalized_);
+  int64_t start_index = num_entries_current_;
+  this->extend_length_raw(start_index + 1);
+
+  assert_type_valid(entry_type_, entry->ty_);
+
+  string entry_str;
+  {
+    ostringstream os;
+    entry->save_raw(os, SOME(ref_context_), NONE<unordered_set<int64_t>*>());
+    entry_str = os.str();
+  }
+
+  constexpr int64_t worker_index = 0;
+  bin_handle h = entries_acc_->append(
+    &entry_str[0], entry_str.length(), worker_index);
+  {
+    ostringstream os;
+    write_bin(os, h.index_);
+    write_bin(os, h.offset_);
+    write_bin(os, h.len_);
+    string table_entry_str = os.str();
+
+    ASSERT_EQ(table_entry_str.size(), COLUMN_TABLE_ENTRY_SIZE_BYTES);
+
+    top_acc_->put_data(
+      get_table_entry_offset(start_index),
+      &table_entry_str[0],
+      COLUMN_TABLE_ENTRY_SIZE_BYTES
+      );
+  }
+}
+
+value_p column_builder::finalize(bool known_unique) {
+  ASSERT_TRUE(!is_finalized_);
+
+  int64_t num_entries_final = num_entries_current_;
+
+  auto res_type = value_type::create_column(
+    entry_type_, SOME<int64_t>(num_entries_final), known_unique);
+
+  ASSERT_TRUE(format_ == column_format_enum::VARIABLE);
+
+  auto meta_acc = make_shared<binary_data_builder_fixed>();
+
+  meta_acc->append_object_header(static_cast<value*>(nullptr));
+  meta_acc->append_value(res_type);
+  meta_acc->append_value(value_enum::COLUMN);
+  meta_acc->append_value(format_);
+
+  auto top_view = make_shared<binary_data_view_fixed>(
+    top_acc_->block_handle_);
+  auto meta_view = make_shared<binary_data_view_fixed>(
+    meta_acc->block_handle_);
+  auto entries_view = make_shared<binary_data_view_variable>(
+    entries_acc_->block_handles_);
+
+  return value_column::load_column_from_binary_data(
+    meta_view,
+    top_view,
+    entries_view,
+    ref_context_,
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+value_p column_builder::finalize() {
+  return this->finalize(false);
+}
+
+void table_builder::append(const vector<value_p>& entries) {
+  ASSERT_EQ(entries.size(), column_builders_.size());
+  for (int64_t i = 0; i < len(entries); i++) {
+    column_builders_[i]->append(entries[i]);
+  }
+}
+
+value_p table_builder::finalize() {
+  vector<value_type_p> ret_element_types;
+  vector<value_p> ret_columns;
+  for (int64_t i = 0; i < len(column_builders_); i++) {
+    ret_element_types.push_back(column_builders_[i]->entry_type_);
+    ret_columns.push_back(column_builders_[i]->finalize());
+  }
+  auto ret_type = value_type_table_create(column_names_, ret_element_types);
+  auto ret = value::create(
+    make_shared<value_record>(ret_type, ret_columns),
+    ret_type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+  is_finalized_ = true;
+  return ret;
+}
+
+column_view_variable::column_view_variable(
+  string base_path, optional<url_p> url_context)
+  : url_context_(url_context) {
+
+  meta_view_ = make_shared<binary_data_view_fixed>(base_path + "/meta");
+  top_view_ = make_shared<binary_data_view_fixed>(base_path + "/top");
+  entries_view_ = make_shared<binary_data_view_variable>(
+    base_path + "/entries");
+
+  auto is_meta = meta_view_->get_istream();
+
+  read_object_header_check<value>(*is_meta);
+  type_ = read_bin<value_type_p>(*is_meta);
+  entry_type_ = type_->as<value_type_column_p>()->element_type_;
+  num_entries_ = *(type_->as<value_type_column_p>()->length_);
+  auto which = read_bin<value_enum>(*is_meta);
+  ASSERT_TRUE(which == value_enum::COLUMN);
+  format_ = read_bin<column_format_enum>(*is_meta);
+  ASSERT_TRUE(format_ == column_format_enum::VARIABLE);
+}
+
+column_view_variable::column_view_variable(
+  binary_data_view_fixed_p meta_view,
+  binary_data_view_fixed_p top_view,
+  binary_data_view_variable_p entries_view,
+  optional<url_p> url_context)
+  : meta_view_(meta_view),
+    top_view_(top_view),
+    entries_view_(entries_view),
+    url_context_(url_context) {
+
+  auto is_meta = meta_view_->get_istream();
+
+  read_object_header_check<value>(*is_meta);
+  type_ = read_bin<value_type_p>(*is_meta);
+  entry_type_ = type_->as<value_type_column_p>()->element_type_;
+  num_entries_ = *(type_->as<value_type_column_p>()->length_);
+  auto which = read_bin<value_enum>(*is_meta);
+  ASSERT_TRUE(which == value_enum::COLUMN);
+  format_ = read_bin<column_format_enum>(*is_meta);
+  ASSERT_TRUE(format_ == column_format_enum::VARIABLE);
+}
+
+value_p column_view_variable::at(int64_t i) {
+  ASSERT_GE(i, 0);
+  ASSERT_LT(i, num_entries_);
+
+  auto h_str = top_view_->get_data_string(
+    get_table_entry_offset(i), COLUMN_TABLE_ENTRY_SIZE_BYTES);
+  bin_handle h;
+  {
+    istringstream is(h_str);
+    h.index_ = read_bin<int64_t>(is);
+    h.offset_ = read_bin<int64_t>(is);
+    h.len_ = read_bin<int64_t>(is);
+  }
+
+  auto data_str = entries_view_->get_data_string(h);
+  {
+    istringstream is(data_str);
+    value_p ret = value::load_raw(is, entry_type_, url_context_);
+    return ret;
+  }
+}
+
+value_p column_builder::at(int64_t i) {
+  ASSERT_GE(i, 0);
+  ASSERT_LT(i, num_entries_current_);
+
+  auto h_str = top_acc_->get_data_string(
+    get_table_entry_offset(i), COLUMN_TABLE_ENTRY_SIZE_BYTES);
+  bin_handle h;
+  {
+    istringstream is(h_str);
+    h.index_ = read_bin<int64_t>(is);
+    h.offset_ = read_bin<int64_t>(is);
+    h.len_ = read_bin<int64_t>(is);
+  }
+
+  auto data_str = entries_acc_->get_data_string(h);
+  {
+    istringstream is(data_str);
+    value_p ret = value::load_raw(is, entry_type_, NONE<url_p>());
+    return ret;
+  }
+}
+
+value::value(value_v v, value_type_p ty, optional<ref_context_p> accum_refs,
+             optional<url_p> url_context, optional<int64_t> id)
+  : v_(v), ty_(ty), url_context_(url_context), value_id_(id),
+    ref_context_(accum_refs) {
+
+  if (!!url_context) {
+    ASSERT_EQ(v.which(), value_enum::COLUMN);
+  }
+}
+
+void write_bin_value(
+  ostream& os, value_p x, optional<ref_context_p> ctx,
+  optional<unordered_set<int64_t>*> local_refs_acc) {
+
+  write_object_header(os, x.get());
+  write_bin(os, x->ty_);
+  x->save_raw(os, ctx, local_refs_acc);
+}
+
+value_p read_bin_value(istream& is, optional<url_p> load_url) {
+  read_object_header_check<value>(is);
+  auto type = read_bin<value_type_p>(is);
+
+  return value::load_raw(is, type, load_url);
+}
+
+void value::save_raw(
+  ostream& os, optional<ref_context_p> ctx,
+  optional<unordered_set<int64_t>*> local_refs_acc) {
+
+  if (!!local_refs_acc) {
+    if (!!ref_context_) {
+      lock_guard<recursive_mutex> lock {
+        (*ref_context_)->ref_targets_lock_ };
+      for (const auto& x : (*ref_context_)->ref_targets_) {
+        (*local_refs_acc)->insert(x->get_value_id());
+      }
+    }
+  }
+
+  auto which = static_cast<value_enum>(v_.which());
+
+  if (!ty_->known_direct_) {
+    write_bin(os, which);
+  }
+
+  switch (which) {
+  case value_enum::ND_VECTOR: {
+    auto cc = this->as<value_nd_vector_p>();
+    if (cc->shape_.size() > 0) {
+      write_bin(os, cc->shape_);
+    }
+    if (cc->contiguous_) {
+      os.write(
+        reinterpret_cast<char*>(cc->base_addr_),
+        product(cc->shape_) * dtype_size_bytes(cc->dtype_));
+    } else {
+      fmt(cerr, "Non-contiguous nd_vectors (e.g. slices) not yet supported\n");
+      AU();
+    }
+    break;
+  }
+
+  case value_enum::RECORD: {
+    auto cc = this->as<value_record_p>();
+    for (int64_t i = 0; i < len(cc->entries_); i++) {
+      cc->entries_[i]->save_raw(os, ctx, local_refs_acc);
+    }
+    break;
+  }
+
+  case value_enum::EITHER: {
+    auto cc = this->as<value_either_p>();
+    write_bin(os, cc->val_which_);
+    cc->val_data_->save_raw(os, ctx, local_refs_acc);
+    break;
+  }
+
+  case value_enum::COLUMN: {
+    auto target = shared_from_this();
+
+    auto id_mode = value_ref_location_enum::LOCAL;
+    if (!!target->url_context_) {
+      id_mode = value_ref_location_enum::SFRAME_URL;
+    }
+
+    write_bin(os, id_mode);
+
+    if (id_mode == value_ref_location_enum::LOCAL) {
+      auto id = target->get_value_id();
+      write_bin<int64_t>(os, id);
+      if (!!local_refs_acc) {
+        (*local_refs_acc)->insert(id);
+      }
+    } else if (id_mode == value_ref_location_enum::SFRAME_URL) {
+      auto id = target->get_value_id();
+      write_bin<string>(os, (*target->url_context_)->url_path_);
+      write_bin<int64_t>(os, id);
+    } else {
+      AU();
+    }
+
+    if (!!ctx) {
+      (*ctx)->enroll_ref_target(target);
+    }
+
+    break;
+  }
+
+  case value_enum::REF: {
+    auto cc = this->as<value_ref_p>();
+
+    write_bin(os, cc->ref_which_);
+
+    if (cc->ref_which_ == value_ref_enum::VALUE) {
+      AU();
+    } else {
+      if (!!cc->target_) {
+        write_bin(os, int8_t(1));
+        write_bin_value(os, *cc->target_, ctx, local_refs_acc);
+      } else {
+        write_bin(os, int8_t(0));
+      }
+
+      write_bin(os, cc->column_element_);
+      write_bin(os, cc->column_range_lo_);
+      write_bin(os, cc->column_range_hi_);
+
+      if (!!cc->column_subset_) {
+        write_bin(os, int8_t(1));
+        write_bin_value(os, *cc->column_subset_, ctx, local_refs_acc);
+      } else {
+        write_bin(os, int8_t(0));
+      }
+    }
+
+    break;
+  }
+
+  case value_enum::INDEX: {
+    fmt(cerr, "Serialization of indices not yet supported\n");
+    AU();
+  }
+
+  default:
+    cerr << which << endl;
+    AU();
+  }
+}
+
+value_ref_p value_ref::create_value(value_type_p type, value_p target) {
+  if (type->which() != value_type_enum::COLUMN) {
+    fmt(cerr, "Non-column refs not yet supported\n");
+    AU();
+  }
+
+  auto ret = make_shared<value_ref>(type, value_ref_enum::VALUE);
+  ASSERT_TRUE(target->which() != value_enum::REF);
+  ret->target_ = SOME(target);
+  return ret;
+}
+
+value_ref_p value_ref::create_value_column(value_p column) {
+  ASSERT_TRUE(column->which() == value_enum::COLUMN);
+  auto cc = column->as<value_column_p>();
+  return value_ref::create_value(column->ty_, column);
+}
+
+value_p value_ref::create_column_element(
+  value_type_p type, value_p target, int64_t i) {
+  fmt(cerr, "Column element references not yet supported\n");
+  AU();
+}
+
+value_p value_ref::create_column_subset(
+  value_p target, value_p column_subset) {
+  auto target_type = target->ty_->as<value_type_column_p>();
+  auto ret_length = column_subset->get_column_length();
+  auto ret_type = value_type::create_column(
+    target_type->element_type_,
+    SOME<int64_t>(ret_length),
+    target_type->known_unique_);
+
+  auto ret = make_shared<value_ref>(ret_type, value_ref_enum::COLUMN_SUBSET);
+  ASSERT_TRUE(target->which() != value_enum::REF);
+  ret->target_ = SOME(target);
+  ret->column_subset_ = SOME(column_subset);
+  return value::create(
+    ret,
+    ret_type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+value_p value_ref::create_column_range(
+  value_p target, int64_t range_lo, int64_t range_hi) {
+  auto target_type = target->ty_->as<value_type_column_p>();
+  ASSERT_TRUE(range_lo <= range_hi);
+  auto ret_length = range_hi - range_lo;
+  auto ret_type = value_type::create_column(
+    target_type->element_type_,
+    SOME<int64_t>(ret_length),
+    target_type->known_unique_);
+
+  auto ret = make_shared<value_ref>(ret_type, value_ref_enum::COLUMN_RANGE);
+  ASSERT_TRUE(target->which() != value_enum::REF);
+  ret->target_ = SOME(target);
+  ret->column_range_lo_ = SOME(range_lo);
+  ret->column_range_hi_ = SOME(range_hi);
+  return value::create(
+    ret,
+    ret_type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+value_p value_ref::ref_column_at_index(int64_t i) {
+  ASSERT_EQ(type_->which(), value_type_enum::COLUMN);
+
+  switch (ref_which_) {
+  case value_ref_enum::VALUE: {
+    return value_ref::create_column_element(
+      type_->as<value_type_column_p>()->element_type_,
+      *target_,
+      i);
+  }
+  case value_ref_enum::COLUMN_ELEMENT: {
+    fmt(cerr, "Column element references not yet supported\n");
+    AU();
+  }
+  case value_ref_enum::COLUMN_RANGE: {
+    auto ri = *column_range_lo_ + i;
+    return value_ref::create_column_element(
+      type_->as<value_type_column_p>()->element_type_,
+      *target_,
+      ri);
+  }
+  case value_ref_enum::COLUMN_SUBSET: {
+    auto ri =
+      value_column_at(*column_subset_, i)
+      ->as<value_nd_vector_p>()->value_scalar_int64();
+    return value_ref::create_column_element(
+      type_->as<value_type_column_p>()->element_type_,
+      *target_,
+      ri);
+  }
+  default:
+    cerr << static_cast<int64_t>(ref_which_) << endl;
+    AU();
+  }
+}
+
+void write_struct_hash_data(ostream& os, value_p x);
+
+void write_struct_hash_data(ostream& os, optional<value_p> x) {
+  if (!!x) {
+    write_bin(os, static_cast<int8_t>(1));
+    write_struct_hash_data(os, *x);
+  } else {
+    write_bin(os, static_cast<int8_t>(0));
+  }
+}
+
+void write_struct_hash_data(ostream& os, value_p x) {
+  auto which = static_cast<value_enum>(x->which());
+
+  switch (which) {
+  case value_enum::COLUMN: {
+    auto ref = value::create(
+      value_ref::create_value_column(x),
+      x->ty_,
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+    write_struct_hash_data(os, ref);
+    break;
+  }
+  case value_enum::ND_VECTOR: {
+    x->save_raw(os, NONE<ref_context_p>(), NONE<unordered_set<int64_t>*>());
+    break;
+  }
+  case value_enum::RECORD: {
+    auto cc = x->as<value_record_p>();
+    for (int64_t i = 0; i < len(cc->entries_); i++) {
+      write_struct_hash_data(os, cc->entries_[i]);
+    }
+    break;
+  }
+  case value_enum::EITHER: {
+    auto cc = x->as<value_either_p>();
+    write_bin(os, cc->val_which_);
+    write_struct_hash_data(os, cc->val_data_);
+    break;
+  }
+  case value_enum::REF: {
+    auto cc = x->as<value_ref_p>();
+    write_bin(os, cc->ref_which_);
+
+    if (cc->ref_which_ == value_ref_enum::VALUE) {
+      auto id = (*cc->target_)->get_value_id();
+      write_bin(os, static_cast<int64_t>(0));
+      write_bin(os, id);
+    } else {
+      write_struct_hash_data(os, cc->target_);
+      write_bin(os, cc->column_element_);
+      write_bin(os, cc->column_range_lo_);
+      write_bin(os, cc->column_range_hi_);
+      write_struct_hash_data(os, cc->column_subset_);
+    }
+
+    break;
+  }
+  default:
+    cerr << which << endl;
+    AU();
+  }
+}
+
+value_enum value_type_to_direct_constructor(value_type_enum x) {
+  switch (x) {
+  case value_type_enum::COLUMN: return value_enum::COLUMN;
+  case value_type_enum::ND_VECTOR: return value_enum::ND_VECTOR;
+  case value_type_enum::RECORD: return value_enum::RECORD;
+  case value_type_enum::EITHER: return value_enum::EITHER;
+  default: AU();
+  }
+}
+
+value_p value::load_raw(
+  istream& is, value_type_p type, optional<url_p> url_context) {
+  value_enum which;
+
+  if (!type->known_direct_) {
+    which = read_bin<value_enum>(is);
+  } else {
+    which = value_type_to_direct_constructor(type->which());
+  }
+
+  switch (which) {
+  case value_enum::COLUMN: {
+    auto id_mode = read_bin<value_ref_location_enum>(is);
+    if (id_mode == value_ref_location_enum::LOCAL) {
+      auto id = read_bin<int64_t>(is);
+      return value::get_value_by_id(url_context, id);
+    } else if (id_mode == value_ref_location_enum::SFRAME_URL) {
+      auto url_path = read_bin<string>(is);
+      auto url_context_new = SOME<url_p>(url::by_path(url_path));
+      auto id = read_bin<int64_t>(is);
+      return value::get_value_by_id(url_context_new, id);
+    } else {
+      AU();
+    }
+    break;
+  }
+  case value_enum::ND_VECTOR: {
+    ASSERT_EQ(type->which(), value_type_enum::ND_VECTOR);
+    auto dtype = type->as<value_type_nd_vector_p>()->dtype_;
+    vector<int64_t> shape;
+    if (type->as<value_type_nd_vector_p>()->ndim_ > 0) {
+      shape = read_bin<vector<int64_t>>(is);
+    }
+    int64_t total_size = product(shape) * dtype_size_bytes(dtype);
+    auto base_addr = malloc(total_size);
+    is.read(reinterpret_cast<char*>(base_addr), total_size);
+    auto strides = contiguous_strides(shape);
+    bool base_addr_owned = true;
+    bool contiguous = true;
+    return value::create(
+      make_shared<value_nd_vector>(
+        base_addr, base_addr_owned, dtype, shape, strides, contiguous),
+      type,
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+  }
+  case value_enum::RECORD: {
+    ASSERT_EQ(type->which(), value_type_enum::RECORD);
+    auto cc_type = type->as<value_type_record_p>();
+    vector<value_p> ret_fields;
+    for (auto p : cc_type->field_types_) {
+      auto field_ty = p.second;
+      ret_fields.push_back(value::load_raw(is, field_ty, url_context));
+    }
+    return value::create(
+      make_shared<value_record>(type, ret_fields),
+      type,
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+  }
+  case value_enum::EITHER: {
+    ASSERT_EQ(type->which(), value_type_enum::EITHER);
+    auto cc_type = type->as<value_type_either_p>();
+    int64_t val_which = read_bin<int64_t>(is);
+    auto val_ty = ::at(cc_type->case_types_, val_which).second;
+    auto val_data = value::load_raw(is, val_ty, url_context);
+    return value::create(
+      make_shared<value_either>(type, val_which, val_data),
+      type,
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+  }
+  case value_enum::REF: {
+    auto ref_which = read_bin<value_ref_enum>(is);
+    if (ref_which == value_ref_enum::VALUE) {
+      AU();
+    } else {
+      auto target = NONE<value_p>();
+      auto target_c = read_bin<int8_t>(is);
+      if (target_c == int8_t(1)) {
+        auto target_v = read_bin_value(is, url_context);
+        target = SOME(target_v);
+      } else {
+        ASSERT_EQ(target_c, int8_t(0));
+      }
+      auto column_element = read_bin<optional<int64_t>>(is);
+      auto column_range_lo = read_bin<optional<int64_t>>(is);
+      auto column_range_hi = read_bin<optional<int64_t>>(is);
+      auto column_subset = NONE<value_p>();
+      auto column_subset_c = read_bin<int8_t>(is);
+      if (column_subset_c == int8_t(1)) {
+        auto column_subset_v = read_bin_value(is, url_context);
+        column_subset = SOME(column_subset_v);
+      } else {
+        ASSERT_EQ(column_subset_c, int8_t(0));
+      }
+      auto ret = make_shared<value_ref>(type, ref_which);
+      ret->target_ = *target;
+      ret->column_element_ = column_element;
+      ret->column_range_lo_ = column_range_lo;
+      ret->column_range_hi_ = column_range_hi;
+      ret->column_subset_ = column_subset;
+      return value::create(
+        ret,
+        type,
+        NONE<ref_context_p>(),
+        NONE<url_p>(),
+        NONE<int64_t>());
+    }
+  }
+  case value_enum::INDEX: {
+    fmt(cerr, "Serialization of indices not yet supported\n");
+    AU();
+  }
+  default:
+    cerr << which << endl;
+    AU();
+    break;
+  }
+}
+
+int64_t value::get_column_length() {
+  ASSERT_EQ(ty_->which(), value_type_enum::COLUMN);
+
+  switch (this->which()) {
+  case value_enum::COLUMN:
+    return this->as<value_column_p>()->length();
+  case value_enum::REF: {
+    auto cc = this->as<value_ref_p>();
+    switch (cc->ref_which_) {
+    case value_ref_enum::VALUE:
+      return (*cc->target_)->get_column_length();
+    case value_ref_enum::COLUMN_ELEMENT:
+      return (*cc->target_)->as<value_column_p>()
+        ->at(*cc->column_element_)->get_column_length();
+    case value_ref_enum::COLUMN_SUBSET:
+      return (*cc->column_subset_)->get_column_length();
+    case value_ref_enum::COLUMN_RANGE:
+      return (*cc->column_range_hi_) - (*cc->column_range_lo_);
+    default:
+      AU();
+    }
+  }
+  default:
+    AU();
+  }
+}
+
+value_p value::get_record_at_field_name(const string& field_name) {
+  auto cc = this->as<value_record_p>();
+  ASSERT_EQ(ty_->which(), value_type_enum::RECORD);
+  auto ty_cc = ty_->as<value_type_record_p>();
+  for (int64_t i = 0; i < len(ty_cc->field_types_); i++) {
+    if (field_name == ty_cc->field_types_[i].first) {
+      return ::at(cc->entries_, i);
+    }
+  }
+  cerr << "Field not found: " << field_name << endl;
+  AU();
+}
+
+void value::save(const string& output_path) {
+  make_directories_strict(output_path);
+
+  auto top_acc = make_shared<binary_data_builder_fixed>();
+
+  unordered_set<int64_t> local_refs_acc;
+
+  string val_str;
+  {
+    ostringstream os;
+    write_bin_value(
+      os, shared_from_this(), NONE<ref_context_p>(),
+      SOME<unordered_set<int64_t>*>(&local_refs_acc));
+    val_str = os.str();
+  }
+
+  set<int64_t> object_ids(local_refs_acc.begin(), local_refs_acc.end());
+
+  string output_path_objects = output_path + "/objects";
+  make_directories_strict(output_path_objects);
+
+  for (auto id : object_ids) {
+    value_p v = value::get_value_by_id(NONE<url_p>(), id);
+    ASSERT_EQ(v->which(), value_enum::COLUMN);
+    auto vc = v->as<value_column_p>();
+    auto dst = turi::fs_util::join(
+      {output_path_objects, cc_sprintf("%08d", id),});
+    turi::fs_util::make_directories_strict(dst);
+    ASSERT_EQ(vc->format_, column_format_enum::VARIABLE);
+    vc->view_variable_cached_->top_view_->save(dst + "/top");
+    vc->view_variable_cached_->meta_view_->save(dst + "/meta");
+    vc->view_variable_cached_->entries_view_->save(dst + "/entries");
+  }
+
+  top_acc->append(&val_str[0], len(val_str));
+  top_acc->save(output_path + "/top");
+}
+
+string value::get_value_string() {
+  ASSERT_EQ(ty_->tag_, value_type_tag_enum::STRING);
+  auto src_v = value_deref(shared_from_this())->as<value_nd_vector_p>();
+  ASSERT_TRUE(src_v->contiguous_);
+  return string(reinterpret_cast<char*>(src_v->base_addr_), src_v->size());
+}
+
+int64_t value::get_value_scalar_int64() {
+  ASSERT_EQ(ty_->which(), value_type_enum::ND_VECTOR);
+  auto cc = value_deref(shared_from_this())->as<value_nd_vector_p>();
+  ASSERT_EQ(cc->shape_.size(), 0);
+  ASSERT_EQ(cc->dtype_, dtype_enum::I64);
+  return *reinterpret_cast<int64_t*>(cc->base_addr_);
+}
+
+double value::get_value_scalar_float64() {
+  ASSERT_EQ(ty_->which(), value_type_enum::ND_VECTOR);
+  auto cc = value_deref(shared_from_this())->as<value_nd_vector_p>();
+  ASSERT_EQ(cc->shape_.size(), 0);
+  ASSERT_EQ(cc->dtype_, dtype_enum::F64);
+  return *reinterpret_cast<double*>(cc->base_addr_);
+}
+
+uint64_t value::get_integral_value() {
+  ASSERT_EQ(ty_->which(), value_type_enum::ND_VECTOR);
+  auto cc = value_deref(shared_from_this())->as<value_nd_vector_p>();
+  ASSERT_EQ(cc->shape_.size(), 0);
+
+  switch (cc->dtype_) {
+  case dtype_enum::I8:
+    return *reinterpret_cast<int8_t*>(cc->base_addr_);
+  case dtype_enum::U8:
+    return *reinterpret_cast<uint8_t*>(cc->base_addr_);
+  case dtype_enum::I64:
+    return *reinterpret_cast<int64_t*>(cc->base_addr_);
+  default:
+    fmt(cerr, "Dtype not yet supported\n");
+    AU();
+  }
+}
+
+value_p value::load_from_path(const string& input_path) {
+  auto top_view = make_shared<binary_data_view_fixed>(input_path + "/top");
+
+  auto is_top = top_view->get_istream();
+  return read_bin_value(*is_top, SOME(url::by_path(input_path)));
+}
+
+value_p value::create_scalar_int64(int64_t x) {
+  return value_nd_vector::create_scalar_int64(x);
+}
+
+value_p value::create_string(string s) {
+  return value::create(
+    value_nd_vector::create_from_buffer_copy_1d(
+      &s[0], dtype_enum::I8, s.size()),
+    value_type::create_string(),
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+value_p value::create_index(
+  value_p index_keys,
+  value_p index_values_flat,
+  value_p index_values_grouped,
+  vector<uint128_t> index_hashes,
+  parallel_hash_map<int64_t> index_map_singleton,
+  parallel_hash_map<pair<int64_t, int64_t>> index_map_range,
+  vector<value_type_p> source_column_types,
+  index_mode_enum index_mode) {
+
+  return value::create(
+    make_shared<value_index>(
+      index_keys,
+      index_values_flat,
+      index_values_grouped,
+      index_hashes,
+      index_map_singleton,
+      index_map_range,
+      index_mode),
+    value_type::create_index(source_column_types, index_mode),
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+value_p value::create_record(value_type_p type, vector<value_p> fields) {
+  ASSERT_EQ(type->which(), value_type_enum::RECORD);
+  auto ty = type->as<value_type_record_p>();
+  ASSERT_EQ(ty->field_types_.size(), fields.size());
+  return value::create(
+    make_shared<value_record>(type, fields),
+    type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+value_p value::create_table(
+  vector<string> column_names, vector<value_p> column_values) {
+
+  vector<value_type_p> column_types;
+  for (auto x : column_values) {
+    column_types.push_back(x->get_type());
+  }
+  auto ret_type = value_type_table_create(column_names, column_types);
+  auto ret = value::create(
+    make_shared<value_record>(ret_type, column_values),
+    ret_type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+  return ret;
+}
+
+value_p value::create_column_from_integers(vector<int64_t>& values, bool unique) {
+  unordered_set<int64_t> values_s;
+  if (unique) {
+    for (auto vi : values) {
+      ASSERT_TRUE(values_s.count(vi) == 0);
+      values_s.insert(vi);
+    }
+  }
+
+  auto ret = column_builder_create(value_type::create_scalar(dtype_enum::I64));
+  for (auto x : values) {
+    ret->append(value_nd_vector::create_scalar_int64(x));
+  }
+  return ret->finalize(unique);
+}
+
+value_p value::build_index(vector<value_p> source_columns, index_mode_enum index_mode) {
+  static unordered_map<string, value_p> build_index_cache;
+  static recursive_mutex build_index_cache_mutex;
+
+  {
+    lock_guard<recursive_mutex> build_index_cache_lock {
+      build_index_cache_mutex };
+    auto it = build_index_cache.find(struct_hash(source_columns));
+    if (it != build_index_cache.end()) {
+      return it->second;
+    }
+  }
+
+  parallel_hash_map<int64_t> ret_keys_map;
+  parallel_hash_map<vector<int64_t>> ret_values_map;
+
+  vector<uint128_t> ret_hashes;
+  parallel_hash_map<int64_t> ret_index_map_singleton;
+  parallel_hash_map<pair<int64_t, int64_t>> ret_index_map_range;
+
+  int64_t n = ::at(source_columns, 0)->get_column_length();
+  int64_t m = source_columns.size();
+  vector<bool> is_direct_column(m);
+  vector<value_column*> source_columns_fast;
+
+  for (int64_t j = 0; j < m; j++) {
+    auto sj_opt = source_columns[j]->get_as_direct_column();
+    is_direct_column[j] = !!sj_opt;
+    if (is_direct_column[j]) {
+      source_columns_fast.push_back(*sj_opt);
+    } else {
+      source_columns_fast.push_back(nullptr);
+    }
+  }
+
+  int64_t nt = turi::thread_pool::get_instance().size();
+  int64_t chunk_size = ceil_divide(n, nt);
+
+  using local_res_type = vector<pair<uint128_t, int64_t>>;
+  vector<vector<local_res_type>> local_res(nt);
+
+  for (int64_t k = 0; k < nt; k++) {
+    for (int64_t r = 0; r < nt; r++) {
+      local_res[k].push_back(local_res_type());
+    }
+  }
+
+  auto hash_chunk_size = get_hash_chunk_size();
+
+  turi::in_parallel_debug([&](int64_t k, int64_t num_threads_actual) {
+    ASSERT_EQ(num_threads_actual, nt);
+
+    int64_t start_k = k * chunk_size;
+    int64_t end_k = min<int64_t>((k+1) * chunk_size, n);
+
+    vector<uint128_t> vi_hashes(m, 0);
+
+    for (int64_t i = start_k; i < end_k; i++) {
+      {
+        for (int64_t j = 0; j < m; j++) {
+          if (is_direct_column[j]) {
+            vi_hashes[j] = source_columns_fast[j]->at_raw_hash(i);
+          } else {
+            ostringstream os;
+            auto w = value_column_at(source_columns[j], i);
+            w = value_deref(w);
+            write_bin_value(os, w, NONE<ref_context_p>(), NONE<unordered_set<int64_t>*>());
+            auto os_str = os.str();
+            vi_hashes[j] = turi::hash128(&os_str[0], os_str.length());
+          }
+        }
+      }
+
+      uint128_t vi_hash;
+      if (m == 1) {
+        vi_hash = vi_hashes[0];
+      } else {
+        vi_hash = turi::hash128(
+          reinterpret_cast<char*>(&vi_hashes[0]), m * sizeof(uint128_t));
+      }
+
+      int64_t r = static_cast<int64_t>(vi_hash / hash_chunk_size);
+      local_res[r][k].push_back(make_pair(vi_hash, i));
+    }
+  });
+
+  turi::in_parallel_debug([&](int64_t r, int64_t num_threads_actual) {
+    ASSERT_EQ(num_threads_actual, nt);
+
+    for (int64_t k = 0; k < nt; k++) {
+      for (auto p : local_res[r][k]) {
+        auto it = ret_values_map.find(p.first);
+        if (it == ret_values_map.end(p.first)) {
+          ret_values_map[p.first] = vector<int64_t>();
+          ret_keys_map[p.first] = 0;
+        }
+      }
+    }
+
+    for (int64_t k = 0; k < nt; k++) {
+      for (auto p : local_res[r][k]) {
+        auto it = ret_values_map.find(p.first);
+        if (it->second.size() == 0) {
+          ret_keys_map[p.first] += p.second;
+        }
+        it->second.push_back(p.second);
+      }
+    }
+  });
+
+  auto ret_keys = column_builder_create(
+    value_type::create_scalar(dtype_enum::I64));
+
+  auto ret_values_grouped_builder = column_builder_create(
+    value_type::create_column(
+      value_type::create_scalar(dtype_enum::I64),
+      NONE<int64_t>(),
+      true));
+
+  value_p ret_values_flat;
+  vector<vector<pair<int64_t, int64_t>>> ret_ranges { static_cast<size_t>(nt) };
+
+  auto ret_values_flat_builder =
+    column_builder_create(value_type::create_scalar(dtype_enum::I64));
+
+  vector<int64_t> map_num_hashes_accum;
+  int64_t map_num_hashes_accum_curr = 0;
+  vector<int64_t> map_num_values_accum;
+  int64_t map_num_values_accum_curr = 0;
+
+  for (auto& m : ret_values_map.maps_) {
+    map_num_hashes_accum.push_back(map_num_hashes_accum_curr);
+    map_num_values_accum.push_back(map_num_values_accum_curr);
+    for (auto p : m) {
+      ret_hashes.push_back(p.first);
+      map_num_values_accum_curr += p.second.size();
+    }
+    map_num_hashes_accum_curr += m.size();
+  }
+
+  map_num_hashes_accum.push_back(map_num_hashes_accum_curr);
+  map_num_values_accum.push_back(map_num_values_accum_curr);
+
+  for (auto x : ret_hashes) {
+    ret_keys->append(
+      value_nd_vector::create_scalar_int64(ret_keys_map[x]));
+  }
+
+  ret_values_flat_builder->extend_length_raw(map_num_values_accum_curr);
+
+  turi::in_parallel_debug([&](int64_t r, int64_t num_threads_actual) {
+    ASSERT_EQ(num_threads_actual, nt);
+
+    int64_t hash_range_base_curr = ::at(map_num_hashes_accum, r);
+    int64_t value_range_base_curr = ::at(map_num_values_accum, r);
+
+    for (int64_t i = ::at(map_num_hashes_accum, r);
+         i < ::at(map_num_hashes_accum, r+1);
+         i++) {
+
+      auto h = ::at(ret_hashes, i);
+      auto p = make_pair(h, ret_values_map[h]);
+      ret_index_map_singleton[p.first] = hash_range_base_curr;
+      ++hash_range_base_curr;
+
+      int64_t value_range_base_curr_init = value_range_base_curr;
+      for (auto x : p.second) {
+        column_value_put_raw_scalar<int64_t>(
+          ret_values_flat_builder, x, value_range_base_curr, r);
+        ++value_range_base_curr;
+      }
+      ret_ranges[r].push_back(
+        make_pair(value_range_base_curr_init, value_range_base_curr));
+      ret_index_map_range[p.first] = make_pair(
+        value_range_base_curr_init, value_range_base_curr);
+    }
+  });
+
+  ret_values_flat = ret_values_flat_builder->finalize(true);
+
+  for (auto& v : ret_ranges) {
+    for (auto p : v) {
+      ret_values_grouped_builder->append(
+        value_ref::create_column_range(ret_values_flat, p.first, p.second));
+    }
+  }
+
+  vector<value_type_p> source_types;
+  for (auto source_column : source_columns) {
+    source_types.push_back(source_column->ty_);
+  }
+
+  auto ret = value::create_index(
+    ret_keys->finalize(true),
+    ret_values_flat,
+    ret_values_grouped_builder->finalize(),
+    ret_hashes,
+    ret_index_map_singleton,
+    ret_index_map_range,
+    source_types,
+    index_mode);
+
+  {
+    lock_guard<recursive_mutex> build_index_cache_lock {
+      build_index_cache_mutex };
+    build_index_cache[struct_hash(source_columns)] = ret;
+  }
+
+  return ret;
+}
+
+value_p value::index_lookup_by_hash(
+  value_p index, uint128_t hash, index_lookup_mode_enum mode) {
+
+  auto cc = value_deref(index)->as<value_index_p>();
+
+  ASSERT_TRUE(cc->index_mode_ == index_mode_enum::EQUALS);
+  ASSERT_TRUE(mode == index_lookup_mode_enum::EQUALS);
+
+  auto it = cc->index_map_singleton_.find(hash);
+  if (it == cc->index_map_singleton_.end(hash)) {
+    vector<int64_t> ret_empty;
+    return value::create_column_from_integers(ret_empty, true);
+  } else {
+    int64_t ret_offset = it->second;
+    auto values = value_deref(cc->index_values_grouped_)->as<value_column_p>();
+    auto ret = values->at(ret_offset);
+    return ret;
+  }
+}
+
+value_p value::index_lookup(
+  value_p index, vector<value_p> keys, index_lookup_mode_enum mode) {
+
+  auto cc = value_deref(index)->as<value_index_p>();
+
+  // Other index types (e.g., numerical ordering) not yet supported
+  ASSERT_TRUE(cc->index_mode_ == index_mode_enum::EQUALS);
+  ASSERT_TRUE(mode == index_lookup_mode_enum::EQUALS);
+
+  uint128_t keys_hash;
+  {
+    ostringstream os;
+    for (auto k : keys) {
+      k->save_raw(os, NONE<ref_context_p>(), NONE<unordered_set<int64_t>*>());
+    }
+    string w = os.str();
+    keys_hash = turi::hash128(&w[0], w.length());
+  }
+
+  return value::index_lookup_by_hash(index, keys_hash, mode);
+}
+
+void ref_context::enroll_ref_target(value_p target) {
+  lock_guard<recursive_mutex> lock__ { ref_targets_lock_ };
+  ref_targets_.push_back(target);
+}
+
+unordered_map<int64_t, weak_ptr<url>>& url::get_url_id_map() {
+  static unordered_map<int64_t, weak_ptr<url>> id_map;
+  return id_map;
+}
+
+recursive_mutex& url::get_url_id_map_lock() {
+  static recursive_mutex mut;
+  return mut;
+}
+
+std::atomic<int64_t>& url::get_next_url_id() {
+  static std::atomic<int64_t> next_url_id { 0 };
+  return next_url_id;
+}
+
+url_p url::by_path(string url_path) {
+  auto ret = make_shared<url>(url_path);
+  ret->url_id_ = url::get_next_url_id();
+  {
+    lock_guard<recursive_mutex> lock__ { url::get_url_id_map_lock() };
+    url::get_url_id_map()[ret->url_id_] = ret;
+  }
+  return ret;
+}
+
+value_id_map_weak_ptr_type& value::get_value_id_map() {
+  static value_id_map_weak_ptr_type id_map;
+  return id_map;
+}
+
+recursive_mutex& value::get_value_id_map_lock() {
+  static recursive_mutex mut;
+  return mut;
+}
+
+value_p value::get_value_by_id(optional<url_p> url_context, int64_t value_id) {
+  lock_guard<recursive_mutex> lock { value::get_value_id_map_lock() };
+  auto& m = value::get_value_id_map();
+
+  auto id_ext = make_pair(int64_t(-1), value_id);
+  if (!!url_context) {
+    id_ext = make_pair((*url_context)->url_id_, value_id);
+  }
+
+  auto it = m.find(id_ext);
+
+  if (it == m.end()) {
+    ASSERT_TRUE(!!url_context);
+    auto src_path = turi::fs_util::join({
+      (*url_context)->url_path_, "objects", cc_sprintf("%08d", value_id),});
+    auto ret = value_column::load_column_from_disk_path(
+      src_path, NONE<ref_context_p>(), url_context, SOME<int64_t>(value_id));
+    m[id_ext] = ret;
+
+    static value_id_map_shared_ptr_type id_map_url_persistent;
+    id_map_url_persistent[id_ext] = ret;
+
+    return ret;
+  } else {
+    weak_ptr<value> ret = it->second;
+    try {
+      return value_p(ret);
+    } catch (std::bad_weak_ptr& exn) {
+      log_and_throw(
+        "value::get_value_by_id: requested value no longer present");
+    }
+  }
+}
+
+int64_t value::get_value_id() {
+  ASSERT_EQ(this->which(), value_enum::COLUMN);
+
+  if (!!value_id_) {
+    return *value_id_;
+  }
+
+  ASSERT_TRUE(!url_context_);
+
+  static std::atomic<int64_t> next_value_id { 0 };
+  int64_t ret = next_value_id.fetch_add(1);
+
+  auto id_ext = make_pair(int64_t(-1), ret);
+
+  value::get_value_id_map()[id_ext] = shared_from_this();
+
+  value_id_ = SOME<int64_t>(ret);
+  return ret;
+}
+
+int64_t value_nd_vector::value_scalar_int64() {
+  ASSERT_EQ(shape_.size(), 0);
+  ASSERT_EQ(dtype_, dtype_enum::I64);
+  return *reinterpret_cast<int64_t*>(base_addr_);
+}
+
+bool value_nd_vector::value_scalar_bool() {
+  ASSERT_EQ(shape_.size(), 0);
+  ASSERT_EQ(dtype_, dtype_enum::BOOL);
+  return *reinterpret_cast<bool*>(base_addr_);
+}
+
+value_p value_column_at(value_p v, int64_t i) {
+  v = value_deref(v);
+
+  int64_t n = v->get_column_length();
+  ASSERT_GE(i, 0);
+  ASSERT_LT(i, n);
+
+  switch (v->which()) {
+  case value_enum::COLUMN: {
+    auto cc = v->as<value_column_p>();
+    return cc->at(i);
+  }
+
+  case value_enum::REF: {
+    auto cc = v->as<value_ref_p>();
+
+    switch (cc->ref_which_) {
+    case value_ref_enum::COLUMN_SUBSET: {
+      auto v_base = *cc->target_;
+      auto col_base = v_base->as<value_column_p>();
+      auto vi = value_column_at(*cc->column_subset_, i);
+      int64_t ii = vi->as<value_nd_vector_p>()->value_scalar_int64();
+      return col_base->at(ii);
+    }
+
+    case value_ref_enum::VALUE: {
+      AU();
+      break;
+    }
+
+    case value_ref_enum::COLUMN_ELEMENT: {
+      AU();
+      break;
+    }
+
+    case value_ref_enum::COLUMN_RANGE: {
+      auto v_base = *cc->target_;
+      auto col_base = v_base->as<value_column_p>();
+      return col_base->at(*cc->column_range_lo_ + i);
+    }
+
+    default:
+      AU();
+    }
+
+    break;
+  }
+
+  case value_enum::ND_VECTOR:
+  case value_enum::RECORD:
+  case value_enum::EITHER:
+  case value_enum::INDEX:
+    AU();
+
+  default:
+    cerr << v->which() << endl;
+    AU();
+  }
+
+  AU();
+}
+
+void value_column_iterate(
+  vector<value_p> vs, function<bool(int64_t, vector<value_p>)> yield) {
+
+  vector<string> ret;
+
+  if (len(vs) == 0) {
+    return;
+  }
+
+  vector<value_p> vs_new;
+
+  auto n = vs[0]->get_column_length();
+  for (int64_t i = 0; i < len(vs); i++) {
+    auto vi = value_deref(vs[i]);
+    ASSERT_EQ(vi->get_column_length(), n);
+    vs_new.push_back(vi);
+  }
+
+  vs = vs_new;
+
+  for (int64_t i = 0; i < n; i++) {
+    vector<value_p> res_i;
+
+    for (auto v : vs) {
+      res_i.push_back(value_column_at(v, i));
+    }
+
+    bool ok = yield(i, res_i);
+    if (!ok) {
+      break;
+    }
+  }
+}
+
+void value_column_iterate(value_p v, function<bool(int64_t, value_p)> yield) {
+  vector<value_p> vs = {v,};
+  value_column_iterate(vs, [&](int64_t i, vector<value_p> res_i) {
+    return yield(i, res_i[0]);
+  });
+}
+
+value_p value_column_at_deref(value_p x, int64_t i) {
+  ASSERT_EQ(x->ty_->which(), value_type_enum::COLUMN);
+  x = value_deref(x);
+
+  if (x->which() == value_enum::COLUMN) {
+    return value_column_at(x, i);
+  }
+
+  ASSERT_EQ(x->which(), value_enum::REF);
+  auto cc = x->as<value_ref_p>();
+
+  switch (cc->ref_which_) {
+  case value_ref_enum::VALUE: {
+    AU();
+  }
+  case value_ref_enum::COLUMN_ELEMENT: {
+    AU();
+  }
+  case value_ref_enum::COLUMN_RANGE: {
+    auto ri = *cc->column_range_lo_ + i;
+    return value_column_at(*cc->target_, ri);
+  }
+  case value_ref_enum::COLUMN_SUBSET: {
+    auto ri =
+      value_column_at(
+        *cc->column_subset_, i)->as<value_nd_vector_p>()->value_scalar_int64();
+    return value_column_at(*cc->target_, ri);
+  }
+  default:
+    cerr << static_cast<int64_t>(cc->ref_which_) << endl;
+    AU();
+  }
+}
+
+value_p value_deref(value_p x) {
+  if (x->which() == value_enum::REF) {
+    auto xc = x->as<value_ref_p>();
+
+    switch (xc->ref_which_) {
+    case value_ref_enum::VALUE: {
+      auto ret = *xc->target_;
+      ASSERT_TRUE(type_valid(xc->type_, ret->ty_));
+      return ret;
+    }
+
+    case value_ref_enum::COLUMN_ELEMENT: {
+      auto rc = *xc->target_;
+      ASSERT_EQ(rc->which(), value_enum::COLUMN);
+      auto ret = rc->as<value_column_p>()->at(*xc->column_element_);
+      ASSERT_TRUE(type_valid(xc->type_, ret->ty_));
+      return value_deref(ret);
+    }
+
+    case value_ref_enum::COLUMN_SUBSET:
+    case value_ref_enum::COLUMN_RANGE: {
+      return x;
+    }
+
+    default:
+      fmt(cerr, "Reference type yet supported: %v\n", xc->ref_which_);
+      AU();
+    }
+  } else {
+    return x;
+  }
+}
+
+bool value_eq(value_p x, value_p y) {
+  x = value_deref(x);
+  y = value_deref(y);
+  ASSERT_EQ(x->which(), y->which());
+
+  switch (x->which()) {
+  case value_enum::ND_VECTOR: {
+    auto xc = x->as<value_nd_vector_p>();
+    auto yc = y->as<value_nd_vector_p>();
+    ASSERT_EQ(xc->dtype_, yc->dtype_);
+    ASSERT_EQ(xc->shape_.size(), yc->shape_.size());
+    if (xc->shape_ != yc->shape_) {
+      return false;
+    }
+    ASSERT_TRUE(xc->contiguous_);
+    ASSERT_TRUE(yc->contiguous_);
+    return !memcmp(
+      xc->base_addr_,
+      yc->base_addr_,
+      xc->size() * dtype_size_bytes(xc->dtype_));
+  }
+
+  default:
+    fmt(cerr, "Type error or equality test not yet supported\n");
+    AU();
+  }
+}
+
+value_p value_column::load_column_from_disk_path(
+  string path, optional<ref_context_p> refs_accum, optional<url_p> url_context,
+  optional<int64_t> value_id) {
+
+  auto ret_view = make_shared<column_view_variable>(path, url_context);
+  auto ret_view_v = column_view_v(ret_view);
+  auto ret = value::create(
+    value_column::create(ret_view_v),
+    ret_view->type_,
+    refs_accum,
+    url_context,
+    value_id);
+  return ret;
+}
+
+value_p value_column::load_column_from_binary_data(
+  binary_data_view_fixed_p meta_view,
+  binary_data_view_fixed_p top_view,
+  binary_data_view_variable_p entries_view,
+  optional<ref_context_p> refs_accum,
+  optional<url_p> url_context,
+  optional<int64_t> value_id) {
+
+  auto ret_view = make_shared<column_view_variable>(
+    meta_view, top_view, entries_view, url_context);
+  auto ret_view_v = column_view_v(ret_view);
+  auto ret = value::create(
+    value_column::create(ret_view_v),
+    ret_view->type_,
+    refs_accum,
+    url_context,
+    value_id);
+  return ret;
+}
+
+value_type_p import_column_type_raw_sf(flex_type_enum type) {
+  switch (type) {
+  case flex_type_enum::INTEGER:
+    return value_type::create_scalar(dtype_enum::I64);
+
+  case flex_type_enum::FLOAT:
+    return value_type::create_scalar(dtype_enum::F64);
+
+  case flex_type_enum::STRING:
+    return value_type::create_string();
+
+  case flex_type_enum::VECTOR:
+  case flex_type_enum::LIST:
+  case flex_type_enum::DICT:
+  case flex_type_enum::DATETIME:
+  case flex_type_enum::IMAGE:
+  case flex_type_enum::ND_VECTOR:
+    log_and_throw("flex_type_enum case not yet supported");
+
+  case flex_type_enum::UNDEFINED:
+    log_and_throw(
+      "Error: flex_type_enum::UNDEFINED found as the type of an SArray");
+
+  default:
+    cerr << static_cast<int64_t>(type) << endl;
+    AU();
+  }
+}
+
+void get_raw_sf_scalar(
+  value_column* src, int64_t i, sarray<flexible_type>::iterator& dst,
+  dtype_enum dtype) {
+
+  switch (dtype) {
+  case dtype_enum::I64: {
+    (*dst) = column_value_get_raw_scalar<int64_t>(src, i);
+    break;
+  }
+  case dtype_enum::F64: {
+    (*dst) = column_value_get_raw_scalar<double>(src, i);
+    break;
+  }
+  default:
+    log_and_throw("Error: data type not yet supported");
+    AU();
+  }
+
+  ++dst;
+}
+
+void get_raw_sf_string(
+  value_column* src, int64_t i, sarray<flexible_type>::iterator& dst) {
+
+  (*dst) = column_value_get_raw_string(src, i);
+  ++dst;
+}
+
+void put_raw_sf(
+  column_builder_p& builder, flexible_type v, int64_t i, int64_t worker_index) {
+
+  switch (v.get_type()) {
+  case flex_type_enum::INTEGER:
+    column_value_put_raw_scalar<int64_t>(builder, v.to<int64_t>(), i, worker_index);
+    break;
+  case flex_type_enum::FLOAT:
+    column_value_put_raw_scalar<double>(builder, v.to<double>(), i, worker_index);
+    break;
+  case flex_type_enum::STRING: {
+    string s = v.to<string>();
+    column_value_put_raw_1d<char>(builder, &s[0], s.length(), i, worker_index);
+    break;
+  }
+  case flex_type_enum::VECTOR:
+  case flex_type_enum::LIST:
+  case flex_type_enum::DICT:
+  case flex_type_enum::DATETIME:
+  case flex_type_enum::IMAGE:
+  case flex_type_enum::ND_VECTOR:
+    log_and_throw("flex_type_enum case not yet supported");
+  case flex_type_enum::UNDEFINED:
+    log_and_throw("Error: flex_type_enum::UNDEFINED not supported");
+  default:
+    cerr << static_cast<int64_t>(v.get_type()) << endl;
+    AU();
+  }
+}
+
+value_p import_value_sf(flexible_type v) {
+  switch (v.get_type()) {
+  case flex_type_enum::INTEGER:
+    return value_nd_vector::create_scalar_int64(v.to<int64_t>());
+  case flex_type_enum::FLOAT:
+    return value_nd_vector::create_scalar_float64(v.to<double>());
+  case flex_type_enum::STRING: {
+    string s = v.to<string>();
+    return value_nd_vector::create_from_string(s);
+  }
+  case flex_type_enum::VECTOR:
+  case flex_type_enum::LIST:
+  case flex_type_enum::DICT:
+  case flex_type_enum::DATETIME:
+  case flex_type_enum::IMAGE:
+  case flex_type_enum::ND_VECTOR:
+    log_and_throw("flex_type_enum case not yet supported");
+  case flex_type_enum::UNDEFINED:
+    log_and_throw("Error: flex_type_enum::UNDEFINED not supported");
+  default:
+    cerr << static_cast<int64_t>(v.get_type()) << endl;
+    AU();
+  }
+}
+
+value_p from_sframe(const gl_sframe& sf) {
+  vector<string> column_names = sf.column_names();
+  ASSERT_TRUE(all_distinct(column_names));
+  vector<flex_type_enum> column_types = sf.column_types();
+
+  int64_t num_columns = len(column_names);
+  ASSERT_EQ(len(column_types), num_columns);
+
+  vector<value_type_p> ret_column_element_types;
+  vector<value_p> ret_columns;
+
+  for (int64_t i = 0; i < num_columns; i++) {
+    auto sf_type_i = at(column_types, i);
+    gl_sarray sf_column_i = sf.select_column(at(column_names, i));
+
+    auto raw_type_i = import_column_type_raw_sf(sf_type_i);
+
+    bool is_optional = false;
+    auto type_i = raw_type_i;
+    if (sf_column_i.num_missing() != 0) {
+      is_optional = true;
+      type_i = value_type::create_optional(raw_type_i);
+    }
+
+    auto builder_i = column_builder_create(type_i);
+
+    int64_t n = sf_column_i.size();
+
+    builder_i->extend_length_raw(n);
+
+    int64_t nt = turi::thread_pool::get_instance().size();
+    int64_t chunk_size = ceil_divide(n, nt);
+
+    turi::in_parallel_debug([&](int64_t k, int64_t num_threads_actual) {
+      ASSERT_EQ(num_threads_actual, nt);
+
+      int64_t start_k = k * chunk_size;
+      int64_t end_k = min<int64_t>((k+1) * chunk_size, n);
+
+      if (start_k >= n) {
+        return;
+      }
+
+      int64_t j = start_k;
+
+      for (flexible_type v_ij : sf_column_i.range_iterator(start_k, end_k)) {
+        if (is_optional) {
+          if (v_ij.get_type() == flex_type_enum::UNDEFINED) {
+            builder_i->put(value::create_optional_none(type_i), j, k);
+          } else {
+            builder_i->put(
+              value::create_optional_some(
+                type_i, import_value_sf(v_ij)), j, k);
+          }
+        } else {
+          ASSERT_EQ(v_ij.get_type(), sf_type_i);
+          put_raw_sf(builder_i, v_ij, j, k);
+        }
+        ++j;
+      }
+    });
+
+    auto column_i = builder_i->finalize();
+    ret_columns.push_back(column_i);
+    ret_column_element_types.push_back(type_i);
+  }
+
+  auto ret_type = value_type_table_create(
+    column_names, ret_column_element_types);
+  auto ret = value::create(
+    make_shared<value_record>(ret_type, ret_columns),
+    ret_type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+
+  return ret;
+}
+
+gl_sarray column_to_sarray(value_p v, value_type_p ty) {
+  auto n = v->get_column_length();
+  auto ret = make_shared<sarray<flexible_type>>();
+  ret->open_for_write();
+  bool is_string = false;
+  auto src = v->get_as_direct_column();
+
+  auto cc_ty = ty->as<value_type_nd_vector_p>();
+  if (cc_ty->ndim_ == 0) {
+    switch (cc_ty->dtype_) {
+    case dtype_enum::I64: ret->set_type(flex_type_enum::INTEGER); break;
+    case dtype_enum::F64: ret->set_type(flex_type_enum::FLOAT); break;
+    default:
+      AU();
+    }
+  } else if (
+    cc_ty->ndim_ == 1 &&
+    cc_ty->dtype_ == dtype_enum::I8 &&
+    ty->tag_ == value_type_tag_enum::STRING) {
+    ret->set_type(flex_type_enum::STRING);
+    is_string = true;
+  } else {
+    cerr << "Data type not yet supported" << endl;
+    AU();
+  }
+
+  auto dst = ret->get_output_iterator(0);
+  for (int64_t i = 0; i < n; i++) {
+    if (!!src) {
+      if (is_string) {
+        get_raw_sf_string(*src, i, dst);
+      } else {
+        get_raw_sf_scalar(*src, i, dst, cc_ty->dtype_);
+      }
+    } else {
+      if (is_string) {
+        (*dst) = value_column_at(v, i)->get_value_string();
+      } else if (cc_ty->dtype_ == dtype_enum::I64) {
+        (*dst) = value_column_at(v, i)->get_value_scalar_int64();
+      } else if (cc_ty->dtype_ == dtype_enum::F64) {
+        (*dst) = value_column_at(v, i)->get_value_scalar_float64();
+      } else {
+        AU();
+      }
+      ++dst;
+    }
+  }
+
+  ret->close();
+
+  return gl_sarray(ret);
+}
+
+gl_sframe to_sframe(value_p v) {
+  ASSERT_TRUE(!!v->ty_->tag_);
+  ASSERT_EQ(*v->ty_->tag_, value_type_tag_enum::DATA_TABLE);
+  auto column_types = v->ty_->as<value_type_record_p>()->field_types_;
+  int64_t n = len(column_types);
+  auto cc = v->as<value_record_p>();
+  gl_sframe ret;
+  for (int64_t i = 0; i < n; i++) {
+    auto fname = at(column_types, i).first;
+    auto fty = at(column_types, i).second->as<value_type_column_p>();
+    if (fty->element_type_->which() == value_type_enum::ND_VECTOR) {
+      ret.add_column(
+        column_to_sarray(at(cc->entries_, i), fty->element_type_), fname);
+    } else {
+      cerr << "Data type not yet supported" << endl;
+      AU();
+    }
+  }
+  return ret;
+}
+
+const char* column_metadata::object_id_    = "CM";
+const char* object_ids_builtin::pair_      = "PA";
+const char* value::object_id_              = "VA";
+const char* object_ids_builtin::vector_    = "VE";
+const char* value_type::object_id_         = "VT";
+
+}}

--- a/src/sframe/sframe_random_access_impl.hpp
+++ b/src/sframe/sframe_random_access_impl.hpp
@@ -1,0 +1,1228 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_SFRAME_RANDOM_ACCESS_IMPL_H_
+#define TURI_SFRAME_RANDOM_ACCESS_IMPL_H_
+
+#include <sframe/sframe_random_access.hpp>
+#include <sframe/sframe_random_access_buffers_impl.hpp>
+
+using std::function;
+
+namespace turi { namespace sframe_random_access {
+
+/**
+ * \internal
+ * \ingroup sframe_physical
+ * \addtogroup sframe_random_access SFrame Random Access Backend
+ * \{
+ */
+
+template<typename T>
+parallel_hash_map<T>::parallel_hash_map()
+  : maps_(turi::thread_pool::get_instance().size()) { }
+
+template<typename T>
+void parallel_hash_map<T>::put(uint128_t k, const T& v) {
+  maps_[static_cast<int64_t>(k / get_hash_chunk_size())] = v;
+}
+
+template<typename T>
+T& parallel_hash_map<T>::operator[](uint128_t k) {
+  return maps_[static_cast<int64_t>(k / get_hash_chunk_size())][k];
+}
+
+template<typename T>
+typename unordered_map<uint128_t, T>::iterator parallel_hash_map<T>::find(uint128_t k) {
+  return maps_[static_cast<int64_t>(k / get_hash_chunk_size())].find(k);
+}
+
+template<typename T>
+typename unordered_map<uint128_t, T>::iterator parallel_hash_map<T>::end(uint128_t k) {
+  return maps_[static_cast<int64_t>(k / get_hash_chunk_size())].end();
+}
+
+template<typename T>
+int64_t parallel_hash_map<T>::count(uint128_t k) {
+  return maps_[static_cast<int64_t>(k / get_hash_chunk_size())].count(k);
+}
+
+template<typename T>
+void parallel_hash_map<T>::clear() {
+  for (auto& m : maps_) {
+    m.clear();
+  }
+}
+
+/**
+ * Enumerates the possible scalar operations over numeric values. Currently only
+ * comparison operators, integer and floating-point addition are supported, but
+ * many others can be added in the future.
+ */
+enum class scalar_builtin_enum {
+  EQ,
+  NE,
+  LT,
+  LE,
+  GT,
+  GE,
+  ADD,
+};
+
+/**
+ * Returns the arity (number of arguments) of a scalar operation.
+ */
+inline int64_t arity(scalar_builtin_enum x) {
+  switch (x) {
+  case scalar_builtin_enum::EQ:
+  case scalar_builtin_enum::NE:
+  case scalar_builtin_enum::LT:
+  case scalar_builtin_enum::LE:
+  case scalar_builtin_enum::GT:
+  case scalar_builtin_enum::GE:
+  case scalar_builtin_enum::ADD:
+    return 2;
+  default:
+    AU();
+  }
+}
+
+/**
+ * Returns the resulting dtype of a scalar operation, given its input dtypes.
+ */
+inline dtype_enum get_result_dtype(
+  scalar_builtin_enum x, dtype_enum input_dtype) {
+
+  switch (x) {
+  case scalar_builtin_enum::EQ:
+  case scalar_builtin_enum::NE:
+  case scalar_builtin_enum::LT:
+  case scalar_builtin_enum::LE:
+  case scalar_builtin_enum::GT:
+  case scalar_builtin_enum::GE:
+    return dtype_enum::BOOL;
+  case scalar_builtin_enum::ADD:
+    return input_dtype;
+  default:
+    AU();
+  }
+}
+
+enum class value_type_tag_enum {
+  DATA_TABLE,
+  OPTIONAL,
+  STRING,
+  DATETIME,
+  IMAGE,
+  IMAGE_DATA,
+};
+
+SERIALIZE_POD(value_type_tag_enum);
+
+/**
+ * Enumerates the possible cases of the \ref value_type union.
+ */
+enum class value_type_enum {
+  /**
+   * Column type.
+   */
+  COLUMN,
+  /**
+   * Multidimensional array type.
+   */
+  ND_VECTOR,
+  /**
+   * Record type (e.g., table),
+   */
+  RECORD,
+  /**
+   * Variant type.
+   */
+  EITHER,
+  /**
+   * Function type.
+   */
+  FUNCTION,
+  /**
+   * Index type (internal use only).
+   */
+  INDEX,
+};
+
+SERIALIZE_POD(value_type_enum);
+
+inline ostream& operator<<(ostream& os, value_type_enum v) {
+  switch (v) {
+  case value_type_enum::COLUMN: os << "COLUMN"; break;
+  case value_type_enum::ND_VECTOR: os << "ND_VECTOR"; break;
+  case value_type_enum::RECORD: os << "RECORD"; break;
+  case value_type_enum::EITHER: os << "EITHER"; break;
+  case value_type_enum::FUNCTION: os << "FUNCTION"; break;
+  case value_type_enum::INDEX: os << "INDEX"; break;
+  default:
+    AU();
+  }
+  return os;
+}
+
+inline ostream& operator<<(ostream& os, value_type_tag_enum v) {
+  switch (v) {
+  case value_type_tag_enum::DATA_TABLE: os << "DATA_TABLE"; break;
+  case value_type_tag_enum::OPTIONAL: os << "OPTIONAL"; break;
+  case value_type_tag_enum::STRING: os << "STRING"; break;
+  case value_type_tag_enum::DATETIME: os << "DATETIME"; break;
+  case value_type_tag_enum::IMAGE: os << "IMAGE"; break;
+  case value_type_tag_enum::IMAGE_DATA: os << "IMAGE_DATA"; break;
+  default:
+    AU();
+  }
+  return os;
+}
+
+SERIALIZE_POD(index_mode_enum);
+SERIALIZE_POD(index_lookup_mode_enum);
+
+DECL_STRUCT(value_type);
+
+DECL_STRUCT(value_type_column);
+DECL_STRUCT(value_type_nd_vector);
+DECL_STRUCT(value_type_record);
+DECL_STRUCT(value_type_either);
+DECL_STRUCT(value_type_function);
+DECL_STRUCT(value_type_index);
+
+typedef typename boost::make_recursive_variant<
+  value_type_column_p,
+  value_type_nd_vector_p,
+  value_type_record_p,
+  value_type_either_p,
+  value_type_function_p,
+  value_type_index_p
+>::type value_type_v;
+
+/**
+ * Represents the type of a random-access SFrame \ref value object.  The \ref
+ * value_type struct is a tagged union of several possible cases. For details,
+ * see \ref value_type_enum. Note that for convenience, types may optionally
+ * also be annotated with a user-friendly tag (\ref value_type_tag_enum).
+ */
+struct value_type : public enable_shared_from_this<value_type> {
+  static const char* object_id_;
+
+  value_type_v v_;
+  optional<value_type_tag_enum> tag_;
+
+  bool known_direct_;
+
+  value_type(value_type_v v, optional<value_type_tag_enum> tag)
+    : v_(v), tag_(tag) {
+    known_direct_ = (this->which() == value_type_enum::ND_VECTOR);
+  }
+
+  template<typename T> static value_type_p create(
+    const T& t, optional<value_type_tag_enum> tag) {
+
+    return make_shared<value_type>(value_type_v(t), tag);
+  }
+
+  template<typename T> static value_type_p create(const T& t) {
+    return value_type::create(t, NONE<value_type_tag_enum>());
+  }
+
+  static value_type_p create_nd_vector(int64_t ndim, dtype_enum dtype);
+  static value_type_p create_column(
+    value_type_p element_type, optional<int64_t> length, bool known_unique);
+  static value_type_p create_bool_column();
+  static value_type_p create_string();
+  static value_type_p create_image();
+  static value_type_p create_scalar(dtype_enum dtype);
+  static value_type_p create_record(
+    vector<pair<string, value_type_p>> field_types);
+  static value_type_p create_data_table(
+    vector<pair<string, value_type_p>> field_types);
+  static value_type_p create_empty_record();
+  static value_type_p create_optional(value_type_p some_ty);
+  static value_type_p create_function(value_type_p left, value_type_p right);
+  static value_type_p create_index(
+    vector<value_type_p> source_column_types, index_mode_enum index_mode);
+
+  value_type_enum which();
+  string which_str();
+
+  template<typename T> T& as() {
+    return vget<value_type_enum, T>(v_);
+  }
+
+  template<typename T> const T& as() const {
+    return vget<value_type_enum, T>(v_);
+  }
+
+  optional<value_type_p> unpack_optional_ext();
+  bool is_optional();
+  value_type_p unpack_optional();
+
+  vector<pair<string, value_type_p>> as_record_items() const;
+  pair<int64_t, dtype_enum> as_nd_vector_items() const;
+
+  string struct_hash();
+};
+
+bool struct_eq(value_type_p x, value_type_p y);
+bool type_valid(value_type_p target, value_type_p sub);
+void assert_type_valid(value_type_p target, value_type_p sub);
+
+SERIALIZE_DECL(value_type_p);
+
+struct value_type_nd_vector {
+  int64_t ndim_;
+  dtype_enum dtype_;
+  value_type_nd_vector(int64_t ndim, dtype_enum dtype)
+    : ndim_(ndim), dtype_(dtype) { }
+  static inline value_type_nd_vector_p create(int64_t ndim, dtype_enum dtype) {
+    return make_shared<value_type_nd_vector>(ndim, dtype);
+  }
+
+  inline void save_sub(ostream& os) const {
+    write_bin(os, ndim_);
+    write_bin(os, dtype_);
+  }
+
+  inline static value_type_nd_vector_p load_sub(istream& is) {
+    auto ndim = read_bin<int64_t>(is);
+    auto dtype = read_bin<dtype_enum>(is);
+    return value_type_nd_vector::create(ndim, dtype);
+  }
+};
+
+struct value_type_column {
+  value_type_p element_type_;
+  optional<int64_t> length_;
+  bool known_unique_;
+
+  value_type_column(
+    value_type_p element_type, optional<int64_t> length, bool known_unique)
+    : element_type_(element_type), length_(length),
+      known_unique_(known_unique) { }
+
+  inline void save_sub(ostream& os) const {
+    write_bin(os, element_type_);
+    write_bin(os, length_);
+    write_bin(os, known_unique_);
+  }
+
+  inline static shared_ptr<value_type_column> load_sub(istream& is) {
+    auto element_type = read_bin<value_type_p>(is);
+    auto length = read_bin<optional<int64_t>>(is);
+    auto known_unique = read_bin<bool>(is);
+    return make_shared<value_type_column>(element_type, length, known_unique);
+  }
+};
+
+struct value_type_record {
+  vector<pair<string, value_type_p>> field_types_;
+  value_type_record(vector<pair<string, value_type_p>> field_types)
+    : field_types_(field_types) { }
+
+  inline void save_sub(ostream& os) const {
+    write_bin(os, field_types_);
+  }
+
+  inline static shared_ptr<value_type_record> load_sub(istream& is) {
+    auto field_types = read_bin<vector<pair<string, value_type_p>>>(is);
+    return make_shared<value_type_record>(field_types);
+  }
+};
+
+struct value_type_function {
+  value_type_p left_;
+  value_type_p right_;
+  value_type_function(value_type_p left, value_type_p right)
+    : left_(left), right_(right) { }
+
+  inline void save_sub(ostream& os) const {
+    write_bin(os, left_);
+    write_bin(os, right_);
+  }
+
+  inline static shared_ptr<value_type_function> load_sub(istream& is) {
+    auto left = read_bin<value_type_p>(is);
+    auto right = read_bin<value_type_p>(is);
+    return make_shared<value_type_function>(left, right);
+  }
+};
+
+struct value_type_index {
+  vector<value_type_p> source_column_types_;
+  index_mode_enum index_mode_;
+  value_type_index(
+    vector<value_type_p> source_column_types, index_mode_enum index_mode)
+    : source_column_types_(source_column_types), index_mode_(index_mode) { }
+
+  inline void save_sub(ostream& os) const {
+    write_bin(os, source_column_types_);
+    write_bin(os, index_mode_);
+  }
+
+  inline static shared_ptr<value_type_index> load_sub(istream& is) {
+    auto source_column_types = read_bin<vector<value_type_p>>(is);
+    auto index_mode = read_bin<index_mode_enum>(is);
+    return make_shared<value_type_index>(source_column_types, index_mode);
+  }
+};
+
+struct value_type_either {
+  vector<pair<string, value_type_p>> case_types_;
+  value_type_either(vector<pair<string, value_type_p>> case_types)
+    : case_types_(case_types) { }
+
+  inline void save_sub(ostream& os) const {
+    write_bin(os, case_types_);
+  }
+
+  inline static shared_ptr<value_type_either> load_sub(istream& is) {
+    auto case_types = read_bin<vector<pair<string, value_type_p>>>(is);
+    return make_shared<value_type_either>(case_types);
+  }
+};
+
+value_type_column_p value_type_column_create(
+  value_type_p element_type, optional<int64_t> length, bool is_unique);
+
+inline value_type_p value_type_table_create(
+  vector<string> column_names,
+  vector<value_type_p> column_element_types) {
+
+  vector<pair<string, value_type_p>> ret;
+
+  ASSERT_EQ(len(column_names), len(column_element_types));
+  for (int64_t i = 0; i < len(column_names); i++) {
+    ret.push_back(
+      make_pair(
+        column_names[i],
+        value_type::create_column(
+          column_element_types[i], NONE<int64_t>(), false)));
+  }
+
+  auto ret_record = value_type_v(make_shared<value_type_record>(ret));
+  return make_shared<value_type>(
+    ret_record, SOME(value_type_tag_enum::DATA_TABLE));
+}
+
+inline value_type_column_p value_type_column_create(
+  value_type_p element_type, optional<int64_t> length, bool known_unique) {
+
+  return make_shared<value_type_column>(element_type, length, known_unique);
+}
+
+ostream& operator<<(ostream& os, value_type_p x);
+
+inline string to_string(value_type_p x) {
+  ostringstream os;
+  os << x;
+  return os.str();
+}
+
+inline value_type_p value_type_parse(const string& src) {
+  if (ends_with(src, "?")) {
+    value_type_p some_ty = value_type_parse(src.substr(0, src.length() - 1));
+    return value_type::create_optional(some_ty);
+  }
+
+  if (src == "str") {
+    return value_type::create_string();
+  } else if (src == "image") {
+    return value_type::create_image();
+  } else if (src == "int") {
+    return value_type::create_scalar(dtype_enum::I64);
+  } else {
+    cerr << "value_type_parse: Not yet supported: " << src << endl;
+    AU();
+    return nullptr;
+  }
+}
+
+value_type_p value_type_create_nd_vector(int64_t ndim, const string& dtype_str);
+
+inline value_p value::create_empty_record() {
+  auto ret_ty = value_type::create_empty_record();
+  return value::create(
+    make_shared<value_record>(ret_ty, vector<value_p>()),
+    ret_ty,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+inline value_p value::create_optional_none(value_type_p ty) {
+  ASSERT_TRUE(ty->is_optional());
+  return value::create(
+    make_shared<value_either>(ty, int64_t(0), value::create_empty_record()),
+    ty,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+inline value_p value::create_optional_some(value_type_p ty, value_p v) {
+  ASSERT_TRUE(ty->is_optional());
+  return value::create(
+    make_shared<value_either>(ty, int64_t(1), v),
+    ty,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+}
+
+inline value_type_p value::get_type() {
+  return ty_;
+}
+
+template<typename T> value_p value::create(
+  T v, value_type_p ty, optional<ref_context_p> accum_refs,
+  optional<url_p> url_context, optional<int64_t> id) {
+
+  return make_shared<value>(value_v(v), ty, accum_refs, url_context, id);
+}
+
+inline value_enum value::which() {
+  return static_cast<value_enum>(v_.which());
+}
+
+template<typename T> T& value::as() {
+  return vget<value_enum, T>(v_);
+}
+
+template<typename T> const T& value::as() const {
+  return vget<value_enum, T>(v_);
+}
+
+/**
+ * If a given value is an indirect reference, follow the reference to obtain the
+ * actual value.
+ */
+value_p value_deref(value_p);
+
+/**
+ * If a given value is really a column (e.g., is not an indirect reference),
+ * returns a raw pointer to that column. This is useful as an optimization to
+ * avoid repeatedly testing whether a value is a column in an inner loop.
+ */
+inline optional<value_column*> value::get_as_direct_column() {
+  ASSERT_EQ(ty_->which(), value_type_enum::COLUMN);
+  auto self = value_deref(shared_from_this());
+  if (self->ty_->as<value_type_column_p>()->element_type_->known_direct_ &&
+      self->which() == value_enum::COLUMN) {
+    return SOME(self->as<value_column_p>().get());
+  } else {
+    return NONE<value_column*>();
+  }
+}
+
+DECL_STRUCT(url);
+
+/**
+ * Represents a URL (path on disk). As an optimization, we also assign a unique
+ * numeric ID to each URL created.
+ */
+struct url {
+  string url_path_;
+  int64_t url_id_;
+
+  static url_p by_path(string url_path);
+
+  // Note: internal use only
+  url(string url_path) : url_path_(url_path) { }
+
+  static recursive_mutex& get_url_id_map_lock();
+
+  // Note: should only access while holding lock
+  static unordered_map<int64_t, weak_ptr<url>>& get_url_id_map();
+  static std::atomic<int64_t>& get_next_url_id();
+};
+
+/**
+ * Indirect references may be local (to another value in memory), or point to an
+ * SFrame on disk by its path.
+ */
+enum class value_ref_location_enum {
+  LOCAL,
+  SFRAME_URL,
+};
+
+SERIALIZE_POD(value_ref_location_enum);
+
+DECL_STRUCT(value_ref_location);
+
+DECL_STRUCT(value_ref_location_local);
+DECL_STRUCT(value_ref_location_sframe_url);
+
+typedef typename boost::make_recursive_variant<
+  value_ref_location_local_p,
+  value_ref_location_sframe_url_p
+>::type value_ref_location_v;
+
+struct value_ref_location_local {
+  int64_t id_;
+  value_ref_location_local(int64_t id) : id_(id) { }
+};
+
+struct value_ref_location_sframe_url {
+  string url_path_;
+  value_ref_location_sframe_url(string url_path) : url_path_(url_path) { }
+};
+
+struct value_ref_location {
+  value_ref_location_v v_;
+
+  template<typename T> static value_ref_location_p create(T v) {
+    return make_shared<value_ref_location>(value_ref_location_v(v));
+  }
+
+  static value_ref_location_p create_local(int64_t id) {
+    return value_ref_location::create(
+      make_shared<value_ref_location_local>(id));
+  }
+
+  static value_ref_location_p create_sframe_url(string url_path) {
+    return value_ref_location::create(
+      make_shared<value_ref_location_sframe_url>(url_path));
+  }
+
+  inline value_ref_location_enum which() {
+    return static_cast<value_ref_location_enum>(v_.which());
+  }
+
+  template<typename T> T& as() {
+    return vget<value_ref_location_enum, T>(v_);
+  }
+
+  template<typename T> const T& as() const {
+    return vget<value_ref_location_enum, T>(v_);
+  }
+
+  value_ref_location(value_ref_location_v v) : v_(v) { }
+};
+
+/**
+ * Indirect references can either refer to some value as a whole, or to a given
+ * element, contiguous range, or subset of a column value.
+ */
+enum class value_ref_enum {
+  VALUE,
+  COLUMN_ELEMENT,
+  COLUMN_RANGE,
+  COLUMN_SUBSET,
+};
+
+
+SERIALIZE_POD(value_ref_enum);
+
+struct value_ref;
+using value_ref_p = shared_ptr<value_ref>;
+
+DECL_STRUCT(value_column);
+DECL_STRUCT(value_nd_vector);
+DECL_STRUCT(value_record);
+DECL_STRUCT(value_either);
+DECL_STRUCT(value_ref);
+DECL_STRUCT(value_index);
+
+SERIALIZE_POD(value_enum);
+
+ostream& operator<<(ostream& os, value_enum x);
+ostream& operator<<(ostream& os, value_ref_enum x);
+
+typedef typename boost::make_recursive_variant<
+  value_column_p,
+  value_nd_vector_p,
+  value_record_p,
+  value_either_p,
+  value_ref_p,
+  value_index_p
+>::type value_v;
+
+DECL_STRUCT(value);
+
+DECL_STRUCT(ref_context);
+
+struct ref_context : public enable_shared_from_this<ref_context> {
+  void enroll_ref_target(value_p target);
+  static ref_context_p create();
+
+  recursive_mutex ref_targets_lock_;
+
+  // Note: should only access while holding lock
+  vector<value_p> ref_targets_;
+};
+
+constexpr int64_t COLUMN_TABLE_ENTRY_SIZE_BYTES = 3 * sizeof(int64_t);
+
+DECL_STRUCT(column_view_variable);
+
+enum class column_format_enum {
+  VARIABLE,
+};
+
+ostream& operator<<(ostream& os, column_format_enum x);
+
+SERIALIZE_POD(column_format_enum);
+
+typedef typename boost::make_recursive_variant<
+  column_view_variable_p
+>::type column_view_v;
+
+struct column_metadata {
+  static const char* object_id_;
+};
+
+/**
+ * Builder for a random-access SFrame column, analogous to the standard SArray
+ * builder. To write serially, use the \ref column_builder::append function; to
+ * write in parallel, first resize via \ref column_builder::extend_length_raw,
+ * then use the \ref column_builder::put function. As with a standard SArray,
+ * call \ref column_builder::finalize to obtain the resulting fully-serialized
+ * column value.
+ */
+struct column_builder {
+  value_type_p entry_type_;
+
+  shared_ptr<binary_data_builder_fixed> top_acc_;
+  shared_ptr<binary_data_builder_variable> entries_acc_;
+
+  int64_t num_entries_current_;
+
+  column_format_enum format_;
+
+  ref_context_p ref_context_;
+
+  bool is_finalized_;
+
+  column_builder(value_type_p entry_type, column_format_enum format);
+
+  inline int64_t get_table_entry_offset(int64_t entry_index) {
+    int64_t ret = entry_index * COLUMN_TABLE_ENTRY_SIZE_BYTES;
+    return ret;
+  }
+
+  void append_raw(buffer src);
+  void append(const value_p& entry);
+
+  inline void put_raw(buffer src, int64_t i, int64_t worker_index) {
+    bin_handle h = entries_acc_->append(src.addr_, src.length_, worker_index);
+    {
+      int64_t header[3];
+      header[0] = h.index_;
+      header[1] = h.offset_;
+      header[2] = h.len_;
+
+      ASSERT_TRUE(sizeof(header) == COLUMN_TABLE_ENTRY_SIZE_BYTES);
+
+      top_acc_->put_data_unchecked(
+        get_table_entry_offset(i),
+        &header[0],
+        COLUMN_TABLE_ENTRY_SIZE_BYTES
+        );
+    }
+  }
+
+  void put(const value_p& entry, int64_t i, int64_t worker_index);
+
+  inline void extend_length_raw(int64_t num_entries_new) {
+    assert(!is_finalized_);
+    if (num_entries_new <= num_entries_current_) {
+      return;
+    }
+    top_acc_->reserve_length(num_entries_new * COLUMN_TABLE_ENTRY_SIZE_BYTES);
+    num_entries_current_ = num_entries_new;
+  }
+
+  inline void extend_with_entries(const vector<value_p>& entries) {
+    int64_t start_index = num_entries_current_;
+    assert(!is_finalized_);
+    this->extend_length_raw(start_index + len(entries));
+    for (int64_t i = 0; i < len(entries); i++) {
+      this->put(entries[i], start_index + i, 0);
+    }
+  }
+
+  value_p at(int64_t i);
+
+  value_p finalize();
+  value_p finalize(bool known_unique);
+};
+
+using column_builder_p = shared_ptr<column_builder>;
+
+inline column_builder_p column_builder_create(value_type_p entry_type) {
+  return make_shared<column_builder>(entry_type, column_format_enum::VARIABLE);
+}
+
+/**
+ * Convenience builder for a random-access SFrame table, which just maintains a
+ * series of column builders internally.
+ */
+struct table_builder {
+  vector<string> column_names_;
+  vector<column_builder_p> column_builders_;
+
+  bool is_finalized_;
+
+  table_builder(vector<string> column_names,
+                vector<value_type_p> column_types)
+    : column_names_(column_names),
+      is_finalized_(false) {
+
+    ASSERT_EQ(len(column_names), len(column_types));
+    for (int64_t i = 0; i < len(column_types); i++) {
+      column_builders_.push_back(column_builder_create(column_types[i]));
+    }
+  }
+
+  void append(const vector<value_p>& entries);
+  value_p finalize();
+};
+
+using table_builder_p = shared_ptr<table_builder>;
+
+inline table_builder_p table_builder_create(
+  vector<string> column_names, vector<value_type_p> column_types) {
+
+  return make_shared<table_builder>(column_names, column_types);
+}
+
+/**
+ * Provides efficient random-access view of a serialized column value in memory.
+ */
+struct column_view_variable {
+  binary_data_view_fixed_p meta_view_;
+  binary_data_view_fixed_p top_view_;
+  binary_data_view_variable_p entries_view_;
+
+  optional<url_p> url_context_;
+
+  value_type_p type_;
+
+  int64_t num_entries_;
+  column_format_enum format_;
+
+  value_type_p entry_type_;
+
+  column_view_variable(string base_path, optional<url_p> url_context);
+  column_view_variable(
+    binary_data_view_fixed_p meta_view,
+    binary_data_view_fixed_p top_view,
+    binary_data_view_variable_p entries_view,
+    optional<url_p> url_context);
+
+  inline int64_t get_table_entry_offset(int64_t entry_index) {
+    auto ret = entry_index * COLUMN_TABLE_ENTRY_SIZE_BYTES;
+    return ret;
+  }
+
+  value_p at(int64_t i);
+
+  inline bin_handle at_raw_locate(int64_t i) {
+    int64_t bin_handle_raw[3];
+    top_view_->get_data(
+      bin_handle_raw,
+      get_table_entry_offset(i),
+      COLUMN_TABLE_ENTRY_SIZE_BYTES);
+
+    bin_handle h;
+    h.index_ = bin_handle_raw[0];
+    h.offset_ = bin_handle_raw[1];
+    h.len_ = bin_handle_raw[2];
+
+    return h;
+  }
+
+  inline buffer at_raw(int64_t i) {
+    auto h = this->at_raw_locate(i);
+    return entries_view_->get_data_raw(h);
+  }
+
+  inline uint128_t at_raw_hash(int64_t i) {
+    auto h = this->at_raw_locate(i);
+    return entries_view_->get_data_hash(h);
+  }
+};
+
+template<typename T>
+inline void column_value_append_raw_scalar(column_builder_p& x, T v) {
+  x->append_raw(buffer(reinterpret_cast<char*>(&v), sizeof(v)));
+}
+
+template<typename T>
+inline void column_value_put_raw_scalar(
+  column_builder_p& x, T v, int64_t i, int64_t worker_index) {
+  x->put_raw(buffer(reinterpret_cast<char*>(&v), sizeof(v)), i, worker_index);
+}
+
+template<typename T>
+inline void column_value_put_raw_1d(
+  column_builder_p& x, const char* addr, int64_t len, int64_t i, int64_t worker_index) {
+
+  int64_t size_bytes = len * sizeof(T);
+  int64_t size_words = ceil_divide<int64_t>(size_bytes, 8);
+  char* addr_ext = reinterpret_cast<char*>(malloc(16 + size_words * 8));
+  reinterpret_cast<int64_t*>(addr_ext)[0] = 1;
+  reinterpret_cast<int64_t*>(addr_ext)[1] = len;
+  memcpy(addr_ext + 16, addr, size_bytes);
+  x->put_raw(buffer(addr_ext, 16 + size_bytes), i, worker_index);
+}
+
+value_p read_bin_value(istream& is, optional<url_p> load_url);
+
+void write_bin_value(
+  ostream& os, value_p x, optional<ref_context_p> ctx,
+  optional<unordered_set<int64_t>*> local_refs_acc);
+
+value_p value_column_at(value_p v, int64_t i);
+value_p value_column_at_deref(value_p x, int64_t i);
+
+void value_column_iterate(
+  vector<value_p> v, function<bool(int64_t, vector<value_p>)> yield);
+void value_column_iterate(value_p v, function<bool(int64_t, value_p)> yield);
+
+value_p value_deref(value_p x);
+
+struct value_nd_vector {
+  void* base_addr_;
+  bool base_addr_owned_;
+
+  dtype_enum dtype_;
+  vector<int64_t> shape_;
+  vector<int64_t> strides_;
+  bool contiguous_;
+
+  inline int64_t size() {
+    return product(shape_);
+  }
+
+  // NOTE: source must be contiguous
+  inline static value_nd_vector_p create_from_buffer_copy(
+    const void* src_addr, dtype_enum dtype, int64_t num_elements,
+    vector<int64_t> shape, vector<int64_t> strides) {
+
+    ASSERT_EQ(product(shape), num_elements);
+
+    int64_t total_size = num_elements * dtype_size_bytes(dtype);
+
+    void* base_addr = malloc(total_size);
+    bool base_addr_owned = true;
+    memcpy(base_addr, src_addr, total_size);
+    bool contiguous = true;
+
+    return value_nd_vector::create(
+      base_addr, base_addr_owned, dtype, shape, strides, contiguous);
+  }
+
+  inline static value_nd_vector_p create_from_buffer_copy_1d(
+    const void* src_addr, dtype_enum dtype, int64_t num_elements) {
+
+    return create_from_buffer_copy(
+      src_addr, dtype, num_elements, {num_elements,}, {1,});
+  }
+
+  inline static value_p create_from_string(const string& x) {
+    auto ret = value_nd_vector::create_from_buffer_copy_1d(
+      reinterpret_cast<const void*>(x.c_str()), dtype_enum::I8, len(x));
+    return value::create(
+      ret,
+      value_type::create_string(),
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+  }
+
+  inline static value_p create_scalar_zero(dtype_enum dtype) {
+    uint64_t zero = 0;
+    auto ret = value_nd_vector::create_from_buffer_copy(
+      &zero, dtype, 1, vector<int64_t>(), vector<int64_t>());
+    return value::create(
+      ret,
+      value_type::create_scalar(dtype),
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+  }
+
+  template<typename T, dtype_enum Dtype>
+  inline static value_p create_scalar(T x) {
+    auto ret = value_nd_vector::create_from_buffer_copy(
+      &x, Dtype, 1, vector<int64_t>(), vector<int64_t>());
+    return value::create(
+      ret,
+      value_type::create_scalar(Dtype),
+      NONE<ref_context_p>(),
+      NONE<url_p>(),
+      NONE<int64_t>());
+  }
+
+  inline static value_p create_scalar_int64(int64_t x) {
+    return create_scalar<int64_t, dtype_enum::I64>(x);
+  }
+
+  inline static value_p create_scalar_float64(double x) {
+    return create_scalar<double, dtype_enum::F64>(x);
+  }
+
+  inline static value_p create_scalar_bool(bool x) {
+    return create_scalar<bool, dtype_enum::BOOL>(x);
+  }
+
+  int64_t value_scalar_int64();
+  bool value_scalar_bool();
+
+  value_nd_vector(
+    void* base_addr, bool base_addr_owned, dtype_enum dtype,
+    const vector<int64_t>& shape, const vector<int64_t>& strides, bool contiguous)
+    : base_addr_(base_addr), base_addr_owned_(base_addr_owned), dtype_(dtype),
+      shape_(shape), strides_(strides), contiguous_(contiguous) { }
+
+  template<typename... Ts> static value_nd_vector_p create(Ts... args) {
+    return make_shared<value_nd_vector>(args...);
+  }
+
+  ~value_nd_vector() {
+    if (base_addr_owned_) {
+      free(base_addr_);
+    }
+  }
+};
+
+inline void value_nd_vector_copy_to_buffer(
+  void* dst_addr, value_p src) {
+
+  src = value_deref(src);
+  auto src_v = src->as<value_nd_vector_p>();
+  ASSERT_TRUE(src_v->contiguous_);
+  memcpy(
+    dst_addr,
+    src_v->base_addr_,
+    src_v->size() * dtype_size_bytes(src_v->dtype_));
+}
+
+inline vector<int64_t> value_nd_vector_shape(value_p src) {
+  src = value_deref(src);
+  auto src_v = src->as<value_nd_vector_p>();
+  return src_v->shape_;
+}
+
+inline dtype_enum value_nd_vector_dtype(value_p src) {
+  src = value_deref(src);
+  auto src_v = src->as<value_nd_vector_p>();
+  return src_v->dtype_;
+}
+
+struct value_record {
+  value_type_p type_;
+  vector<value_p> entries_;
+
+  value_record(value_type_p type, const vector<value_p>& entries)
+    : type_(type), entries_(entries) { }
+};
+
+inline vector<string> value_record_get_keys(value_p src) {
+  auto src_v = src->as<value_record_p>();
+  auto cc = src_v->type_->as<value_type_record_p>();
+  vector<string> ret;
+  for (auto x : cc->field_types_) {
+    ret.push_back(x.first);
+  }
+  return ret;
+}
+
+inline vector<value_p> value_record_get_values(value_p src) {
+  auto src_v = src->as<value_record_p>();
+  return src_v->entries_;
+}
+
+inline value_p value_create_table_from_columns(
+  vector<string> column_names, vector<value_p> columns) {
+
+  vector<value_type_p> ret_element_types;
+  for (auto x : columns) {
+    ret_element_types.push_back(
+      x->get_type()->as<value_type_column_p>()->element_type_);
+  }
+
+  auto ret_type = value_type_table_create(column_names, ret_element_types);
+  auto ret = value::create(
+    make_shared<value_record>(ret_type, columns),
+    ret_type,
+    NONE<ref_context_p>(),
+    NONE<url_p>(),
+    NONE<int64_t>());
+  return ret;
+}
+
+struct value_either {
+  value_type_p type_;
+
+  int64_t val_which_;
+  value_p val_data_;
+
+  value_either(value_type_p type, int64_t val_which, value_p val_data)
+    : type_(type), val_which_(val_which), val_data_(val_data) { }
+};
+
+struct value_ref {
+  value_type_p type_;
+
+  value_ref_enum ref_which_;
+
+  optional<value_p> target_;
+
+  optional<int64_t> column_element_;
+  optional<int64_t> column_range_lo_;
+  optional<int64_t> column_range_hi_;
+  optional<value_p> column_subset_;
+
+  static value_ref_p create_value(value_type_p type, value_p target);
+  static value_ref_p create_value_column(value_p column);
+  static value_p create_column_element(
+    value_type_p type, value_p target, int64_t i);
+  static value_p create_column_range(
+    value_p target, int64_t range_lo, int64_t range_hi);
+  static value_p create_column_subset(value_p target, value_p column_subset);
+
+  value_p ref_column_at_index(int64_t i);
+
+  // NOTE: should only be called by create_* methods, not directly
+  value_ref(value_type_p type, value_ref_enum ref_which)
+    : type_(type), ref_which_(ref_which) { }
+};
+
+struct value_index {
+  value_p index_keys_;
+  value_p index_values_flat_;
+  value_p index_values_grouped_;
+  vector<uint128_t> index_hashes_;
+  parallel_hash_map<int64_t> index_map_singleton_;
+  parallel_hash_map<pair<int64_t, int64_t>> index_map_range_;
+  index_mode_enum index_mode_;
+
+  value_index(
+    value_p index_keys,
+    value_p index_values_flat,
+    value_p index_values_grouped,
+    vector<uint128_t> index_hashes,
+    parallel_hash_map<int64_t> index_map_singleton,
+    parallel_hash_map<pair<int64_t, int64_t>> index_map_range,
+    index_mode_enum index_mode)
+    : index_keys_(index_keys),
+      index_values_flat_(index_values_flat),
+      index_values_grouped_(index_values_grouped),
+      index_hashes_(index_hashes),
+      index_map_singleton_(index_map_singleton),
+      index_map_range_(index_map_range),
+      index_mode_(index_mode) { }
+};
+
+struct value_column {
+  column_format_enum format_;
+  column_view_v view_;
+
+  column_view_variable* view_variable_cached_ { nullptr };
+
+  value_column(column_view_v view)
+    : format_(static_cast<column_format_enum>(view.which())), view_(view) {
+
+    switch (format_) {
+    case column_format_enum::VARIABLE:
+      view_variable_cached_ =
+        vget<column_format_enum, column_view_variable_p>(view_).get();
+      break;
+    default: AU();
+    }
+  }
+
+  inline int64_t length() {
+    switch (format_) {
+    case column_format_enum::VARIABLE:
+      return view_variable_cached_->num_entries_;
+    default: AU();
+    }
+  }
+
+  inline value_p at(int64_t i) {
+    switch (format_) {
+    case column_format_enum::VARIABLE: return view_variable_cached_->at(i);
+    default: AU();
+    }
+  }
+
+  inline buffer at_raw(int64_t i) {
+    switch (format_) {
+    case column_format_enum::VARIABLE: return view_variable_cached_->at_raw(i);
+    default: AU();
+    }
+  }
+
+  inline uint128_t at_raw_hash(int64_t i) {
+    switch (format_) {
+    case column_format_enum::VARIABLE:
+      return view_variable_cached_->at_raw_hash(i);
+    default: AU();
+    }
+  }
+
+  static inline value_column_p create(column_view_v view) {
+    return make_shared<value_column>(view);
+  }
+
+  static value_p load_column_from_disk_path(
+    string path, optional<ref_context_p> refs_accum,
+    optional<url_p> url_context, optional<int64_t> value_id);
+
+  static value_p load_column_from_binary_data(
+    binary_data_view_fixed_p meta_view,
+    binary_data_view_fixed_p top_view,
+    binary_data_view_variable_p entries_view,
+    optional<ref_context_p> refs_accum,
+    optional<url_p> url_context,
+    optional<int64_t> value_id);
+};
+
+inline int64_t column_value_get_raw_scalar(
+  value_column* x, int64_t i, type_specializer<int64_t>) {
+  int64_t ret = 0;
+  memcpy(&ret, x->at_raw(i).addr_, sizeof(int64_t));
+  return ret;
+}
+
+inline double column_value_get_raw_scalar(
+  value_column* x, int64_t i, type_specializer<double>) {
+  double ret = 0;
+  memcpy(&ret, x->at_raw(i).addr_, sizeof(double));
+  return ret;
+}
+
+template<typename T> T column_value_get_raw_scalar(value_column* x, int64_t i) {
+  return column_value_get_raw_scalar(x, i, type_specializer<T>());
+}
+
+inline string column_value_get_raw_string(value_column* x, int64_t i) {
+  buffer src = x->at_raw(i);
+  auto len = reinterpret_cast<int64_t*>(src.addr_)[1];
+  return string(src.addr_ + 16, len);
+}
+
+bool value_eq(value_p x, value_p y);
+
+void write_struct_hash_data(ostream& os, value_p x);
+
+ostream& operator<<(ostream& os, value_p v);
+
+inline string to_string(value_p x) {
+  ostringstream os;
+  os << x;
+  return os.str();
+}
+
+}}
+
+#endif

--- a/src/unity/toolkits/util/sframe_test_util.hpp
+++ b/src/unity/toolkits/util/sframe_test_util.hpp
@@ -1,0 +1,65 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TURI_UNITY_SFRAME_TEST_UTIL_H_
+#define TURI_UNITY_SFRAME_TEST_UTIL_H_
+
+#include <boost/test/unit_test.hpp>
+#include <unity/lib/gl_sarray.hpp>
+#include <unity/lib/gl_sframe.hpp>
+#include <util/test_macros.hpp>
+
+#include <string>
+
+__attribute__((__unused__))
+inline bool check_equality_gl_sframe(
+  turi::gl_sframe sf_gl, turi::gl_sframe ref_gl, bool check_row_order=true) {
+
+  size_t num_columns_sf = sf_gl.num_columns();
+  size_t num_columns_ref = ref_gl.num_columns();
+
+  TS_ASSERT_EQUALS(num_columns_sf, num_columns_ref);
+
+  std::vector<std::string> column_names_sf = sf_gl.column_names();
+  std::vector<std::string> column_names_ref = ref_gl.column_names();
+  TS_ASSERT(column_names_sf == column_names_ref);
+
+  if (!check_row_order) {
+      sf_gl = sf_gl.sort(column_names_sf);
+      ref_gl = ref_gl.sort(column_names_ref);
+  }
+
+  for (size_t column_index=0; column_index < num_columns_sf; column_index++) {
+    // go through all columns and check for sarray equality one by one
+
+    turi::gl_sarray column_sf = sf_gl.select_column(
+      column_names_sf[column_index]);
+    turi::gl_sarray column_ref = ref_gl.select_column(
+      column_names_ref[column_index]);
+
+    TS_ASSERT_EQUALS(column_sf.size(), column_ref.size());
+    TS_ASSERT_EQUALS(column_sf.dtype(), column_ref.dtype());
+
+    for (size_t i = 0; i < column_sf.size(); i++) {
+      if (column_sf.dtype() == turi::flex_type_enum::FLOAT) {
+        if ((std::isnan(column_sf[i].get<turi::flex_float>()))
+          && (std::isnan(column_ref[i].get<turi::flex_float>()))) {
+          continue;
+        }
+        if ((std::isinf(column_sf[i].get<turi::flex_float>()))
+          && (std::isinf(column_ref[i].get<turi::flex_float>()))) {
+          // check for both positive or both negative
+          TS_ASSERT_EQUALS(column_sf[i] > 0, column_ref[i] > 0);
+          TS_ASSERT_EQUALS(column_sf[i] < 0, column_ref[i] < 0);
+        }
+      }
+      TS_ASSERT_EQUALS(column_sf[i], column_ref[i]);
+    }
+  }
+
+  return true;
+}
+
+#endif /* TURI_UNITY_SFRAME_TEST_UTIL_H_ */

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -11,6 +11,7 @@ SOURCES
   string_util.cpp
   syserr_reporting.cpp 
   testing_utils.cpp 
+  time_spec.cpp
   web_util.cpp
 REQUIRES 
   logger 

--- a/src/util/time_spec.cpp
+++ b/src/util/time_spec.cpp
@@ -1,0 +1,106 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <util/time_spec.hpp>
+
+#include <chrono>
+
+int64_t time_spec::val() {
+  assert (this->sec < (1LL<<32));
+  return (int64_t)this->sign * (this->sec * 1000000000LL + this->nsec);
+}
+
+time_spec operator+(time_spec a, time_spec b) {
+  time_spec ret;
+  if (a.sign == b.sign) {
+    ret.sec = a.sec + b.sec;
+    ret.nsec = a.nsec + b.nsec;
+    if (ret.nsec >= 1000000000) {
+      ret.nsec -= 1000000000;
+      ++ret.sec;
+    }
+    ret.sign = a.sign;
+  } else {
+    if (b.sec > a.sec || (b.sec == a.sec && b.nsec > a.nsec)) {
+      return b + a;
+    } else {
+      ret.sec = a.sec - b.sec;
+      ret.nsec = a.nsec - b.nsec;
+      if (ret.nsec < 0) {
+        ret.nsec += 1000000000;
+        --ret.sec;
+      }
+      ret.sign = a.sign;
+    }
+  }
+  return ret;
+}
+
+time_spec operator-(time_spec a) {
+  time_spec ap;
+  ap.sign = -a.sign;
+  ap.sec = a.sec;
+  ap.nsec = a.nsec;
+  return ap;
+}
+
+time_spec operator-(time_spec a, time_spec b) {
+  return a + (-b);
+}
+
+bool operator==(time_spec a, time_spec b) {
+  return a.nsec == b.nsec && a.sec == b.sec && a.sign == b.sign;
+}
+
+int32_t cmp(time_spec a, time_spec b) {
+  if (a.sign != b.sign) {
+    return (a.sign < b.sign ? -1 : 1);
+  }
+  auto a_sec = a.sign * a.sec;
+  auto b_sec = b.sign * b.sec;
+  if (a_sec < b_sec) {
+    return -1;
+  }
+  if (b_sec < a_sec) {
+    return 1;
+  }
+  auto a_nsec = a.sign * a.nsec;
+  auto b_nsec = b.sign * b.nsec;
+  if (a_nsec < b_nsec) {
+    return -1;
+  }
+  if (b_nsec < a_nsec) {
+    return 1;
+  }
+  return 0;
+}
+
+bool operator<(time_spec a, time_spec b) {
+  return cmp(a, b) == -1;
+}
+
+bool operator>(time_spec a, time_spec b) {
+  return b < a;
+}
+
+bool operator<=(time_spec a, time_spec b) {
+  return !(b < a);
+}
+
+bool operator>=(time_spec a, time_spec b) {
+  return !(a < b);
+}
+
+time_spec now() {
+  time_spec ret;
+  auto t = std::chrono::high_resolution_clock::now().time_since_epoch();
+  auto ts = std::chrono::duration_cast<std::chrono::seconds>(t);
+  ret.sec = ts.count();
+  auto tn = t - ts;
+  ret.nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(tn).count();
+  ret.sign = +1;
+  return ret;
+}

--- a/src/util/time_spec.hpp
+++ b/src/util/time_spec.hpp
@@ -1,0 +1,32 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef _TURI_TIME_SPEC_H_
+#define _TURI_TIME_SPEC_H_
+
+#include <util/basic_types.hpp>
+
+struct time_spec {
+  int8_t sign;
+  int64_t sec;
+  int64_t nsec;
+
+  int64_t val();
+};
+
+time_spec operator+(time_spec a, time_spec b);
+time_spec operator-(time_spec a);
+time_spec operator-(time_spec a, time_spec b);
+
+bool operator<(time_spec a, time_spec b);
+bool operator>(time_spec a, time_spec b);
+bool operator<=(time_spec a, time_spec b);
+bool operator>=(time_spec a, time_spec b);
+bool operator==(time_spec a, time_spec b);
+
+time_spec now();
+
+#endif

--- a/test/capi/capi_utils.hpp
+++ b/test/capi/capi_utils.hpp
@@ -7,12 +7,13 @@
 #ifndef CAPI_TEST_UTILS
 #define CAPI_TEST_UTILS
 
+#include <capi/impl/capi_wrapper_structs.hpp>
 #include <capi/TuriCreate.h>
-#include <capi/impl/capi_wrapper_structs.hpp>
-#include <unity/lib/gl_sframe.hpp>
-#include <unity/lib/gl_sarray.hpp>
-#include <capi/impl/capi_wrapper_structs.hpp>
 #include <flexible_type/flexible_type.hpp>
+#include <unity/lib/gl_sarray.hpp>
+#include <unity/lib/gl_sframe.hpp>
+#include <unity/toolkits/util/sframe_test_util.hpp>
+
 #include <cmath>
 #include <vector>
 #include <iostream>
@@ -338,54 +339,6 @@ static tc_sframe* make_sframe_integer(const std::vector<std::pair<std::string, s
   }
 
   return sf;
-}
-
-__attribute__((__unused__))
-static bool check_equality_gl_sframe(
-  turi::gl_sframe sf_gl, turi::gl_sframe ref_gl, bool check_row_order=true) {
-
-  size_t num_columns_sf = sf_gl.num_columns();
-  size_t num_columns_ref = ref_gl.num_columns();
-
-  TS_ASSERT_EQUALS(num_columns_sf, num_columns_ref);
-
-  std::vector<std::string> column_names_sf = sf_gl.column_names();
-  std::vector<std::string> column_names_ref = ref_gl.column_names();
-  TS_ASSERT(column_names_sf == column_names_ref);
-
-  if (!check_row_order) {
-      sf_gl = sf_gl.sort(column_names_sf);
-      ref_gl = ref_gl.sort(column_names_ref);
-  }
-
-  for (size_t column_index=0; column_index < num_columns_sf; column_index++) {
-    // go through all columns and check for sarray equality one by one
-
-    turi::gl_sarray column_sf = sf_gl.select_column(
-      column_names_sf[column_index]);
-    turi::gl_sarray column_ref = ref_gl.select_column(
-      column_names_ref[column_index]);
-
-    TS_ASSERT_EQUALS(column_sf.dtype(), column_ref.dtype());
-
-    for (size_t i = 0; i < column_sf.size(); i++) {
-      if (column_sf.dtype() == turi::flex_type_enum::FLOAT) {
-        if ((std::isnan(column_sf[i].get<turi::flex_float>()))
-          && (std::isnan(column_ref[i].get<turi::flex_float>()))) {
-          continue;
-        }
-        if ((std::isinf(column_sf[i].get<turi::flex_float>()))
-          && (std::isinf(column_ref[i].get<turi::flex_float>()))) {
-          // check for both positive or both negative
-          TS_ASSERT_EQUALS(column_sf[i] > 0, column_ref[i] > 0);
-          TS_ASSERT_EQUALS(column_sf[i] < 0, column_ref[i] < 0);
-        }
-      }
-      TS_ASSERT_EQUALS(column_sf[i], column_ref[i]);
-    }
-  }
-
-  return true;
 }
 
 __attribute__((__unused__))

--- a/test/sframe/CMakeLists.txt
+++ b/test/sframe/CMakeLists.txt
@@ -9,3 +9,5 @@ make_boost_test(parallel_sframe_iterator.cxx REQUIRES sframe)
 make_boost_test(test_sarray_iterators.cxx REQUIRES sframe)
 make_boost_test(integer_pack_test.cxx REQUIRES sframe)
 make_boost_test(sframe_csv_test.cxx REQUIRES sframe)
+make_boost_test(
+  sframe_random_access_test.cxx REQUIRES sframe unity_core unity_toolkits)

--- a/test/sframe/sframe_random_access_test.cxx
+++ b/test/sframe/sframe_random_access_test.cxx
@@ -1,0 +1,69 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#define BOOST_TEST_MODULE
+
+#include <boost/test/unit_test.hpp>
+#include <sframe/sframe_random_access.hpp>
+#include <unity/toolkits/util/random_sframe_generation.hpp>
+#include <unity/toolkits/util/sframe_test_util.hpp>
+#include <util/basic_types.hpp>
+#include <util/string_util.hpp>
+#include <util/test_macros.hpp>
+#include <util/time_spec.hpp>
+
+using namespace turi;
+
+struct sframe_random_access_test {
+  void test_sframe_random_access_conversion() {
+    int64_t seed = 0;
+
+    vector<int64_t> n_rows_pool = {
+      10,
+      1000,
+      100000,
+    };
+
+    vector<string> column_types_pool = {
+      "z",
+      "n",
+      "r",
+      "R",
+      "S",
+      "X",
+      "H",
+      "znr",
+      "rHnS",
+      "zznHrRSXH",
+    };
+
+    for (int64_t n_rows : n_rows_pool) {
+      for (string column_types : column_types_pool) {
+        auto sf1 = _generate_random_sframe(
+          n_rows, column_types, seed, false, 0.0);
+
+        auto t0 = now();
+        auto sfr = sframe_random_access::from_sframe(sf1);
+        auto sf2 = sframe_random_access::to_sframe(sfr);
+        auto tr = (now() - t0).val();
+
+        TS_ASSERT(check_equality_gl_sframe(sf1, sf2));
+        fmt(cerr,
+            "test_sframe_random_access_conversion complete [%v sec]: %v, %v\n",
+            cc_sprintf("%5.3f", tr / 1.0e9),
+            n_rows,
+            column_types);
+
+        ++seed;
+      }
+    }
+  }
+};
+
+BOOST_FIXTURE_TEST_SUITE(_sframe_random_access_test, sframe_random_access_test)
+BOOST_AUTO_TEST_CASE(test_sframe_random_access_conversion) {
+  sframe_random_access_test::test_sframe_random_access_conversion();
+}
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
    SFrame random access backend:

    Initial prototype of SFrame random access backend

        - This implementation provides an alternate binary representation of
          (strongly-typed) SArray and SFrame values, which supports fast random
          access and indirect references, as well as the corresponding query
          execution and optimization machinery for the usual relational operations
          (join, groupby, filter, etc.). This also enables us to implement an
          in-memory hash-based index for relatively small SFrames, which speeds up
          repeated relational queries over the same database.

    Implement time_spec struct and corresponding operations

        - This enables simple speed benchmarking via the now() function.

    Minor fix for capi/test_utils

        - Previously, the gl_sframe equality test in capi/test_utils was not
          checking that the two SFrames have the same number of rows. This could
          cause the equality check to pass incorrectly when one SFrame is actually a
          proper subset of the other.

    Test for SFrame random access