### PR TITLE
Fixes #1407

### DIFF
--- a/src/unity/python/turicreate/test/test_evaluation.py
+++ b/src/unity/python/turicreate/test/test_evaluation.py
@@ -966,6 +966,8 @@ class MetricsTest(unittest.TestCase):
         self.assertAlmostEqual(skl_score, str_score)
 
         # Act [Average = None]
+        prec_score = precision_score(list(targets), list(predictions),
+            average = None)
         score = turicreate.toolkits.evaluation.accuracy(targets,
                                             predictions,
                                             average = None)
@@ -979,12 +981,12 @@ class MetricsTest(unittest.TestCase):
 
         # Note: Explicitly not putting it into a for loop for ease of
         # debugging when the tests fail.
-        self.assertAlmostEqual(cls_skl_score[0], score[0])
-        self.assertAlmostEqual(cls_skl_score[0], str_score['0'])
-        self.assertAlmostEqual(cls_skl_score[1], score[1])
-        self.assertAlmostEqual(cls_skl_score[1], str_score['1'])
-        self.assertAlmostEqual(cls_skl_score[2], score[2])
-        self.assertAlmostEqual(cls_skl_score[2], str_score['2'])
+        self.assertAlmostEqual(prec_score[0], score[0])
+        self.assertAlmostEqual(prec_score[0], str_score['0'])
+        self.assertAlmostEqual(prec_score[1], score[1])
+        self.assertAlmostEqual(prec_score[1], str_score['1'])
+        self.assertAlmostEqual(prec_score[2], score[2])
+        self.assertAlmostEqual(prec_score[2], str_score['2'])
 
     def test_missing_values(self):
         # Arrange

--- a/src/unity/toolkits/evaluation/evaluation_interface-inl.hpp
+++ b/src/unity/toolkits/evaluation/evaluation_interface-inl.hpp
@@ -1388,8 +1388,10 @@ class flexible_accuracy : public precision_recall_base {
 
     // Multi-class vs binary classification.
     std::unordered_map<flexible_type, double> accuracy_scores;
+    std::unordered_map<flexible_type, flexible_type> precision_scores;
     for (const auto& l: labels) {
       accuracy_scores[l] = double(tp[l] + tn[l])/(tp[l] + fp[l] + tn[l] + fn[l]);
+      precision_scores[l] = compute_precision_score(tp[l], fp[l]);
     }
 
     // For binary classification, return the scores for the final label.
@@ -1430,7 +1432,7 @@ class flexible_accuracy : public precision_recall_base {
       // All scores.
       case average_type_enum::NONE:
       {
-        return to_variant(accuracy_scores);
+        return to_variant(precision_scores);
       }
 
       default: {

--- a/userguide/evaluation/classification.md
+++ b/userguide/evaluation/classification.md
@@ -70,8 +70,8 @@ print(tc.evaluation.accuracy(y, yhat, average = None))
 ```
 ```no-highlight
 0.5
-0.666666666667
-{'dog': 0.75, 'foosa': 0.75, 'cat': 0.5}
+0.6666666666666666
+{'foosa': None, 'dog': 0.5, 'cat': 0.5}
 ```
 
 In general, when there are different numbers of examples per class, the average

--- a/userguide/evaluation/classification.md
+++ b/userguide/evaluation/classification.md
@@ -56,7 +56,8 @@ them are:
   each class was correctly predicted and incorrectly predicted.
 * **macro**: Calculate metrics for each "class" independently, and find their
   unweighted mean. This does not take label imbalance into account.
-* **None**: Return a metric corresponding to each class.
+* **None**: Return a metric corresponding to each class, which is the 
+  precision for each class.
 
 ```python
 import turicreate as tc
@@ -85,6 +86,9 @@ without its own caveats, however: for instance, if there are very few examples o
 class, the test statistics for that class will be unreliable (i.e., they have
 large variance), so it’s not statistically sound to average quantities with
 different degrees of variance.
+
+Note that the `average` parameter passed into `tc.evaluation.accuracy`
+may be deprecated soon, and will break code that uses this API.
 
 
 ## Confusion matrix {#confusion_matrix}


### PR DESCRIPTION
As per the conversation with @hoytak , we want to return the precision and not the accuracy when `average=None` is passed into `tc.evaluation.accuracy`.

As of this change, when the input is:
```
import turicreate as tc 
y    = tc.SArray(["cat", "dog", "foosa", "cat"])
yhat = tc.SArray(["cat", "dog", "cat", "dog"])
print(tc.evaluation.accuracy(y, yhat, average = "micro"))
print(tc.evaluation.accuracy(y, yhat, average = "macro"))
print(tc.evaluation.accuracy(y, yhat, average = None))
```
The output is:
```
0.5
0.6666666666666666
{'foosa': None, 'dog': 0.5, 'cat': 0.5}
```
