### PR TITLE
Handle exception thrown when calling `nvidia-smi` when no GPU is installed

### DIFF
--- a/src/unity/python/turicreate/util/__init__.py
+++ b/src/unity/python/turicreate/util/__init__.py
@@ -731,6 +731,8 @@ def _get_cuda_gpus():
                                          universal_newlines=True)
     except OSError:
         return []
+    except subprocess.CalledProcessError:
+        return []
 
     gpus = []
     for gpu_line in output.split('\n'):


### PR DESCRIPTION
This fixed the issue noted in the related ticket; seems the exception type is just not as expected.