### PR TITLE
Check Linear Regression target column data type

### DIFF
--- a/src/unity/toolkits/supervised_learning/supervised_learning.cpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.cpp
@@ -1037,6 +1037,8 @@ void supervised_learning_model_base::api_train(
   sframe X = f_data.materialize_to_sframe(); 
     
   sframe y = data.select_columns({target}).materialize_to_sframe();
+    
+  check_target_column_type(this->name(), y);
 
   ml_missing_value_action missing_value_action =
     this->support_missing_value() ? ml_missing_value_action::USE_NAN
@@ -1049,9 +1051,6 @@ void supervised_learning_model_base::api_train(
     valid_X = validation_data.select_columns(f_data.column_names()).materialize_to_sframe();
     
     valid_y = validation_data.select_columns({target}).materialize_to_sframe();
-
-    
-    check_target_column_type(this->name(), valid_y);
 
     auto valid_filter_names = f_data.column_names();
     valid_filter_names.push_back(target);

--- a/src/unity/toolkits/supervised_learning/supervised_learning.cpp
+++ b/src/unity/toolkits/supervised_learning/supervised_learning.cpp
@@ -1051,6 +1051,8 @@ void supervised_learning_model_base::api_train(
     valid_X = validation_data.select_columns(f_data.column_names()).materialize_to_sframe();
     
     valid_y = validation_data.select_columns({target}).materialize_to_sframe();
+      
+    check_target_column_type(this->name(), valid_y);
 
     auto valid_filter_names = f_data.column_names();
     valid_filter_names.push_back(target);


### PR DESCRIPTION
Linear Regression accepts 'int' and 'float' target values. Previously `check_target_column_type()` which checks the type of target values was called on the validation set. Validation set is only created for a dataset size 100 or larger. For cases when data with fewer than 100 examples was given, the check was not applied and target values of type string were being accepted and handled incorrectly. 

The check for target values type is now applied on the target column of the data passed in. Fixes https://github.com/apple/turicreate/issues/1298