### PR TITLE
Fix axis title bug in Box & Whisker plot

### DIFF
--- a/src/unity/lib/visualization/show.cpp
+++ b/src/unity/lib/visualization/show.cpp
@@ -64,7 +64,7 @@ namespace turi {
           // TODO -- actually show this with the axes the user asked for
           // but for now, just flip them
 
-          return plot_boxes_and_whiskers(y, x, xlabel, ylabel, title);
+          return plot_boxes_and_whiskers(y, x, ylabel, xlabel, title);
         } else if (isNumeric(y) && isString(x)) {
 
           return plot_boxes_and_whiskers(x, y, xlabel, ylabel, title);


### PR DESCRIPTION
When the axes are flipped from what the user intended (because we only
have a vertical-layout box plot currently), we also need to flip the
axis titles.