### PR TITLE
Fix Travis CI failure on assert(HAS_NUMPY)

### DIFF
--- a/scripts/make_wheel.sh
+++ b/scripts/make_wheel.sh
@@ -270,7 +270,8 @@ package_wheel() {
   fi
 
   # Install the wheel and do a sanity check
-  $PIP_EXECUTABLE install --force-reinstall --ignore-installed ${WHEEL_PATH}
+  $PIP_EXECUTABLE uninstall turicreate # make sure any existing build is uninstalled first
+  $PIP_EXECUTABLE install ${WHEEL_PATH}
   unset PYTHONPATH
   $PYTHON_EXECUTABLE -c "import turicreate; turicreate.SArray(range(100)).apply(lambda x: x)"
 

--- a/scripts/make_wheel.sh
+++ b/scripts/make_wheel.sh
@@ -270,9 +270,9 @@ package_wheel() {
   fi
 
   # Install the wheel and do a sanity check
+  unset PYTHONPATH
   $PIP_EXECUTABLE uninstall turicreate # make sure any existing build is uninstalled first
   $PIP_EXECUTABLE install ${WHEEL_PATH}
-  unset PYTHONPATH
   $PYTHON_EXECUTABLE -c "import turicreate; turicreate.SArray(range(100)).apply(lambda x: x)"
 
   # Done copy to the target directory

--- a/src/unity/python/turicreate/cython/cy_flexible_type.pyx
+++ b/src/unity/python/turicreate/cython/cy_flexible_type.pyx
@@ -287,14 +287,10 @@ timedelta_type = datetime.timedelta
 cdef object _image_type
 cdef bint have_imagetype
 
-cdef bint HAS_NUMPY = False
+cdef bint HAS_NUMPY = True
 cdef bint HAS_PANDAS = False
 
-try:
-    import numpy as np
-    HAS_NUMPY = True
-except ImportError:
-    HAS_NUMPY = False
+import numpy as np
 
 try:
     import pandas as pd
@@ -304,7 +300,6 @@ except ImportError:
 
 cdef type np_ndarray
 cdef type np_matrix
-assert(HAS_NUMPY)
 np_ndarray = np.ndarray
 np_matrix = np.matrix
 


### PR DESCRIPTION
Initial commit: Don't put import numpy behind a try/catch.
Since we're immediately going to fail anyway if numpy is missing, let's just
import it whether it'll fail or not, and let it fail with a proper stack
trace if it's going to. That should at least give us more information in CI.