### PR TITLE
numba and llvmlite now have Python 3.5 wheels on PyPI

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,3 @@
-numba==0.42.0
-llvmlite==0.27.0
 coremltools==2.1.0
 scipy==0.19.1
 numpy==1.11.1

--- a/src/unity/python/setup.py
+++ b/src/unity/python/setup.py
@@ -175,8 +175,6 @@ if __name__ == '__main__':
         long_description=long_description,
         classifiers=classifiers,
         install_requires=[
-            "numba == 0.42.0",
-            "llvmlite == 0.27.0",
             "decorator >= 4.0.9",
             "prettytable == 0.7.2",
             "requests >= 2.9.1",


### PR DESCRIPTION
The latest versions of [numba](https://pypi.org/project/numba/#files) and [llvmlite](https://pypi.org/project/llvmlite/#files) now both have wheels for Python 3.5. So I think it's safe to remove these pins. 