### PR TITLE
Fix issue with documentation failing to display generated images

### DIFF
--- a/userguide/_layouts/website/page.html
+++ b/userguide/_layouts/website/page.html
@@ -1,0 +1,9 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    <script src="{{ "turi/js/jquery/jquery-2.1.3.min.js"|resolveFile }}"></script>
+    <script src="{{ "turi/js/d3/d3.min.js"|resolveFile }}"></script>
+    <script src="{{ "supervised-learning/images/random-utils.js"|resolveFile }}"></script>
+    <script src="{{ "supervised-learning/images/plotting-utils.js"|resolveFile }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary

This adds the necessary Javascript files used to generate the documentation images. Instead of using a custom plugin to accomplish this we are extending the default theme and appending these Javascript sources to `<head>`. Gitbook works [automagically](https://toolchain.gitbook.com/themes/) to inspect the `_layouts` directory and applies contents to the appropriate parent files. Note that this restores functionality present in the [previous documentation set](https://github.com/turi-code/userguide/blob/master/book.json).

Fixes #1092.

## Open question

- This only adds back in the Javascript files but does not republish the static site; I believe this is done with `gitbook build .` and then publishing those static files