### PR TITLE
Fix method name in error message

### DIFF
--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -2523,7 +2523,7 @@ class SArray(object):
         """
 
         if (dtype == _Image) and (self.dtype == array.array):
-            raise TypeError("Cannot cast from image type to array with sarray.astype(). Please use sarray.pixel_array_to_img() instead.")
+            raise TypeError("Cannot cast from image type to array with sarray.astype(). Please use sarray.pixel_array_to_image() instead.")
 
         with cython_context():
             return SArray(_proxy=self.__proxy__.astype(dtype, undefined_on_failure))


### PR DESCRIPTION
The method is actually called `pixel_array_to_image`.