### PR TITLE
Don't build AppKit on IOS

### DIFF
--- a/src/vega_renderer/CMakeLists.txt
+++ b/src/vega_renderer/CMakeLists.txt
@@ -1,6 +1,6 @@
 project( vega_renderer )
 
-if(APPLE)
+if(APPLE AND NOT ${TC_BUILD_IOS})
 
    find_library( FOUNDATION_LIBRARY Foundation)
    message( STATUS "Foundation found at ${FOUNDATION_LIBRARY}")


### PR DESCRIPTION
Fixes a build break such that AppKit isn't being built as part of the recommender dylib.