### PR TITLE
Prevent multithreaded execution within lambda workers. 

### DIFF
--- a/src/unity/python/turicreate/_scripts/_pylambda_worker.py
+++ b/src/unity/python/turicreate/_scripts/_pylambda_worker.py
@@ -48,6 +48,17 @@ def setup_environment(info_log_function = None, error_log_function = None):
     for i, p in enumerate(sys.path):
         _write_log("  sys.path[%d] = %s. " % (i, sys.path[i]))
 
+    #######################################
+    # Write some specific local environment variables to try to keep everything 
+    # run in a lambda worker to single thread mode.
+
+    os.environ["OMP_NUM_THREADS"] = "1"
+    os.environ["OPENBLAS_NUM_THREADS"] = "1"
+    os.environ["MKL_NUM_THREADS"] = "1"
+    os.environ["MKL_DOMAIN_NUM_THREADS"] = "1"
+    os.environ["NUMBA_NUM_THREADS"] = "1"
+
+
     ########################################
     # Now, import thnigs
 

--- a/src/unity/python/turicreate/test/test_lambda.py
+++ b/src/unity/python/turicreate/test/test_lambda.py
@@ -13,6 +13,7 @@ import logging
 import array
 from ..connect import main as glconnect
 from ..cython import cy_test_utils
+import os
 
 
 def fib(i):
@@ -61,6 +62,27 @@ class LambdaTests(unittest.TestCase):
         ans = fib(xin)
         for a in ans_list:
             self.assertEqual(a, ans)
+
+    def test_environments(self):
+
+        def test_env(i):
+
+            if i > 500:
+                assert os.environ["OMP_NUM_THREADS"] == "1"
+                assert os.environ["OPENBLAS_NUM_THREADS"] == "1"
+                assert os.environ["MKL_NUM_THREADS"] == "1"
+                assert os.environ["MKL_DOMAIN_NUM_THREADS"] == "1"
+                assert os.environ["NUMBA_NUM_THREADS"] == "1"
+
+            return i
+
+
+        import turicreate as tc
+        x = tc.SArray(range(10000)) 
+        y = x.apply(test_env)
+
+        self.assertTrue( (x == y).all() )
+ 
 
     @unittest.skip("Disabling crash recovery test")
     def test_crash_recovery(self):


### PR DESCRIPTION
Added environment variables in the lambda workers to try to prevent multithreaded execution by common frameworks on lambda workers. 
