### PR TITLE
Updated a compiler flag to get external lib to compile under clang edge.

### DIFF
--- a/src/external/aws-sdk-cpp/CMakeLists.txt
+++ b/src/external/aws-sdk-cpp/CMakeLists.txt
@@ -250,6 +250,7 @@ make_library(aws-sdk-cpp
     curl openssl uuid
   COMPILE_FLAGS_EXTRA_CLANG
     -Wno-delete-non-virtual-dtor
+    -Wno-return-std-move
   )
 
 target_include_directories(aws-sdk-cpp SYSTEM


### PR DESCRIPTION
Current master doesn't compile in release mode on clang edge.