### PR TITLE
Link build status badge to branch overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Quick Links: [Installation](#supported-platforms) | [Documentation](#documentation) | [WWDC 2018 Talk](https://developer.apple.com/videos/play/wwdc2018/712/)
 
-[![Build Status](https://travis-ci.com/apple/turicreate.svg?branch=master)](https://travis-ci.com/apple/turicreate)
+[![Build Status](https://travis-ci.com/apple/turicreate.svg?branch=master)](https://travis-ci.com/apple/turicreate/branches)
 
 <img align="right" src="https://docs-assets.developer.apple.com/turicreate/turi-dog.svg" alt="Turi Create" width="100">
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 Quick Links: [Installation](#supported-platforms) | [Documentation](#documentation) | [WWDC 2018 Talk](https://developer.apple.com/videos/play/wwdc2018/712/)
 
-[![Build Status](https://travis-ci.com/apple/turicreate.svg?branch=master)](https://travis-ci.com/apple/turicreate/branches)
+[![Build Status](https://travis-ci.com/apple/turicreate.svg?branch=master)](#)
+[![PyPI Release](https://img.shields.io/pypi/v/turicreate.svg)](#)
+[![Python Versions](https://img.shields.io/pypi/pyversions/turicreate.svg)](#)
 
-<img align="right" src="https://docs-assets.developer.apple.com/turicreate/turi-dog.svg" alt="Turi Create" width="100">
+[<img align="right" src="https://docs-assets.developer.apple.com/turicreate/turi-dog.svg" alt="Turi Create" width="100">](#)
 
 # Turi Create 
 


### PR DESCRIPTION
Currently, our build status badge links to whatever happens to be the "current" build, which is usually a random pull request build. This commit changes that to link to the branch overview page (which lists the default branch, master, separately and first). I couldn't find a better direct link for just the master branch.