### PR TITLE
Sound Classifier: Allow Reusing Deep Features

### DIFF
--- a/src/unity/python/turicreate/test/test_audio_functionality.py
+++ b/src/unity/python/turicreate/test/test_audio_functionality.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import as _
 
 from .util import TempDirectory
 
+from copy import copy
 import math
 from os import mkdir
 import unittest
@@ -145,11 +146,14 @@ def _generate_binary_test_data():
     return data
 
 
+binary_test_data = _generate_binary_test_data()
+
+
 class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        self.data = _generate_binary_test_data()
+        self.data = copy(binary_test_data)
         self.is_binary_classification = True
         self.model = tc.sound_classifier.create(self.data, 'labels', feature='audio')
 
@@ -213,7 +217,7 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
         old_model_probs = self.model.predict(self.data['audio'], output_type='probability_vector')
         new_model_probs = new_model.predict(self.data['audio'], output_type='probability_vector')
         for a, b in zip(old_model_probs, new_model_probs):
-            self.assertItemsEqual(a, b)
+            np.testing.assert_array_almost_equal(a, b, decimal=6)
 
     @unittest.skipIf(_mac_ver() < (10,14), 'Custom models only supported on macOS 10.14+')
     def test_export_coreml_with_prediction(self):
@@ -281,14 +285,16 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
         self.assertTrue(len(unique_ranks) == 1)
         self.assertTrue(unique_ranks[0] == 0)
 
+    def test_validation_set(self):
+        self.assertTrue(self.model.validation_accuracy is None)
+
 
 class ClassifierTestTwoClassesIntLabels(ClassifierTestTwoClassesStringLabels):
     @classmethod
     def setUpClass(self):
-        self.data = _generate_binary_test_data()
+        self.data = copy(binary_test_data)
         self.data['labels'] = self.data['labels'].apply(lambda x: 0 if x == 'white noise' else 1)
         self.is_binary_classification = True
-
         self.model = tc.sound_classifier.create(self.data, 'labels', feature='audio', validation_set=None)
 
 
@@ -303,10 +309,13 @@ class ClassifierTestThreeClassesStringLabels(ClassifierTestTwoClassesStringLabel
                           generate_constant_noise(1, 17000)]
         constant_noise = tc.SFrame({'audio': constant_noise,
                                     'labels': ['constant noise'] * len(constant_noise)})
-        self.data = _generate_binary_test_data().append(constant_noise)
+        self.data = copy(binary_test_data).append(constant_noise)
 
         self.is_binary_classification = False
         self.model = tc.sound_classifier.create(self.data, 'labels', feature='audio', validation_set=self.data)
+
+    def test_validation_set(self):
+        self.assertTrue(self.model.validation_accuracy is not None)
 
 
 @unittest.skipIf(_mac_ver() < (10,14), 'Custom models only supported on macOS 10.14+')
@@ -347,3 +356,54 @@ class CoreMlCustomModelPreprocessingTest(unittest.TestCase):
 
         self.assertEqual(y2.shape, (1,96,64))
         self.assertTrue(np.isclose(y1, y2, atol=1e-04).all())
+
+
+class ReuseDeepFeatures(unittest.TestCase):
+    def test_simple_case(self):
+        data = copy(binary_test_data)
+        deep_features = tc.sound_classifier.get_deep_features(data['audio'])
+
+        # Verify deep features in correct format
+        self.assertTrue(isinstance(deep_features, tc.SArray))
+        self.assertEqual(len(data), len(deep_features))
+        self.assertEqual(deep_features.dtype, list)
+        self.assertEqual(len(deep_features[0]), 3)
+        self.assertTrue(isinstance(deep_features[0][0], np.ndarray))
+        self.assertEqual(deep_features[0][0].dtype, np.float64)
+        self.assertEqual(len(deep_features[0][0]), 12288)
+
+        # Test helper methods
+        self.assertTrue(tc.sound_classifier._is_audio_data_sarray(data['audio']))
+        self.assertTrue(tc.sound_classifier._is_deep_feature_sarray(deep_features))
+
+        original_audio_data = data['audio']
+        del data['audio']
+
+        # Create a model using the deep features
+        data['features'] = deep_features
+        model = tc.sound_classifier.create(data, 'labels', feature='features')
+
+        # Test predict
+        predictions_from_audio = model.predict(original_audio_data, output_type='probability_vector')
+        predictions_from_deep_features = model.predict(deep_features, output_type='probability_vector')
+        for a, b in zip(predictions_from_audio, predictions_from_deep_features):
+            self.assertEqual(a, b)
+
+        # Test classify
+        predictions_from_audio = model.classify(original_audio_data)
+        predictions_from_deep_features = model.classify(deep_features)
+        for a, b in zip(predictions_from_audio, predictions_from_deep_features):
+            self.assertEqual(a, b)
+
+        # Test predict_topk
+        predictions_from_audio = model.predict_topk(original_audio_data, k=2)
+        predictions_from_deep_features = model.predict_topk(deep_features, k=2)
+        for a, b in zip(predictions_from_audio, predictions_from_deep_features):
+            self.assertEqual(a, b)
+
+        # Test evaluate
+        predictions_from_audio = model.evaluate(tc.SFrame({'features': original_audio_data,
+                                                           'labels': data['labels']}))
+        predictions_from_deep_features = model.evaluate(tc.SFrame({'features': deep_features,
+                                                                   'labels': data['labels']}))
+        self.assertEqual(predictions_from_audio['f1_score'], predictions_from_deep_features['f1_score'])

--- a/src/unity/python/turicreate/test/test_audio_functionality.py
+++ b/src/unity/python/turicreate/test/test_audio_functionality.py
@@ -387,7 +387,7 @@ class ReuseDeepFeatures(unittest.TestCase):
         predictions_from_audio = model.predict(original_audio_data, output_type='probability_vector')
         predictions_from_deep_features = model.predict(deep_features, output_type='probability_vector')
         for a, b in zip(predictions_from_audio, predictions_from_deep_features):
-            self.assertEqual(a, b)
+            self.assertAlmostEqual(a, b)
 
         # Test classify
         predictions_from_audio = model.classify(original_audio_data)

--- a/src/unity/python/turicreate/toolkits/audio_analysis/audio_analysis.py
+++ b/src/unity/python/turicreate/toolkits/audio_analysis/audio_analysis.py
@@ -57,7 +57,7 @@ def load_audio(path, with_path=True, recursive=True, ignore_failure=True, random
     Examples
     --------
     >>> audio_path = "~/Documents/myAudioFiles/"
-    >>> audio_sframe = tc.audio_analysis.load_audio(audio_analysis, recursive=True)
+    >>> audio_sframe = tc.audio_analysis.load_audio(audio_path, recursive=True)
     """
     all_wav_files = []
 

--- a/src/unity/python/turicreate/toolkits/sound_classifier/__init__.py
+++ b/src/unity/python/turicreate/toolkits/sound_classifier/__init__.py
@@ -9,4 +9,4 @@ from __future__ import absolute_import as _
 from __future__ import print_function as _
 from __future__ import division as _
 
-from .sound_classifier import *
+from .sound_classifier import create, get_deep_features, SoundClassifier

--- a/src/unity/python/turicreate/toolkits/sound_classifier/sound_classifier.py
+++ b/src/unity/python/turicreate/toolkits/sound_classifier/sound_classifier.py
@@ -14,7 +14,6 @@ import numpy as _np
 
 from .. import _mxnet_utils
 
-from ._audio_feature_extractor import _get_feature_extractor
 import turicreate as _tc
 import turicreate.toolkits._internal_utils as _tk_utils
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
@@ -66,6 +65,8 @@ def get_deep_features(audio_data, verbose=True):
     >>> model = tc.sound_classifier.create(train, 'label', 'deep_features')
     >>> predictions = model.predict(test)
     '''
+    from ._audio_feature_extractor import _get_feature_extractor
+
     if not _is_audio_data_sarray(audio_data):
         raise TypeError("Input must be audio data")
 
@@ -95,7 +96,7 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
         contain audio data or deep audio features.
         Audio data is represented as dicts with key 'data' and 'sample_rate',
         see `turicreate.load_audio(...)`.
-        Deep audio features are represent as a list of numpy arrays, each of
+        Deep audio features are represented as a list of numpy arrays, each of
         size 12288, see `turicreate.sound_classifier.get_deep_features(...)`.
 
     max_iterations : int, optional
@@ -118,8 +119,10 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
         If you are getting memory errors, try decreasing this value. If you
         have a powerful computer, increasing this value may improve performance.
     '''
-    import time as time
+    import time
     import mxnet as mx
+
+    from ._audio_feature_extractor import _get_feature_extractor
 
     start_time = time.time()
 
@@ -332,6 +335,8 @@ class SoundClassifier(_CustomModel):
         """
         A function to load a previously saved SoundClassifier instance.
         """
+        from ._audio_feature_extractor import _get_feature_extractor
+
         state['_feature_extractor'] = _get_feature_extractor(state['feature_extractor_name'])
 
         # Load the custom nerual network

--- a/src/unity/python/turicreate/toolkits/sound_classifier/sound_classifier.py
+++ b/src/unity/python/turicreate/toolkits/sound_classifier/sound_classifier.py
@@ -12,13 +12,68 @@ from __future__ import absolute_import as _
 
 import numpy as _np
 
+import mxnet as _mx
 from .. import _mxnet_utils
 
+from ._audio_feature_extractor import _get_feature_extractor
 import turicreate as _tc
 import turicreate.toolkits._internal_utils as _tk_utils
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._model import CustomModel as _CustomModel
 from turicreate.toolkits._model import PythonProxy as _PythonProxy
+
+
+def _is_deep_feature_sarray(sa):
+    if not isinstance(sa, _tc.SArray):
+        return False
+    if sa.dtype != list:
+        return False
+    if not isinstance(sa[0][0], _np.ndarray):
+        return False
+    if sa[0][0].dtype != _np.float64:
+        return False
+    if len(sa[0][0]) != 12288:
+        return False
+    return True
+
+def _is_audio_data_sarray(sa):
+    if not isinstance(sa, _tc.SArray):
+        return False
+    if sa.dtype != dict:
+        return False
+    if set(sa[0].keys()) != {'sample_rate', 'data'}:
+        return False
+    return True
+
+def get_deep_features(audio_data, verbose=True):
+    '''
+    Calculates the deep features used by the Sound Classifier.
+
+    Internally the Sound Classifier calculates deep features for both model
+    creation and predictions. If the same data will be used multiple times,
+    calculating the deep features just once will result in a significant speed
+    up.
+
+    Parameters
+    ----------
+    audio_data : SArray
+        Audio data is represented as dicts with key 'data' and 'sample_rate',
+        see `turicreate.load_audio(...)`.
+
+    Examples
+    --------
+    >>> my_audio_data['deep_features'] = get_deep_features(my_audio_data['audio'])
+    >>> train, test = my_audio_data.random_split(.8)
+    >>> model = tc.sound_classifier.create(train, 'label', 'deep_features')
+    >>> predictions = model.predict(test)
+    '''
+    if not _is_audio_data_sarray(audio_data):
+        raise TypeError("Input must be audio data")
+
+    feature_extractor_name = 'VGGish'
+    feature_extractor = _get_feature_extractor(feature_extractor_name)
+
+    return feature_extractor.get_deep_features(audio_data, verbose=verbose)
 
 
 def create(dataset, target, feature, max_iterations=10, verbose=True,
@@ -38,8 +93,11 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
 
     feature : string, optional
         Name of the column containing the feature column. This column must
-        contain audio data (represented as dicts with key 'data' and
-        'sample_rate').
+        contain audio data or deep audio features.
+        Audio data is represented as dicts with key 'data' and 'sample_rate',
+        see `turicreate.load_audio(...)`.
+        Deep audio features are represent as a list of numpy arrays, each of
+        size 12288, see `turicreate.sound_classifier.get_deep_features(...)`.
 
     max_iterations : int, optional
         The maximum number of allowed passes through the data. More passes over
@@ -61,8 +119,6 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
         If you are getting memory errors, try decreasing this value. If you
         have a powerful computer, increasing this value may improve performance.
     '''
-    from ._audio_feature_extractor import _get_feature_extractor
-    import mxnet as _mx
     import time as _time
 
     start_time = _time.time()
@@ -72,7 +128,7 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
         raise _ToolkitError('Unable to train on empty dataset')
     if feature not in dataset.column_names():
         raise _ToolkitError("Audio feature column '%s' does not exist" % feature)
-    if (dataset[feature].dtype != dict) or (set(dataset[feature][0].keys()) != {'sample_rate', 'data'}):
+    if not _is_deep_feature_sarray(dataset[feature]) and not _is_audio_data_sarray(dataset[feature]):
         raise _ToolkitError("'%s' column is not audio data." % feature)
     if target not in dataset.column_names():
         raise _ToolkitError("Target column '%s' does not exist" % target)
@@ -94,32 +150,38 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
     if not isinstance(validation_set, _tc.SFrame) and validation_set == 'auto':
         if len(dataset) >= 100:
             print ( "Creating a validation set from 5 percent of training data. This may take a while.\n"
-                    "\tYou can set ``validation_set=None`` to disable validation tracking.")
+                    "\tYou can set ``validation_set=None`` to disable validation tracking.\n")
             dataset, validation_set = dataset.random_split(0.95)
         else:
             validation_set = None
 
     encoded_target = dataset[target].apply(lambda x: class_label_to_id[x])
 
-    if verbose:
-        print("\nPreprocessing audio data -")
-    preprocessed_data, labels = feature_extractor.preprocess_data(dataset[feature], encoded_target, verbose=verbose)
+    if _is_deep_feature_sarray(dataset[feature]):
+        train_deep_features = dataset[feature]
+    else:
+        # do the preprocess and VGGish feature extraction
+        train_deep_features = get_deep_features(dataset[feature], verbose=verbose)
 
-    if verbose:
-        print("\nExtracting deep features -")
-    deep_features = feature_extractor.extract_features(preprocessed_data, verbose=verbose)
-    del preprocessed_data
+    train_data = _tc.SFrame({'deep features': train_deep_features, 'labels': encoded_target})
+    train_data = train_data.stack('deep features', new_column_name='deep features')
 
     if validation_set is not None:
         if verbose:
             print("Preparing validataion set")
         validation_encoded_target = validation_set[target].apply(lambda x: class_label_to_id[x])
-        preprocessed_validataion_data, validataion_labels = feature_extractor.preprocess_data(validation_set[feature],
-                                                                                              validation_encoded_target,
-                                                                                              verbose=verbose)
-        validataion_deep_features = feature_extractor.extract_features(preprocessed_validataion_data, verbose=verbose)
-        validation_batch_size = min(len(validataion_deep_features), batch_size)
-        validation_data = _mx.io.NDArrayIter(validataion_deep_features, label=validataion_labels,
+
+        if _is_deep_feature_sarray(validation_set[feature]):
+            validation_deep_features = validation_set[feature]
+        else:
+            validation_deep_features = get_deep_features(validation_set[feature], verbose=verbose)
+
+        validation_data = _tc.SFrame({'deep features': validation_deep_features, 'labels': validation_encoded_target})
+        validation_data = validation_data.stack('deep features', new_column_name='deep features')
+
+        validation_batch_size = min(len(validation_data), batch_size)
+        validation_data = _mx.io.NDArrayIter(validation_data['deep features'].to_numpy(),
+                                             label=validation_data['labels'].to_numpy(),
                                              batch_size=validation_batch_size)
     else:
         validation_data = []
@@ -127,8 +189,10 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
     if verbose:
         print("\nTraining a custom neural network -")
 
-    training_batch_size = min(len(deep_features), batch_size)
-    train_data = _mx.io.NDArrayIter(deep_features, label=labels, batch_size=training_batch_size, shuffle=True)
+    training_batch_size = min(len(train_data), batch_size)
+    train_data = _mx.io.NDArrayIter(train_data['deep features'].to_numpy(),
+                                    label=train_data['labels'].to_numpy(),
+                                    batch_size=training_batch_size, shuffle=True)
 
     custom_NN = SoundClassifier._build_custom_neural_network(feature_extractor.output_length, num_labels)
     ctx = _mxnet_utils.get_mxnet_context()
@@ -205,7 +269,7 @@ def create(dataset, target, feature, max_iterations=10, verbose=True,
         '_id_to_class_label': {v: k for k, v in class_label_to_id.items()},
         'classes': classes,
         'feature': feature,
-        'feature_extractor_name': feature_extractor_name,
+        'feature_extractor_name': feature_extractor.name,
         'num_classes': num_labels,
         'num_examples': len(dataset),
         'target': target,
@@ -221,6 +285,10 @@ class SoundClassifier(_CustomModel):
     A trained model that is ready to use for sound classification or to export to CoreML.
 
     This model should not be constructed directly.
+
+    See Also
+    ----------
+    create
     """
     _PYTHON_SOUND_CLASSIFIER_VERSION = 1
 
@@ -262,11 +330,8 @@ class SoundClassifier(_CustomModel):
     @classmethod
     def _load_version(cls, state, version):
         """
-        A function to load a previously saved SoundClassifier
-        instance.
+        A function to load a previously saved SoundClassifier instance.
         """
-        from ._audio_feature_extractor import _get_feature_extractor
-
         state['_feature_extractor'] = _get_feature_extractor(state['feature_extractor_name'])
 
         # Load the custom nerual network
@@ -335,16 +400,21 @@ class SoundClassifier(_CustomModel):
         section_titles = ['Schema', 'Training Summary']
         return([model_fields, training_fields], section_titles)
 
-    def classify(self, dataset, batch_size=64):
+    def classify(self, dataset, verbose=True, batch_size=64):
         """
         Return the classification for each examples in the ``dataset``.
         The output SFrame contains predicted class labels and its probability.
 
         Parameters
         ----------
-        dataset : SFrame
-            Dataset to classify, must include columns with the same names as
-            data used for model training. Additional columns are ignored.
+        dataset : SFrame | SArray | dict
+            The audio data to be classified.
+            If dataset is an SFrame, it must have a column with the same name as
+            the feature used for model training, but does not require a target
+            column. Additional columns are ignored.
+
+        verbose : bool, optional
+            If True, prints progress updates and model details.
 
         batch_size : int, optional
             If you are getting memory errors, try decreasing this value. If you
@@ -363,13 +433,8 @@ class SoundClassifier(_CustomModel):
         ----------
         >>> classes = model.classify(data)
         """
-        # check parameters
-        if not isinstance(dataset, _tc.SFrame):
-            raise TypeError('\'dataset\' parameter must be an SFrame')
-        if batch_size < 1:
-            raise ValueError('\'batch_size\' must be greater than or equal to 1')
-
-        prob_vector = self.predict(dataset, output_type='probability_vector', batch_size=batch_size)
+        prob_vector = self.predict(dataset, output_type='probability_vector',
+                                   verbose=verbose, batch_size=batch_size)
         id_to_label = self._id_to_class_label
 
         return _tc.SFrame({
@@ -377,7 +442,7 @@ class SoundClassifier(_CustomModel):
             'probability': prob_vector.apply(_np.max)
         })
 
-    def evaluate(self, dataset, metric='auto', batch_size=64):
+    def evaluate(self, dataset, metric='auto', verbose=True, batch_size=64):
         """
         Evaluate the model by making predictions of target values and comparing
         these to actual values.
@@ -403,6 +468,9 @@ class SoundClassifier(_CustomModel):
                                    prediction/true label combinations.
             - 'roc_curve'        : An SFrame containing information needed for an
                                    ROC curve
+
+        verbose : bool, optional
+            If True, prints progress updates and model details.
 
         batch_size : int, optional
             If you are getting memory errors, try decreasing this value. If you
@@ -431,8 +499,6 @@ class SoundClassifier(_CustomModel):
         # parameter checking
         if not isinstance(dataset, _tc.SFrame):
             raise TypeError('\'dataset\' parameter must be an SFrame')
-        if(batch_size < 1):
-            raise ValueError('\'batch_size\' must be greater than or equal to 1')
 
         avail_metrics = ['accuracy', 'auc', 'precision', 'recall',
                          'f1_score', 'log_loss', 'confusion_matrix', 'roc_curve']
@@ -445,9 +511,11 @@ class SoundClassifier(_CustomModel):
             metrics = [metric]
 
         if any([m in metrics for m in ('roc_curve', 'log_loss', 'auc')]):
-            probs = self.predict(dataset, output_type='probability_vector', batch_size=batch_size)
+            probs = self.predict(dataset, output_type='probability_vector',
+                                 verbose=verbose, batch_size=batch_size)
         if any([m in metrics for m in ('accuracy', 'precision', 'recall', 'f1_score', 'confusion_matrix')]):
-            classes = self.predict(dataset, output_type='class', batch_size=batch_size)
+            classes = self.predict(dataset, output_type='class',
+                                   verbose=verbose, batch_size=batch_size)
 
         ret = {}
         if 'accuracy' in metrics:
@@ -589,7 +657,7 @@ class SoundClassifier(_CustomModel):
         mlmodel = coremltools.models.MLModel(top_level_spec)
         mlmodel.save(filename)
 
-    def predict(self, dataset, output_type='class', batch_size=64):
+    def predict(self, dataset, output_type='class', verbose=True, batch_size=64):
         """
         Return predictions for ``dataset``. Predictions can be generated
         as class labels or probabilities.
@@ -613,6 +681,9 @@ class SoundClassifier(_CustomModel):
               class as a vector. Label ordering is dictated by the ``classes``
               member variable.
 
+        verbose : bool, optional
+            If True, prints progress updates and model details.
+
         batch_size : int, optional
             If you are getting memory errors, try decreasing this value. If you
             have a powerful computer, increasing this value may improve performance.
@@ -633,16 +704,18 @@ class SoundClassifier(_CustomModel):
         >>> class_predictions = model.predict(data, output_type='class')
 
         """
-        import mxnet as _mx
-
         if not isinstance(dataset, (_tc.SFrame, _tc.SArray, dict)):
             raise TypeError('\'dataset\' parameter must be either an SFrame, SArray or dictionary')
+
         if isinstance(dataset, dict):
             if(set(dataset.keys()) != {'sample_rate', 'data'}):
                 raise ValueError('\'dataset\' parameter is a dictionary but does not appear to be audio data.')
             dataset = _tc.SArray([dataset])
         elif isinstance(dataset, _tc.SFrame):
             dataset = dataset[self.feature]
+
+        if not _is_deep_feature_sarray(dataset) and not _is_audio_data_sarray(dataset):
+            raise ValueError('\'dataset\' must be either audio data or audio deep features.')
 
         if output_type not in ('probability', 'probability_vector', 'class'):
             raise ValueError('\'dataset\' parameter must be either an SFrame, SArray or dictionary')
@@ -653,15 +726,20 @@ class SoundClassifier(_CustomModel):
         if(batch_size < 1):
             raise ValueError("'batch_size' must be greater than or equal to 1")
 
-        preprocessed_data, example_id = self._feature_extractor.preprocess_data(dataset, range(len(dataset)))
-        deep_features = self._feature_extractor.extract_features(preprocessed_data)
-        del preprocessed_data
-
+        if _is_deep_feature_sarray(dataset):
+            deep_features = dataset
+        else:
+            deep_features = get_deep_features(dataset, verbose=verbose)
+        
+        deep_features = _tc.SFrame({'deep features': deep_features})
+        deep_features = deep_features.add_row_number()
+        deep_features = deep_features.stack('deep features', new_column_name='deep features')
+        
         if batch_size > len(deep_features):
             batch_size = len(deep_features)
 
         y = []
-        for batch in _mx.io.NDArrayIter(deep_features, batch_size=batch_size):
+        for batch in _mx.io.NDArrayIter(deep_features['deep features'].to_numpy(), batch_size=batch_size):
             ctx = _mxnet_utils.get_mxnet_context()
             if(len(batch.data[0]) < len(ctx)):
                 ctx = ctx[:len(batch.data[0])]
@@ -673,7 +751,7 @@ class SoundClassifier(_CustomModel):
                 y += _mx.nd.softmax(forward_output).asnumpy().tolist()
 
         # Combine predictions from multiple frames
-        sf = _tc.SFrame({'predictions': y, 'id': example_id})
+        sf = _tc.SFrame({'predictions': y, 'id': deep_features['id']})
         probabilities_sum = sf.groupby('id', {'prob_sum': _tc.aggregate.SUM('predictions')})
 
         if output_type == 'class':
@@ -688,7 +766,7 @@ class SoundClassifier(_CustomModel):
             probabilities_sum = probabilities_sum.sort('id')
             return probabilities_sum.apply(lambda row: [i / row['Count'] for i in row['prob_sum']])
 
-    def predict_topk(self, dataset, output_type='probability', k=3, batch_size=64):
+    def predict_topk(self, dataset, output_type='probability', k=3, verbose=True, batch_size=64):
         """
         Return top-k predictions for the ``dataset``.
         Predictions are returned as an SFrame with three columns: `id`,
@@ -697,9 +775,11 @@ class SoundClassifier(_CustomModel):
 
         Parameters
         ----------
-        dataset : SFrame
-            Dataset to classify. Must include columns with the same
-            names as the features. Additional columns are ignored.
+        dataset : SFrame | SArray | dict
+            The audio data to be classified.
+            If dataset is an SFrame, it must have a column with the same name as
+            the feature used for model training, but does not require a target
+            column. Additional columns are ignored.
 
         output_type : {'probability', 'rank'}, optional
             Choose the return type of the prediction:
@@ -708,6 +788,9 @@ class SoundClassifier(_CustomModel):
 
         k : int, optional
             Number of classes to return for each input example.
+
+        verbose : bool, optional
+            If True, prints progress updates and model details.
 
         batch_size : int, optional
             If you are getting memory errors, try decreasing this value. If you
@@ -742,14 +825,8 @@ class SoundClassifier(_CustomModel):
         | ...  |  ...  |        ...        |
         +------+-------+-------------------+
         """
-        # parameter checking
-        if not isinstance(dataset, _tc.SFrame):
-            raise TypeError('\'dataset\' parameter must be an SFrame')
-        _tk_utils._check_categorical_option_type('output_type', output_type, ['probability', 'rank'])
-        if(batch_size < 1):
-            raise ValueError('\'batch_size\' must be greater than or equal to 1')
-
-        prob_vector = self.predict(dataset, output_type='probability_vector', batch_size=64)
+        prob_vector = self.predict(dataset, output_type='probability_vector',
+                                   verbose=verbose, batch_size=64)
         id_to_label = self._id_to_class_label
 
         if output_type == 'probability':

--- a/userguide/sound_classifier/advanced-usage.md
+++ b/userguide/sound_classifier/advanced-usage.md
@@ -4,7 +4,7 @@
 #### Reusing Deep Features
 Often it is necessary to train more than one instance of a model on the same data. For example this is required by both [K-Folds Cross Validataion](https://en.wikipedia.org/wiki/Cross-validation_(statistics)) and [Hyperparameter Tuning](https://en.wikipedia.org/wiki/Hyperparameter_optimization).
 
-Much of the work accross differnt training run can be reused. Sound Classification is done using a [three stage process](how-it-works.md). The first two of these stages (signal preprocessing and VGGish feature extraction) will be identical and can be reused.
+Much of the work accross different training runs can be reused. Sound Classification is done using a [three stage process](how-it-works.md). The first two of these stages (signal preprocessing and VGGish feature extraction) will be identical and can be reused.
 
 The code below use the ESC-10 dataset from the [Introductory Example](./README.md#introductory-example) to do K-Folds Cross Validataion. In this example reusing the deep feature allow us to perform 5-fold cross validation more than twice as fast.
 ```python

--- a/userguide/sound_classifier/advanced-usage.md
+++ b/userguide/sound_classifier/advanced-usage.md
@@ -1,0 +1,29 @@
+# Advanced Sound Classifier Usage
+
+
+#### Reusing Deep Features
+Often it is necessary to train more than one instance of a model on the same data. For example this is required by both [K-Folds Cross Validataion](https://en.wikipedia.org/wiki/Cross-validation_(statistics)) and [Hyperparameter Tuning](https://en.wikipedia.org/wiki/Hyperparameter_optimization).
+
+Much of the work accross differnt training run can be reused. Sound Classification is done using a [three stage process](how-it-works.md). The first two of these stages (signal preprocessing and VGGish feature extraction) will be identical and can be reused.
+
+The code below use the ESC-10 dataset from the [Introductory Example](./README.md#introductory-example) to do K-Folds Cross Validataion. In this example reusing the deep feature allow us to perform 5-fold cross validation more than twice as fast.
+```python
+import turicreate as tc
+
+data = tc.load_sframe('./ESC-10')
+
+# Calculate the deep features just once.
+data['deep_features'] = tc.sound_classifier.get_deep_features(data['audio'])
+
+accuracies = []
+for cur_fold in data['fold'].unique():
+    test_set = data.filter_by(cur_fold, 'fold')
+    train_set = data.filter_by(cur_fold, 'fold', exclude=True)
+
+    model = tc.sound_classifier.create(train_set, target='category', feature='deep_features')
+
+    metrics = model.evaluate(test_set)
+    accuracies.append(metrics['accuracy'])
+
+print("Accuracies: {}".format(accuracies))
+```


### PR DESCRIPTION
Fixes #1601

- Add tc.sound_classifier.get_deep_features.
- Change sound classifier (create & predict) to use get_deep_features.
- Allow sound classifier (create & predict) to use deep features directly.
-----------------------------------------
- Use SArrayBuilder to construct deep features
- Logging: print header info only if printing progress info.
- Any function which could result in deep feature extraction should have `verbose` flag.
- Allow predict to do parameter checking. Rather than doing it, not as well, in a bunch of other
      places that just call predict anyways.
- classify/evaluate/predict_topk should allow SFrame or dict input, in addition to SArray.
-----------------------------------------
- Unit tests: test deep feature reuse.
- Unit tests: copy data rather than regenerate each time.
- Unit tests: make problematic test less sensitive (six decimal places is fine).
- Unit tests: test validation set is actually getting used or not.
-----------------------------------------
- Took a first stab at the user guide section for this feature, more will be added later (#1649).