### PR TITLE
Re-factor Activity Classifier MPS backend to adopt same backend interface as Object Detection

### DIFF
--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -494,7 +494,7 @@ class MpsGraphAPI(object):
         result_handle = _ctypes.c_void_p()
         status_code = self._LIB.TCMPSTrainGraph(
             self.handle, input_array.handle, label_array.handle,
-                _ctypes.byref(result_handle))
+            _ctypes.byref(result_handle))
 
         assert status_code == 0, "Error calling TCMPSTrainGraph"
         assert result_handle, "TCMPSTrainGraph unexpectedly returned NULL pointer"

--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -624,104 +624,8 @@ class MpsLowLevelAPI(object):
         sz = n * c_in * h_in * w_in
         self._buf_g = (_ctypes.c_float * sz)()
 
-        if (h_in == 1 and h_out == 1):
-            self._ishape = (n, w_in, c_in)
-            self._oshape = (n, w_out, c_out)
-        else:
-            self._ishape = (n, h_in, w_in, c_in)
-            self._oshape = (n, h_out, w_out, c_out)
-
-    def forward(self, x, is_train=True):
-        assert x.shape == self._ishape
-        x_array = MpsFloatArray(x)
-
-        self._LIB.TCMPSForward(
-            self.handle, x_array.handle, _ctypes.byref(self._buf),
-            _ctypes.c_bool(is_train))
-
-        output = (_np.frombuffer(self._buf, dtype=_np.float32).reshape(self._oshape)).copy()
-        return output
-
-    def forward_with_loss(self, x, labels, weights, loss_image_required, is_train=True):
-        assert x.shape == self._ishape
-        return self._loss_or_iteration_call(self._LIB.TCMPSForwardWithLoss, x, labels, weights, loss_image_required, is_train=is_train)
-
-    def backward(self, g):
-        assert g.shape == self._oshape
-        g_array = MpsFloatArray(g)
-
-        self._LIB.TCMPSBackward(self.handle, g_array.handle,
-                                _ctypes.byref(self._buf_g))
-
-        output = (_np.frombuffer(self._buf_g, dtype=_np.float32).reshape(self._ishape)).copy()
-        return output
-
-    def loss(self, x, labels, weights, loss_image_required):
-        assert x.shape == self._oshape
-        return self._loss_or_iteration_call(self._LIB.TCMPSLoss, x, labels, weights, loss_image_required)
-
-    def _loss_or_iteration_call(self, lib_method, x, labels, weights, loss_image_required, is_train=None, async_batch_id=None):
-        expected_label_shape = (self._oshape[:-1] + (1,))
-
-        assert labels.shape == expected_label_shape
-        assert weights.shape == expected_label_shape
-
-        x_array = MpsFloatArray(x)
-        labels_array = MpsFloatArray(labels)
-        weights_array = MpsFloatArray(weights)
-        loss_rq_bool = _ctypes.c_bool(loss_image_required)
-
-        if async_batch_id is not None:
-            batch_id = _ctypes.c_int(async_batch_id)
-            if is_train is None:
-                lib_method(self.handle, batch_id, x_array.handle,
-                           labels_array.handle, weights_array.handle,
-                           loss_rq_bool)
-            else:
-                lib_method(self.handle, batch_id, x_array.handle,
-                           labels_array.handle, weights_array.handle,
-                           loss_rq_bool, _ctypes.c_bool(is_train))
-            return  # Async requests don't return anything immediately
-
-        if is_train is None:
-            lib_method(self.handle, x_array.handle, labels_array.handle,
-                       weights_array.handle, loss_rq_bool,
-                       _ctypes.byref(self._buf))
-        else:
-            lib_method(self.handle, x_array.handle, labels_array.handle,
-                       weights_array.handle, loss_rq_bool,
-                       _ctypes.c_bool(is_train), _ctypes.byref(self._buf))
-
-        output = (_np.frombuffer(self._buf, dtype=_np.float32).reshape(self._oshape)).copy()
-        return output
-
-    def forward_backward(self, x, labels, weights, loss_image_required):
-        assert x.shape == self._ishape
-        return self._loss_or_iteration_call(self._LIB.TCMPSForwardBackward, x, labels, weights, loss_image_required)
-
-    def get_loss_output(self):
-        batch_size = self._ishape[0]
-        loss_buff = (_ctypes.c_float * batch_size)()
-        self._LIB.TCMPSGetLossImages(self.handle, _ctypes.byref(loss_buff))
-        output = (_np.frombuffer(loss_buff, dtype=_np.float32)).copy()
-        return output
-
-    def begin_forward_batch(self, async_batch_id, x, labels, weights, loss_image_required, is_train=True):
-        assert x.shape == self._ishape
-        self._loss_or_iteration_call(self._LIB.TCMPSBeginForwardBatch, x, labels, weights, loss_image_required, is_train=is_train, async_batch_id=async_batch_id)
-
-    def begin_forward_backward_batch(self, async_batch_id, x, labels, weights, loss_image_required):
-        assert x.shape == self._ishape
-        self._loss_or_iteration_call(self._LIB.TCMPSBeginForwardBackwardBatch, x, labels, weights, loss_image_required, async_batch_id=async_batch_id)
-
-    def wait_for_batch(self, async_batch_id):
-        batch_size = self._ishape[0]
-        loss_buff = (_ctypes.c_float * batch_size)()
-        self._LIB.TCMPSWaitForBatch(self.handle, _ctypes.c_int(async_batch_id),
-                               _ctypes.byref(self._buf), _ctypes.byref(loss_buff))
-        forward_output = (_np.frombuffer(self._buf, dtype=_np.float32).reshape(self._oshape)).copy()
-        loss_output = (_np.frombuffer(loss_buff, dtype=_np.float32)).copy()
-        return (forward_output, loss_output)
+        self._ishape = (n, h_in, w_in, c_in)
+        self._oshape = (n, h_out, w_out, c_out)
 
     def load(self, weights):
         weights_items, weights_name, weights_arr, weights_sz = _prepare_network_parameters(weights)
@@ -734,15 +638,62 @@ class MpsLowLevelAPI(object):
         assert status_code == 0
         return dict(MpsFloatArrayIterator(iter_handle))
 
-    def cpu_update(self):
-        self._LIB.TCMPSCpuUpdate(self.handle)
-
-    def update(self):
-        self._LIB.TCMPSUpdate(self.handle)
-
     def initalize_weights(self):
         args = self.export()
         for key, val in args.items():
             if key.endswith("weight"):
                 args[key] = _xavier_init(val)
         self.load(args)
+
+    def _loss_or_iteration_call(self, lib_method, input, labels, weights):
+        expected_label_shape = (self._oshape[:-1] + (1,))
+        assert input.shape == self._ishape
+        assert labels.shape == expected_label_shape
+        assert weights.shape == expected_label_shape
+
+        input_array = MpsFloatArray(input)
+        labels_array = MpsFloatArray(labels)
+        weights_array = MpsFloatArray(weights)
+        output_handle = _ctypes.c_void_p()
+        loss_handle = _ctypes.c_void_p()
+        status_code = lib_method(
+            self.handle,
+            input_array.handle, labels_array.handle, weights_array.handle,
+            _ctypes.byref(output_handle), _ctypes.byref(loss_handle))
+
+        assert status_code == 0, "Error calling TCMPS"
+        assert output_handle, "TCMPS unexpectedly returned NULL pointer"
+        assert loss_handle, "TCMPS unexpectedly returned NULL pointer"
+
+        output = MpsFloatArray(output_handle)
+        loss = MpsFloatArray(loss_handle)
+
+        assert output.shape() == self._oshape
+        assert loss.shape() == (self._oshape[0], 1, 1, 1)
+
+        return (output, loss)
+
+    def train(self, input, labels, weights):
+        return self._loss_or_iteration_call(self._LIB.TCMPSTrain, input, labels,
+                                            weights)
+
+    def predict_with_loss(self, input, labels, weights):
+        return self._loss_or_iteration_call(self._LIB.TCMPSPredict, input,
+                                            labels, weights)
+
+    def predict(self, input):
+        assert input.shape == self._ishape
+
+        input_array = MpsFloatArray(input)
+        output_handle = _ctypes.c_void_p()
+        status_code = self._LIB.TCMPSPredict(
+            self.handle, input_array.handle, None, None,
+            _ctypes.byref(output_handle), None)
+
+        assert status_code == 0, "Error calling TCMPSPredict"
+        assert output_handle, "TCMPSPredict unexpectedly returned NULL pointer"
+
+        output = MpsFloatArray(output_handle)
+        assert output.shape() == self._oshape
+
+        return output

--- a/src/unity/toolkits/neural_net/compute_context.hpp
+++ b/src/unity/toolkits/neural_net/compute_context.hpp
@@ -9,8 +9,8 @@
 
 #include <memory>
 
-#include <unity/toolkits/neural_net/cnn_module.hpp>
 #include <unity/toolkits/neural_net/image_augmentation.hpp>
+#include <unity/toolkits/neural_net/model_backend.hpp>
 
 namespace turi {
 namespace neural_net {
@@ -53,7 +53,7 @@ public:
    * \todo Initialize the network directly from a model_spec, in lieu of passing
    *       weights as a float_array_map.
    */
-  virtual std::unique_ptr<cnn_module> create_object_detector(
+  virtual std::unique_ptr<model_backend> create_object_detector(
       int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
       const float_array_map& config, const float_array_map& weights) = 0;
 

--- a/src/unity/toolkits/neural_net/model_backend.hpp
+++ b/src/unity/toolkits/neural_net/model_backend.hpp
@@ -26,23 +26,6 @@ public:
   virtual ~model_backend() = default;
 
   /**
-   * Sets the learning rate to be used for future calls to train.
-   */
-  virtual void set_learning_rate(float lr) = 0;
-
-  /**
-   * Performs one forward-backward pass.
-   */
-  virtual deferred_float_array train(const float_array& input_batch,
-                                     const float_array& label_batch) = 0;
-
-  /**
-   * Performs a forward pass.
-   */
-  virtual deferred_float_array predict(
-      const float_array& input_batch) const = 0;
-
-  /**
    * Exports the network weights.
    *
    * \todo Someday, once no Python frontend depends on this method, this could
@@ -50,6 +33,37 @@ public:
    *       the model_backend).
    */
   virtual float_array_map export_weights() const = 0;
+
+  // TODO: Accessors describing name inputs and expected shapes.
+
+  /**
+   * Performs a forward pass.
+   *
+   * \param inputs A map containing all the named inputs required by the model.
+   * \return A map containing all the named outputs from the model. The values
+   *         may be deferred_float_array instances wrapping future
+   *         (asynchronous) results.
+   */
+  virtual float_array_map predict(const float_array_map& inputs) const = 0;
+
+  /**
+   * Sets the learning rate to be used for future calls to train.
+   */
+  virtual void set_learning_rate(float lr) = 0;
+
+  /**
+   * Performs one forward-backward pass.
+   *
+   * \param inputs A map containing all the named inputs and labels required by
+   *            the model.
+   * \return A map containing all the named outputs and loss images from the
+   *         model. The values may be deferred_float_array instances wrapping
+   *         future (asynchronous) results.
+   *
+   * \todo Introduce a separate mutable subclass, so that prediction-only models
+   *       don't need to have a `train` method at all.
+   */
+  virtual float_array_map train(const float_array_map& inputs) = 0;
 };
 
 }  // namespace neural_net

--- a/src/unity/toolkits/neural_net/model_backend.hpp
+++ b/src/unity/toolkits/neural_net/model_backend.hpp
@@ -4,8 +4,8 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef UNITY_TOOLKITS_NEURAL_NET_CNN_MODULE_HPP_
-#define UNITY_TOOLKITS_NEURAL_NET_CNN_MODULE_HPP_
+#ifndef UNITY_TOOLKITS_NEURAL_NET_MODEL_BACKEND_HPP_
+#define UNITY_TOOLKITS_NEURAL_NET_MODEL_BACKEND_HPP_
 
 #include <memory>
 #include <string>
@@ -20,22 +20,10 @@ namespace neural_net {
  * A pure virtual interface for neural networks, used to abstract across model
  * architectures and backend implementations.
  */
-class cnn_module {
+class model_backend {
 public:
-  virtual ~cnn_module() = default;
 
-  /**
-   * Creates an object detection network using a backend appropriate to the
-   * current platform and hardware.
-   *
-   * \todo Define a object_detector_config struct to encapsulate these
-   *       parameters in a more self-documenting and typesafe way.
-   * \todo Initialize the network directly from a model_spec, in lieu of passing
-   *       weights as a float_array_map.
-   */
-  static std::unique_ptr<cnn_module> create_object_detector(
-      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
-      const float_array_map& config, const float_array_map& weights);
+  virtual ~model_backend() = default;
 
   /**
    * Sets the learning rate to be used for future calls to train.
@@ -59,7 +47,7 @@ public:
    *
    * \todo Someday, once no Python frontend depends on this method, this could
    *       just take a mutable model_spec (updating the one used to initialize
-   *       the cnn_module).
+   *       the model_backend).
    */
   virtual float_array_map export_weights() const = 0;
 };
@@ -67,4 +55,4 @@ public:
 }  // namespace neural_net
 }  // namespace turi
 
-#endif  // UNITY_TOOLKITS_NEURAL_NET_CNN_MODULE_HPP_
+#endif  // UNITY_TOOLKITS_NEURAL_NET_MODEL_BACKEND_HPP_

--- a/src/unity/toolkits/neural_net/mps_compute_context.hpp
+++ b/src/unity/toolkits/neural_net/mps_compute_context.hpp
@@ -34,7 +34,7 @@ public:
   std::vector<std::string> gpu_names() const override;
   size_t memory_budget() const override;
 
-  std::unique_ptr<cnn_module> create_object_detector(
+  std::unique_ptr<model_backend> create_object_detector(
       int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
       const float_array_map& config, const float_array_map& weights) override;
 

--- a/src/unity/toolkits/neural_net/mps_compute_context.mm
+++ b/src/unity/toolkits/neural_net/mps_compute_context.mm
@@ -53,7 +53,7 @@ mps_compute_context::create_image_augmenter_for_testing(
   return std::unique_ptr<image_augmenter>(new mps_image_augmenter(opts, rng));
 }
 
-std::unique_ptr<cnn_module> mps_compute_context::create_object_detector(
+std::unique_ptr<model_backend> mps_compute_context::create_object_detector(
     int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
     const float_array_map& config, const float_array_map& weights) {
 

--- a/src/unity/toolkits/neural_net/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/neural_net/mps_graph_cnnmodule.h
@@ -39,11 +39,10 @@ public:
 
   // Training
   void set_learning_rate(float lr) override;
-  deferred_float_array train(const float_array& input_batch,
-                             const float_array& label_batch) override;
+  float_array_map train(const float_array_map& inputs) override;
 
   // Inference
-  deferred_float_array predict(const float_array& input_batch) const override;
+  float_array_map predict(const float_array_map& inputs) const override;
 
   // Forward-backward pass with specified input and top-gradient images
   deferred_float_array train_return_grad(const float_array& input_batch,
@@ -52,6 +51,7 @@ public:
   float_array_map export_weights() const override;
 
 private:
+
   MPSImageBatch *create_image_batch(MPSImageDescriptor *desc) const;
   MPSImageBatch *copy_input(const float_array& input) const;
   MPSImageBatch *copy_grad(const float_array& gradient) const;

--- a/src/unity/toolkits/neural_net/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/neural_net/mps_graph_cnnmodule.h
@@ -11,8 +11,8 @@
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
-#include <unity/toolkits/neural_net/cnn_module.hpp>
 #include <unity/toolkits/neural_net/float_array.hpp>
+#include <unity/toolkits/neural_net/model_backend.hpp>
 
 #import "mps_utils.h"
 #import "mps_graph_networks.h"
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 namespace turi {
 namespace neural_net {
 
-class mps_graph_cnn_module: public cnn_module {
+class mps_graph_cnn_module: public model_backend {
 public:
 
   mps_graph_cnn_module();

--- a/src/unity/toolkits/neural_net/mps_trainer.h
+++ b/src/unity/toolkits/neural_net/mps_trainer.h
@@ -47,40 +47,6 @@ EXPORT int TCMPSDeleteFloatArrayMapIterator(
 EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
 EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
 
-EXPORT int TCMPSForward(MPSHandle handle, TCMPSFloatArrayRef inputs, float *out,
-                        bool is_train);
-
-EXPORT int TCMPSBackward(MPSHandle handle, TCMPSFloatArrayRef gradient,
-                         float *out);
-
-EXPORT int TCMPSLoss(MPSHandle handle, TCMPSFloatArrayRef inputs,
-                     TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
-                     bool loss_image_required, float *out);
-    
-EXPORT int TCMPSForwardBackward(
-    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
-    TCMPSFloatArrayRef weights, bool loss_image_required, float *out);
-
-EXPORT int TCMPSForwardWithLoss(
-    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
-    TCMPSFloatArrayRef weights, bool loss_image_required, bool is_train,
-    float *out);
-
-EXPORT int TCMPSGetLossImages(MPSHandle handle, float *out);
-
-EXPORT int TCMPSBeginForwardBatch(
-    MPSHandle handle, int batch_id, TCMPSFloatArrayRef inputs,
-    TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
-    bool loss_image_required, bool is_train);
-
-EXPORT int TCMPSBeginForwardBackwardBatch(
-    MPSHandle handle, int batch_id, TCMPSFloatArrayRef inputs,
-    TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
-    bool loss_image_required);
-
-EXPORT int TCMPSWaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
-                        float *loss_out);
-
 EXPORT int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
                 int c_out, int h_out, int w_out, int updater_id,
                 char **config_names, void **config_arrays,
@@ -88,15 +54,18 @@ EXPORT int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in
 
 EXPORT int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len);
 
-EXPORT int TCMPSNumParams(MPSHandle handle, int *num);
-
 EXPORT int TCMPSExport(MPSHandle handle,
                        TCMPSFloatArrayMapIteratorRef* float_array_map_out);
 
-EXPORT int TCMPSCpuUpdate(MPSHandle handle);
-EXPORT int TCMPSUpdate(MPSHandle handle);
+EXPORT int TCMPSPredict(MPSHandle handle, TCMPSFloatArrayRef input,
+                        TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
+                        TCMPSFloatArrayRef* fwd_out,
+                        TCMPSFloatArrayRef* loss_out);
 
-EXPORT int TCMPSSetLearningRate(MPSHandle handle, float new_lr);
+EXPORT int TCMPSTrain(MPSHandle handle, TCMPSFloatArrayRef inputs,
+                      TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
+                      TCMPSFloatArrayRef* fwd_out,
+                      TCMPSFloatArrayRef* loss_out);
 
 #ifdef __cplusplus
 }

--- a/src/unity/toolkits/neural_net/mps_trainer.mm
+++ b/src/unity/toolkits/neural_net/mps_trainer.mm
@@ -5,29 +5,39 @@
 #include <string>
 #include <unordered_map>
 
+#include <logger/logger.hpp>
 #include <unity/toolkits/neural_net/float_array.hpp>
 
 #import "mps_cnnmodule.h"
+#import "mps_device_manager.h"
 #import "mps_utils.h"
 
-using turi::neural_net::MPSCNNModule;
 using turi::neural_net::external_float_array;
 using turi::neural_net::float_array;
 using turi::neural_net::float_array_map;
 using turi::neural_net::float_array_map_iterator;
 using turi::neural_net::make_array_map;
+using turi::neural_net::mps_cnn_module;
 using turi::neural_net::shared_float_array;
 
 int TCMPSCreateCNNModule(MPSHandle *out) {
+
   API_BEGIN();
-  MPSCNNModule *mps = new MPSCNNModule();
+
+  id <MTLDevice> dev = [[TCMPSDeviceManager sharedInstance] preferredDevice];
+  if (!dev) {
+    log_and_throw("No valid Metal device.");
+  }
+
+  mps_cnn_module *mps = new mps_cnn_module(dev);
   *out = (void *)mps;
+
   API_END();
 }
 
 int TCMPSDeleteCNNModule(MPSHandle handle) {
   API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
+  mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
   delete obj;
   API_END();
 }
@@ -106,111 +116,6 @@ int TCMPSDeleteFloatArrayMapIterator(TCMPSFloatArrayMapIteratorRef iter) {
   API_END();
 }
 
-int TCMPSForward(MPSHandle handle, TCMPSFloatArrayRef inputs, float *out,
-                 bool is_train) {
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  float_array* inputs_array = reinterpret_cast<float_array*>(inputs);
-  obj->Forward(*inputs_array, out, is_train);
-  API_END();
-}
-
-int TCMPSBackward(MPSHandle handle, TCMPSFloatArrayRef gradient,
-             float *out) {
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  float_array* gradient_array = reinterpret_cast<float_array*>(gradient);
-  obj->Backward(*gradient_array, out);
-  API_END();
-}
-
-int TCMPSLoss(MPSHandle handle, TCMPSFloatArrayRef inputs,
-              TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
-              bool loss_image_required, float *out) {
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  float_array* inputs_array = reinterpret_cast<float_array*>(inputs);
-  float_array* labels_array = reinterpret_cast<float_array*>(labels);
-  float_array* weights_array = reinterpret_cast<float_array*>(weights);
-  obj->Loss(*inputs_array, *labels_array, *weights_array, loss_image_required,
-            out);
-  API_END();
-}
-
-int TCMPSForwardBackward(
-    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
-    TCMPSFloatArrayRef weights, bool loss_image_required, float *out) {
-
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  float_array* inputs_array = reinterpret_cast<float_array*>(inputs);
-  float_array* labels_array = reinterpret_cast<float_array*>(labels);
-  float_array* weights_array = reinterpret_cast<float_array*>(weights);
-  obj->ForwardBackward(*inputs_array, *labels_array, *weights_array,
-                       loss_image_required, out);
-  API_END();
-}
-
-int TCMPSForwardWithLoss(
-    MPSHandle handle, TCMPSFloatArrayRef inputs, TCMPSFloatArrayRef labels,
-    TCMPSFloatArrayRef weights, bool loss_image_required, bool is_train,
-    float *out) {
-
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  float_array* inputs_array = reinterpret_cast<float_array*>(inputs);
-  float_array* labels_array = reinterpret_cast<float_array*>(labels);
-  float_array* weights_array = reinterpret_cast<float_array*>(weights);
-  obj->Forward(*inputs_array, *labels_array, *weights_array,
-               loss_image_required, is_train, out);
-  API_END();
-}
-
-int TCMPSGetLossImages(MPSHandle handle, float *out) {
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  obj->GetLossImages(out);
-  API_END();
-}
-
-int TCMPSBeginForwardBatch(
-    MPSHandle handle, int batch_id, TCMPSFloatArrayRef inputs,
-    TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
-    bool loss_image_required, bool is_train) {
-
-  API_BEGIN();
-  MPSCNNModule *obj = reinterpret_cast<MPSCNNModule *>(handle);
-  float_array* inputs_array = reinterpret_cast<float_array*>(inputs);
-  float_array* labels_array = reinterpret_cast<float_array*>(labels);
-  float_array* weights_array = reinterpret_cast<float_array*>(weights);
-  obj->BeginForwardBatch(batch_id, *inputs_array, *labels_array, *weights_array,
-                         loss_image_required, is_train);
-  API_END();
-}
-
-int TCMPSBeginForwardBackwardBatch(
-    MPSHandle handle, int batch_id, TCMPSFloatArrayRef inputs,
-    TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
-    bool loss_image_required) {
-
-  API_BEGIN();
-  MPSCNNModule *obj = reinterpret_cast<MPSCNNModule *>(handle);
-  float_array* inputs_array = reinterpret_cast<float_array*>(inputs);
-  float_array* labels_array = reinterpret_cast<float_array*>(labels);
-  float_array* weights_array = reinterpret_cast<float_array*>(weights);
-  obj->BeginForwardBackwardBatch(batch_id, *inputs_array, *labels_array,
-                                 *weights_array, loss_image_required);
-  API_END();
-}
-
-int TCMPSWaitForBatch(MPSHandle handle, int batch_id, float *forward_out,
-                 float *loss_out) {
-  API_BEGIN();
-  MPSCNNModule *obj = reinterpret_cast<MPSCNNModule *>(handle);
-  obj->WaitForBatch(batch_id, forward_out, loss_out);
-  API_END();
-}
-
 int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
          int c_out, int h_out, int w_out,  int updater_id,
          char **config_names, void **config_arrays,
@@ -220,8 +125,10 @@ int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w
   float_array_map config =
       make_array_map(config_names, config_arrays, config_sizes, config_len);
 
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  obj->Init(network_id, n, c_in, h_in, w_in, c_out, h_out, w_out, updater_id, config);
+  mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
+  obj->init(network_id, n, c_in, h_in, w_in, c_out, h_out, w_out, updater_id,
+            config);
+
   API_END();
 }
 
@@ -230,45 +137,82 @@ int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len)
 
   float_array_map weights = make_array_map(names, arrs, sz, len);
 
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  obj->Load(weights);
-  API_END();
-}
+  mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
+  obj->load(weights);
 
-int TCMPSNumParams(MPSHandle handle, int *num) {
-  API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  *num = obj->NumParams();
   API_END();
 }
 
 int TCMPSExport(MPSHandle handle,
                 TCMPSFloatArrayMapIteratorRef* float_array_map_out) {
   API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  auto* float_array_map = new float_array_map_iterator(obj->Export());
+  mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
+  auto* float_array_map = new float_array_map_iterator(obj->export_weights());
   *float_array_map_out =
       reinterpret_cast<TCMPSFloatArrayMapIteratorRef>(float_array_map);
   API_END();
 }
 
-int TCMPSCpuUpdate(MPSHandle handle) {
+int TCMPSPredict(MPSHandle handle, TCMPSFloatArrayRef input,
+                 TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
+                 TCMPSFloatArrayRef* fwd_out, TCMPSFloatArrayRef* loss_out) {
+
   API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  obj->Update();
+
+  mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
+
+  // This function can be called either on the training model (to compute
+  // validation statistics), or on the prediction model. In the former case, we
+  // expect validation labels and want to compute validation loss.
+  float_array_map inputs;
+  float_array* input_ptr = reinterpret_cast<float_array*>(input);
+  inputs.emplace("input", std::make_shared<external_float_array>(*input_ptr));
+
+  bool loss_image_required = labels != nullptr && weights != nullptr;
+  if (loss_image_required) {
+    float_array* labels_ptr = reinterpret_cast<float_array*>(labels);
+    float_array* weights_ptr = reinterpret_cast<float_array*>(weights);
+    inputs.emplace("labels",
+                   std::make_shared<external_float_array>(*labels_ptr));
+    inputs.emplace("weights",
+                   std::make_shared<external_float_array>(*weights_ptr));
+  }
+
+  // Perform inference.
+  float_array_map outputs = obj->predict(inputs);
+
+  // Extract the desired results.
+  shared_float_array* output = new shared_float_array(outputs.at("output"));
+  *fwd_out = reinterpret_cast<TCMPSFloatArrayRef>(output);
+  if (loss_out != nullptr) {
+    shared_float_array* loss = new shared_float_array(outputs.at("loss"));
+    *loss_out = reinterpret_cast<TCMPSFloatArrayRef>(loss);
+  }
+
   API_END();
 }
 
-int TCMPSUpdate(MPSHandle handle){
-    API_BEGIN();
-    MPSCNNModule *obj = (MPSCNNModule *)handle;
-    obj->GpuUpdate();
-    API_END();
-}
+int TCMPSTrain(MPSHandle handle, TCMPSFloatArrayRef inputs,
+               TCMPSFloatArrayRef labels, TCMPSFloatArrayRef weights,
+               TCMPSFloatArrayRef* fwd_out, TCMPSFloatArrayRef* loss_out) {
 
-int TCMPSSetLearningRate(MPSHandle handle, float new_lr) {
   API_BEGIN();
-  MPSCNNModule *obj = (MPSCNNModule *)handle;
-  obj->SetLearningRate(new_lr);
+  mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
+  float_array* inputs_ptr = reinterpret_cast<float_array*>(inputs);
+  float_array* labels_ptr = reinterpret_cast<float_array*>(labels);
+  float_array* weights_ptr = reinterpret_cast<float_array*>(weights);
+  shared_float_array inputs_array(
+      std::make_shared<external_float_array>(*inputs_ptr));
+  shared_float_array labels_array(
+      std::make_shared<external_float_array>(*labels_ptr));
+  shared_float_array weights_array(
+      std::make_shared<external_float_array>(*weights_ptr));
+  auto outputs = obj->train({ { "input",   inputs_array  },
+                              { "labels",  labels_array  },
+                              { "weights", weights_array }  });
+  shared_float_array* output = new shared_float_array(outputs.at("output"));
+  shared_float_array* loss = new shared_float_array(outputs.at("loss"));
+  *fwd_out = reinterpret_cast<TCMPSFloatArrayRef>(output);
+  *loss_out = reinterpret_cast<TCMPSFloatArrayRef>(loss);
   API_END();
 }

--- a/src/unity/toolkits/neural_net/mps_utils.h
+++ b/src/unity/toolkits/neural_net/mps_utils.h
@@ -72,6 +72,10 @@ shared_float_array copy_image_batch_float16(std::vector<size_t> shape,
                                         MPSImageBatch * _Nonnull batch);
 
 API_AVAILABLE(macos(10.14))
+shared_float_array copy_image_batch(std::vector<size_t> shape,
+                                    MPSImageBatch * _Nonnull batch);
+
+API_AVAILABLE(macos(10.14))
 void fill_image_batch(const float_array& data, MPSImageBatch * _Nonnull batch);
 
 void convert_chw_to_hwc(const float_array& image, float* out_first,

--- a/src/unity/toolkits/object_detection/object_detector.cpp
+++ b/src/unity/toolkits/object_detection/object_detector.cpp
@@ -25,13 +25,13 @@
 #include <unity/toolkits/object_detection/od_yolo.hpp>
 
 using turi::coreml::MLModelWrapper;
-using turi::neural_net::cnn_module;
 using turi::neural_net::compute_context;
 using turi::neural_net::deferred_float_array;
 using turi::neural_net::float_array_map;
 using turi::neural_net::image_annotation;
 using turi::neural_net::image_augmenter;
 using turi::neural_net::labeled_image;
+using turi::neural_net::model_backend;
 using turi::neural_net::model_spec;
 using turi::neural_net::shared_float_array;
 
@@ -284,7 +284,7 @@ void object_detector::train(gl_sframe data,
       {{ "Iteration", 12}, {"Loss", 12}, {"Elapsed Time", 12}}));
 
   // Instantiate the training dependencies: data iterator, image augmenter,
-  // backend NN module.
+  // backend NN model.
   init_train(std::move(data), std::move(annotations_column_name),
              std::move(image_column_name), std::move(opts));
 
@@ -301,11 +301,11 @@ void object_detector::train(gl_sframe data,
   training_table_printer_.reset();
 
   // Sync trained weights to our local storage of the NN weights.
-  float_array_map raw_trained_weights = training_module_->export_weights();
+  float_array_map raw_trained_weights = training_model_->export_weights();
   float_array_map trained_weights;
   for (const auto& kv : raw_trained_weights) {
-    // Convert keys from the cnn_module names (e.g. "conv7_weight") to the names
-    // we're exporting to CoreML (e.g. "conv7_fwd_weight").
+    // Convert keys from the model_backend names (e.g. "conv7_weight") to the
+    // names we're exporting to CoreML (e.g. "conv7_fwd_weight").
     const std::string modifier = "_fwd";
     std::string key = kv.first;
     std::string::iterator it = std::find(key.begin(), key.end(), '_');
@@ -350,7 +350,7 @@ variant_map_type object_detector::evaluate(
   // For each anchor box, we have 4 bbox coords + 1 conf + one-hot class labels
   int num_outputs_per_anchor = 5 + read_state<int>("num_classes");
   int num_output_channels = num_outputs_per_anchor * anchor_boxes().size();
-  std::unique_ptr<cnn_module> module = ctx->create_object_detector(
+  std::unique_ptr<model_backend> model = ctx->create_object_detector(
       /* n */     options.value("batch_size"),
       /* c_in */  NUM_INPUT_CHANNELS,
       /* h_in */  GRID_SIZE * SPATIAL_REDUCTION,
@@ -421,7 +421,7 @@ variant_map_type object_detector::evaluate(
     image_augmenter::result prepared_input_batch =
         augmenter->prepare_images(std::move(input_batch));
     auto pending_prediction = std::make_shared<deferred_float_array>(
-        module->predict(prepared_input_batch.image_batch));
+        model->predict(prepared_input_batch.image_batch));
     result_batch.image_batch = shared_float_array(pending_prediction);
 
     // Add the pending result to our queue and move on to the next input batch.
@@ -556,7 +556,7 @@ std::unique_ptr<model_spec> object_detector::init_model(
 std::shared_ptr<MLModelWrapper> object_detector::export_to_coreml(
     std::string filename, std::map<std::string, flexible_type> opts) {
 
-  // Initialize the result with the learned layers from the cnn_module.
+  // Initialize the result with the learned layers from the model_backend.
   model_spec yolo_nn_spec(nn_spec_->get_coreml_spec());
   
   std::string coordinates_str = "coordinates";
@@ -713,7 +713,7 @@ void object_detector::init_train(gl_sframe data,
   int num_outputs_per_anchor =  // 4 bbox coords + 1 conf + one-hot class labels
       5 + static_cast<int>(training_data_iterator_->class_labels().size());
   int num_output_channels = num_outputs_per_anchor * anchor_boxes().size();
-  training_module_ = training_compute_context_->create_object_detector(
+  training_model_ = training_compute_context_->create_object_detector(
       /* n */     options.value("batch_size"),
       /* c_in */  NUM_INPUT_CHANNELS,
       /* h_in */  GRID_SIZE * SPATIAL_REDUCTION,
@@ -734,7 +734,7 @@ void object_detector::perform_training_iteration() {
   // Training must have been initialized.
   ASSERT_TRUE(training_data_iterator_ != nullptr);
   ASSERT_TRUE(training_data_augmenter_ != nullptr);
-  ASSERT_TRUE(training_module_ != nullptr);
+  ASSERT_TRUE(training_model_ != nullptr);
 
   // We want to have no more than two pending batches at a time (double
   // buffering). We're about to add a new one, so wait until we only have one.
@@ -746,16 +746,16 @@ void object_detector::perform_training_iteration() {
   flex_int max_iterations = get_max_iterations();
   if (iteration_idx == max_iterations / 2) {
 
-    training_module_->set_learning_rate(BASE_LEARNING_RATE / 10.f);
+    training_model_->set_learning_rate(BASE_LEARNING_RATE / 10.f);
 
   } else if (iteration_idx == max_iterations * 3 / 4) {
 
-    training_module_->set_learning_rate(BASE_LEARNING_RATE / 100.f);
+    training_model_->set_learning_rate(BASE_LEARNING_RATE / 100.f);
 
   } else if (iteration_idx == max_iterations) {
 
     // Handle any manually triggered iterations after the last planned one.
-    training_module_->set_learning_rate(BASE_LEARNING_RATE / 1000.f);
+    training_model_->set_learning_rate(BASE_LEARNING_RATE / 1000.f);
   }
 
   // Update the model fields tracking how much training we've done.
@@ -778,8 +778,8 @@ void object_detector::perform_training_iteration() {
   shared_float_array label_batch =
       prepare_label_batch(augmenter_result.annotations_batch);
 
-  // Submit the batch to the neural net module.
-  deferred_float_array loss_batch = training_module_->train(
+  // Submit the batch to the neural net model.
+  deferred_float_array loss_batch = training_model_->train(
       augmenter_result.image_batch, label_batch);
 
   // Save the result, which is a future that can synchronize with the
@@ -795,7 +795,7 @@ float_array_map object_detector::get_model_params() const {
   // the compute backend. (We preserve the substring in nn_spec_ for inclusion
   // in the final exported model.)
   // TODO: Someday, this will all be an implementation detail of each
-  // cnn_module implementation, once they actually take model_spec values as
+  // model_backend implementation, once they actually take model_spec values as
   // inputs. Or maybe we should just not use "_fwd" in the exported model?
   float_array_map model_params;
   for (const float_array_map::value_type& kv : raw_model_params) {

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -15,9 +15,9 @@
 #include <unity/lib/extensions/ml_model.hpp>
 #include <unity/lib/gl_sframe.hpp>
 #include <unity/toolkits/coreml_export/mlmodel_wrapper.hpp>
-#include <unity/toolkits/neural_net/cnn_module.hpp>
 #include <unity/toolkits/neural_net/compute_context.hpp>
 #include <unity/toolkits/neural_net/image_augmentation.hpp>
+#include <unity/toolkits/neural_net/model_backend.hpp>
 #include <unity/toolkits/neural_net/model_spec.hpp>
 #include <unity/toolkits/object_detection/od_data_iterator.hpp>
 
@@ -156,7 +156,7 @@ class EXPORT object_detector: public ml_model_base {
   std::unique_ptr<neural_net::compute_context> training_compute_context_;
   std::unique_ptr<data_iterator> training_data_iterator_;
   std::unique_ptr<neural_net::image_augmenter> training_data_augmenter_;
-  std::unique_ptr<neural_net::cnn_module> training_module_;
+  std::unique_ptr<neural_net::model_backend> training_model_;
 
   // Nonnull while training is in progress, if progress printing is enabled.
   std::unique_ptr<table_printer> training_table_printer_;

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -162,7 +162,7 @@ class EXPORT object_detector: public ml_model_base {
   std::unique_ptr<table_printer> training_table_printer_;
 
   // Map from iteration index to the loss future.
-  std::map<size_t, neural_net::deferred_float_array> pending_training_batches_;
+  std::map<size_t, neural_net::shared_float_array> pending_training_batches_;
 };
 
 }  // object_detection

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -21,7 +21,6 @@ namespace object_detection {
 namespace {
 
 using CoreML::Specification::NeuralNetwork;
-using turi::neural_net::cnn_module;
 using turi::neural_net::compute_context;
 using turi::neural_net::deferred_float_array;
 using turi::neural_net::float_array;
@@ -29,6 +28,7 @@ using turi::neural_net::float_array_map;
 using turi::neural_net::image_annotation;
 using turi::neural_net::image_augmenter;
 using turi::neural_net::labeled_image;
+using turi::neural_net::model_backend;
 using turi::neural_net::model_spec;
 using turi::neural_net::shared_float_array;
 
@@ -97,7 +97,7 @@ public:
   std::deque<prepare_images_call> prepare_images_calls_;
 };
 
-class mock_cnn_module: public cnn_module {
+class mock_model_backend: public model_backend {
 public:
 
   using set_learning_rate_call = std::function<void(float lr)>;
@@ -109,7 +109,7 @@ public:
   using predict_call =
       std::function<deferred_float_array(const float_array& input_batch)>;
 
-  ~mock_cnn_module() {
+  ~mock_model_backend() {
     TS_ASSERT(train_calls_.empty());
     TS_ASSERT(predict_calls_.empty());
   }
@@ -154,13 +154,14 @@ public:
   using create_augmenter_call = std::function<std::unique_ptr<image_augmenter>(
       const image_augmenter::options& opts)>;
 
-  using create_cnn_module_call = std::function<std::unique_ptr<cnn_module>(
-      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
-      const float_array_map& config, const float_array_map& weights)>;
+  using create_object_detector_call =
+      std::function<std::unique_ptr<model_backend>(
+          int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+          const float_array_map& config, const float_array_map& weights)>;
 
   ~mock_compute_context() {
     TS_ASSERT(create_augmenter_calls_.empty());
-    TS_ASSERT(create_cnn_module_calls_.empty());
+    TS_ASSERT(create_object_detector_calls_.empty());
   }
 
   size_t memory_budget() const override {
@@ -181,21 +182,21 @@ public:
     return expected_call(opts);
   }
 
-  std::unique_ptr<cnn_module> create_object_detector(
+  std::unique_ptr<model_backend> create_object_detector(
       int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
       const float_array_map& config,
       const float_array_map& weights) override {
 
-    TS_ASSERT(!create_cnn_module_calls_.empty());
-    create_cnn_module_call expected_call =
-        std::move(create_cnn_module_calls_.front());
-    create_cnn_module_calls_.pop_front();
+    TS_ASSERT(!create_object_detector_calls_.empty());
+    create_object_detector_call expected_call =
+        std::move(create_object_detector_calls_.front());
+    create_object_detector_calls_.pop_front();
     return expected_call(n, c_in, h_in, w_in, c_out, h_out, w_out, config,
                          weights);
   }
 
   mutable std::deque<create_augmenter_call> create_augmenter_calls_;
-  mutable std::deque<create_cnn_module_call> create_cnn_module_calls_;
+  mutable std::deque<create_object_detector_call> create_object_detector_calls_;
 };
 
 // Subclass of object_detector that mocks out the methods that inject the
@@ -273,7 +274,8 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
   std::unique_ptr<mock_data_iterator> mock_iterator(new mock_data_iterator);
   std::unique_ptr<mock_image_augmenter> mock_augmenter(
       new mock_image_augmenter);
-  std::unique_ptr<mock_cnn_module> mock_module(new mock_cnn_module);
+  std::unique_ptr<mock_model_backend> mock_nn_model(
+      new mock_model_backend);
   std::unique_ptr<mock_compute_context> mock_context(new mock_compute_context);
 
   // We'll request 4 training iterations, since the learning rate schedule
@@ -343,17 +345,17 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
     };
     mock_augmenter->prepare_images_calls_.push_back(prepare_images_impl);
 
-    // The mock_module should expect calls to set_learning_rate just at the 50%
-    // and 75% marks.
+    // The mock_model_backend should expect calls to set_learning_rate just at
+    // the 50% and 75% marks.
     if (i == test_max_iterations / 2 || i == test_max_iterations * 3 / 4) {
 
       auto set_learning_rate_impl = [=](float lr) {
         TS_ASSERT_EQUALS(*num_iterations_submitted, i);
       };
-      mock_module->set_learning_rate_calls_.push_back(set_learning_rate_impl);
+      mock_nn_model->set_learning_rate_calls_.push_back(set_learning_rate_impl);
     }
 
-    // The mock_module should expect calls to train on every iteration.
+    // The mock_model_backend should expect `train` calls on every iteration.
     auto train_impl = [=](const float_array& input_batch,
                           const float_array& label_batch) {
 
@@ -367,7 +369,7 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
       // hardwired in to avoid fp16 underflow in MPS.
       return deferred_float_array(shared_float_array::wrap(8 * test_loss));
     };
-    mock_module->train_calls_.push_back(train_impl);
+    mock_nn_model->train_calls_.push_back(train_impl);
   }
 
   const std::string test_annotations_name = "test_annotations";
@@ -413,7 +415,7 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
     return nn_spec;
   });
 
-  auto create_cnn_module_impl = [&](int n, int c_in, int h_in, int w_in,
+  auto create_object_detector_impl = [&](int n, int c_in, int h_in, int w_in,
                                     int c_out, int h_out, int w_out,
                                     const float_array_map& config,
                                     const float_array_map& weights) {
@@ -437,9 +439,10 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
     // TODO: Assert the config values?
 
-    return std::move(mock_module);
+    return std::move(mock_nn_model);
   };
-  mock_context->create_cnn_module_calls_.push_back(create_cnn_module_impl);
+  mock_context->create_object_detector_calls_.push_back(
+      create_object_detector_impl);
 
   auto create_compute_context_impl = [&] { return std::move(mock_context); };
   model.create_compute_context_calls_.push_back(create_compute_context_impl);


### PR DESCRIPTION
This is the first step towards creating a C++ implementation of the AC toolkit, to parallel the new OD implementation. I had to generalize the `neural_net::cnn_module` interface I had created for OD, since AC requires an additional input (weights) for each training batch, and the training model returns both the forward output and the loss. To this end, I made the interface more like the MPS and CoreML interfaces, in that they take named inputs and return named outputs. Along the way, I renamed `cnn_module` to `model_backend`, since "CNN" was always a bit of a misnomer.

Note, this constitutes a dramatic narrowing of the interface for the "low-level" MPS backend. AFAICT much of this interface surface supported debugging and testing during the original development, but should not generally be needed. Much of this functionality would be straightforward to add back via configuration parameters of the revamped class.

It may be easier to review this work one commit at a time; the commit boundaries were chosen with an eye towards reviewable/logical chunks.

@igiloh,@tjia1818 FYI 