### PR TITLE
Fix target linking syntax in older CMake

### DIFF
--- a/src/capi/CMakeLists.txt
+++ b/src/capi/CMakeLists.txt
@@ -39,9 +39,6 @@ endif()
 add_dependencies(_capi_objects ${_capi_requires})
 
 set(_capi_sources "$<TARGET_OBJECTS:_capi_objects>")
-if(APPLE)
-  set(_capi_sources ${_capi_sources} "$<TARGET_OBJECTS:vega_renderer>")
-endif()
 
 make_library(capi 
   SOURCES

--- a/src/vega_renderer/CMakeLists.txt
+++ b/src/vega_renderer/CMakeLists.txt
@@ -65,26 +65,16 @@ if(APPLE)
    ## VegaRenderer
    ##
 
-   add_library( vega_renderer OBJECT
-   ${VEGA_RENDERER_SOURCES}
-   ${VEGA_RENDERER_PUBLIC_HEADERS}
-   ${VEGA_RENDERER_PROJECT_HEADERS}
-   ${VEGA_RENDERER_PRIVATE_HEADERS}
-   ${VEGA_RENDERER_RESOURCES}
+   make_library( vega_renderer
+      SOURCES
+         ${VEGA_RENDERER_SOURCES}
+      REQUIRES
+         ${VEGA_RENDERER_DEPENDENCIES}
    )
 
    add_dependencies(
       vega_renderer
       preprocessed_javascript
-   )
-
-   target_link_libraries(
-      vega_renderer
-      ${FOUNDATION_LIBRARY}
-      ${APPKIT_LIBRARY}
-      ${COREGRAPHICS_LIBRARY}
-      ${JAVASCRIPTCORE_LIBRARY}
-      ${CORETEXT_LIBRARY}
    )
 
    target_compile_options(vega_renderer PUBLIC "-fobjc-arc")


### PR DESCRIPTION
Fixes #1384

The initial commit of `src/vega_renderer/CMakeLists.txt` was relying on
behavior new to CMake 3.12. Since we support older versions of CMake
in the build, we should not rely on it.