### PR TITLE
Fix empty space on null plot title

### DIFF
--- a/src/unity/lib/visualization/vega_spec.cpp
+++ b/src/unity/lib/visualization/vega_spec.cpp
@@ -106,15 +106,28 @@ static std::string label_or_default(const flexible_type& label,
   }
 }
 
+static std::string title_or_default(const flexible_type& title, const std::string& default_title) {
+  if (title == FLEX_UNDEFINED) {
+    // undefined/not provided should render as null in JSON
+    return "null";
+  } else if (title == "__TURI_DEFAULT_LABEL") {
+    return extra_label_escape(default_title, true /* include_quotes */);
+  } else {
+    // user-provided label should render with quotes/escaping
+    return extra_label_escape(title.get<flex_string>(), true /* include_quotes */);
+  }
+
+}
+
 static std::string title_or_default(const flexible_type& title, const std::string& xlabel, const std::string& ylabel) {
   if (title == FLEX_UNDEFINED) {
     // undefined/not provided should render as null in JSON
     return "null";
   } else if (title == "__TURI_DEFAULT_LABEL") {
-    return extra_label_escape(xlabel + " vs. " + ylabel, false /* include_quotes */);
+    return extra_label_escape(xlabel + " vs. " + ylabel, true /* include_quotes */);
   } else {
     // user-provided label should render with quotes/escaping
-    return extra_label_escape(title.get<flex_string>(), false /* include_quotes */);
+    return extra_label_escape(title.get<flex_string>(), true /* include_quotes */);
   }
 
 }
@@ -126,7 +139,7 @@ EXPORT std::string histogram_spec(const flexible_type& _title,
   static std::string default_title = std::string("Distribution of Values [") +
                                      flex_type_enum_to_name(dtype) +
                                      "]";
-  flexible_type title = label_or_default(_title, default_title);
+  flexible_type title = title_or_default(_title, default_title);
   flexible_type xlabel = label_or_default(_xlabel, "Count");
   flexible_type ylabel = label_or_default(_ylabel, "Values");
 
@@ -147,7 +160,7 @@ EXPORT std::string categorical_spec(size_t length_list,
                                      flex_type_enum_to_name(dtype) +
                                      "]";
 
-  flexible_type title = label_or_default(_title, default_title);
+  flexible_type title = title_or_default(_title, default_title);
   flexible_type xlabel = label_or_default(_xlabel, "Values");
   flexible_type ylabel = label_or_default(_ylabel, "Count");
 

--- a/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
+++ b/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
@@ -27,9 +27,7 @@
       ]
     }
   },
-  "title": {
-    "text": "{{title}}"
-  },
+  "title": {{title}},
   "height": {{height}},
   "style": "cell",
   "data": [

--- a/src/unity/lib/visualization/vega_spec/categorical.json
+++ b/src/unity/lib/visualization/vega_spec/categorical.json
@@ -20,10 +20,7 @@
   },
   "width": {{width}},
   "height": {{computed_height}},
-  "title": {
-    "text": "{{title}}",
-    "offset": 30
-  },
+  "title": {{title}},
   "style": "cell",
   "data": [
     {

--- a/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
@@ -52,13 +52,7 @@
       "fill": "color"
     }
   ],
-  "title": {
-    "text": "{{title}}",
-    "frame": "group",
-    "fontSize": 16,
-    "anchor": "middle",
-    "offset": 4
-  },
+  "title": {{title}},
   "scales": [
     {
       "range": [

--- a/src/unity/lib/visualization/vega_spec/heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/heatmap.json
@@ -4,9 +4,7 @@
   "padding": 8,
   "width": {{width}},
   "height": {{height}},
-  "title": {
-    "text": "{{title}}"
-  },
+  "title": {{title}},
   "data": [
     {
       "name": "source_2"

--- a/src/unity/lib/visualization/vega_spec/histogram.json
+++ b/src/unity/lib/visualization/vega_spec/histogram.json
@@ -5,10 +5,7 @@
   "width": {{width}},
   "height": {{height}},
   "padding": 8,
-  "title": {
-    "text": "{{title}}",
-    "offset": 30
-  },
+  "title": {{title}},
   "style": "cell",
   "data": [
     {

--- a/src/unity/lib/visualization/vega_spec/scatter.json
+++ b/src/unity/lib/visualization/vega_spec/scatter.json
@@ -5,10 +5,7 @@
   "width": {{width}},
   "height": {{height}},
   "style": "cell",
-  "title": {
-    "text": "{{title}}",
-    "offset": 30
-  },
+  "title": {{title}},
   "data": [
     {
       "name": "source_2"


### PR DESCRIPTION
Fixes the various title display issues across the different plots. Now
the behavior is:

* Default plot titles (unspecified) are plot-specific generated strings.
* None/null plot titles don't take up any space (the plot expands to
  fill the height).
* Empty string titles explicitly take up space but don't display anything.
* User-provided string titles work as expected.

Depends on #1318 