### PR TITLE
Make CMake compat requirements consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 project(Turi)
 
-# We require the most recent version of cmake and automatically
-# install the correct version when using the cmake lists
-cmake_minimum_required(VERSION 2.8.3)
+# We require a recent version of cmake and automatically
+# install a compatible version when using the cmake lists,
+# if one is not already present.
+cmake_minimum_required(VERSION 3.9.3)
 
 # Libraries linked via full path no longer produce linker search paths.
 cmake_policy(SET CMP0003 NEW)

--- a/configure
+++ b/configure
@@ -429,9 +429,9 @@ function check_cmake {
     #test cmake version
     echo "Testing existing cmake version..."
     currentversion=`$CMAKE --version | awk -F "patch" '{print $1;}' | tr -dc '[0-9].'`
-    echo "Detected ${currentversion}. Required 3.5.0"
+    echo "Detected ${currentversion}. Required 3.9.3"
 
-    check_version $currentversion "3.5.1"
+    check_version $currentversion "3.9.3"
 
     if [ $? -ne 2 ]; then
       echo "CMake version is good; using built-in version."


### PR DESCRIPTION
Prior to this PR, we claimed to be compatible with:

* CMake 2.8.3 (checked in `CMakeLists.txt`)
* CMake 3.5.0 (printed by `./configure`).
* CMake 3.5.1 (actually checked by `./configure`).

Since we provide 3.9.3 in the repo, and rarely test with anything below
that, it doesn't really make sense to claim (wildly and inconsistently)
that we support any particular versions below that. This PR updates all
claims to match what we actually build & test with most commonly, which
is 3.9.3.

For existing users of various CMake versions:

* Below 3.9.3, builds will now start using the CMake provided in deps,
  which will ensure consistent builds with what we're testing in CI.

* At or above 3.9.3, this change will have no effect on existing users.