### PR TITLE
Allow plots to vary in size/color/etc.

### DIFF
--- a/src/capi/TuriCreate.h
+++ b/src/capi/TuriCreate.h
@@ -872,6 +872,30 @@ tc_variant* tc_function_call(
 /*                                                                            */
 /******************************************************************************/
 
+/*
+ * Bit flags to configure plot variations.
+ * The bit layout is as follows:
+ * The first 4 bits (1 hex digit) represents size.
+ * The next 4 bits (1 hex digit) represents color mode (light/dark).
+ * Zeroes in any set of bits imply defaults should be used.
+ * To apply multiple flags, simply OR them together.
+ * (Note: only a single flag within each bit range should be used.)
+ */
+typedef enum {
+    tc_plot_variation_default   = 0x00,
+
+    // Sizes
+    tc_plot_size_default        = 0x01, // defaults to medium
+    //tc_plot_size_small        = 0x02,
+    tc_plot_size_medium         = 0x03,
+
+    // Color variations
+    tc_plot_color_default       = 0x10, // could be light/dark depending on OS settings
+    tc_plot_color_light         = 0x20,
+    //tc_plot_color_dark        = 0x30,
+
+} tc_plot_variation;
+
 // Single SArray view (`.show` on an SArray)
 tc_plot* tc_plot_create_1d(const tc_sarray* sa,
                            const char* title,
@@ -894,15 +918,15 @@ tc_plot* tc_plot_create_2d(const tc_sarray* sa_x,
                            const tc_parameters* params,
                            tc_error** error);
 
-// SFrame summary view (`.show` on an SFrame)
-tc_plot* tc_plot_create_sframe_summary(const tc_sframe* sf, const tc_parameters* params, tc_error** error);
-
 // returns true if no further computation can be done on this stream
 // (should probably be used as a loop condition)
 bool tc_plot_finished_streaming(const tc_plot* plot, const tc_parameters *params, tc_error** error);
 
 // returns a flex string containing the Vega JSON spec for this plot
-tc_flexible_type* tc_plot_get_vega_spec(const tc_plot* plot, const tc_parameters *params, tc_error** error);
+tc_flexible_type* tc_plot_get_vega_spec(const tc_plot* plot,
+                                        tc_plot_variation variation,
+                                        const tc_parameters *params,
+                                        tc_error** error);
 
 // computes the next batch of results, and returns a flex string of JSON data
 tc_flexible_type* tc_plot_get_next_data(const tc_plot* plot, const tc_parameters *params, tc_error** error); 

--- a/src/capi/impl/capi_visualization.cpp
+++ b/src/capi/impl/capi_visualization.cpp
@@ -73,6 +73,7 @@ EXPORT tc_plot* tc_plot_create_sframe_summary(const tc_sframe* sf,
 }
 
 EXPORT tc_flexible_type* tc_plot_get_vega_spec(const tc_plot* plot,
+                                               tc_plot_variation variation,
                                                const tc_parameters*,
                                                tc_error** error) {
   ERROR_HANDLE_START();
@@ -80,7 +81,7 @@ EXPORT tc_flexible_type* tc_plot_get_vega_spec(const tc_plot* plot,
 
   CHECK_NOT_NULL(error, plot, "plot", NULL);
 
-  std::string vega_spec = plot->value->get_spec();
+  std::string vega_spec = plot->value->get_spec(variation);
   return tc_ft_create_from_string(vega_spec.data(), vega_spec.size(), error);
 
   ERROR_HANDLE_END(error, NULL);

--- a/src/unity/lib/visualization/plot.cpp
+++ b/src/unity/lib/visualization/plot.cpp
@@ -13,13 +13,13 @@
 
 namespace turi{
   namespace visualization{
-    void Plot::show(const std::string& path_to_client) {
+    void Plot::show(const std::string& path_to_client, tc_plot_variation variation) {
 
       std::shared_ptr<Plot> self = std::make_shared<Plot>(*this);
 
-      ::turi::visualization::run_thread([self, path_to_client]() {
+      ::turi::visualization::run_thread([self, path_to_client, variation]() {
         process_wrapper ew(path_to_client);
-        ew << "{\"vega_spec\": " << self->m_vega_spec << "}\n";
+        ew << "{\"vega_spec\": " << self->get_spec(variation) << "}\n";
 
         while(ew.good()) {
           vega_data vd;
@@ -67,7 +67,8 @@ namespace turi{
       return vd.get_data_spec(100 /* percent_complete */);
     }
 
-    std::string Plot::get_spec() {
+    std::string Plot::get_spec(tc_plot_variation variation) {
+      (void)variation; // TODO support multiple variations
       return m_vega_spec;
     }
   }

--- a/src/unity/lib/visualization/plot.hpp
+++ b/src/unity/lib/visualization/plot.hpp
@@ -6,11 +6,16 @@
 #include <unity/lib/visualization/transformation.hpp>
 #include <unity/lib/extensions/model_base.hpp>
 #include <string>
+#include <capi/TuriCreate.h>
 
 namespace turi {
   namespace visualization {
 
     class Plot: public model_base {
+      private:
+        std::string m_vega_spec;
+        double m_size_array;
+        std::shared_ptr<transformation_base> m_transformer;
 
       public:
         Plot(){};
@@ -18,11 +23,11 @@ namespace turi {
                                               m_vega_spec(vega_spec),
                                               m_size_array(size_array),
                                               m_transformer(transformer){}
-        void show(const std::string& path_to_client);
+        void show(const std::string& path_to_client, tc_plot_variation variation = tc_plot_variation_default);
         void materialize();
 
         // vega specification
-        std::string get_spec();
+        std::string get_spec(tc_plot_variation variation = tc_plot_variation_default);
 
         // streaming data aggregation
         double get_percent_complete() const; // out of 1.0
@@ -31,11 +36,6 @@ namespace turi {
 
         // non-streaming data aggregation: causes full materialization
         std::string get_data();
-
-        // TODO - these hould be private
-        std::string m_vega_spec;
-        double m_size_array;
-        std::shared_ptr<transformation_base> m_transformer;
 
         BEGIN_CLASS_MEMBER_REGISTRATION("_Plot")
         REGISTER_CLASS_MEMBER_FUNCTION(Plot::show, "path_to_client")

--- a/test/capi/capi_visualization.cxx
+++ b/test/capi/capi_visualization.cxx
@@ -90,7 +90,7 @@ class capi_test_visualization {
             tc_error *error = nullptr;
             tc_plot *actual_obj = tc_plot_create_1d(m_sa_int, "foo", "bar", "baz", nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            tc_flexible_type *actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            tc_flexible_type *actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             const char *actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -121,7 +121,7 @@ class capi_test_visualization {
             error = nullptr;
             actual_obj = tc_plot_create_1d(m_sa_float, nullptr, nullptr, nullptr, nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -152,7 +152,7 @@ class capi_test_visualization {
             error = nullptr;
             actual_obj = tc_plot_create_1d(m_sa_str, "foo", "bar", "baz", nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -185,7 +185,7 @@ class capi_test_visualization {
             tc_error *error = nullptr;
             tc_plot *actual_obj = tc_plot_create_2d(m_sa_int, m_sa_float, "foo", "bar", "baz", nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            tc_flexible_type *actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            tc_flexible_type *actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             const char *actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -216,7 +216,7 @@ class capi_test_visualization {
             error = nullptr;
             actual_obj = tc_plot_create_2d(m_sa_float_10k, m_sa_float_10k, "foo", "bar", "baz", nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -247,7 +247,7 @@ class capi_test_visualization {
             error = nullptr;
             actual_obj = tc_plot_create_2d(m_sa_float, m_sa_str, "foo", "bar", "baz", nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -278,7 +278,7 @@ class capi_test_visualization {
             error = nullptr;
             actual_obj = tc_plot_create_2d(m_sa_str, m_sa_str, "foo", "bar", "baz", nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);
@@ -310,7 +310,7 @@ class capi_test_visualization {
             tc_error *error = nullptr;
             tc_plot *actual_obj = tc_plot_create_sframe_summary(m_sf_float, nullptr, &error);
             CAPI_CHECK_ERROR(error);
-            tc_flexible_type *actual_spec_ft = tc_plot_get_vega_spec(actual_obj, nullptr, &error);
+            tc_flexible_type *actual_spec_ft = tc_plot_get_vega_spec(actual_obj, tc_plot_variation_default, nullptr, &error);
             CAPI_CHECK_ERROR(error);
             const char *actual_spec_data = tc_ft_string_data(actual_spec_ft, &error);
             CAPI_CHECK_ERROR(error);


### PR DESCRIPTION
* Creates a enum to describe plot variations in C API.
* Passes the enum into C++ API to allow the logic to determine the spec from the variations.
* Uses the plot variation enum to determine Vega spec (Not yet implemented in this commit).

This change will eventually allow for small/medium/large and light/dark variations of each plot.

Depends on #1308.