### PR TITLE
Add image_classifier.annotate method to pydocs

### DIFF
--- a/src/unity/python/doc/source/turicreate.toolkits.image_classifier.rst
+++ b/src/unity/python/doc/source/turicreate.toolkits.image_classifier.rst
@@ -15,3 +15,4 @@ image classifier
 
   image_classifier.create
   image_classifier.ImageClassifier
+  image_classifier.annotate


### PR DESCRIPTION
Fixes https://github.com/apple/turicreate/issues/1645

The new docs will need to be [pushed live](https://apple.github.io/turicreate/docs/api/index.html) once they're built.