### PR TITLE
Implement object_detector::evaluate (C-API)

### DIFF
--- a/src/unity/toolkits/neural_net/image_augmentation.cpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.cpp
@@ -72,7 +72,7 @@ bool operator==(const image_annotation& a, const image_annotation& b) {
 image_augmenter::result resize_only_image_augmenter::prepare_images(
     std::vector<labeled_image> source_batch) {
 
-  const size_t n = source_batch.size();
+  const size_t n = opts_.batch_size;
   const size_t h = opts_.output_height;
   const size_t w = opts_.output_width;
   constexpr size_t c = 3;
@@ -80,11 +80,15 @@ image_augmenter::result resize_only_image_augmenter::prepare_images(
   result res;
   res.annotations_batch.reserve(n);
 
+  // Discard any source data in excess of the batch size.
+  if (source_batch.size() > n) {
+    source_batch.resize(n);
+  }
+
   // Allocate a float vector large enough to contain the entire image batch.
   std::vector<float> result_array(n * h * w * c);
 
-  // TODO: Parallelize this computation, which is currently the bottleneck in
-  // training!
+  // Note: this computation could probably be parallelized, if needed.
   auto out_it = result_array.begin();
   for (labeled_image& source : source_batch) {
     // Resize the input image.

--- a/src/unity/toolkits/neural_net/image_augmentation.cpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.cpp
@@ -32,6 +32,26 @@ void image_box::clip(image_box clip_box) {
   height = y_max - y;
 }
 
+void image_box::extend(const image_box& other) {
+
+  if (other.empty()) return;
+
+  if (empty()) {
+
+    *this = other;
+
+  } else {
+
+    float x_max = std::max(x + width, other.x + other.width);
+    x = std::min(x, other.x);
+    width = x_max - x;
+
+    float y_max = std::max(y + height, other.y + other.height);
+    y = std::min(y, other.y);
+    height = y_max - y;
+  }
+}
+
 bool operator==(const image_box& a, const image_box& b) {
   return a.x == b.x && a.y == b.y && a.width == b.width && a.height == b.height;
 }

--- a/src/unity/toolkits/neural_net/image_augmentation.hpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.hpp
@@ -29,10 +29,11 @@ struct image_box {
     : x(x), y(y), width(width), height(height)
   {}
 
+  bool empty() const { return width <= 0.f || height <= 0.f; }
+
   // Computes the area if the width and height are positive, otherwise returns 0
   float area() const {
-    if (width < 0.f || height < 0.f) return 0.f;
-    return width * height;
+    return empty() ? 0.f : (width * height);
   }
 
   // Divides each coordinate and length by the appropriate normalizer.
@@ -42,6 +43,10 @@ struct image_box {
   // intersection exists, then the result will have area() of 0.f (and may have
   // negative width or height).
   void clip(image_box clip_box = image_box(0.f, 0.f, 1.f, 1.f));
+
+  // Grows this instance (minimally) so that its area contains the (non-empty)
+  // area of the other image_box.
+  void extend(const image_box& other);
 
   float x = 0.f;
   float y = 0.f;

--- a/src/unity/toolkits/neural_net/image_augmentation.hpp
+++ b/src/unity/toolkits/neural_net/image_augmentation.hpp
@@ -161,6 +161,9 @@ public:
    */
   struct options {
 
+    /** The N dimension of the resulting float array. */
+    size_t batch_size = 0;
+
     /** The W dimension of the resulting float array. */
     size_t output_width = 0;
 
@@ -224,7 +227,7 @@ public:
 
     /**
      * The transformed annotations for each augmented image. This vector's size
-     * should equal the size of the N dimension in the image_batch above, and
+     * should equal the size of the source batch that generated the result, and
      * each inner vector should have the same length as the corresponding input
      * image's annotations vector. */
     std::vector<std::vector<image_annotation>> annotations_batch;
@@ -237,6 +240,9 @@ public:
 
   /**
    * Performs augmentation on a batch of images (and their annotations).
+   *
+   * If the source batch is smaller than the batch size specified in the
+   * options, then the result is padded with zeroes as needed.
    */
   virtual result prepare_images(std::vector<labeled_image> source_batch) = 0;
 };

--- a/src/unity/toolkits/object_detection/CMakeLists.txt
+++ b/src/unity/toolkits/object_detection/CMakeLists.txt
@@ -6,6 +6,7 @@ make_library(unity_object_detection
     object_detector.cpp
     od_data_iterator.cpp
     od_yolo.cpp
+    od_evaluation.cpp
   REQUIRES
     image_io
     random

--- a/src/unity/toolkits/object_detection/object_detector.cpp
+++ b/src/unity/toolkits/object_detection/object_detector.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <limits>
 #include <numeric>
+#include <queue>
 #include <utility>
 #include <vector>
 
@@ -20,6 +21,7 @@
 #include <logger/logger.hpp>
 #include <random/random.hpp>
 #include <unity/toolkits/coreml_export/neural_net_models_exporter.hpp>
+#include <unity/toolkits/object_detection/od_evaluation.hpp>
 #include <unity/toolkits/object_detection/od_yolo.hpp>
 
 using turi::coreml::MLModelWrapper;
@@ -67,6 +69,12 @@ constexpr float MPS_LOSS_MULTIPLIER = 8;
 
 constexpr float BASE_LEARNING_RATE = 0.001f / MPS_LOSS_MULTIPLIER;
 
+constexpr float DEFAULT_NON_MAXIMUM_SUPPRESSION_THRESHOLD = 0.45f;
+
+// Predictions with confidence scores below this threshold will be discarded
+// before generation precision-recall curves.
+constexpr float EVAL_CONFIDENCE_THRESHOLD = 0.001f;
+
 // Each bounding box is evaluated relative to a list of pre-defined sizes.
 const std::vector<std::pair<float, float>>& anchor_boxes() {
   static const std::vector<std::pair<float, float>>* const default_boxes =
@@ -79,6 +87,19 @@ const std::vector<std::pair<float, float>>& anchor_boxes() {
       });
   return *default_boxes;
 };
+
+// For computing average precision averaged over IOU thresholds from 50% to 90%,
+// at intervals of 5%, as popularized by COCO.
+std::vector<float> iou_thresholds_for_evaluation() {
+
+  std::vector<float> result;
+
+  for (float x = 50.f; x < 100.f; x += 5.f) {
+    result.push_back(x / 100.f);
+  }
+
+  return result;
+}
 
 // These are the fixed values that the Python implementation currently passes
 // into TCMPS.
@@ -108,6 +129,14 @@ float_array_map get_training_config() {
       shared_float_array::wrap(10.0f * MPS_LOSS_MULTIPLIER);
   config["use_sgd"]                  = shared_float_array::wrap(1.0f);
   config["weight_decay"]             = shared_float_array::wrap(0.0005f);
+  return config;
+}
+
+float_array_map get_prediction_config() {
+  float_array_map config;
+  config["mode"]                     = shared_float_array::wrap(2.0f);
+  config["od_include_loss"]          = shared_float_array::wrap(0.0f);
+  config["od_include_network"]       = shared_float_array::wrap(1.0f);
   return config;
 }
 
@@ -286,6 +315,167 @@ void object_detector::train(gl_sframe data,
   nn_spec_->update_params(trained_weights);
 }
 
+variant_map_type object_detector::evaluate(
+    gl_sframe data, std::string metric,
+    std::map<std::string, flexible_type> opts) {
+
+  // TODO: Support user-configurable metric and options.
+
+  std::string image_column_name = read_state<flex_string>("feature");
+  std::string annotations_column_name = read_state<flex_string>("annotations");
+  size_t batch_size = static_cast<size_t>(options.value("batch_size"));
+  float iou_threshold =
+      read_state<flex_float>("non_maximum_suppression_threshold");
+
+  // Bind the data to a data iterator.
+  std::unique_ptr<data_iterator> data_iter = create_iterator(
+      data, annotations_column_name, image_column_name, /* repeat */ false);
+
+  // Instantiate the compute context.
+  std::unique_ptr<compute_context> ctx = create_compute_context();
+  if (ctx == nullptr) {
+    log_and_throw("No neural network compute context provided");
+  }
+
+  // Instantiate the data augmenter. Don't enable any of the actual
+  // augmentations, just resize the input images to the desired shape.
+  image_augmenter::options augmenter_opts;
+  augmenter_opts.batch_size = batch_size;
+  augmenter_opts.output_width = GRID_SIZE * SPATIAL_REDUCTION;
+  augmenter_opts.output_height = GRID_SIZE * SPATIAL_REDUCTION;
+  std::unique_ptr<image_augmenter> augmenter =
+      ctx->create_image_augmenter(augmenter_opts);
+
+  // Instantiate the NN backend.
+  // For each anchor box, we have 4 bbox coords + 1 conf + one-hot class labels
+  int num_outputs_per_anchor = 5 + read_state<int>("num_classes");
+  int num_output_channels = num_outputs_per_anchor * anchor_boxes().size();
+  std::unique_ptr<cnn_module> module = ctx->create_object_detector(
+      /* n */     options.value("batch_size"),
+      /* c_in */  NUM_INPUT_CHANNELS,
+      /* h_in */  GRID_SIZE * SPATIAL_REDUCTION,
+      /* w_in */  GRID_SIZE * SPATIAL_REDUCTION,
+      /* c_out */ num_output_channels,
+      /* h_out */ GRID_SIZE,
+      /* w_out */ GRID_SIZE,
+      get_prediction_config(),
+      get_model_params());
+
+  // Initialize the metric calculator
+  average_precision_calculator calculator(
+      data_iter->class_labels().size(), iou_thresholds_for_evaluation());
+
+  // To support double buffering, use a queue of pending inference results.
+  std::queue<image_augmenter::result> pending_batches;
+
+  // Helper function to process results until the queue reaches a given size.
+  auto pop_until_size = [&](size_t remaining) {
+
+    while (pending_batches.size() > remaining) {
+
+      // Pop one batch from the queue.
+      image_augmenter::result batch = pending_batches.front();
+      pending_batches.pop();
+
+      for (size_t i = 0; i < batch.annotations_batch.size(); ++i) {
+
+        // For this row (corresponding to one image), extract the prediction.
+        shared_float_array raw_prediction = batch.image_batch[i];
+
+        // Translate the raw output into predicted labels and bounding boxes.
+        std::vector<image_annotation> predicted_annotations =
+            convert_yolo_to_annotations(raw_prediction, anchor_boxes(),
+                                        EVAL_CONFIDENCE_THRESHOLD);
+
+        // Remove overlapping predictions.
+        predicted_annotations = apply_non_maximum_suppression(
+            std::move(predicted_annotations), iou_threshold);
+
+        // Tally the predictions and ground truth labels.
+        calculator.add_row(predicted_annotations, batch.annotations_batch[i]);
+      }
+    }
+  };
+
+  // Iterate through the data once.
+  std::vector<labeled_image> input_batch = data_iter->next_batch(batch_size);
+  while (!input_batch.empty()) {
+
+    // Wait until we have just one asynchronous batch outstanding. The work
+    // below should be concurrent with the neural net inference for that batch.
+    pop_until_size(1);
+
+    image_augmenter::result result_batch;
+
+    // Instead of giving the ground truth data to the image augmenter and the
+    // neural net, instead save them for later, pairing them with the future
+    // predictions.
+    result_batch.annotations_batch.resize(input_batch.size());
+    for (size_t i = 0; i < input_batch.size(); ++i) {
+      result_batch.annotations_batch[i] = std::move(input_batch[i].annotations);
+      input_batch[i].annotations.clear();
+    }
+
+    // Use the image augmenter to format the images into float arrays, and
+    // submit them to the neural net.
+    image_augmenter::result prepared_input_batch =
+        augmenter->prepare_images(std::move(input_batch));
+    auto pending_prediction = std::make_shared<deferred_float_array>(
+        module->predict(prepared_input_batch.image_batch));
+    result_batch.image_batch = shared_float_array(pending_prediction);
+
+    // Add the pending result to our queue and move on to the next input batch.
+    pending_batches.push(std::move(result_batch));
+    input_batch = data_iter->next_batch(batch_size);
+  }
+
+  // Process all remaining batches.
+  pop_until_size(0);
+
+  // Compute the average precision (area under the precision-recall curve) for
+  // each combination of IOU threshold and class label.
+  flex_list class_labels = read_state<flex_list>("classes");
+  std::vector<std::map<float,float>> raw_average_precisions =
+      calculator.evaluate();
+  ASSERT_EQ(class_labels.size(), raw_average_precisions.size());
+
+  std::vector<float> average_precision_50(class_labels.size());
+  std::vector<float> average_precision(class_labels.size());
+  for (size_t i = 0; i < class_labels.size(); ++i) {
+
+    // Extract the average precision for this class at IOU threshold 50%.
+    average_precision_50[i] = raw_average_precisions[i].at(0.5f);
+
+    // Compute the average precision for this class averaged over all the IOU
+    // threshold.
+    float sum = 0.f;
+    for (const auto& threshold_and_ap : raw_average_precisions[i]) {
+      sum += threshold_and_ap.second;
+    }
+    average_precision[i] = sum /= raw_average_precisions[i].size();
+  }
+
+  // Store the requested summary statistics.
+  // TODO: Respect the `metric` argument instead of supplying all metrics. Even
+  // though almost all the cost of computing these metrics is shared?
+  auto create_dict = [&class_labels](const std::vector<float>& v) {
+    variant_map_type class_map;
+    for (size_t i = 0; i < class_labels.size(); ++i) {
+      class_map[class_labels[i]] = v[i];
+    }
+    return class_map;
+  };
+  auto compute_mean = [](const std::vector<float>& v) {
+    return std::accumulate(v.begin(), v.end(), 0.f) / v.size();
+  };
+  variant_map_type result_map;
+  result_map["average_precision_50"] = create_dict(average_precision_50);
+  result_map["average_precision"] = create_dict(average_precision);
+  result_map["mean_average_precision_50"] = compute_mean(average_precision_50);
+  result_map["mean_average_precision"] = compute_mean(average_precision);
+  return result_map;
+}
+
 std::unique_ptr<model_spec> object_detector::init_model(
     const std::string& pretrained_mlmodel_path) const {
 
@@ -444,12 +634,13 @@ std::shared_ptr<MLModelWrapper> object_detector::export_to_coreml(
 
 std::unique_ptr<data_iterator> object_detector::create_iterator(
     gl_sframe data, std::string annotations_column_name,
-    std::string image_column_name) const {
+    std::string image_column_name, bool repeat) const {
 
   data_iterator::parameters iterator_params;
   iterator_params.data = std::move(data);
   iterator_params.annotations_column_name = std::move(annotations_column_name);
   iterator_params.image_column_name = std::move(image_column_name);
+  iterator_params.repeat = repeat;
 
   return std::unique_ptr<data_iterator>(
       new simple_data_iterator(iterator_params));  
@@ -466,8 +657,8 @@ void object_detector::init_train(gl_sframe data,
                                  std::map<std::string, flexible_type> opts) {
 
   // Bind the data to a data iterator.
-  training_data_iterator_ = create_iterator(data, annotations_column_name,
-                                            image_column_name);
+  training_data_iterator_ = create_iterator(
+      data, annotations_column_name, image_column_name, /* repeat */ true);
 
   // Instantiate the compute context.
   training_compute_context_ = create_compute_context();
@@ -486,24 +677,6 @@ void object_detector::init_train(gl_sframe data,
 
   // Load the pre-trained model from the provided path.
   nn_spec_ = init_model(mlmodel_path);
-  float_array_map raw_model_params = nn_spec_->export_params_view();
-
-  // Strip the substring "_fwd" from any parameter names, for compatibility with
-  // the training backend. (We preserve the substring in nn_spec_ for inclusion
-  // in the final exported model.)
-  // TODO: Someday, this will all be an implementation detail of each
-  // cnn_module implementation, once they actually take model_spec values as
-  // inputs. Or maybe we should just not use "_fwd" in the exported model?
-  float_array_map model_params;
-  for (const float_array_map::value_type& kv : raw_model_params) {
-    const std::string modifier = "_fwd";
-    std::string name = kv.first;
-    size_t pos = name.find(modifier);
-    if (pos != std::string::npos) {
-      name.erase(pos, modifier.size());
-    }
-    model_params[name] = kv.second;
-  }
 
   // Validate options, and infer values for unspecified options. Note that this
   // depends on training data statistics in the general case.
@@ -521,6 +694,8 @@ void object_detector::init_train(gl_sframe data,
       { "input_image_shape", flex_list(input_image_shape.begin(),
                                        input_image_shape.end()) },
       { "model", "darknet-yolo" },
+      { "non_maximum_suppression_threshold",
+        DEFAULT_NON_MAXIMUM_SUPPRESSION_THRESHOLD },
       { "num_bounding_boxes", training_data_iterator_->num_instances() },
       { "num_classes", training_data_iterator_->class_labels().size() },
       { "num_examples", data.size() },
@@ -547,7 +722,7 @@ void object_detector::init_train(gl_sframe data,
       /* h_out */ GRID_SIZE,
       /* w_out */ GRID_SIZE,
       get_training_config(),
-      std::move(model_params));
+      get_model_params());
 
   // Print the header last, after any logging triggered by initialization above.
   if (training_table_printer_) {
@@ -610,6 +785,30 @@ void object_detector::perform_training_iteration() {
   // Save the result, which is a future that can synchronize with the
   // completion of this batch.
   pending_training_batches_.emplace(iteration_idx, std::move(loss_batch));
+}
+
+float_array_map object_detector::get_model_params() const {
+
+  float_array_map raw_model_params = nn_spec_->export_params_view();
+
+  // Strip the substring "_fwd" from any parameter names, for compatibility with
+  // the compute backend. (We preserve the substring in nn_spec_ for inclusion
+  // in the final exported model.)
+  // TODO: Someday, this will all be an implementation detail of each
+  // cnn_module implementation, once they actually take model_spec values as
+  // inputs. Or maybe we should just not use "_fwd" in the exported model?
+  float_array_map model_params;
+  for (const float_array_map::value_type& kv : raw_model_params) {
+    const std::string modifier = "_fwd";
+    std::string name = kv.first;
+    size_t pos = name.find(modifier);
+    if (pos != std::string::npos) {
+      name.erase(pos, modifier.size());
+    }
+    model_params[name] = kv.second;
+  }
+
+  return model_params;
 }
 
 shared_float_array object_detector::prepare_label_batch(

--- a/src/unity/toolkits/object_detection/object_detector.cpp
+++ b/src/unity/toolkits/object_detection/object_detector.cpp
@@ -624,9 +624,8 @@ shared_float_array object_detector::prepare_label_batch(
   float* result_out = result.data();
   for (const std::vector<image_annotation>& annotations : annotations_batch) {
 
-    data_iterator::convert_annotations_to_yolo(
-        annotations, GRID_SIZE, GRID_SIZE, anchor_boxes().size(), num_classes,
-        result_out);
+    convert_annotations_to_yolo(annotations, GRID_SIZE, GRID_SIZE,
+                                anchor_boxes().size(), num_classes, result_out);
 
     result_out += batch_stride;
   }

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -29,8 +29,7 @@ class EXPORT object_detector: public ml_model_base {
 
   // ml_model_base interface
 
-  void init_options(const std::map<std::string,
-                    flexible_type>& options) override;
+  void init_options(const std::map<std::string, flexible_type>& opts) override;
   size_t get_version() const override;
   void save_impl(oarchive& oarc) const override;
   void load_version(iarchive& iarc, size_t version) override;
@@ -39,9 +38,9 @@ class EXPORT object_detector: public ml_model_base {
 
   void train(gl_sframe data, std::string annotations_column_name,
              std::string image_column_name,
-             std::map<std::string, flexible_type> options);
+             std::map<std::string, flexible_type> opts);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename, std::map<std::string, flexible_type> options);
+      std::string filename, std::map<std::string, flexible_type> opts);
 
   // Register with Unity server
 
@@ -116,10 +115,10 @@ class EXPORT object_detector: public ml_model_base {
   // Support for iterative training.
   // TODO: Expose via forthcoming C-API checkpointing mechanism?
 
-  void init_train(gl_sframe data, std::string annotations_column_name,
-                  std::string image_column_name,
-                  std::map<std::string, flexible_type> options);
-  void perform_training_iteration();
+  virtual void init_train(gl_sframe data, std::string annotations_column_name,
+                          std::string image_column_name,
+                          std::map<std::string, flexible_type> opts);
+  virtual void perform_training_iteration();
 
   // Utility code
 

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -68,7 +68,6 @@ class EXPORT object_detector: public ml_model_base {
       "    The number of training iterations. If 0, then it will be automatically\n"
       "    be determined based on the amount of data you provide.\n"
   );
-  // TODO: Addition training options: batch_size, max_iterations, etc.
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename",
     "options");

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -39,6 +39,8 @@ class EXPORT object_detector: public ml_model_base {
   void train(gl_sframe data, std::string annotations_column_name,
              std::string image_column_name,
              std::map<std::string, flexible_type> opts);
+  variant_map_type evaluate(gl_sframe data, std::string metric,
+                            std::map<std::string, flexible_type> opts);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename, std::map<std::string, flexible_type> opts);
 
@@ -67,6 +69,12 @@ class EXPORT object_detector: public ml_model_base {
       "    The number of training iterations. If 0, then it will be automatically\n"
       "    be determined based on the amount of data you provide.\n"
   );
+
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric",
+                                 "options");
+  register_defaults("evaluate",
+      {{"metric", std::string("auto")},
+       {"options", to_variant(std::map<std::string, flexible_type>())}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename",
     "options");
@@ -100,7 +108,7 @@ class EXPORT object_detector: public ml_model_base {
   // Factory for data_iterator
   virtual std::unique_ptr<data_iterator> create_iterator(
       gl_sframe data, std::string annotations_column_name,
-      std::string image_column_name) const;
+      std::string image_column_name, bool repeat) const;
 
   // Factory for compute_context
   virtual
@@ -128,6 +136,9 @@ class EXPORT object_detector: public ml_model_base {
   }
 
  private:
+
+  neural_net::float_array_map get_model_params() const;
+
   neural_net::shared_float_array prepare_label_batch(
       std::vector<std::vector<neural_net::image_annotation>> annotations_batch)
       const;

--- a/src/unity/toolkits/object_detection/od_data_iterator.cpp
+++ b/src/unity/toolkits/object_detection/od_data_iterator.cpp
@@ -12,7 +12,6 @@ namespace object_detection {
 namespace {
 
 using neural_net::image_annotation;
-using neural_net::image_box;
 using neural_net::labeled_image;
 using neural_net::shared_float_array;
 
@@ -124,81 +123,6 @@ std::vector<image_annotation> parse_annotations(
 }
 
 }  // namespace
-
-// static
-void data_iterator::convert_annotations_to_yolo(
-    const std::vector<image_annotation>& annotations, size_t output_height,
-    size_t output_width, size_t num_anchors, size_t num_classes, float* out) {
-
-  // Number of floats to represent bbox (4), confidence (1), and a one-hot
-  // encoding of the class (num_classes).
-  size_t label_size = 5 + num_classes;
-
-  // Initialize the output buffer. We can iterate by "label", which is
-  // conceptually the lowest-order dimension of the (H,W,num_anchors,label_size)
-  // array.
-  // TODO: Add a mutable float_array interface so we can validate size.
-  float* out_end =
-      out + output_height * output_width * num_anchors * label_size;
-  for (float* ptr = out; ptr < out_end; ptr += label_size) {
-
-    // Initialize the bounding boxes and confidences to 0.
-    std::fill(ptr, ptr + 5, 0.f);
-
-    // Initialize the class probabilities for each output-grid cell and anchor
-    // box to 1/num_classes.
-    std::fill(ptr + 5, ptr + label_size, 1.0f / num_classes);
-  }
-
-  // Iterate through all the annotations for one image.
-  for (const image_annotation& annotation : annotations) {
-
-    // Scale the bounding box to the output grid, converting to the YOLO
-    // representation, defining each box by its center.
-    const image_box& bbox = annotation.bounding_box;
-    float center_x = output_width * (bbox.x + (bbox.width / 2.f));
-    float center_y = output_height * (bbox.y + (bbox.height / 2.f));
-    float width = output_width * bbox.width;
-    float height = output_height * bbox.height;
-
-    // Skip bounding boxes with trivial area, to guard against issues in
-    // augmentation.
-    if (width * height < 0.001f) continue;
-
-    // Write the label into the output grid cell containing the bounding box
-    // center.
-    float icenter_x = std::floor(center_x);
-    float icenter_y = std::floor(center_y);
-    if (0.f <= icenter_x && icenter_x < output_width &&
-        0.f <= icenter_y && icenter_y < output_height) {
-
-      size_t output_grid_stride = num_anchors * label_size;
-      size_t output_grid_offset = static_cast<size_t>(icenter_x) +
-          static_cast<size_t>(icenter_y) * output_width;
-
-      // Write the label once for each anchor box.
-      float* anchor_out = out + output_grid_offset * output_grid_stride;
-      for (size_t anchor_idx = 0; anchor_idx < num_anchors; ++anchor_idx) {
-
-        // Write YOLO-formatted bounding box. YOLO uses (x, y)/(w, h) order.
-        anchor_out[0] = center_x - icenter_x;
-        anchor_out[1] = center_y - icenter_y;
-        anchor_out[2] = width;
-        anchor_out[3] = height;
-
-        // Set confidence to 1.
-        anchor_out[4] = 1.f;
-
-        // One-hot encoding of the class label.
-        std::fill(anchor_out + 5, anchor_out + label_size, 0.f);
-        anchor_out[5 + annotation.identifier] = 1.f;
-
-        // Advance the output iterator to the next anchor.
-        anchor_out += label_size;
-      }
-    }
-  }
-}
 
 simple_data_iterator::annotation_properties
 simple_data_iterator::compute_properties(const gl_sarray& annotations) {

--- a/src/unity/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/unity/toolkits/object_detection/od_data_iterator.hpp
@@ -26,27 +26,6 @@ class data_iterator {
 public:
 
   /**
-   * Writes a list of image_annotation values into an output float buffer.
-   *
-   * \param annotations The list of annotations (for one image) to write
-   * \param output_height The height of the YOLO output grid
-   * \param output_width The width of the YOLO output grid
-   * \param num_anchors The number of YOLO anchors
-   * \param num_classes The number of classes in the output one-hot encoding
-   * \param out Address to a float buffer of size output_height * output_width *
-   *            num_anchors * (5 + num_classes)
-   * \todo Add a mutable_float_array or shared_float_buffer type for functions
-   *       like this one to write into.
-   * \todo This strictly speaking doesn't belong in this data iterator type but
-   *       probably doesn't warrant its own file yet (and would be nice not to
-   *       bury in object_detector.cpp).
-   */
-  static void convert_annotations_to_yolo(
-      const std::vector<neural_net::image_annotation>& annotations,
-      size_t output_height, size_t output_width, size_t num_anchors,
-      size_t num_classes, float* out);
-
-  /**
    * Defines the inputs to a data_iterator factory function.
    */
   struct parameters {

--- a/src/unity/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/unity/toolkits/object_detection/od_data_iterator.hpp
@@ -51,6 +51,11 @@ public:
      * Each value is either an image or a path to an image file on disk.
      */
     std::string image_column_name;
+
+    /**
+     * Whether to traverse the data more than once.
+     */
+    bool repeat = true;
   };
 
   virtual ~data_iterator() = default;
@@ -58,9 +63,13 @@ public:
   /**
    * Returns a vector whose size is equal to `batch_size`.
    *
-   * Note that the iterator will cycle indefinitely through the SFrame over and
-   * over. The x,y coordinates in the returned annotations indicate the
-   * upper-left corner of the bounding box.
+   * If `repeat` was set in the parameters, then the iterator will cycle
+   * indefinitely through the SFrame over and over. Otherwise, the last
+   * non-empty batch may contain fewer than `batch_size` elements, and every
+   * batch after that will be empty.
+   *
+   * The x,y coordinates in the returned annotations indicate the upper-left
+   * corner of the bounding box.
    */
   virtual std::vector<neural_net::labeled_image>
       next_batch(size_t batch_size) = 0;
@@ -115,6 +124,7 @@ private:
   gl_sframe data_;
   const size_t annotations_index_;
   const size_t image_index_;
+  const bool repeat_;
 
   const annotation_properties annotation_properties_;
 

--- a/src/unity/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/unity/toolkits/object_detection/od_data_iterator.hpp
@@ -53,6 +53,14 @@ public:
     std::string image_column_name;
 
     /**
+     * The expected class labels, indexed by identifier.
+     *
+     * If empty, then the labels will be inferred from the data. If non-empty,
+     * an exception will be thrown upon encountering an unexpected label.
+     */
+    std::vector<std::string> class_labels;
+
+    /**
      * Whether to traverse the data more than once.
      */
     bool repeat = true;
@@ -119,7 +127,9 @@ private:
     size_t num_instances;
   };
 
-  annotation_properties compute_properties(const gl_sarray& annotations);
+  annotation_properties compute_properties(
+      const gl_sarray& annotations,
+      std::vector<std::string> expected_class_labels);
 
   gl_sframe data_;
   const size_t annotations_index_;

--- a/src/unity/toolkits/object_detection/od_evaluation.cpp
+++ b/src/unity/toolkits/object_detection/od_evaluation.cpp
@@ -1,0 +1,111 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <unity/toolkits/object_detection/od_evaluation.hpp>
+
+#include <algorithm>
+
+#include <logger/assertions.hpp>
+
+namespace turi {
+namespace object_detection {
+
+using neural_net::image_annotation;
+using neural_net::image_box;
+
+namespace {
+
+float compute_iou(const image_annotation& a, const image_annotation& b) {
+
+  image_box intersection_box = a.bounding_box;
+  intersection_box.clip(b.bounding_box);
+
+  float intersection_area = intersection_box.area();
+  float union_area =
+      a.bounding_box.area() + b.bounding_box.area() - intersection_area;
+
+  return intersection_area / union_area;
+}
+
+}  // namespace
+
+std::vector<image_annotation> apply_non_maximum_suppression(
+    std::vector<image_annotation> predictions, float iou_threshold) {
+
+  // We're going to perform this algorithm in place, since it doesn't seem too
+  // much more complex and allows us to avoid any memory allocations whatsoever.
+  // First, sort the predictions first by class and then in descending order of
+  // confidence.
+  auto comparator = [](const image_annotation& a, const image_annotation& b) {
+    if (a.identifier < b.identifier) return true;
+    if (a.identifier > b.identifier) return false;
+    return a.confidence > b.confidence;
+  };
+  std::sort(predictions.begin(), predictions.end(), comparator);
+
+  // Invariant: the range (predictions.begin(), result_end) contains the results
+  // for all classes processed so far.
+  using iterator = std::vector<image_annotation>::iterator;
+  iterator result_end = predictions.begin();
+
+  // Iterate through each class label, one at a time.
+  iterator class_begin = predictions.begin();
+  while (class_begin != predictions.end()) {
+
+    // Find the range corresponding to this class label.
+    auto different_class = [=](const image_annotation& ann) {
+      return ann.identifier != class_begin->identifier;
+    };
+    iterator class_end = std::find_if(class_begin + 1, predictions.end(),
+                                      different_class);
+    const iterator next_class_begin = class_end;
+
+    // Filter the predictions for this range to remove overlaps.
+    iterator class_it = class_begin;
+    while (class_it != class_end) {
+
+      // Remove lower-confidence predictions overlapping with *class_it.
+      auto overlaps = [=](const image_annotation& ann) {
+        return compute_iou(*class_it, ann) > iou_threshold;
+      };
+      class_end = std::remove_if(class_it + 1, class_end, overlaps);
+
+      // All non-overlapping predictions have been moved (if needed) to the
+      // (possibly smaller) range (class_it, class_end). Whatever's left in
+      // (class_end, next_class_begin) is just garbage now. Move on to the next
+      // kept prediction.
+      ++class_it;
+    }
+
+    // Add the remaining predictions for this class to our results.
+    if (result_end == class_begin) {
+
+      // We've kept everything so far, so our final results are still a prefix
+      // of the sorted original predictions, plus whatever we've done for this
+      // class.
+      result_end = class_end;
+
+    } else {
+
+      // Copy the results for this class to the end of our accumulated results.
+      // This really just moves these values to an earlier location in
+      // `predictions`.
+      result_end = std::copy(class_begin, class_end, result_end);
+    }
+
+    // What's left in the range (results_end, next_class_begin) is garbage that
+    // can be overwritten by the next iteration.
+    class_begin = next_class_begin;
+  }
+
+  // Take out the garbage.
+  predictions.erase(result_end, predictions.end());
+
+  return predictions;
+}
+
+}  // object_detection
+}  // turi

--- a/src/unity/toolkits/object_detection/od_evaluation.hpp
+++ b/src/unity/toolkits/object_detection/od_evaluation.hpp
@@ -1,0 +1,31 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef TURI_OBJECT_DETECTION_OD_EVALUATION_H_
+#define TURI_OBJECT_DETECTION_OD_EVALUATION_H_
+
+#include <unity/toolkits/neural_net/image_augmentation.hpp>
+
+namespace turi {
+namespace object_detection {
+
+/**
+ * Performs class-independent non-maximum suppression on the given predictions.
+ *
+ * \param predictions A collection of possibly overlapping predictions
+ * \param iou_threshold The maximum allowed overlap (computed as the ratio
+ *            between the intersection area and the union area) between any two
+ *            predictions for the same class
+ * \return A subset of the given predictions, removing overlapping results,
+ *         greedily preferring those with the highest confidence.
+ */
+std::vector<neural_net::image_annotation> apply_non_maximum_suppression(
+    std::vector<neural_net::image_annotation> predictions, float iou_threshold);
+
+}  // object_detection
+}  // turi
+
+#endif  // TURI_OBJECT_DETECTION_OD_EVALUATION_H_

--- a/src/unity/toolkits/object_detection/od_evaluation.hpp
+++ b/src/unity/toolkits/object_detection/od_evaluation.hpp
@@ -7,6 +7,8 @@
 #ifndef TURI_OBJECT_DETECTION_OD_EVALUATION_H_
 #define TURI_OBJECT_DETECTION_OD_EVALUATION_H_
 
+#include <vector>
+
 #include <unity/toolkits/neural_net/image_augmentation.hpp>
 
 namespace turi {
@@ -24,6 +26,79 @@ namespace object_detection {
  */
 std::vector<neural_net::image_annotation> apply_non_maximum_suppression(
     std::vector<neural_net::image_annotation> predictions, float iou_threshold);
+
+/**
+ * Helper class for computing AP and mAP metrics.
+ */
+class average_precision_calculator {
+public:
+
+  /**
+   * \param num_classes The number of class labels. Each prediction and ground
+   *            truth annotation must have a nonnegative identifier smaller than
+   *            this value.
+   * \param iou_thresholds The IOU (intersection over union) thresholds at which
+   *            to compute the average precisions. This threshold determines
+   *            whether a predicted bounding box and a ground truth bounding box
+   *            are considered to match.
+   */
+  average_precision_calculator(size_t num_classes,
+                               std::vector<float> iou_thresholds);
+
+  /**
+   * Registers the predictions and ground truth annotations for one image.
+   */
+  void add_row(const std::vector<neural_net::image_annotation>& predictions,
+               const std::vector<neural_net::image_annotation>& ground_truth);
+
+  /**
+   * Computes the average precision for each combination of class and requested
+   * IOU threshold.
+   *
+   * \return A vector, indexed by class identifier, of maps associating IOU
+   *         threshold to average precision.
+   *
+   * Each value is the average precision for a specific class label with a
+   * specific IOU threshold. This metric can be interpreted as the area under
+   * the precision-recall curve.
+   */
+  std::vector<std::map<float,float>> evaluate();
+
+private:
+
+  std::map<float, float> evaluate_class(size_t identifier);
+
+  // Representation of one model prediction (for a given class).
+  struct prediction {
+    prediction(float confidence, neural_net::image_box bounding_box,
+               size_t row_index)
+      : confidence(confidence), bounding_box(std::move(bounding_box)),
+        row_index(row_index)
+    {}
+
+    float confidence;
+    neural_net::image_box bounding_box;
+    size_t row_index;
+  };
+
+  // All the data relevant to computing average precision for a single class.
+  struct class_data {
+
+    // All the predictions with the class's label.
+    std::vector<prediction> predictions;
+
+    // All the ground truth bounding boxes for the class.
+    std::vector<neural_net::image_box> ground_truth_boxes;
+
+    // Given row index `i`, the elements of ground_truth_boxes associated with
+    // that row begin with `ground_truth_boxes[ground_truth_indices[i - 1]]` and
+    // end just before `ground_truth_boxes[ground_truth_indices[i]]`.
+    std::vector<size_t> ground_truth_indices;
+  };
+
+  std::vector<class_data> data_;
+  std::vector<float> iou_thresholds_;
+};
 
 }  // object_detection
 }  // turi

--- a/src/unity/toolkits/object_detection/od_yolo.cpp
+++ b/src/unity/toolkits/object_detection/od_yolo.cpp
@@ -4,14 +4,90 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include <unity/toolkits/neural_net/model_spec.hpp>
+#include <unity/toolkits/object_detection/od_yolo.hpp>
 
 #include <logger/assertions.hpp>
 
-using turi::neural_net::model_spec;
-
 namespace turi {
 namespace object_detection {
+
+using neural_net::image_annotation;
+using neural_net::image_box;
+using neural_net::model_spec;
+
+void convert_annotations_to_yolo(
+    const std::vector<image_annotation>& annotations, size_t output_height,
+    size_t output_width, size_t num_anchors, size_t num_classes, float* out) {
+
+  // Number of floats to represent bbox (4), confidence (1), and a one-hot
+  // encoding of the class (num_classes).
+  size_t label_size = 5 + num_classes;
+
+  // Initialize the output buffer. We can iterate by "label", which is
+  // conceptually the lowest-order dimension of the (H,W,num_anchors,label_size)
+  // array.
+  // TODO: Add a mutable float_array interface so we can validate size.
+  float* out_end =
+      out + output_height * output_width * num_anchors * label_size;
+  for (float* ptr = out; ptr < out_end; ptr += label_size) {
+
+    // Initialize the bounding boxes and confidences to 0.
+    std::fill(ptr, ptr + 5, 0.f);
+
+    // Initialize the class probabilities for each output-grid cell and anchor
+    // box to 1/num_classes.
+    std::fill(ptr + 5, ptr + label_size, 1.0f / num_classes);
+  }
+
+  // Iterate through all the annotations for one image.
+  for (const image_annotation& annotation : annotations) {
+
+    // Scale the bounding box to the output grid, converting to the YOLO
+    // representation, defining each box by its center.
+    const image_box& bbox = annotation.bounding_box;
+    float center_x = output_width * (bbox.x + (bbox.width / 2.f));
+    float center_y = output_height * (bbox.y + (bbox.height / 2.f));
+    float width = output_width * bbox.width;
+    float height = output_height * bbox.height;
+
+    // Skip bounding boxes with trivial area, to guard against issues in
+    // augmentation.
+    if (width * height < 0.001f) continue;
+
+    // Write the label into the output grid cell containing the bounding box
+    // center.
+    float icenter_x = std::floor(center_x);
+    float icenter_y = std::floor(center_y);
+    if (0.f <= icenter_x && icenter_x < output_width &&
+        0.f <= icenter_y && icenter_y < output_height) {
+
+      size_t output_grid_stride = num_anchors * label_size;
+      size_t output_grid_offset = static_cast<size_t>(icenter_x) +
+          static_cast<size_t>(icenter_y) * output_width;
+
+      // Write the label once for each anchor box.
+      float* anchor_out = out + output_grid_offset * output_grid_stride;
+      for (size_t anchor_idx = 0; anchor_idx < num_anchors; ++anchor_idx) {
+
+        // Write YOLO-formatted bounding box. YOLO uses (x, y)/(w, h) order.
+        anchor_out[0] = center_x - icenter_x;
+        anchor_out[1] = center_y - icenter_y;
+        anchor_out[2] = width;
+        anchor_out[3] = height;
+
+        // Set confidence to 1.
+        anchor_out[4] = 1.f;
+
+        // One-hot encoding of the class label.
+        std::fill(anchor_out + 5, anchor_out + label_size, 0.f);
+        anchor_out[5 + annotation.identifier] = 1.f;
+
+        // Advance the output iterator to the next anchor.
+        anchor_out += label_size;
+      }
+    }
+  }
+}
 
 void add_yolo(model_spec* nn_spec, const std::string& coordinates_name,
               const std::string& confidence_name, const std::string& input,

--- a/src/unity/toolkits/object_detection/od_yolo.hpp
+++ b/src/unity/toolkits/object_detection/od_yolo.hpp
@@ -7,10 +7,32 @@
 #ifndef TURI_OBJECT_DETECTION_OD_YOLO_H_
 #define TURI_OBJECT_DETECTION_OD_YOLO_H_
 
+#include <unity/toolkits/neural_net/image_augmentation.hpp>
 #include <unity/toolkits/neural_net/model_spec.hpp>
 
 namespace turi {
 namespace object_detection {
+
+/**
+ * Writes a list of image_annotation values into an output float buffer.
+ *
+ * \param annotations The list of annotations (for one image) to write
+ * \param output_height The height of the YOLO output grid
+ * \param output_width The width of the YOLO output grid
+ * \param num_anchors The number of YOLO anchors
+ * \param num_classes The number of classes in the output one-hot encoding
+ * \param out Address to a float buffer of size output_height * output_width *
+ *            num_anchors * (5 + num_classes)
+ * \todo Add a mutable_float_array or shared_float_buffer type for functions
+ *       like this one to write into.
+ * \todo This strictly speaking doesn't belong in this data iterator type but
+ *       probably doesn't warrant its own file yet (and would be nice not to
+ *       bury in object_detector.cpp).
+ */
+void convert_annotations_to_yolo(
+    const std::vector<neural_net::image_annotation>& annotations,
+    size_t output_height, size_t output_width, size_t num_anchors,
+    size_t num_classes, float* out);
 
 /**
  * Appends layers to an existing neural net spec, implementing the conversion

--- a/src/unity/toolkits/object_detection/od_yolo.hpp
+++ b/src/unity/toolkits/object_detection/od_yolo.hpp
@@ -35,6 +35,23 @@ void convert_annotations_to_yolo(
     size_t num_classes, float* out);
 
 /**
+ * Parses the raw YOLO output map into annotations.
+ *
+ * \param yolo_map A float array with shape (H, W, B*(5+C)), where B is the
+ *            number of anchors, C is the number of classes, and H and W are the
+ *            height and width of the output grid.
+ * \param anchor_boxes The B anchor boxes used to train the YOLO model, as a
+ *            vector of (width, height) pairs (in the output grid coordinates).
+ * \param min_confidence The smallest confidence score to allow in the returned
+ *            results.
+ * \return Annotations in the coordinate space of the output grid.
+ */
+std::vector<neural_net::image_annotation> convert_yolo_to_annotations(
+    const neural_net::float_array& yolo_map,
+    const std::vector<std::pair<float, float>>& anchor_boxes,
+    float min_confidence);
+
+/**
  * Appends layers to an existing neural net spec, implementing the conversion
  * from a trained YOLO model to predicted bounding boxes and class labels.
  *

--- a/test/unity/toolkits/neural_net/test_image_augmentation.cxx
+++ b/test/unity/toolkits/neural_net/test_image_augmentation.cxx
@@ -110,6 +110,7 @@ BOOST_AUTO_TEST_CASE(test_resize_only_image_augmenter) {
 
   // Configure an augmenter to resize to 400x300.
   image_augmenter::options options;
+  options.batch_size = source_batch.size();
   options.output_width = 400;
   options.output_height = 300;
 

--- a/test/unity/toolkits/neural_net/test_mps_image_augmentation.cxx
+++ b/test/unity/toolkits/neural_net/test_mps_image_augmentation.cxx
@@ -77,6 +77,7 @@ BOOST_AUTO_TEST_CASE(test_resize) {
 
   // Create an augmenter that just resizes to 512 by 512.
   image_augmenter::options opts;
+  opts.batch_size = 1;
   opts.output_width = 512;
   opts.output_height = 512;
   auto augmenter = mps_compute_context().create_image_augmenter(opts);
@@ -137,6 +138,7 @@ BOOST_AUTO_TEST_CASE(test_horizontal_flip) {
 
   // Create an augmenter that just performs horizontal flip.
   image_augmenter::options opts;
+  opts.batch_size = 1;
   opts.output_width = 256;
   opts.output_height = 256;
   opts.horizontal_flip_prob = 0.5;
@@ -208,6 +210,7 @@ BOOST_AUTO_TEST_CASE(test_crop) {
 
   // Create an augmenter that just performs crops.
   image_augmenter::options opts;
+  opts.batch_size = 1;
   opts.output_width = 256;
   opts.output_height = 256;
   opts.crop_prob = 0.5f;
@@ -319,6 +322,7 @@ BOOST_AUTO_TEST_CASE(test_pad) {
 
   // Create an augmenter that just performs padding
   image_augmenter::options opts;
+  opts.batch_size = 1;
   opts.output_width = 256;
   opts.output_height = 256;
   opts.pad_prob = 0.5f;

--- a/test/unity/toolkits/object_detection/CMakeLists.txt
+++ b/test/unity/toolkits/object_detection/CMakeLists.txt
@@ -12,3 +12,4 @@ make_boost_test(test_od_yolo.cxx
     -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
 )
 
+make_boost_test(test_od_evaluation.cxx REQUIRES unity_toolkits)

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -205,7 +205,7 @@ public:
   using create_iterator_call =
       std::function<std::unique_ptr<data_iterator>(
           gl_sframe data, std::string annotations_column_name,
-          std::string image_column_name)>;
+          std::string image_column_name, bool repeat)>;
 
   using create_compute_context_call =
       std::function<std::unique_ptr<compute_context>()>;
@@ -221,13 +221,14 @@ public:
 
   std::unique_ptr<data_iterator> create_iterator(
       gl_sframe data, std::string annotations_column_name,
-      std::string image_column_name) const override {
+      std::string image_column_name, bool repeat) const override {
 
     TS_ASSERT(!create_iterator_calls_.empty());
     create_iterator_call expected_call =
         std::move(create_iterator_calls_.front());
     create_iterator_calls_.pop_front();
-    return expected_call(data, annotations_column_name, image_column_name);
+    return expected_call(data, annotations_column_name, image_column_name,
+                         repeat);
   }
 
   std::unique_ptr<compute_context> create_compute_context() const override {
@@ -377,10 +378,11 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
   auto create_iterator_impl = [&](gl_sframe data,
                                   std::string annotations_column_name,
-                                  std::string image_column_name) {
+                                  std::string image_column_name, bool repeat) {
 
     TS_ASSERT_EQUALS(annotations_column_name, test_annotations_name);
     TS_ASSERT_EQUALS(image_column_name, test_image_name);
+    TS_ASSERT(repeat);
 
     return std::move(mock_iterator);
   };

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -150,8 +150,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
 
   // The data contains the label "foo", which is not among the expected class
   // labels.
-  simple_data_iterator* data_source;
-  TS_ASSERT_THROWS_ANYTHING(data_source = new simple_data_iterator(params));
+  TS_ASSERT_THROWS_ANYTHING(simple_data_iterator unused_var(params));
 }
 
 }  // namespace

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -118,6 +118,42 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
   assert_batch(batch, 0);
 }
 
+BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_classes) {
+
+  static constexpr size_t NUM_ROWS = 1;
+  static constexpr size_t BATCH_SIZE = 1;
+
+  data_iterator::parameters params = create_data(NUM_ROWS);
+
+  std::vector<std::string> class_labels = { "bar", "foo" };
+  params.class_labels = class_labels;
+
+  simple_data_iterator data_source(params);
+  TS_ASSERT_EQUALS(data_source.class_labels(), class_labels);
+  TS_ASSERT_EQUALS(data_source.num_instances(), 1);
+
+  std::vector<labeled_image> batch = data_source.next_batch(BATCH_SIZE);
+  TS_ASSERT_EQUALS(batch.size(), BATCH_SIZE);
+
+  // Even though the data only contained one label, "foo", it should receive
+  // identifier 1 because we specified the class labels upfront.
+  TS_ASSERT_EQUALS(batch[0].annotations.size(), 1);
+  TS_ASSERT_EQUALS(batch[0].annotations[0].identifier, 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
+
+  static constexpr size_t NUM_ROWS = 1;
+
+  data_iterator::parameters params = create_data(NUM_ROWS);
+  params.class_labels = { "bar" };
+
+  // The data contains the label "foo", which is not among the expected class
+  // labels.
+  simple_data_iterator* data_source;
+  TS_ASSERT_THROWS_ANYTHING(data_source = new simple_data_iterator(params));
+}
+
 }  // namespace
 }  // namespace object_detection
 }  // namespace turi

--- a/test/unity/toolkits/object_detection/test_od_evaluation.cxx
+++ b/test/unity/toolkits/object_detection/test_od_evaluation.cxx
@@ -97,6 +97,212 @@ BOOST_AUTO_TEST_CASE(test_nms_with_overlap_across_classes) {
   TS_ASSERT(result[1] == predictions[1]);
 }
 
+BOOST_AUTO_TEST_CASE(test_average_precision_iou_threshold) {
+
+  // Ground truth label on entire unit square, for convenience.
+  std::vector<image_annotation> gt_labels(1);
+  gt_labels[0].identifier = 0;
+  gt_labels[0].confidence = 1.f;
+  gt_labels[0].bounding_box = image_box(0.f, 0.f, 1.f, 1.f);
+
+  // Prediction with 62.5% overlap.
+  std::vector<image_annotation> preds(1);
+  preds[0].identifier = 0;
+  preds[0].confidence = 0.5f;
+  preds[0].bounding_box = image_box(0.f, 0.f, 0.625f, 1.f);
+
+  // Compute metrics at IOU thresholds 0.5 and 0.75.
+  average_precision_calculator calc(/* num_classes */ 2,
+                                    /* iou_thresholds */ { 0.5f, 0.75f });
+  calc.add_row(preds, gt_labels);
+
+  auto average_precisions = calc.evaluate();
+  TS_ASSERT_EQUALS(average_precisions.size(), 2);  // num_classes == 2
+
+  // For class 0, we should have AP 1.0 at IOU 50 and 0.0 at IOU 75
+  TS_ASSERT_EQUALS(average_precisions[0][0.5f], 1.f);
+  TS_ASSERT_EQUALS(average_precisions[0][0.75f], 0.f);
+
+  // For class 1, we had no ground truth labels, so AP is always 0.
+  TS_ASSERT_EQUALS(average_precisions[1][0.5f], 0.f);
+  TS_ASSERT_EQUALS(average_precisions[1][0.75f], 0.f);
+}
+
+BOOST_AUTO_TEST_CASE(test_average_precision_class_label_mismatch) {
+
+  // Ground truth label on entire unit square, for convenience.
+  std::vector<image_annotation> gt_labels(1);
+  gt_labels[0].identifier = 0;
+  gt_labels[0].confidence = 1.f;
+  gt_labels[0].bounding_box = image_box(0.f, 0.f, 1.f, 1.f);
+
+  // One prediction, overlapping the ground truth box but with the wrong label.
+  std::vector<image_annotation> preds(1);
+  preds[0].identifier = 1;
+  preds[0].confidence = 0.9f;
+  preds[0].bounding_box = image_box(0.f, 0.f, 0.625f, 1.f);
+
+  // Compute metrics at IOU thresholds 0.5.
+  average_precision_calculator calc(/* num_classes */ 2,
+                                    /* iou_thresholds */ { 0.5f });
+  calc.add_row(preds, gt_labels);
+
+  auto average_precisions = calc.evaluate();
+  TS_ASSERT_EQUALS(average_precisions.size(), 2);  // num_classes == 2
+
+  // AP should be 0 for both classes, since the one prediction and the one
+  // ground truth label had different class labels.
+  TS_ASSERT_EQUALS(average_precisions[0][0.5f], 0.f);
+  TS_ASSERT_EQUALS(average_precisions[1][0.5f], 0.f);
+}
+
+BOOST_AUTO_TEST_CASE(test_average_precision_image_row_mismatch) {
+
+  // Ground truth label on entire unit square, for convenience.
+  std::vector<image_annotation> gt_labels(1);
+  gt_labels[0].identifier = 0;
+  gt_labels[0].confidence = 1.f;
+  gt_labels[0].bounding_box = image_box(0.f, 0.f, 1.f, 1.f);
+
+  // One prediction, overlapping the ground truth box but with the wrong label.
+  std::vector<image_annotation> preds(1);
+  preds[0].identifier = 0;
+  preds[0].confidence = 0.9f;
+  preds[0].bounding_box = image_box(0.f, 0.f, 1.f, 1.f);
+
+  // Compute metrics at IOU thresholds 0.5.
+  average_precision_calculator calc(/* num_classes */ 1,
+                                    /* iou_thresholds */ { 0.5f });
+  calc.add_row(preds, {});
+  calc.add_row({}, gt_labels);
+
+  auto average_precisions = calc.evaluate();
+  TS_ASSERT_EQUALS(average_precisions.size(), 1);  // num_classes == 1
+
+  // The AP should be 0, since although the prediction was for image/row 0, and
+  // only image/row1 had a labeled annotation.
+  TS_ASSERT_EQUALS(average_precisions[0][0.5f], 0.f);
+}
+
+BOOST_AUTO_TEST_CASE(test_average_precision_overlapping_match) {
+
+  // Two ground truth labels, one on the top half of the unit square and one on
+  // the bottom half.
+  std::vector<image_annotation> gt_labels(2);
+  gt_labels[0].identifier = 0;
+  gt_labels[0].confidence = 1.f;
+  gt_labels[0].bounding_box = image_box(0.f, 0.f, 1.f, 0.5f);
+  gt_labels[1].identifier = 0;
+  gt_labels[1].confidence = 1.f;
+  gt_labels[1].bounding_box = image_box(0.f, 0.5f, 1.f, 0.5f);
+
+  // Three predictions, all overlapping one of the two ground-truth labels.
+  std::vector<image_annotation> preds(3);
+  preds[0].identifier = 0;
+  preds[0].confidence = 0.9f;
+  preds[0].bounding_box = image_box(0.f, 0.f, 1.f, 0.5f);
+  preds[1].identifier = 0;
+  preds[1].confidence = 0.75f;
+  preds[1].bounding_box = image_box(0.f, 0.f, 1.f, 0.5f);
+  preds[2].identifier = 0;
+  preds[2].confidence = 0.5f;
+  preds[2].bounding_box = image_box(0.f, 0.5f, 1.f, 0.5f);
+
+  // Compute metrics at IOU thresholds 0.5.
+  average_precision_calculator calc(/* num_classes */ 1,
+                                    /* iou_thresholds */ { 0.5f });
+  calc.add_row(preds, gt_labels);
+
+  auto average_precisions = calc.evaluate();
+  TS_ASSERT_EQUALS(average_precisions.size(), 1);  // num_classes == 1
+
+  // For class 0, the AP should be an average of precision 1.0 for the first
+  // matched label, and precision 0.666 for the second matched label, since only
+  // one of the matches for first ground truth label can count.
+  TS_ASSERT_DELTA(average_precisions[0][0.5f], 5.f/6.f, 0.0001f);
+}
+
+BOOST_AUTO_TEST_CASE(test_average_precision_aggregate_across_rows) {
+
+  // Compute metrics at IOU thresholds 0.5.
+  average_precision_calculator calc(/* num_classes */ 1,
+                                    /* iou_thresholds */ { 0.5f });
+
+  // Ground truth label on entire unit square, for convenience.
+  std::vector<image_annotation> gt_labels(1);
+  gt_labels[0].identifier = 0;
+  gt_labels[0].confidence = 1.f;
+  gt_labels[0].bounding_box = image_box(0.f, 0.f, 1.f, 1.f);
+
+  // Two predictions, only the first of which will have IOU > 0.5
+  std::vector<image_annotation> preds(2);
+  preds[0].identifier = 0;
+  preds[0].bounding_box = image_box(0.f, 0.f, 1.f, 0.75f);
+  preds[1].identifier = 0;
+  preds[1].bounding_box = image_box(0.f, 0.f, 1.f, 0.25f);
+
+  // For the first row, use both predictions, giving the good prediction
+  // higher confidence.
+  preds[0].confidence = 0.9f;
+  preds[1].confidence = 0.7f;
+  calc.add_row(preds, gt_labels);
+
+  // For the second row, only use the first prediction. Give it a low confidence
+  preds.resize(1);
+  preds[0].confidence = 0.5f;
+  calc.add_row(preds, gt_labels);
+
+  // Compute AP.
+  auto average_precisions = calc.evaluate();
+  TS_ASSERT_EQUALS(average_precisions.size(), 1);  // num_classes == 1
+
+  // The AP should be an average of precision 1.0 for the first matched label,
+  // and precision 0.666 for the second matched label (in the second image/row),
+  // since the bad prediction for the first image/row ranks higher.
+  TS_ASSERT_DELTA(average_precisions[0][0.5f], 5.f/6.f, 0.0001f);
+}
+
+BOOST_AUTO_TEST_CASE(test_average_precision_monotonic_precision) {
+
+  // Compute metrics at IOU thresholds 0.5.
+  average_precision_calculator calc(/* num_classes */ 1,
+                                    /* iou_thresholds */ { 0.5f });
+
+  // Ground truth label on entire unit square, for convenience.
+  std::vector<image_annotation> gt_labels(1);
+  gt_labels[0].identifier = 0;
+  gt_labels[0].confidence = 1.f;
+  gt_labels[0].bounding_box = image_box(0.f, 0.f, 1.f, 1.f);
+
+  // Two predictions, only the first of which will have IOU > 0.5
+  std::vector<image_annotation> preds(2);
+  preds[0].identifier = 0;
+  preds[0].bounding_box = image_box(0.f, 0.f, 1.f, 0.75f);
+  preds[1].identifier = 0;
+  preds[1].bounding_box = image_box(0.f, 0.f, 1.f, 0.25f);
+
+  // For the first row, use both predictions, but give the bad prediction the
+  // highest confidence
+  preds[0].confidence = 0.7f;
+  preds[1].confidence = 0.9f;
+  calc.add_row(preds, gt_labels);
+
+  // For the second row, only use the first prediction. Give it a low confidence
+  preds.resize(1);
+  preds[0].confidence = 0.5f;
+  calc.add_row(preds, gt_labels);
+
+  // Compute AP.
+  auto average_precisions = calc.evaluate();
+  TS_ASSERT_EQUALS(average_precisions.size(), 1);  // num_classes == 1
+
+  // The AP should be 0.666, even though the precision upon matching the first
+  // ground truth label is 0.5 (and the precision upon matching the second is
+  // 0.666), since the user is assumed to prefer the point on the raw curve that
+  // dominates in both precision and recall.
+  TS_ASSERT_DELTA(average_precisions[0][0.5f], 2.f/3.f, 0.0001f);
+}
+
 }  // namespace
 }  // namespace object_detection
 }  // namespace turi

--- a/test/unity/toolkits/object_detection/test_od_evaluation.cxx
+++ b/test/unity/toolkits/object_detection/test_od_evaluation.cxx
@@ -1,0 +1,102 @@
+/* Copyright © 2018 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_od_evaluation
+
+#include <unity/toolkits/object_detection/od_evaluation.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <util/test_macros.hpp>
+
+namespace turi {
+namespace object_detection {
+namespace {
+
+using neural_net::image_annotation;
+using neural_net::image_box;
+
+BOOST_AUTO_TEST_CASE(test_nms_with_empty_preds) {
+
+  std::vector<image_annotation> empty;
+  std::vector<image_annotation> result =
+      apply_non_maximum_suppression(empty, 1.f);
+  TS_ASSERT(result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_nms_with_single_pred) {
+
+  // Define one prediction with low confidence and arbitrary label and bounds.
+  std::vector<image_annotation> predictions(1);
+  predictions[0].confidence = 0.f;
+  predictions[0].bounding_box = image_box(0.25f, 0.25f, 0.5f, 0.5f);
+
+  // Should keep the low-confidence prediction.
+  std::vector<image_annotation> result =
+      apply_non_maximum_suppression(predictions, 0.5f);
+  TS_ASSERT_EQUALS(result.size(), 1);
+  TS_ASSERT(result[0] == predictions[0]);
+}
+
+BOOST_AUTO_TEST_CASE(test_nms_with_overlap_within_class) {
+
+  // Define two predictions with the same class and overlapping bounding boxes.
+  std::vector<image_annotation> predictions(2);
+  predictions[0].identifier = 3;
+  predictions[0].confidence = 0.75f;
+  predictions[0].bounding_box = image_box(0.25f, 0.25f, 0.5f, 0.5f);
+  predictions[1].identifier = 3;
+  predictions[1].confidence = 0.95f;
+  predictions[1].bounding_box = image_box(0.20f, 0.20f, 0.5f, 0.5f);
+
+  // Should keep only the higher-confidence prediction.
+  std::vector<image_annotation> result =
+      apply_non_maximum_suppression(predictions, 0.5f);
+  TS_ASSERT_EQUALS(result.size(), 1);
+  TS_ASSERT(result[0] == predictions[1]);
+}
+
+BOOST_AUTO_TEST_CASE(test_nms_with_no_overlap_within_class) {
+
+  // Define two predictions with the same class and minimal overlap.
+  std::vector<image_annotation> predictions(2);
+  predictions[0].identifier = 3;
+  predictions[0].confidence = 0.75f;
+  predictions[0].bounding_box = image_box(0.25f, 0.25f, 0.3f, 0.3f);
+  predictions[1].identifier = 3;
+  predictions[1].confidence = 0.95f;
+  predictions[1].bounding_box = image_box(0.45f, 0.25f, 0.3f, 0.3f);
+
+  // Should keep both predictions. (The higher-confidence prediction should now
+  // come first.)
+  std::vector<image_annotation> result =
+      apply_non_maximum_suppression(predictions, 0.5f);
+  TS_ASSERT_EQUALS(result.size(), 2);
+  TS_ASSERT(result[0] == predictions[1]);
+  TS_ASSERT(result[1] == predictions[0]);
+}
+
+BOOST_AUTO_TEST_CASE(test_nms_with_overlap_across_classes) {
+
+  // Define two predictions with different classes and overlapping boxes.
+  std::vector<image_annotation> predictions(2);
+  predictions[0].identifier = 2;
+  predictions[0].confidence = 0.75f;
+  predictions[0].bounding_box = image_box(0.25f, 0.25f, 0.5f, 0.5f);
+  predictions[1].identifier = 3;
+  predictions[1].confidence = 0.95f;
+  predictions[1].bounding_box = image_box(0.20f, 0.20f, 0.5f, 0.5f);
+
+  // Should keep both predictions.
+  std::vector<image_annotation> result =
+      apply_non_maximum_suppression(predictions, 0.5f);
+  TS_ASSERT_EQUALS(result.size(), 2);
+  TS_ASSERT(result[0] == predictions[0]);
+  TS_ASSERT(result[1] == predictions[1]);
+}
+
+}  // namespace
+}  // namespace object_detection
+}  // namespace turi


### PR DESCRIPTION
Using the Python bindings, for the following script (for a partially trained model):
```
import turicreate as tc
data = tc.SFrame('breakfast-data.sframe')
m = tc.extensions.object_detector()
m.train(data, 'annotation', 'image', {'mlmodel_path':'/Users/jong/Desktop/darknet.mlmodel', 'max_iterations' : 1000})
print(m.evaluate(data))
```
I get
```
Using GPU to create model (AMD Radeon Pro 560)
Setting 'batch_size' to 32
+--------------+--------------+--------------+
| Iteration    | Loss         | Elapsed Time |
+--------------+--------------+--------------+
| 1            | 7.46523      | 3.14s        |
[...]
| 1000         | 2.98155      | 17m 27s      |
+--------------+--------------+--------------+
{'average_precision_50': {'Coffee': 0.3338097333908081, 'Croissant': 0.5798972845077515, 'Waffle': 0.6876717209815979, 'Bagel': 0.6917844414710999, 'Egg': 0.6757196187973022, 'Banana': 0.8208531737327576}, 'mean_average_precision_50': 0.6316226124763489, 'mean_average_precision': 0.2744746506214142, 'average_precision': {'Coffee': 0.1412852257490158, 'Croissant': 0.25779861211776733, 'Waffle': 0.27859237790107727, 'Bagel': 0.3109457194805145, 'Egg': 0.2973583936691284, 'Banana': 0.3608674705028534}}
```