### PR TITLE
Added in check for cmake install as an osx app.

### DIFF
--- a/configure
+++ b/configure
@@ -407,6 +407,11 @@ function install_cmake {
 }
 
 CMAKE=`which cmake || echo ""`
+if [[ ! -f ${CMAKE} ]] ; then
+  if [[ -f /Applications/CMake.app/Contents/bin/cmake ]] ; then
+    CMAKE=/Applications/CMake.app/Contents/bin/cmake
+  fi
+fi
 
 function check_cmake { 
 


### PR DESCRIPTION
Installing cmake as an OSX app doesn't always install the command line utilities into the path.  This checks the default cmake app installation for cmake as well. 