### PR TITLE
Implement Core ML export for C++ activity classifier

### DIFF
--- a/src/unity/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/unity/toolkits/activity_classification/activity_classifier.hpp
@@ -10,6 +10,7 @@
 #include <unity/lib/extensions/ml_model.hpp>
 #include <unity/lib/gl_sframe.hpp>
 #include <unity/toolkits/activity_classification/ac_data_iterator.hpp>
+#include <unity/toolkits/coreml_export/mlmodel_wrapper.hpp>
 #include <unity/toolkits/neural_net/compute_context.hpp>
 #include <unity/toolkits/neural_net/model_backend.hpp>
 #include <unity/toolkits/neural_net/model_spec.hpp>
@@ -31,6 +32,8 @@ class EXPORT activity_classifier: public ml_model_base {
              std::string session_id_column_name,
              variant_type validation_data,
              std::map<std::string, flexible_type> opts);
+  std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
+      std::string filename);
 
   // TODO: Remainder of public interface: export, evaluate, predict, save/load
 
@@ -87,6 +90,9 @@ class EXPORT activity_classifier: public ml_model_base {
       "    Number of sequence chunks used per training step. Must be greater than\n"
       "    the number of GPUs in use. The default is 32.\n"
   );
+
+  REGISTER_CLASS_MEMBER_FUNCTION(activity_classifier::export_to_coreml,
+                                 "filename");
 
   END_CLASS_MEMBER_REGISTRATION
 

--- a/src/unity/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/unity/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -34,6 +34,12 @@ std::shared_ptr<coreml::MLModelWrapper> export_object_detector_model(
     size_t image_height, size_t num_classes, size_t num_predictions,
     flex_dict user_defined_metadata, flex_list class_labels, std::map<std::string, flexible_type> options);
 
+/** Wraps a trained activity classifier model_spec as a complete MLModel. */
+std::shared_ptr<coreml::MLModelWrapper> export_activity_classifier_model(
+    const neural_net::model_spec& nn_spec, size_t prediction_window,
+    const flex_list& features, size_t lstm_hidden_layer_size,
+    const flex_list& class_labels, const flex_string& target);
+
 }  // namespace turi
 
 #endif  // UNITY_TOOLKITS_COREML_EXPORT_NEURAL_NETS_MODELS_EXPORTER_HPP_

--- a/src/unity/toolkits/neural_net/model_spec.cpp
+++ b/src/unity/toolkits/neural_net/model_spec.cpp
@@ -139,7 +139,7 @@ void wrap_network_params(const std::string& name,
   const size_t c = inner_product.inputchannels();
 
   shared_float_array weights = weight_params_float_array::create_view(
-      {n, c}, inner_product.weights());
+      {n, c, 1, 1}, inner_product.weights());
   params_out->emplace(name + "_weight", std::move(weights));
 
   if (inner_product.has_bias()) {

--- a/src/unity/toolkits/neural_net/mps_trainer.h
+++ b/src/unity/toolkits/neural_net/mps_trainer.h
@@ -47,12 +47,12 @@ EXPORT int TCMPSDeleteFloatArrayMapIterator(
 EXPORT int TCMPSCreateCNNModule(MPSHandle *handle);
 EXPORT int TCMPSDeleteCNNModule(MPSHandle handle);
 
-EXPORT int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
-                int c_out, int h_out, int w_out, int updater_id,
-                char **config_names, void **config_arrays,
-                int64_t *config_sizes, int config_len);
+EXPORT int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in,
+                     int h_in, int w_in, int c_out, int h_out, int w_out,
+                     int updater_id, char **config_names, void **config_arrays,
+                     int config_len);
 
-EXPORT int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len);
+EXPORT int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int len);
 
 EXPORT int TCMPSExport(MPSHandle handle,
                        TCMPSFloatArrayMapIteratorRef* float_array_map_out);

--- a/src/unity/toolkits/neural_net/mps_trainer.mm
+++ b/src/unity/toolkits/neural_net/mps_trainer.mm
@@ -116,14 +116,14 @@ int TCMPSDeleteFloatArrayMapIterator(TCMPSFloatArrayMapIteratorRef iter) {
   API_END();
 }
 
-int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w_in,
-         int c_out, int h_out, int w_out,  int updater_id,
-         char **config_names, void **config_arrays,
-         int64_t *config_sizes, int config_len) {
+int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in,
+              int w_in, int c_out, int h_out, int w_out,  int updater_id,
+              char **config_names, void **config_arrays, int config_len)
+{
   API_BEGIN();
 
   float_array_map config =
-      make_array_map(config_names, config_arrays, config_sizes, config_len);
+      make_array_map(config_names, config_arrays, config_len);
 
   mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
   obj->init(network_id, n, c_in, h_in, w_in, c_out, h_out, w_out, updater_id,
@@ -132,10 +132,10 @@ int TCMPSInit(MPSHandle handle, int network_id, int n, int c_in, int h_in, int w
   API_END();
 }
 
-int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int64_t *sz, int len) {
+int TCMPSLoad(MPSHandle handle, char **names, void **arrs, int len) {
   API_BEGIN();
 
-  float_array_map weights = make_array_map(names, arrs, sz, len);
+  float_array_map weights = make_array_map(names, arrs, len);
 
   mps_cnn_module *obj = reinterpret_cast<mps_cnn_module*>(handle);
   obj->load(weights);

--- a/src/unity/toolkits/neural_net/mps_utils.h
+++ b/src/unity/toolkits/neural_net/mps_utils.h
@@ -83,9 +83,6 @@ void convert_chw_to_hwc(const float_array& image, float* out_first,
 void convert_hwc_to_chw(const float_array& image, float* out_first,
                         float* out_last);
 
-float_array_map make_array_map(char **names, void **arrays,
-                               int64_t *sizes, int len);
-
 // This version assumes that each void* is actually a float_array*. This casting
 // from plain C should go away once we remove the original Python frontend.
 float_array_map make_array_map(char **names, void **arrays, int len);

--- a/src/unity/toolkits/neural_net/mps_utils.mm
+++ b/src/unity/toolkits/neural_net/mps_utils.mm
@@ -233,19 +233,7 @@ void fill_image_batch(const float_array& blob, MPSImageBatch *batch) {
   }
 }
 
-float_array_map make_array_map(char **names, void **arrays,
-                               int64_t *sizes, int len) {
-  float_array_map ret;
-  for (int i = 0; i < len; ++i) {
-    std::string name = names[i];
-    const float* array = reinterpret_cast<const float*>(arrays[i]);
-    const size_t size = static_cast<size_t>(sizes[i]);
-    ret[name] = shared_float_array::copy(array, {size});
-  }
-  return ret;
-}
-
-// This version assumes that each void* is actually a float_array*. This casting
+// Assumes that each void* is actually a float_array*. This casting
 // from plain C should go away once we remove the original Python frontend.
 float_array_map make_array_map(char **names, void **arrays, int len) {
   float_array_map ret;


### PR DESCRIPTION
The Python toolkit was assuming NHWC at the interface with TCMPS, but we should adopt NCHW for consistency with the Core ML representation. Note that this didn't matter before, since on the weights loaded into TCMPS were random, and the weights exported from TCMPS weren't being consumed. Now they're being exported further to the .mlmodel file.