### PR TITLE
API docs for Drawing Classifier evaluate have a tab indent now

### DIFF
--- a/src/unity/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/unity/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -586,33 +586,33 @@ class DrawingClassifier(_CustomModel):
         Parameters
         ----------
         dataset : SFrame
-        Dataset of new observations. Must include columns with the same
-        names as the feature and target columns used for model training.
-        Additional columns are ignored.
+            Dataset of new observations. Must include columns with the same
+            names as the feature and target columns used for model training.
+            Additional columns are ignored.
         
-        metric : str optional
-        Name of the evaluation metric. Possible values are:
+        metric : str, optional
+            Name of the evaluation metric. Possible values are:
+            
+            - 'auto'             : Returns all available metrics.
+            - 'accuracy'         : Classification accuracy (micro average).
+            - 'auc'              : Area under the ROC curve (macro average)
+            - 'precision'        : Precision score (macro average)
+            - 'recall'           : Recall score (macro average)
+            - 'f1_score'         : F1 score (macro average)
+            - 'confusion_matrix' : An SFrame with counts of possible 
+                                   prediction/true label combinations.
+            - 'roc_curve'        : An SFrame containing information needed for an
+                                   ROC curve
         
-        - 'auto'             : Returns all available metrics.
-        - 'accuracy'         : Classification accuracy (micro average).
-        - 'auc'              : Area under the ROC curve (macro average)
-        - 'precision'        : Precision score (macro average)
-        - 'recall'           : Recall score (macro average)
-        - 'f1_score'         : F1 score (macro average)
-        - 'confusion_matrix' : An SFrame with counts of possible 
-                               prediction/true label combinations.
-        - 'roc_curve'        : An SFrame containing information needed for an
-                               ROC curve
-        
-        verbose : bool optional
-        If True, prints prediction progress.
+        verbose : bool, optional
+            If True, prints prediction progress.
 
         Returns
         -------
         out : dict
-        Dictionary of evaluation results where the key is the name of the
-        evaluation metric (e.g. `accuracy`) and the value is the evaluation
-        score.
+            Dictionary of evaluation results where the key is the name of the
+            evaluation metric (e.g. `accuracy`) and the value is the evaluation
+            score.
         
         See Also
         ----------
@@ -622,8 +622,8 @@ class DrawingClassifier(_CustomModel):
         ----------
         .. sourcecode:: python
         
-        >>> results = model.evaluate(data)
-        >>> print(results['accuracy'])
+          >>> results = model.evaluate(data)
+          >>> print(results['accuracy'])
         """
 
         if self.target not in dataset.column_names():
@@ -685,6 +685,7 @@ class DrawingClassifier(_CustomModel):
 
         output_type : {'probability', 'rank'}, optional
             Choose the return type of the prediction:
+
             - `probability`: Probability associated with each label in the 
                              prediction.
             - `rank`       : Rank associated with each label in the prediction.
@@ -777,8 +778,9 @@ class DrawingClassifier(_CustomModel):
             in which case it is a bitmap-based drawing input,
             or of type list, in which case it is a stroke-based drawing input.
 
-        output_type : {'probability', 'class', 'probability_vector'} optional
+        output_type : {'probability', 'class', 'probability_vector'}, optional
             Form of the predictions which are one of:
+            
             - 'class': Class prediction. For multi-class classification, this
               returns the class with maximum probability.
             - 'probability': Prediction probability associated with the True
@@ -792,7 +794,7 @@ class DrawingClassifier(_CustomModel):
             have a powerful computer, increasing this value may improve
             performance.
 
-        verbose : bool optional
+        verbose : bool, optional
             If True, prints prediction progress.
 
         Returns


### PR DESCRIPTION
Fixes #1648 