### PR TITLE
WIP: Add missing JS files used to generate documentation images

### DIFF
--- a/userguide/README.md
+++ b/userguide/README.md
@@ -89,3 +89,7 @@ With Core ML, you can integrate machine learning models into your macOS,
 iOS, watchOS, and tvOS app. Many models created  in Turi Create can be
 exported for use in Core ML.
 
+<script type="text/javascript" src="../turi/js/jquery/jquery-2.1.3.min.js"></script>
+<script type="text/javascript" src="../turi/js/d3/d3.min.js"></script>
+<script type="text/javascript" src="../supervised-learning/images/random-utils.js"></script>
+<script type="text/javascript" src="../supervised-learning/images/plotting-utils.js"></script>


### PR DESCRIPTION
## Summary

This adds the necessary Javascript files used to generate the documentation images like [here](https://turi.com/learn/userguide/supervised-learning/linear-regression.html). Fixes #1092.

## Open questions

- It's unclear if this is the conventional "gitbook-y" way to include these relevant files
- It's unclear how these files were not included during the documentation transition from Turi.com to Github.io
- This only adds back in the Javascript files but does not republish the static site; I believe this is done with `gitbook build .`