### PR TITLE
Fix build errors (warnings)

### DIFF
--- a/src/unity/toolkits/drawing_classifier/data_preparation.cpp
+++ b/src/unity/toolkits/drawing_classifier/data_preparation.cpp
@@ -82,8 +82,8 @@ public:
         return m_y;
     }
 private:
-    float m_x = 0;
-    float m_y = 0;
+    float m_x = 0.0f;
+    float m_y = 0.0f;
 };
 
 class Line {

--- a/src/unity/toolkits/drawing_classifier/data_preparation.cpp
+++ b/src/unity/toolkits/drawing_classifier/data_preparation.cpp
@@ -82,8 +82,8 @@ public:
         return m_y;
     }
 private:
-    float m_x;
-    float m_y;
+    float m_x = 0;
+    float m_y = 0;
 };
 
 class Line {


### PR DESCRIPTION
Looks like the compiler was not happy with m_x and m_y staying uninitialized. In theory, it could happen that we make a point with m_x and no m_y or vice versa, but in practice, we would throw an error if any of the "x" or "y" coordinates was missing.