### PR TITLE
Make 3.9.2 the required version of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,16 @@ project(Turi)
 # We require a recent version of cmake and automatically
 # install a compatible version when using the cmake lists,
 # if one is not already present.
-cmake_minimum_required(VERSION 3.9.3)
+cmake_minimum_required(VERSION 3.9.2)
 
 # Libraries linked via full path no longer produce linker search paths.
 cmake_policy(SET CMP0003 NEW)
 # Preprocessor definition values are now escaped automatically.
 cmake_policy(SET CMP0005 NEW)
 # for cmake 3.0
-if(${CMAKE_MAJOR_VERSION} GREATER 2)
 cmake_policy(SET CMP0045 OLD)
 cmake_policy(SET CMP0046 OLD)
 cmake_policy(SET CMP0042 NEW)
-endif()
 
 # Generate a compilation database for use with automated tools like IDE/editor
 # plugins. See http://clang.llvm.org/docs/JSONCompilationDatabase.html

--- a/configure
+++ b/configure
@@ -429,9 +429,9 @@ function check_cmake {
     #test cmake version
     echo "Testing existing cmake version..."
     currentversion=`$CMAKE --version | awk -F "patch" '{print $1;}' | tr -dc '[0-9].'`
-    echo "Detected ${currentversion}. Required 3.9.3"
+    echo "Detected ${currentversion}. Required 3.9.2"
 
-    check_version $currentversion "3.9.3"
+    check_version $currentversion "3.9.2"
 
     if [ $? -ne 2 ]; then
       echo "CMake version is good; using built-in version."


### PR DESCRIPTION
PR #1388 went a bit too far in bumping the min version of CMake to 3.9.3.
Our Travis CI build uses 3.9.2, so since that PR went in, we have been
building CMake from source in Travis builds.

With this PR, builds should succeed on Travis without needing to build
CMake from source.