### PR TITLE
Updated default compiler flags to enable newer architectures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,10 +483,10 @@ set(CMAKE_CXX_FLAGS_DEBUG
   CACHE STRING "compiler options" FORCE)
 
 set(CMAKE_C_FLAGS_RELEASE
-  "${RELEASE_OPTIMIZATION_FLAGS} -Wno-attributes ${ARCH_FLAG} ${MTUNE} ${PROFILING_FLAGS} ${C_REAL_COMPILER_FLAGS} ${WERROR_FLAGS} -DNDEBUG ${ALTERNATE_LINKER} -DHAVE_PTHREAD=1 -DARMA_NO_DEBUG"
+  "${RELEASE_OPTIMIZATION_FLAGS} -Wno-attributes ${ARCH_FLAG} ${MTUNE} ${PROFILING_FLAGS} ${C_REAL_COMPILER_FLAGS} ${WERROR_FLAGS} -DNDEBUG ${ALTERNATE_LINKER} -DHAVE_PTHREAD=1"
   CACHE STRING "compiler options" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE
-  "${RELEASE_OPTIMIZATION_FLAGS} ${EXTRA_OPTIMIZATION_FLAGS} ${DISABLE_WARNING_FLAGS} ${PROFILING_FLAGS} -Wno-attributes ${ARCH_FLAG} ${MTUNE} ${CPP_REAL_COMPILER_FLAGS} ${WERROR_FLAGS} ${INT128_FLAGS} ${ALTERNATE_LINKER} -DNDEBUG -DHAVE_PTHREAD=1 -DARMA_NO_DEBUG"
+  "${RELEASE_OPTIMIZATION_FLAGS} ${EXTRA_OPTIMIZATION_FLAGS} ${DISABLE_WARNING_FLAGS} ${PROFILING_FLAGS} -Wno-attributes ${ARCH_FLAG} ${MTUNE} ${CPP_REAL_COMPILER_FLAGS} ${WERROR_FLAGS} ${INT128_FLAGS} ${ALTERNATE_LINKER} -DNDEBUG -DHAVE_PTHREAD=1"
   CACHE STRING "compiler options" FORCE)
 
 #**************************************************************************/
@@ -552,7 +552,6 @@ endif()
 add_compile_options(-Dgoogle=__tc_google)
 add_compile_options(-DCoreML=__tc_CoreML)
 add_compile_options(-DHAVE_PTHREAD=1)
-add_compile_options(-DEIGEN_MPL2_ONLY)
 
 ##############################################################################
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,23 +404,13 @@ if (MARCH)
 elseif (ARCH)
   set(ARCH_FLAG "-arch ${ARCH}")
 else()
-  set(MARCH "x86-64")
+  set(MARCH "nehalem")  # Old CPU archetecture; enables SSE up to 4.2 + popcnt + other instructions. 
   set(ARCH_FLAG "-march=${MARCH}")
 endif()
 
 # check if MTUNE is set
 if (NOT MTUNE)
-  #set to native if supported
-  check_cxx_compiler_flag(-mtune=native HAS_MTUNE_NATIVE)
-  check_cxx_compiler_flag(-mtune=${MARCH} HAS_MTUNE_MARCH)
-  check_cxx_compiler_flag(-mtune=${ARCH} HAS_MTUNE_ARCH)
-  if(HAS_MTUNE_NATIVE)
-    set(MTUNE "-mtune=native")
-  elseif(HAS_MTUNE_MARCH)
-    set(MTUNE "-mtune=${MARCH}")
-  elseif(HAS_MTUNE_ARCH)
-    set(MTUNE "-mtune=${ARCH}")
-  endif()
+  set(MTUNE "-mtune=generic") # Reommended way of setting this for generic distributions
 endif()
 
 set(EXTRA_OPTIMIZATION_FLAGS "")
@@ -498,7 +488,6 @@ set(CMAKE_C_FLAGS_RELEASE
 set(CMAKE_CXX_FLAGS_RELEASE
   "${RELEASE_OPTIMIZATION_FLAGS} ${EXTRA_OPTIMIZATION_FLAGS} ${DISABLE_WARNING_FLAGS} ${PROFILING_FLAGS} -Wno-attributes ${ARCH_FLAG} ${MTUNE} ${CPP_REAL_COMPILER_FLAGS} ${WERROR_FLAGS} ${INT128_FLAGS} ${ALTERNATE_LINKER} -DNDEBUG -DHAVE_PTHREAD=1 -DARMA_NO_DEBUG"
   CACHE STRING "compiler options" FORCE)
-
 
 #**************************************************************************/
 #*                                                                        */


### PR DESCRIPTION
Turns out the default one was REALLY old. 