### PR TITLE
Move Vega spec including data down to C++

### DIFF
--- a/src/unity/lib/visualization/plot.cpp
+++ b/src/unity/lib/visualization/plot.cpp
@@ -70,7 +70,8 @@ namespace turi{
       return vd.get_data_spec(100 /* percent_complete */);
     }
 
-    std::string Plot::get_spec(tc_plot_variation variation) {
+    std::string Plot::get_spec(tc_plot_variation variation,
+                               bool include_data) {
       // Replace config from predefined config (maintained separately so we don't
       // have to repeat the same config in each file, and we can make sure it stays
       // consistent across the different plots)
@@ -95,6 +96,7 @@ namespace turi{
       std::string titleFontSize = "18";
       std::string titleOffset = "30";
       std::string tickColor = escape_string("rgb(136,136,136)");
+      std::string data = "";
 
       // Default (medium) size is 720x550
       std::string width = "720";
@@ -136,6 +138,11 @@ namespace turi{
         titleOffset = "30";
       }
 
+      // Override for data inclusion
+      if (include_data) {
+        data = ", \"values\": [" + m_transformer->get()->vega_column_data() + "]";
+      }
+
       return format(ret, {
         {"{{gridColor}}", gridColor},
         {"{{axisTitlePadding}}", axisTitlePadding},
@@ -153,6 +160,7 @@ namespace turi{
         {"{{tickColor}}", tickColor},
         {"{{width}}", width},
         {"{{height}}", height},
+        {"{{pre_filled_data_values}}", data},
       });
     }
   }

--- a/src/unity/lib/visualization/plot.hpp
+++ b/src/unity/lib/visualization/plot.hpp
@@ -27,7 +27,8 @@ namespace turi {
         void materialize();
 
         // vega specification
-        std::string get_spec(tc_plot_variation variation = tc_plot_variation_default);
+        std::string get_spec(tc_plot_variation variation=tc_plot_variation_default,
+                             bool include_data=false);
 
         // streaming data aggregation
         double get_percent_complete() const; // out of 1.0
@@ -40,7 +41,7 @@ namespace turi {
         BEGIN_CLASS_MEMBER_REGISTRATION("_Plot")
         REGISTER_CLASS_MEMBER_FUNCTION(Plot::show, "path_to_client", "variation")
         REGISTER_CLASS_MEMBER_FUNCTION(Plot::materialize)
-        REGISTER_CLASS_MEMBER_FUNCTION(Plot::get_spec, "variation")
+        REGISTER_CLASS_MEMBER_FUNCTION(Plot::get_spec, "variation", "include_data")
         REGISTER_CLASS_MEMBER_FUNCTION(Plot::get_data)
         END_CLASS_MEMBER_REGISTRATION
     };

--- a/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
+++ b/src/unity/lib/visualization/vega_spec/boxes_and_whiskers.json
@@ -38,7 +38,8 @@
           "type": "collect",
           "sort": {"field": "median"}
         }
-      ] 
+      ]
+      {{pre_filled_data_values}}
     }
   ],
   "signals": [

--- a/src/unity/lib/visualization/vega_spec/categorical.json
+++ b/src/unity/lib/visualization/vega_spec/categorical.json
@@ -28,6 +28,7 @@
     },
     {
       "name": "source_2"
+      {{pre_filled_data_values}}
     },
     {
       "name": "data_0",

--- a/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/categorical_heatmap.json
@@ -137,14 +137,8 @@
   ],
   "data": [
     {
-      "name": "source_2",
-      "values": [
-        {
-          "x": 100000000,
-          "y": "loading_data_from_tc",
-          "count": 0
-        }
-      ]
+      "name": "source_2"
+      {{pre_filled_data_values}}
     }
   ],
   {{config}}

--- a/src/unity/lib/visualization/vega_spec/heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/heatmap.json
@@ -8,6 +8,7 @@
   "data": [
     {
       "name": "source_2"
+      {{pre_filled_data_values}}
     }
   ],
   "marks": [

--- a/src/unity/lib/visualization/vega_spec/histogram.json
+++ b/src/unity/lib/visualization/vega_spec/histogram.json
@@ -20,6 +20,7 @@
   "data": [
     {
       "name": "source_2"
+      {{pre_filled_data_values}}
     },
     {
       "name": "data_0",

--- a/src/unity/lib/visualization/vega_spec/scatter.json
+++ b/src/unity/lib/visualization/vega_spec/scatter.json
@@ -9,6 +9,7 @@
   "data": [
     {
       "name": "source_2"
+      {{pre_filled_data_values}}
     }
   ],
   "marks": [

--- a/src/unity/lib/visualization/vega_spec/summary_view.json
+++ b/src/unity/lib/visualization/vega_spec/summary_view.json
@@ -28,6 +28,7 @@
     },
     {
       "name":"source_2"
+      {{pre_filled_data_values}}
     },
     {
       "name":"data_2",

--- a/src/unity/python/turicreate/visualization/_plot.py
+++ b/src/unity/python/turicreate/visualization/_plot.py
@@ -168,12 +168,12 @@ class Plot(object):
 
         if filepath.endswith(".json"):
             # save as vega json
-            spec = self._get_vega(include_data = True)
+            spec = self.get_vega(include_data = True)
             with open(filepath, 'w') as fp:
                 _json.dump(spec, fp)
         elif filepath.endswith(".png") or filepath.endswith(".svg"):
             # save as png/svg, but json first
-            spec = self._get_vega(include_data = True)
+            spec = self.get_vega(include_data = True)
             EXTENSION_START_INDEX = -3
             extension = filepath[EXTENSION_START_INDEX:]
             temp_file_tuple = _mkstemp()
@@ -240,25 +240,23 @@ class Plot(object):
             raise NotImplementedError("filename must end in" +
                 " .json, .svg, or .png")
 
-    def _get_data(self):
+    def get_data(self):
         return _json.loads(self.__proxy__.call_function('get_data'))
 
-    def _get_vega(self, include_data=True):
-        if(include_data):
-            spec = _json.loads(self.__proxy__.call_function('get_spec'))
-            data = _json.loads(self.__proxy__.call_function('get_data'))
-            for x in range(len(spec["data"])):
-                if(spec["data"][x]["name"] == "source_2"):
-                    spec["data"][x] = data
-                    break
-            return spec
-        else:
-            return _json.loads(self.__proxy__.call_function('get_spec'))
+    def get_vega(self, include_data=True):
+        # TODO: allow autodetection of light/dark mode.
+        # Disabled for now, since the GUI side needs some work (ie. background color).
+        plot_variation = 0x10 # force light mode
+        return _json.loads(self.__proxy__.call_function('get_spec', {'include_data': include_data, 'variation': plot_variation}))
+
+    def materialize(self):
+        self.__proxy__.call_function('materialize')
 
     def _repr_javascript_(self):
         from IPython.core.display import display, HTML
 
-        vega_spec = self._get_vega(True)
+        self.materialize()
+        vega_spec = self.get_vega(True)
 
         vega_html = '<html lang="en"> \
                         <head> \


### PR DESCRIPTION
This change adds C++ API to include (streaming) data in the Vega spec
returned by the Plot.

This was previously implemented only in Python. Implementing in C++ is
both more efficient, and will allow API consumers beneath Python to have
this functionality.