### PR TITLE
Simplify plot config and autosize

### DIFF
--- a/src/unity/lib/visualization/CMakeLists.txt
+++ b/src/unity/lib/visualization/CMakeLists.txt
@@ -37,6 +37,7 @@ set(GENERATED_VEGA_JSON_HEADERS
   vega_spec/boxes_and_whiskers.json
   vega_spec/categorical.json
   vega_spec/categorical_heatmap.json
+  vega_spec/config.json
   vega_spec/heatmap.json
   vega_spec/histogram.json
   vega_spec/scatter.json

--- a/src/unity/lib/visualization/vega_spec.hpp
+++ b/src/unity/lib/visualization/vega_spec.hpp
@@ -23,9 +23,10 @@ namespace turi {
     std::string boxes_and_whiskers_spec(const flexible_type& xlabel, const flexible_type& ylabel, const flexible_type& title);
 
     // Utility for escaping JSON string literals. Not concerned with Vega implications of the contents of those strings.
-    std::string escape_string(const std::string& str);
+    std::string escape_string(const std::string& str, bool include_quotes=true);
     std::string replace_all(std::string str, const std::string& from, const std::string& to);
-    std::string extra_label_escape(const std::string& str);
+    std::string extra_label_escape(const std::string& str, bool include_quotes=true);
+    std::string format(const std::string& format_str, const std::unordered_map<std::string, std::string>& format_params);
   }
 }
 

--- a/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
+++ b/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
@@ -27,7 +27,7 @@
     }
   },
   "title": {
-    "text": %1%
+    "text": "{{title}}"
   },
   "height": 550,
   "style": "cell",
@@ -258,7 +258,7 @@
       "scale": "x",
       "labelOverlap": true,
       "orient": "bottom",
-      "title": %2%,
+      "title": "{{xlabel}}",
       "zindex": 1,
       "encode": {
         "labels": {
@@ -277,7 +277,7 @@
       }
     },
     {
-      "title": %3%,
+      "title": "{{ylabel}}",
       "scale": "y",
       "labelOverlap": true,
       "orient": "left",

--- a/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
+++ b/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
@@ -302,31 +302,5 @@
       "gridScale": "x"
     }
   ],
-  "config": {
-    "axis": {
-      "labelFont": "HelveticaNeue, Arial",
-      "labelFontSize": 12,
-      "labelPadding": 10,
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue-Medium, Arial",
-      "titleFontWeight": "normal",
-      "titlePadding": 30,
-      "titleFontSize": 15,
-      "titleColor": "rgba(0,0,0,0.65)"
-    },
-    "axisY": {
-      "minExtent": 30
-    },
-    "style": {
-      "rect": {
-        "stroke": "rgba(200, 200, 200, 0.5)"
-      },
-      "group-title": {
-        "fontSize": 29,
-        "font": "HelveticaNeue, Arial",
-        "fontWeight": "normal",
-        "fill": "rgba(0,0,0,0.65)"
-      }
-    }
-  }
+  {{config}}
 }

--- a/src/unity/lib/visualization/vega_spec/categorical.json
+++ b/src/unity/lib/visualization/vega_spec/categorical.json
@@ -19,9 +19,9 @@
     }
   },
   "width": 720,
-  "height": %1%,
+  "height": {{height}},
   "title": {
-    "text": %2%,
+    "text": "{{title}}",
     "offset": 30
   },
   "style": "cell",
@@ -177,7 +177,7 @@
       "tickCount": {
         "signal": "ceil(width/40)"
       },
-      "title": %3%,
+      "title": "{{xlabel}}",
       "zindex": 1
     },
     {
@@ -199,7 +199,7 @@
       "scale": "y",
       "labelOverlap": true,
       "orient": "left",
-      "title": %4%,
+      "title": "{{ylabel}}",
       "zindex": 1
     }
   ],

--- a/src/unity/lib/visualization/vega_spec/categorical.json
+++ b/src/unity/lib/visualization/vega_spec/categorical.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v4.json",
-  "autosize": "fit",
+  "autosize": {"type": "fit", "resize": true, "contains": "padding"},
   "padding": 5,
   "metadata": {
     "bubbleOpts": {
@@ -203,31 +203,5 @@
       "zindex": 1
     }
   ],
-  "config": {
-    "axis": {
-      "labelFont": "HelveticaNeue, Arial",
-      "labelFontSize": 12,
-      "labelPadding": 10,
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue-Medium, Arial",
-      "titleFontWeight": "normal",
-      "titlePadding": 30,
-      "titleFontSize": 15,
-      "titleColor": "rgba(0,0,0,0.65)"
-    },
-    "axisY": {
-      "minExtent": 30
-    },
-    "style": {
-      "rect": {
-        "stroke": "rgba(200, 200, 200, 0.5)"
-      },
-      "group-title": {
-        "fontSize": 29,
-        "font": "HelveticaNeue, Arial",
-        "fontWeight": "normal",
-        "fill": "rgba(0,0,0,0.65)"
-      }
-    }
-  }
+  {{config}}
 }

--- a/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v4.json",
-  "autosize": "fit",
+  "autosize": {"type": "fit", "resize": true, "contains": "padding"},
   "axes": [
     {
       "scale": "x",
@@ -58,46 +58,6 @@
     "fontSize": 16,
     "anchor": "middle",
     "offset": 4
-  },
-  "config": {
-    "range": {
-      "heatmap": {
-        "scheme": "greenblue"
-      }
-    },
-    "style": {
-      "cell": {
-        "stroke": "transparent"
-      },
-      "group-title": {
-        "fontWeight": "normal",
-        "font": "HelveticaNeue, Arial",
-        "fontSize": 29,
-        "fill": "rgba(0,0,0,0.65)"
-      }
-    },
-    "axis": {
-      "titlePadding": 30,
-      "labelPadding": 10,
-      "labelFont": "HelveticaNeue, Arial",
-      "labelFontSize": 12,
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue-Medium, Arial",
-      "titleFontSize": 15,
-      "titleColor": "rgba(0,0,0,0.65)",
-      "titleFontWeight": "normal"
-    },
-    "axisY": {
-      "minExtent": 30
-    },
-    "legend": {
-      "labelFont": "HelveticaNeue, Arial",
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue, Arial",
-      "cornerRadius": 30,
-      "gradientWidth": 600,
-      "titleColor": "rgba(0,0,0,0.65)"
-    }
   },
   "scales": [
     {
@@ -192,5 +152,6 @@
         }
       ]
     }
-  ]
+  ],
+  {{config}}
 }

--- a/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
@@ -4,7 +4,7 @@
   "axes": [
     {
       "scale": "x",
-      "title": %2%,
+      "title": "{{xlabel}}",
       "tickCount": {
         "signal": "min(ceil(width/40), 60)"
       },
@@ -29,7 +29,7 @@
     },
     {
       "scale": "y",
-      "title": %3%,
+      "title": "{{ylabel}}",
       "tickCount": {
         "signal": "min(ceil(height/40), 40)"
       },
@@ -53,7 +53,7 @@
     }
   ],
   "title": {
-    "text": %1%,
+    "text": "{{title}}",
     "frame": "group",
     "fontSize": 16,
     "anchor": "middle",

--- a/src/unity/lib/visualization/vega_spec/config.json
+++ b/src/unity/lib/visualization/vega_spec/config.json
@@ -1,0 +1,43 @@
+"config": {
+    "axis": {
+        "labelFont": "HelveticaNeue, Arial",
+        "labelFontSize": 12,
+        "labelPadding": 10,
+        "labelColor": "rgba(0,0,0,0.65)",
+        "titleFont": "HelveticaNeue-Medium, Arial",
+        "titleFontWeight": "normal",
+        "titlePadding": 30,
+        "titleFontSize": 15,
+        "titleColor": "rgba(0,0,0,0.65)"
+    },
+    "axisY": {
+        "minExtent": 30
+    },
+    "legend": {
+        "labelFont": "HelveticaNeue, Arial",
+        "labelColor": "rgba(0,0,0,0.65)",
+        "titleFont": "HelveticaNeue, Arial",
+        "cornerRadius": 30,
+        "gradientLength": 608,
+        "titleColor": "rgba(0,0,0,0.65)"
+    },
+    "range": {
+        "heatmap": {
+            "scheme": "greenblue"
+        }
+    },
+    "style": {
+        "rect": {
+            "stroke": "rgba(200, 200, 200, 0.5)"
+        },
+        "cell": {
+            "stroke": "transparent"
+        },
+        "group-title": {
+            "fontSize": 29,
+            "font": "HelveticaNeue, Arial",
+            "fontWeight": "normal",
+            "fill": "rgba(0,0,0,0.65)"
+        }
+    }
+}

--- a/src/unity/lib/visualization/vega_spec/heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/heatmap.json
@@ -4,7 +4,6 @@
   "padding": 5,
   "width": 720,
   "height": 550,
-  "style": "cell",
   "title": {
     "text": "{{title}}"
   },
@@ -18,7 +17,7 @@
       "name": "marks",
       "type": "rect",
       "style": [
-        "rect"
+        "cell"
       ],
       "from": {
         "data": "source_2"
@@ -146,44 +145,5 @@
       "type": "gradient"
     }
   ],
-  "config": {
-    "legend": {
-      "titleFont": "HelveticaNeue, Arial",
-      "titleColor": "rgba(0,0,0,0.65)",
-      "labelFont": "HelveticaNeue, Arial",
-      "labelColor": "rgba(0,0,0,0.65)",
-      "cornerRadius": 30,
-      "gradientLength": 620
-    },
-    "axis": {
-      "labelFont": "HelveticaNeue, Arial",
-      "labelFontSize": 12,
-      "labelPadding": 10,
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue-Medium, Arial",
-      "titleFontWeight": "normal",
-      "titlePadding": 30,
-      "titleFontSize": 15,
-      "titleColor": "rgba(0,0,0,0.65)"
-    },
-    "axisY": {
-      "minExtent": 30
-    },
-    "style": {
-      "cell": {
-        "stroke": "transparent"
-      },
-      "group-title": {
-        "fontSize": 29,
-        "font": "HelveticaNeue, Arial",
-        "fontWeight": "normal",
-        "fill": "rgba(0,0,0,0.65)"
-      }
-    },
-    "range": {
-      "heatmap": {
-        "scheme": "greenblue"
-      }
-    }
-  }
+  {{config}}
 }

--- a/src/unity/lib/visualization/vega_spec/heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/heatmap.json
@@ -6,7 +6,7 @@
   "height": 550,
   "style": "cell",
   "title": {
-    "text": %1%
+    "text": "{{title}}"
   },
   "data": [
     {
@@ -108,7 +108,7 @@
       "tickCount": {
         "signal": "min(ceil(width/40), 60)"
       },
-      "title": %2%,
+      "title": "{{xlabel}}",
       "zindex": 1,
       "encode": {
         "labels": {
@@ -133,7 +133,7 @@
       "tickCount": {
         "signal": "min(ceil(height/40), 40)"
       },
-      "title": %3%,
+      "title": "{{ylabel}}",
       "zindex": 1
     }
   ],

--- a/src/unity/lib/visualization/vega_spec/histogram.json
+++ b/src/unity/lib/visualization/vega_spec/histogram.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v4.json",
   "description": "A simple bar chart with embedded data.",
-  "autosize": "pad",
+  "autosize": {"type": "fit", "resize": true, "contains": "padding"},
   "width": 720,
   "height": 550,
   "padding": 5,
@@ -170,31 +170,5 @@
       "gridScale": "x"
     }
   ],
-  "config": {
-    "axis": {
-      "labelFont": "HelveticaNeue, Arial",
-      "labelFontSize": 12,
-      "labelPadding": 10,
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue-Medium, Arial",
-      "titleFontWeight": "normal",
-      "titlePadding": 30,
-      "titleFontSize": 15,
-      "titleColor": "rgba(0,0,0,0.65)"
-    },
-    "axisY": {
-      "minExtent": 30
-    },
-    "style": {
-      "rect": {
-        "stroke": "rgba(200, 200, 200, 0.5)"
-      },
-      "group-title": {
-        "fontSize": 29,
-        "font": "HelveticaNeue, Arial",
-        "fontWeight": "normal",
-        "fill": "rgba(0,0,0,0.65)"
-      }
-    }
-  }
+  {{config}}
 }

--- a/src/unity/lib/visualization/vega_spec/histogram.json
+++ b/src/unity/lib/visualization/vega_spec/histogram.json
@@ -6,7 +6,7 @@
   "height": 550,
   "padding": 5,
   "title": {
-    "text": %1%,
+    "text": "{{title}}",
     "offset": 30
   },
   "style": "cell",
@@ -120,7 +120,7 @@
   ],
   "axes": [
     {
-      "title": %2%,
+      "title": "{{xlabel}}",
       "scale": "x",
       "labelOverlap": true,
       "orient": "bottom",
@@ -145,7 +145,7 @@
       "gridScale": "y"
     },
     {
-      "title": %3%,
+      "title": "{{ylabel}}",
       "scale": "y",
       "labelOverlap": true,
       "orient": "left",

--- a/src/unity/lib/visualization/vega_spec/scatter.json
+++ b/src/unity/lib/visualization/vega_spec/scatter.json
@@ -6,7 +6,7 @@
   "height": 550,
   "style": "cell",
   "title": {
-    "text": %1%,
+    "text": "{{title}}",
     "offset": 30
   },
   "data": [
@@ -95,7 +95,7 @@
       "tickCount": {
         "signal": "ceil(width/40)"
       },
-      "title": %2%,
+      "title": "{{xlabel}}",
       "zindex": 1
     },
     {
@@ -120,7 +120,7 @@
       "tickCount": {
         "signal": "ceil(height/40)"
       },
-      "title": %3%,
+      "title": "{{ylabel}}",
       "zindex": 1
     },
     {

--- a/src/unity/lib/visualization/vega_spec/scatter.json
+++ b/src/unity/lib/visualization/vega_spec/scatter.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v4.json",
-  "autosize": "pad",
+  "autosize": {"type": "fit", "resize": true, "contains": "padding"},
   "padding": 5,
   "width": 720,
   "height": 550,
@@ -139,31 +139,5 @@
       "gridScale": "x"
     }
   ],
-  "config": {
-    "axis": {
-      "labelFont": "HelveticaNeue, Arial",
-      "labelFontSize": 12,
-      "labelPadding": 10,
-      "labelColor": "rgba(0,0,0,0.65)",
-      "titleFont": "HelveticaNeue-Medium, Arial",
-      "titleFontWeight": "normal",
-      "titlePadding": 30,
-      "titleFontSize": 15,
-      "titleColor": "rgba(0,0,0,0.65)"
-    },
-    "axisY": {
-      "minExtent": 30
-    },
-    "style": {
-      "rect": {
-        "stroke": "rgba(200, 200, 200, 0.5)"
-      },
-      "group-title": {
-        "fontSize": 29,
-        "font": "HelveticaNeue, Arial",
-        "fontWeight": "normal",
-        "fill": "rgba(0,0,0,0.65)"
-      }
-    }
-  }
+  {{config}}
 }

--- a/src/unity/lib/visualization/vega_spec/summary_view.json
+++ b/src/unity/lib/visualization/vega_spec/summary_view.json
@@ -20,7 +20,7 @@
     }
   },
   "width":800,
-  "height":%1%,
+  "height":{{height}},
   "padding":0,
   "data":[
     {

--- a/src/unity/python/turicreate/visualization/show.py
+++ b/src/unity/python/turicreate/visualization/show.py
@@ -51,8 +51,9 @@ def plot(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAULT):
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Y".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
 
     Examples
@@ -114,8 +115,9 @@ def show(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAULT):
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Y".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
 
     Examples
@@ -161,8 +163,9 @@ def scatter(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAUL
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Y".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
 
     Returns
@@ -209,8 +212,9 @@ def categorical_heatmap(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Y".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
 
     Returns
@@ -257,8 +261,9 @@ def heatmap(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAUL
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Y".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
 
     Returns
@@ -304,8 +309,9 @@ def box_plot(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAU
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Y".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
 
     Returns
@@ -378,8 +384,9 @@ def histogram(sa, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAUL
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Count".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
     
     Returns
@@ -419,8 +426,9 @@ def item_frequency(sa, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_D
     ylabel : str (optional)
       The text label for the Y axis. Defaults to "Count".
     title : str (optional)
-      The title of the plot. Defaults to None. If the value is None, the title
-      will be "<xlabel> vs. <ylabel>". Otherwise, the string passed in as the
+      The title of the plot. Defaults to LABEL_DEFAULT. If the value is
+      LABEL_DEFAULT, the title will be "<xlabel> vs. <ylabel>". If the value
+      is None, the title will be omitted. Otherwise, the string passed in as the
       title will be used as the plot title.
     
     Returns


### PR DESCRIPTION
* Implements a simpler plot templating system that allows for named and optional template parameters.
* Shares [Vega config](https://vega.github.io/vega/docs/config/) among all plots (except summary view).
* Fixes plot title display issues (as mentioned in #1296) and corresponding Python API docs.