### PR TITLE
Temporarily mark CoreML export test as xfail

### DIFF
--- a/src/unity/python/turicreate/test/test_coreml_export.py
+++ b/src/unity/python/turicreate/test/test_coreml_export.py
@@ -178,6 +178,8 @@ class CoreMLExportTest(unittest.TestCase):
     # Classification 
 
     def test_logistic_classifier(self):
+        if _mac_ver() < (10, 14):
+            pytest.xfail("See https://github.com/apple/turicreate/issues/1332")
         for code_string in ["b"*40, "nnnn", "v", "d", "A", "bnsCvAd"]:
             train, test = self.generate_data("classification", 100, code_string)
             model = tc.logistic_classifier.create(train, "target", validation_set = None)
@@ -185,6 +187,8 @@ class CoreMLExportTest(unittest.TestCase):
             self._test_coreml_export(model, test, False)
 
     def test_svm_classifier(self):
+        if _mac_ver() < (10, 14):
+            pytest.xfail("See https://github.com/apple/turicreate/issues/1332")
         for code_string in ["b"*40, "nnnn", "v", "d", "A", "bnsCvAd"]:
             train, test = self.generate_data("classification", 100, code_string)
             model = tc.svm_classifier.create(train, "target", validation_set = None)
@@ -246,6 +250,8 @@ class CoreMLExportTest(unittest.TestCase):
     #  Muliclass 
 
     def test_logistic_multiclass(self):
+        if _mac_ver() < (10, 14):
+            pytest.xfail("See https://github.com/apple/turicreate/issues/1332")
         for code_string in ["b"*40, "nnnn", "v", "d", "A", "bnsCvAd"]:
             train, test = self.generate_data("multiclass", 100, code_string)
             model = tc.logistic_classifier.create(train, "target", validation_set = None, max_iterations = 5)
@@ -311,6 +317,8 @@ class CoreMLExportTest(unittest.TestCase):
 
 
     def test_logistic_multiclass_tiny(self):
+        if _mac_ver() < (10, 14):
+            pytest.xfail("See https://github.com/apple/turicreate/issues/1332")
         for code_string in ["b"*40, "nnnn", "v", "d", "A", "bnsCvAd"]:
             train, test = self.generate_data("multiclass", 8, code_string)
             model = tc.logistic_classifier.create(train, "target", validation_set = None)

--- a/src/unity/python/turicreate/test/test_coreml_export.py
+++ b/src/unity/python/turicreate/test/test_coreml_export.py
@@ -114,6 +114,8 @@ class CoreMLExportTest(unittest.TestCase):
     # Regression 
 
     def test_linear_regression(self):
+        if _mac_ver() < (10, 14):
+            pytest.xfail("See https://github.com/apple/turicreate/issues/1332")
         for code_string in ["b"*40, "nnnn", "v", "d", "A", "bnsCvAd"]:
             train, test = self.generate_data("regression", 100, code_string)
             model = tc.linear_regression.create(train, "target", validation_set = None)


### PR DESCRIPTION
This will suppress the failure in #1332. When that issue is fixed, we
should remove the xfail.