### PR TITLE
Fix scatter plot and heat map axes

### DIFF
--- a/src/unity/lib/visualization/heatmap.cpp
+++ b/src/unity/lib/visualization/heatmap.cpp
@@ -298,7 +298,7 @@ flexible_type heatmap_result::emit() const {
       flex_dict value;
       size_t count = row[j];
       double yScale = static_cast<double>(j) / static_cast<double>(row_size);
-      double y1 = yScale * yWidth;
+      double y1 = (yScale * yWidth) + extrema.y.get_min();
       double y2 = y1 + yBinWidth;
       value.push_back(std::make_pair("x_left", x1));
       value.push_back(std::make_pair("x_right", x2));

--- a/src/unity/lib/visualization/vega_spec/heatmap.json
+++ b/src/unity/lib/visualization/vega_spec/heatmap.json
@@ -126,13 +126,12 @@
     },
     {
       "scale": "y",
-      "labelOverlap": true,
+      "labelOverlap": false,
       "orient": "left",
       "tickCount": {
         "signal": "min(ceil(height/40), 40)"
       },
-      "title": "{{ylabel}}",
-      "zindex": 1
+      "title": "{{ylabel}}"
     }
   ],
   "legends": [

--- a/src/unity/lib/visualization/vega_spec/scatter.json
+++ b/src/unity/lib/visualization/vega_spec/scatter.json
@@ -66,7 +66,8 @@
         }
       ],
       "nice": true,
-      "zero": true
+      "zero": false,
+      "padding": 5
     },
     {
       "name": "y",
@@ -82,7 +83,8 @@
         0
       ],
       "nice": true,
-      "zero": true
+      "zero": false,
+      "padding": 5
     }
   ],
   "axes": [


### PR DESCRIPTION
Fixes #1194 by setting `zero: false` and using padding on scatter plot.

Also fixes heat map Y axis labels -- they were appearing relative to
Y-min, not absolute. No issue appears to be tracking this however.