### PR TITLE
Update LINUX_INSTALL.md

### DIFF
--- a/LINUX_INSTALL.md
+++ b/LINUX_INSTALL.md
@@ -11,7 +11,12 @@ The minimum requirements are:
 
 ### Ubuntu >= 17.10
 
-Follow the instructions for Ubuntu >= 16.04, but also install `libgconf-2-4`. This was previously included in desktop Ubuntu distributions but now needs to be installed separately starting with 17.10.
+Follow the instructions for Ubuntu >= 16.04, but also install the following dependencies. These was previously included in desktop Ubuntu distributions but now needs to be installed separately starting with 17.10.
+
+```shell
+sudo apt-get install libgconf-2-4
+sudo apt-get install libatlas3-base
+```
 
 ### Ubuntu >= 16.04
 On recent versions of Ubuntu, we just need a few dependencies


### PR DESCRIPTION
Adding `libatlas3-base` as a dependency for turicreate. Several user-repoted turicreate imports failed with this error (`ImportError: libblas.so.3: cannot open shared object file: No such file or directory`). Installing `libatlas3-base` fixes that on Ubuntu 18.04. 

For reference, see issues here: https://github.com/apple/turicreate/issues/1047 and https://github.com/apple/turicreate/issues/191