### PR TITLE
Move test_object_detector_export_coreml_with_nms to its own file with the appropriate protobuf workarounds

### DIFF
--- a/test/unity/toolkits/CMakeLists.txt
+++ b/test/unity/toolkits/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(sparse_similarity)
 add_subdirectory(pattern_mining)
 add_subdirectory(neural_net)
 add_subdirectory(object_detection)
+add_subdirectory(coreml_export)
 
 make_boost_test(kmeans_test.cxx
   REQUIRES unity_clustering util numerics

--- a/test/unity/toolkits/coreml_export/CMakeLists.txt
+++ b/test/unity/toolkits/coreml_export/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(unity_test_toolkits)
+
+make_boost_test(test_neural_nets_model_exporter.cxx
+  REQUIRES
+    unity_toolkits
+  COMPILE_FLAGS_EXTRA_GCC
+    -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
+    -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
+)

--- a/test/unity/toolkits/coreml_export/test_neural_nets_model_exporter.cxx
+++ b/test/unity/toolkits/coreml_export/test_neural_nets_model_exporter.cxx
@@ -1,0 +1,95 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_neural_nets_model_exporter
+
+#include <unity/toolkits/coreml_export/neural_net_models_exporter.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_include.hpp>
+#include <util/test_macros.hpp>
+
+namespace turi {
+namespace object_detection {
+namespace {
+
+using turi::neural_net::model_spec;
+
+BOOST_AUTO_TEST_CASE(test_object_detector_export_coreml_with_nms) {
+    
+    const std::string test_annotations_name = "test_annotations";
+    const std::string test_image_name = "test_image";
+    const std::vector<std::string> test_class_labels = { "label1", "label2" };
+    static constexpr size_t test_max_iterations = 4;
+    double test_iou_threshold = 0.55;
+    double test_confidence_threshold = 0.15;
+    
+    std::map<std::string, flexible_type> options;
+    options["include_non_maximum_suppression"] = 1;
+    options["iou_threshold"] = test_iou_threshold;
+    options["confidence_threshold"] = test_confidence_threshold;
+    
+    flex_dict user_defined_metadata;
+    user_defined_metadata.emplace_back("model", "model");
+    user_defined_metadata.emplace_back("max_iterations", test_max_iterations);
+    user_defined_metadata.emplace_back("training_iterations", test_max_iterations);
+    user_defined_metadata.emplace_back("include_non_maximum_suppression", "True");
+    user_defined_metadata.emplace_back("feature", test_image_name);
+    user_defined_metadata.emplace_back("annotations", test_annotations_name);
+    user_defined_metadata.emplace_back("classes", "label1, label2");
+    user_defined_metadata.emplace_back("type", "object_detector");
+    user_defined_metadata.emplace_back("confidence_threshold", options["confidence_threshold"]);
+    user_defined_metadata.emplace_back("iou_threshold", options["iou_threshold"]);
+    
+    flex_list t_class_labels = flex_list(test_class_labels.begin(), test_class_labels.end());
+    
+    model_spec yolo_nn_spec;
+    yolo_nn_spec.add_convolution("test_layer", "image", 16, 16, 3,
+                                 /* weight_init_fn */ [](float*w , float* w_end) {
+                                     for (int i = 0; i < w_end - w; ++i) {
+                                         w[i] = static_cast<float>(i);
+                                     }
+                                 });
+    
+    std::shared_ptr<coreml::MLModelWrapper> model_wrapper =
+    export_object_detector_model(yolo_nn_spec,
+                                 13 * 32,
+                                 13 * 32,
+                                 test_class_labels.size(),
+                                 13 * 13 * 15,
+                                 std::move(user_defined_metadata), std::move(t_class_labels),
+                                 std::move(options));
+    
+    std::shared_ptr<CoreML::Model> c_model = model_wrapper->coreml_model();
+    auto p_model = c_model->getProto();
+    
+    const ::CoreML::Specification::Pipeline &pipeline = p_model.pipeline();
+    
+    const auto &model_nms = pipeline.models(1).nonmaximumsuppression();
+    
+    auto labels = model_nms.stringclasslabels();
+    for (int i = 0; i < labels.vector_size(); i++) {
+        TS_ASSERT_EQUALS(labels.vector(i), test_class_labels[i]);
+    }
+    TS_ASSERT_EQUALS(model_nms.iouthreshold(), test_iou_threshold);
+    TS_ASSERT_EQUALS(model_nms.confidencethreshold(), test_confidence_threshold);
+    TS_ASSERT_EQUALS(model_nms.confidenceinputfeaturename(), "raw_confidence");
+    TS_ASSERT_EQUALS(model_nms.coordinatesinputfeaturename(), "raw_coordinates");
+    TS_ASSERT_EQUALS(model_nms.iouthresholdinputfeaturename(), "iouThreshold");
+    TS_ASSERT_EQUALS(model_nms.confidencethresholdinputfeaturename(), "confidenceThreshold");
+    TS_ASSERT_EQUALS(model_nms.confidenceoutputfeaturename(), "confidence");
+    TS_ASSERT_EQUALS(model_nms.coordinatesoutputfeaturename(), "coordinates");
+    
+}
+    
+}  // namespace
+}  // namespace object_detection
+}  // namespace turi

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -7,8 +7,6 @@
 #define BOOST_TEST_MODULE test_object_detector
 
 #include <unity/toolkits/object_detection/object_detector.hpp>
-#include <unity/toolkits/coreml_export/neural_net_models_exporter.hpp>
-#include <unity/toolkits/coreml_export/MLModel/src/Model.hpp>
 
 #include <array>
 #include <deque>
@@ -477,73 +475,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
   // Deconstructing `model` here will assert that every expected call to a
   // mocked-out method has been called.
-}
-    
-BOOST_AUTO_TEST_CASE(test_object_detector_export_coreml_with_nms) {
-    
-    const std::string test_annotations_name = "test_annotations";
-    const std::string test_image_name = "test_image";
-    const std::vector<std::string> test_class_labels = { "label1", "label2" };
-    static constexpr size_t test_max_iterations = 4;
-    double test_iou_threshold = 0.55;
-    double test_confidence_threshold = 0.15;
-    
-    std::map<std::string, flexible_type> options;
-    options["include_non_maximum_suppression"] = 1;
-    options["iou_threshold"] = test_iou_threshold;
-    options["confidence_threshold"] = test_confidence_threshold;
-    
-    flex_dict user_defined_metadata;
-    user_defined_metadata.emplace_back("model", "model");
-    user_defined_metadata.emplace_back("max_iterations", test_max_iterations);
-    user_defined_metadata.emplace_back("training_iterations", test_max_iterations);
-    user_defined_metadata.emplace_back("include_non_maximum_suppression", "True");
-    user_defined_metadata.emplace_back("feature", test_image_name);
-    user_defined_metadata.emplace_back("annotations", test_annotations_name);
-    user_defined_metadata.emplace_back("classes", "label1, label2");
-    user_defined_metadata.emplace_back("type", "object_detector");
-    user_defined_metadata.emplace_back("confidence_threshold", options["confidence_threshold"]);
-    user_defined_metadata.emplace_back("iou_threshold", options["iou_threshold"]);
-    
-    flex_list t_class_labels = flex_list(test_class_labels.begin(), test_class_labels.end());
-    
-    model_spec yolo_nn_spec;
-    yolo_nn_spec.add_convolution("test_layer", "image", 16, 16, 3,
-                                 /* weight_init_fn */ [](float*w , float* w_end) {
-                                     for (int i = 0; i < w_end - w; ++i) {
-                                         w[i] = static_cast<float>(i);
-                                     }
-                                 });
-    
-    std::shared_ptr<coreml::MLModelWrapper> model_wrapper =
-    export_object_detector_model(yolo_nn_spec,
-                                 13 * 32,
-                                 13 * 32,
-                                 test_class_labels.size(),
-                                 13 * 13 * 15,
-                                 std::move(user_defined_metadata), std::move(t_class_labels),
-                                 std::move(options));
-    
-    std::shared_ptr<CoreML::Model> c_model = model_wrapper->coreml_model();
-    auto p_model = c_model->getProto();
-    
-    const ::CoreML::Specification::Pipeline &pipeline = p_model.pipeline();
-    
-    const auto &model_nms = pipeline.models(1).nonmaximumsuppression();
-    
-    auto labels = model_nms.stringclasslabels();
-    for (int i = 0; i < labels.vector_size(); i++) {
-        TS_ASSERT_EQUALS(labels.vector(i), test_class_labels[i]);
-    }
-    TS_ASSERT_EQUALS(model_nms.iouthreshold(), test_iou_threshold);
-    TS_ASSERT_EQUALS(model_nms.confidencethreshold(), test_confidence_threshold);
-    TS_ASSERT_EQUALS(model_nms.confidenceinputfeaturename(), "raw_confidence");
-    TS_ASSERT_EQUALS(model_nms.coordinatesinputfeaturename(), "raw_coordinates");
-    TS_ASSERT_EQUALS(model_nms.iouthresholdinputfeaturename(), "iouThreshold");
-    TS_ASSERT_EQUALS(model_nms.confidencethresholdinputfeaturename(), "confidenceThreshold");
-    TS_ASSERT_EQUALS(model_nms.confidenceoutputfeaturename(), "confidence");
-    TS_ASSERT_EQUALS(model_nms.coordinatesoutputfeaturename(), "coordinates");
-    
 }
     
 }  // namespace


### PR DESCRIPTION
Bleargh, in some Linux configurations the new test was failing to compile because test_object_detector.cxx wasn't being compiled with the magic incantations to avoid errors in protobuf headers.

Rather than allow this weirdness to spread to test_object_detector.cxx, I just moved the test to a new file, which makes some sense anyway since the code under test is actually defined in unity_coreml_export, not unity_object_detection.