### PR TITLE
gl_sframe cache invalidation bug

### DIFF
--- a/src/sframe/sarray_reader.hpp
+++ b/src/sframe/sarray_reader.hpp
@@ -208,7 +208,7 @@ class sarray_reader: public siterable<sarray_iterator<T> > {
 
 
 
-  ~sarray_reader() { 
+  ~sarray_reader() {
     if (reader) delete reader;
   }
 
@@ -563,31 +563,7 @@ class sarray_reader: public siterable<sarray_iterator<T> > {
     for (size_t i = 0;i < m_segment_lengths.size(); ++i) {
       m_segment_lengths[i] = 
           segment_row_start_end[i].second - segment_row_start_end[i].first;
-      /*
-       * We would like to reuse the sarray_reader_buffer here.
-       * However, we have a singularly annoying problem. Which is that
-       * the sarray_reader_buffer takes a shared_ptr to the sarray_reader.
-       * There are 5 possible solutions:
-       *  - change sarray.get_reader() to return a shared_ptr and have sarray
-       *    inherit from std::enable_shared_from_this. This will allow me to
-       *    hand off a shared_ptr to the sarray_reader_buffer and be reference
-       *    counted correctly. However, this is bad since it introduces a 
-       *    circular reference meaning sarray_reader will never be deleted.
-       *  - change sarray.get_reader() to return a shared_ptr and have sarray
-       *    inherit from std::enable_shared_from_this. And modify 
-       *    sarray_reader_buffer to take a weak_ptr to break the circular 
-       *    reference. Problematic and liable to break things. For instance
-       *    if sarray_reader_buffer is constructed from a get_reader() and
-       *    the reader is thrown away.
-       *  - change sarray_reader_buffer to a regular pointer. Problematic.
-       *    like the above.
-       *  - Re-implement the sarray_reader_buffer here. Code duplication is ugly.
-       *  - keep the shared_ptr in the sarray_reader_buffer, but give it a 
-       *    shared_ptr that doesn't actually delete the pointer. Not pretty, 
-       *    but works.
-       */
-      std::shared_ptr<sarray_reader<T>> bad_ptr_to_this(this, [](void*){});
-      m_read_buffers[i].init(bad_ptr_to_this, 
+      m_read_buffers[i].init(this,
                              segment_row_start_end[i].first, 
                              segment_row_start_end[i].second);
     }

--- a/src/sframe/sarray_v2_block_manager.hpp
+++ b/src/sframe/sarray_v2_block_manager.hpp
@@ -301,7 +301,7 @@ class block_manager {
   /** 
    * file handle pool management. We implement a simple LIFO pool.
    */
-  std::deque<std::shared_ptr<general_ifstream> > m_file_handle_pool;
+  std::deque<std::weak_ptr<general_ifstream> > m_file_handle_pool;
 
   /// Pool of buffers used for decompression, returns, etc.
   buffer_pool<std::vector<char> > m_buffer_pool;

--- a/src/sframe/sframe_reader.hpp
+++ b/src/sframe/sframe_reader.hpp
@@ -220,7 +220,6 @@ class sframe_reader : public siterable<sframe_iterator> {
   /// Deleted Assignment operator
   sframe_reader& operator=(const sframe_reader& other) = delete;
 
-
   /**
    * Attempts to construct an sframe_iterator which reads 
    * If the index file cannot be opened, an exception is thrown.

--- a/src/unity/lib/gl_sframe.hpp
+++ b/src/unity/lib/gl_sframe.hpp
@@ -2816,15 +2816,14 @@ class gl_sframe {
 
   virtual std::shared_ptr<unity_sframe> get_proxy() const;
 
+
  private:
   void instantiate_new();
-  void ensure_has_sframe_reader() const;
 
   std::shared_ptr<unity_sframe> m_sframe;
-  mutable std::shared_ptr<sframe_reader> m_sframe_reader;
 
+  std::shared_ptr<sframe_reader> get_sframe_reader() const;
 };
-
 
 /**
  * Provides printing of the gl_sframe.

--- a/src/unity/lib/unity_sframe.hpp
+++ b/src/unity/lib/unity_sframe.hpp
@@ -559,11 +559,13 @@ class unity_sframe : public unity_sframe_base {
  private:
   /**
    * Pointer to the lazy evaluator logical operator node.
-   * Should never be NULL.
+   * Should never be NULL.  Must be set with the set_planner_node() function above.
    */
   std::shared_ptr<query_eval::planner_node> m_planner_node;
 
   std::vector<std::string> m_column_names;
+
+  std::shared_ptr<sframe> m_cached_sframe;
 
   /**
    * Supports \ref begin_iterator() and \ref iterator_get_next().

--- a/test/optimization/optimization_interface_test.cxx
+++ b/test/optimization/optimization_interface_test.cxx
@@ -21,7 +21,7 @@
 #include <optimization/newton_method-inl.hpp>
 #include <optimization/gradient_descent-inl.hpp>
 #include <optimization/accelerated_gradient-inl.hpp>
-#include <optimization/lbfgs-inl.hpp>
+#include <optimization/lbfgs.hpp>
 
 
 using namespace turi;
@@ -431,7 +431,7 @@ struct optimization_interface_test  {
 
     void test_lbfgs(){
       optimization::solver_return stats;
-      stats = turi::optimization::lbfgs(*solver_interface,
+      stats = turi::optimization::lbfgs_compat(solver_interface,
           init_point, opts);
       TS_ASSERT(stats.solution.isApprox(solution, 1e-2));
     }


### PR DESCRIPTION
gl_sframe had a cache invalidation bug that caused old data to be referenced by iterators that were not cleared up properly after sort.  This PR cleans up this layer as well as some messy code in the sarray reader and file handle cache layers. 