### PR TITLE
WIP: Possible fix for numba bug.

### DIFF
--- a/src/lambda/pylambda.hpp
+++ b/src/lambda/pylambda.hpp
@@ -77,6 +77,7 @@ struct lambda_graph_triple_apply_data {
   size_t srcid_column, dstid_column;
 };
 
+typedef void __PyThreadState;
 
 struct pylambda_evaluation_functions {
   void (*set_random_seed)(size_t seed);
@@ -86,6 +87,8 @@ struct pylambda_evaluation_functions {
   void (*eval_lambda_by_dict)(size_t, lambda_call_by_dict_data*);
   void (*eval_lambda_by_sframe_rows)(size_t, lambda_call_by_sframe_rows_data*);
   void (*eval_graph_triple_apply)(size_t, lambda_graph_triple_apply_data*);  
+  __PyThreadState* (*PyThreadState_Swap)(__PyThreadState*);
+  __PyThreadState* (*PyThreadState_Get)(void);
 };
 
 /** This is called through the cython functions to set up the

--- a/src/unity/python/turicreate/test/test_lambda.py
+++ b/src/unity/python/turicreate/test/test_lambda.py
@@ -76,3 +76,20 @@ class LambdaTests(unittest.TestCase):
             return x
         self.assertRaises(RuntimeError, lambda: glconnect.get_unity().parallel_eval_lambda(lambda x: bad_fun(x), ls))
         glconnect.get_unity().parallel_eval_lambda(lambda x: good_fun(x), ls)
+
+    def test_numba(self):
+
+        from numba import jit
+        import numpy as np
+        import turicreate as tc
+
+        @jit
+        def _sum(x):
+            return x[0, 0]
+
+        print("BORK")
+        tc.SArray([np.random.normal(size=(2,2))]*1000).apply(_sum)
+        print("BORK2")
+
+         
+


### PR DESCRIPTION
This bug is extremely interesting.  It appears to be a numba bug revealed in the cfunc path of numba, which is exposed when numpy is used (as documented in https://github.com/numba/numba/issues/2904. ) This bug is exposed when the a thread other than the main thread on which the python interpreter is started is actually the thread executing the function.  When this happens, PyGILState_Ensure() goes down a different path and attempts to acquire a lock on the interpreter, but the main thread never releases that lock.  

The workaround is to swap the thread states of the interpreter between the evaluation thread and the main thread before evaluation calls to the lambda function.
