### PR TITLE
Implement dark mode plot API

### DIFF
--- a/src/capi/TuriCreate.h
+++ b/src/capi/TuriCreate.h
@@ -884,15 +884,14 @@ tc_variant* tc_function_call(
 typedef enum {
     tc_plot_variation_default   = 0x00,
 
-    // Sizes
-    tc_plot_size_default        = 0x01, // defaults to medium
-    //tc_plot_size_small        = 0x02,
-    tc_plot_size_medium         = 0x03,
+    // Sizes (defaults to medium)
+    //tc_plot_size_small        = 0x01,
+    tc_plot_size_medium         = 0x02,
 
     // Color variations
-    tc_plot_color_default       = 0x10, // could be light/dark depending on OS settings
-    tc_plot_color_light         = 0x20,
-    //tc_plot_color_dark        = 0x30,
+    // default could be light/dark depending on OS settings
+    tc_plot_color_light         = 0x10,
+    tc_plot_color_dark          = 0x20,
 
 } tc_plot_variation;
 

--- a/src/unity/lib/visualization/CMakeLists.txt
+++ b/src/unity/lib/visualization/CMakeLists.txt
@@ -12,6 +12,7 @@ make_library(
     batch_size.cpp
     boxes_and_whiskers.cpp
     categorical_heatmap.cpp
+    dark_mode.cpp
     escape.cpp
     groupby.cpp
     heatmap.cpp

--- a/src/unity/lib/visualization/dark_mode.cpp
+++ b/src/unity/lib/visualization/dark_mode.cpp
@@ -1,0 +1,32 @@
+#include <unity/lib/visualization/dark_mode.hpp>
+
+#ifdef __APPLE__
+#import <CoreFoundation/CoreFoundation.h>
+#endif
+
+namespace turi {
+namespace visualization {
+
+bool is_system_dark_mode() {
+#ifdef __APPLE__
+    CFStringRef key = CFSTR("AppleInterfaceStyle");
+    CFStringRef expectedValue = CFSTR("Dark");
+    CFPropertyListRef propertyList = CFPreferencesCopyValue(
+        key,
+        kCFPreferencesAnyApplication,
+        kCFPreferencesCurrentUser,
+        kCFPreferencesAnyHost);
+    if (propertyList == nullptr) {
+        return false;
+    }
+    bool ret = CFEqual(propertyList, expectedValue);
+    CFRelease(propertyList);
+    return ret;
+#else
+    // TODO - what should this do on other platforms?
+    return false;
+#endif
+}
+
+}
+}

--- a/src/unity/lib/visualization/dark_mode.hpp
+++ b/src/unity/lib/visualization/dark_mode.hpp
@@ -1,0 +1,10 @@
+#ifndef __TC_DARK_MODE_HPP_
+#define __TC_DARK_MODE_HPP_
+
+namespace turi {
+    namespace visualization {
+        bool is_system_dark_mode();
+    }
+}
+
+#endif

--- a/src/unity/lib/visualization/plot.hpp
+++ b/src/unity/lib/visualization/plot.hpp
@@ -38,9 +38,9 @@ namespace turi {
         std::string get_data();
 
         BEGIN_CLASS_MEMBER_REGISTRATION("_Plot")
-        REGISTER_CLASS_MEMBER_FUNCTION(Plot::show, "path_to_client")
+        REGISTER_CLASS_MEMBER_FUNCTION(Plot::show, "path_to_client", "variation")
         REGISTER_CLASS_MEMBER_FUNCTION(Plot::materialize)
-        REGISTER_CLASS_MEMBER_FUNCTION(Plot::get_spec)
+        REGISTER_CLASS_MEMBER_FUNCTION(Plot::get_spec, "variation")
         REGISTER_CLASS_MEMBER_FUNCTION(Plot::get_data)
         END_CLASS_MEMBER_REGISTRATION
     };

--- a/src/unity/lib/visualization/vega_spec.cpp
+++ b/src/unity/lib/visualization/vega_spec.cpp
@@ -12,7 +12,6 @@
 #include <unity/lib/visualization/vega_spec/boxes_and_whiskers.h>
 #include <unity/lib/visualization/vega_spec/categorical.h>
 #include <unity/lib/visualization/vega_spec/categorical_heatmap.h>
-#include <unity/lib/visualization/vega_spec/config.h>
 #include <unity/lib/visualization/vega_spec/heatmap.h>
 #include <unity/lib/visualization/vega_spec/histogram.h>
 #include <unity/lib/visualization/vega_spec/scatter.h>
@@ -60,7 +59,7 @@ std::string extra_label_escape(const std::string& str, bool include_quotes){
  * by doing the following:
  * 1. Strips all newlines.
  */
-static std::string make_format_string(unsigned char *raw_format_str_ptr,
+std::string make_format_string(unsigned char *raw_format_str_ptr,
                                       size_t raw_format_str_len) {
   auto raw_format_str = std::string(
     reinterpret_cast<char *>(raw_format_str_ptr),
@@ -88,11 +87,6 @@ std::string format(const std::string& format_str, const std::unordered_map<std::
   for (const auto& it : format_params) {
     _format_impl(ret, it.first, it.second);
   }
-  // Also replace config from predefined config (maintained separately so we don't
-  // have to repeat the same config in each file, and we can make sure it stays
-  // consistent across the different plots)
-  static std::string config_str = make_format_string(vega_spec_config_json, vega_spec_config_json_len);
-  _format_impl(ret, "{{config}}", config_str);
   return ret;
 }
 

--- a/src/unity/lib/visualization/vega_spec.hpp
+++ b/src/unity/lib/visualization/vega_spec.hpp
@@ -23,6 +23,8 @@ namespace turi {
     std::string boxes_and_whiskers_spec(const flexible_type& xlabel, const flexible_type& ylabel, const flexible_type& title);
 
     // Utility for escaping JSON string literals. Not concerned with Vega implications of the contents of those strings.
+    std::string make_format_string(unsigned char *raw_format_str_ptr,
+                                           size_t raw_format_str_len);
     std::string escape_string(const std::string& str, bool include_quotes=true);
     std::string replace_all(std::string str, const std::string& from, const std::string& to);
     std::string extra_label_escape(const std::string& str, bool include_quotes=true);

--- a/src/unity/lib/visualization/vega_spec/config.json
+++ b/src/unity/lib/visualization/vega_spec/config.json
@@ -1,25 +1,27 @@
 "config": {
     "axis": {
-        "labelFont": "HelveticaNeue, Arial",
-        "labelFontSize": 12,
-        "labelPadding": 10,
-        "labelColor": "rgba(0,0,0,0.65)",
-        "titleFont": "HelveticaNeue-Medium, Arial",
-        "titleFontWeight": "normal",
-        "titlePadding": 30,
-        "titleFontSize": 15,
-        "titleColor": "rgba(0,0,0,0.65)"
+        "gridColor": {{gridColor}},
+        "labelFont": {{labelFont}},
+        "labelFontSize": {{labelFontSize}},
+        "labelPadding": {{labelPadding}},
+        "labelColor": {{labelColor}},
+        "tickColor": {{tickColor}},
+        "titleFont": {{titleFont}},
+        "titleFontWeight": {{axisTitleFontWeight}},
+        "titlePadding": {{axisTitlePadding}},
+        "titleFontSize": {{axisTitleFontSize}},
+        "titleColor": {{titleColor}}
     },
     "axisY": {
         "minExtent": 30
     },
     "legend": {
-        "labelFont": "HelveticaNeue, Arial",
-        "labelColor": "rgba(0,0,0,0.65)",
-        "titleFont": "HelveticaNeue, Arial",
+        "labelFont": {{labelFont}},
+        "labelColor": {{labelColor}},
+        "titleFont": {{titleFont}},
         "cornerRadius": 30,
         "gradientLength": 608,
-        "titleColor": "rgba(0,0,0,0.65)"
+        "titleColor": {{titleColor}}
     },
     "range": {
         "heatmap": {
@@ -39,5 +41,12 @@
             "fontWeight": "normal",
             "fill": "rgba(0,0,0,0.65)"
         }
+    },
+    "title": {
+        "color": {{titleColor}},
+        "font": {{titleFont}},
+        "fontSize": {{titleFontSize}},
+        "fontWeight": {{titleFontWeight}},
+        "offset": {{titleOffset}}
     }
 }

--- a/src/unity/python/turicreate/visualization/_plot.py
+++ b/src/unity/python/turicreate/visualization/_plot.py
@@ -128,7 +128,11 @@ class Plot(object):
                      raise NotImplementedError('Visualization is currently supported only on macOS and Linux.')
 
                 path_to_client = _get_client_app_path()
-                self.__proxy__.call_function('show', {'path_to_client': path_to_client})
+
+                # TODO: allow autodetection of light/dark mode.
+                # Disabled for now, since the GUI side needs some work (ie. background color).
+                plot_variation = 0x10 # force light mode
+                self.__proxy__.call_function('show', {'path_to_client': path_to_client, 'variation': plot_variation})
 
     def save(self, filepath):
         """


### PR DESCRIPTION
Completed in this change:

* C and C++ API for retrieving and showing dark mode Vega spec for a Plot object
* macOS support

Not yet implemented (will come in future changes):

* Python API for retrieving and showing dark mode Vega spec for a Plot object
* Linux support (TBD: can this be done w.r.t. popular desktop
  environments or via a standard?)
* Proper UX support for dark mode (i.e. the native app changes
  background color and switches appropriately in real time).

Depends on #1309.