### PR TITLE
Added six as a depedency to setup.py

### DIFF
--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -183,6 +183,7 @@ if __name__ == '__main__':
             "pillow >= 3.3.0",
             "pandas >= 0.19.0",
             "scipy >= 0.14.0",
+            "six >= 1.10.0",
             "resampy == 0.2.1",
             "numpy"
         ],


### PR DESCRIPTION
The version of `coremltools` we use also requires `"six >= 1.10.0"`

Finishes the fix for #1417.