### PR TITLE
Include master build status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Quick Links: [Installation](#supported-platforms) | [Documentation](#documentation) | [WWDC 2018 Talk](https://developer.apple.com/videos/play/wwdc2018/712/)
 
+[![Build Status](https://travis-ci.com/apple/turicreate.svg?branch=master)](https://travis-ci.com/apple/turicreate)
+
 <img align="right" src="https://docs-assets.developer.apple.com/turicreate/turi-dog.svg" alt="Turi Create" width="100">
 
 # Turi Create 


### PR DESCRIPTION
Using the Markdown exported from Travis CI, we can see (and get a link to) the latest build status on Travis.