### PR TITLE
WIP: Towards elimination of mutable_get.

### DIFF
--- a/src/flexible_type/flexible_type_base_types.hpp
+++ b/src/flexible_type/flexible_type_base_types.hpp
@@ -791,29 +791,31 @@ inline flex_type_enum flex_type_enum_from_name(const std::string& name) {
  */
 template <typename T>
 struct has_direct_conversion_to_flexible_type {
+  typedef typename std::decay<T>::type _T;
+
   static constexpr bool value =
-      !std::is_same<T, flexible_type>::value && (
-      std::is_integral<T>::value ||
-      std::is_floating_point<T>::value ||
-      std::is_convertible<T, flex_string>::value ||
-      std::is_convertible<T, flex_list>::value ||
-      std::is_convertible<T, flex_vec>::value ||
-      std::is_convertible<T, flex_nd_vec>::value ||
-      std::is_convertible<T, flex_dict>::value ||
-      std::is_convertible<T, flex_date_time>::value ||
-      std::is_convertible<T, flex_image>::value ||
-      std::is_same<T, flex_undefined>::value);
+      !std::is_same<_T, flexible_type>::value && (
+      std::is_integral<_T>::value ||
+      std::is_floating_point<_T>::value ||
+      std::is_convertible<_T, flex_string>::value ||
+      std::is_convertible<_T, flex_list>::value ||
+      std::is_convertible<_T, flex_vec>::value ||
+      std::is_convertible<_T, flex_nd_vec>::value ||
+      std::is_convertible<_T, flex_dict>::value ||
+      std::is_convertible<_T, flex_date_time>::value ||
+      std::is_convertible<_T, flex_image>::value ||
+      std::is_same<_T, flex_undefined>::value);
 
   static constexpr flex_type_enum desired_type =
-      std::is_integral<T>::value ? flex_type_enum::INTEGER :
-      std::is_floating_point<T>::value ? flex_type_enum::FLOAT :
-      std::is_convertible<T, flex_string>::value ? flex_type_enum::STRING :
-      std::is_convertible<T, flex_list>::value ? flex_type_enum::LIST :
-      std::is_convertible<T, flex_vec>::value ? flex_type_enum::VECTOR :
-      std::is_convertible<T, flex_nd_vec>::value ? flex_type_enum::ND_VECTOR :
-      std::is_convertible<T, flex_dict>::value ? flex_type_enum::DICT :
-      std::is_convertible<T, flex_date_time>::value ? flex_type_enum::DATETIME :
-      std::is_convertible<T, flex_image>::value ? flex_type_enum::IMAGE :
+      std::is_integral<_T>::value ? flex_type_enum::INTEGER :
+      std::is_floating_point<_T>::value ? flex_type_enum::FLOAT :
+      std::is_convertible<_T, flex_string>::value ? flex_type_enum::STRING :
+      std::is_convertible<_T, flex_list>::value ? flex_type_enum::LIST :
+      std::is_convertible<_T, flex_vec>::value ? flex_type_enum::VECTOR :
+      std::is_convertible<_T, flex_nd_vec>::value ? flex_type_enum::ND_VECTOR :
+      std::is_convertible<_T, flex_dict>::value ? flex_type_enum::DICT :
+      std::is_convertible<_T, flex_date_time>::value ? flex_type_enum::DATETIME :
+      std::is_convertible<_T, flex_image>::value ? flex_type_enum::IMAGE :
       flex_type_enum::UNDEFINED;
 };
 

--- a/src/ml_data/data_storage/ml_data_row_translation.cpp
+++ b/src/ml_data/data_storage/ml_data_row_translation.cpp
@@ -176,15 +176,16 @@ std::vector<flexible_type> translate_row_to_original(
 
         flexible_type key = m_idx->map_index_to_value(v.index);
 
-        flex_dict& dv = ret[c_idx].mutable_get<flex_dict>();
+        flex_dict dv = ret[c_idx].get<flex_dict>();
         dv.push_back(std::make_pair(key, flexible_type(v.value)));
         std::sort(dv.begin(), dv.end());
+        ret[c_idx] = std::move(dv);
 
         break;
       }
       case ml_column_mode::NUMERIC_VECTOR: {
 
-        flex_vec& vv = ret[c_idx].mutable_get<flex_vec>();
+        flex_vec vv = ret[c_idx].get<flex_vec>();
 
         DASSERT_EQ(vv.size(), metadata->column_size(c_idx));
         DASSERT_LT(v.index, vv.size());
@@ -194,15 +195,18 @@ std::vector<flexible_type> translate_row_to_original(
           vv[v.index] = v.value;
 
         vv[v.index] = v.value;
+
+        ret[c_idx] = std::move(vv);
         break;
       }
 
       case ml_column_mode::CATEGORICAL_VECTOR: {
-        ret[c_idx].mutable_get<flex_list>().push_back(m_idx->map_index_to_value(v.index));
+        flex_list fl = ret[c_idx].get<flex_list>();
+        fl.push_back(m_idx->map_index_to_value(v.index));
 
-        std::sort(ret[c_idx].mutable_get<flex_list>().begin(),
-                  ret[c_idx].mutable_get<flex_list>().end());
+        std::sort(fl.begin(), fl.end());
 
+        ret[c_idx] = std::move(fl); 
         break;
       }
 
@@ -213,7 +217,7 @@ std::vector<flexible_type> translate_row_to_original(
 
       case ml_column_mode::NUMERIC_ND_VECTOR: {
 
-        flex_nd_vec& vv = ret[c_idx].mutable_get<flex_nd_vec>();
+        flex_nd_vec vv = ret[c_idx].get<flex_nd_vec>();
 
         DASSERT_TRUE(vv.is_canonical());
         DASSERT_EQ(vv.num_elem(), metadata->column_size(c_idx));
@@ -225,6 +229,7 @@ std::vector<flexible_type> translate_row_to_original(
         }
 
         vv[v.index] = v.value;
+        ret[c_idx] = std::move(vv);
         break;
       }
     }

--- a/src/ml_data/data_storage/ml_data_row_translation.cpp
+++ b/src/ml_data/data_storage/ml_data_row_translation.cpp
@@ -176,7 +176,7 @@ std::vector<flexible_type> translate_row_to_original(
 
         flexible_type key = m_idx->map_index_to_value(v.index);
 
-        flex_dict dv = ret[c_idx].get<flex_dict>();
+        flex_dict dv = ret[c_idx].get_and_reset<flex_dict>();
         dv.push_back(std::make_pair(key, flexible_type(v.value)));
         std::sort(dv.begin(), dv.end());
         ret[c_idx] = std::move(dv);
@@ -185,7 +185,7 @@ std::vector<flexible_type> translate_row_to_original(
       }
       case ml_column_mode::NUMERIC_VECTOR: {
 
-        flex_vec vv = ret[c_idx].get<flex_vec>();
+        flex_vec vv = ret[c_idx].get_and_reset<flex_vec>();
 
         DASSERT_EQ(vv.size(), metadata->column_size(c_idx));
         DASSERT_LT(v.index, vv.size());
@@ -201,7 +201,7 @@ std::vector<flexible_type> translate_row_to_original(
       }
 
       case ml_column_mode::CATEGORICAL_VECTOR: {
-        flex_list fl = ret[c_idx].get<flex_list>();
+        flex_list fl = ret[c_idx].get_and_reset<flex_list>();
         fl.push_back(m_idx->map_index_to_value(v.index));
 
         std::sort(fl.begin(), fl.end());
@@ -217,7 +217,7 @@ std::vector<flexible_type> translate_row_to_original(
 
       case ml_column_mode::NUMERIC_ND_VECTOR: {
 
-        flex_nd_vec vv = ret[c_idx].get<flex_nd_vec>();
+        flex_nd_vec vv = ret[c_idx].get_and_reset<flex_nd_vec>();
 
         DASSERT_TRUE(vv.is_canonical());
         DASSERT_EQ(vv.num_elem(), metadata->column_size(c_idx));

--- a/src/sframe/csv_line_tokenizer.cpp
+++ b/src/sframe/csv_line_tokenizer.cpp
@@ -330,18 +330,22 @@ bool csv_line_tokenizer::parse_as(char** buf, size_t len,
      // takes care of the left trim
      {
        bool is_quoted = false;
+       flex_string out_s; 
+
        while(len > 0 && std::isspace((*buf)[len - 1])) len--;
        if (len >= 2 && (*buf)[0] == quote_char && (*buf)[len - 1] == quote_char) {
-         out.mutable_get<flex_string>() = std::string((*buf)+1, len-2);
+         out_s = flex_string((*buf)+1, len-2);
          is_quoted = true;
        } else {
-         out.mutable_get<flex_string>() = std::string(*buf, len);
+         out_s = flex_string(*buf, len);
        }
        parse_success = true;
        if (is_quoted) {
-         unescape_string(out.mutable_get<flex_string>(), use_escape_char, escape_char, 
+
+         unescape_string(out_s, use_escape_char, escape_char, 
                          quote_char, double_quote);
        }
+       out = std::move(out_s);
        break;
      }
    case flex_type_enum::DICT:

--- a/src/sframe/sarray_v2_type_encoding.cpp
+++ b/src/sframe/sarray_v2_type_encoding.cpp
@@ -50,7 +50,7 @@ void decode_number(iarchive& iarc,
   for (size_t i = 0;i < ret.size(); ++i) {
     if (ret[i].get_type() != flex_type_enum::UNDEFINED) {
       if (bufstart < buflen) {
-        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
+        ret[i]._unsafe_set_payload(buf[bufstart]);
         ++bufstart;
         --num_values_to_read;
       } else {
@@ -63,7 +63,7 @@ void decode_number(iarchive& iarc,
 //         }
 //         logstream(LOG_INFO) << std::endl;
         bufstart = 0;
-        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
+        ret[i]._unsafe_set_payload(buf[bufstart]);
         ++bufstart;
         --num_values_to_read;
       }
@@ -157,7 +157,7 @@ void decode_double_legacy(iarchive& iarc,
   for (size_t i = 0;i < ret.size(); ++i) {
     if (ret[i].get_type() != flex_type_enum::UNDEFINED) {
       if (bufstart < buflen) {
-        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
+        ret[i]._unsafe_set_payload(buf[bufstart]);
         ++bufstart;
         --num_values_to_read;
       } else {
@@ -169,7 +169,7 @@ void decode_double_legacy(iarchive& iarc,
           buf[j] = (buf[j] >> 1) | (buf[j] << 63);
         }
         bufstart = 0;
-        ret[i].reinterpret_mutable_get<flex_int>() = buf[bufstart];
+        ret[i]._unsafe_set_payload(buf[bufstart]);
         ++bufstart;
         --num_values_to_read;
       }
@@ -236,7 +236,7 @@ static void encode_string(block_info& info,
     if (data[i].get_type() != flex_type_enum::UNDEFINED) {
       auto iter = unique_values.find(data[i].get<std::string>());
       if (iter != unique_values.end()) {
-        idx_values[idxctr++].mutable_get<flex_int>() = iter->second;
+        idx_values[idxctr++] = flex_int(iter->second);
       } else {
         // if we have too many unique values, fail.
         if (unique_values.size() >= 64) {
@@ -246,7 +246,7 @@ static void encode_string(block_info& info,
         size_t newidx = unique_values.size();
         unique_values[data[i].get<std::string>()] = newidx;
         str_values.push_back(data[i].get<std::string>());
-        idx_values[idxctr++].mutable_get<flex_int>() = newidx;
+        idx_values[idxctr++] = flex_int(newidx);
       }
     }
   }
@@ -265,7 +265,7 @@ static void encode_string(block_info& info,
     idxctr = 0;
     for (auto& f: data) {
       if (f.get_type() != flex_type_enum::UNDEFINED) {
-        idx_values[idxctr++].mutable_get<flex_int>() = f.get<std::string>().length();
+        idx_values[idxctr++] = flex_int(f.get<std::string>().length());
       }
     }
     idx_values.resize(idxctr);

--- a/src/sframe/sarray_v2_type_encoding.hpp
+++ b/src/sframe/sarray_v2_type_encoding.hpp
@@ -186,9 +186,10 @@ static void decode_double_stream_legacy(size_t num_elements,
     frame_of_reference_decode_128(iarc, buflen, buf);
     for (uint64_t i = 0;i < buflen; ++i) {
       uint64_t intval = (buf[i] >> 1) | (buf[i] << 63);
-      // make a double flexible_type
-      flexible_type ret(*reinterpret_cast<const flex_float*>(&intval) );
-      callback(ret);
+      double r = 0;
+      std::memcpy(&r, &intval, 8); 
+
+      callback(flexible_type(r));
     }
     num_elements -= buflen;
   }

--- a/src/unity/lib/image_util.cpp
+++ b/src/unity/lib/image_util.cpp
@@ -37,10 +37,10 @@ namespace image_util{
         [&failure, &reference_size, &failure_size]
         (const flexible_type& in, std::pair<bool, flexible_type>& sum)->bool {
           if (in.get_type() != flex_type_enum::UNDEFINED) {
-            flexible_type tmp_img = in;
-            image_util_detail::decode_image_impl(tmp_img.mutable_get<flex_image>());
+            flex_image img = in.get<flex_image>(); 
+            image_util_detail::decode_image_impl(img);
             flexible_type f(flex_type_enum::VECTOR);
-            f.soft_assign(tmp_img);
+            f.soft_assign(img);
             if (sum.first == false) {
               // initial val
               sum.first = true;
@@ -354,9 +354,9 @@ flexible_type decode_image(const flexible_type& image) {
   if (image.get<flex_image>().is_decoded()) {
     return image;
   }
-  flexible_type ret = image;
-  flex_image& img = ret.mutable_get<flex_image>();
+  flex_image img = image.get<flex_image>();
   turi::decode_image_inplace(img);
+  flexible_type ret = std::move(img);
   return ret;
 };
 
@@ -367,9 +367,9 @@ flexible_type encode_image(const flexible_type& image) {
   if (!image.get<flex_image>().is_decoded()) {
     return image;
   }
-  flexible_type ret = image;
-  flex_image& img = ret.mutable_get<flex_image>();
+  flex_image img = image.get<flex_image>();
   turi::encode_image_inplace(img);
+  flexible_type ret = std::move(img);
   return ret;
 };
 

--- a/src/unity/lib/unity_sarray_binary_operations.cpp
+++ b/src/unity/lib/unity_sarray_binary_operations.cpp
@@ -268,12 +268,13 @@ get_binary_operator(flex_type_enum left, flex_type_enum right, std::string op) {
     } else if (right == flex_type_enum::ND_VECTOR) {
      return [](const flexible_type& l, const flexible_type& r)->flexible_type{ 
        flexible_type ret = r;
-       flex_nd_vec& v = ret.mutable_get<flex_nd_vec>();
+       flex_nd_vec v = ret.get_and_reset<flex_nd_vec>();
        v.ensure_unique();
        double dl = l.to<double>();
        for (auto & i: v.elements()) {
          i = dl / i;
        }
+       ret = std::move(v);
        return ret;
      };
     } else {

--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -718,10 +718,12 @@ std::shared_ptr<unity_sframe_base> unity_sframe::flat_map(
       if (result.get_type() == flex_type_enum::UNDEFINED) {
         continue;
       } else if (result.get_type() == flex_type_enum::LIST) {
-        flex_list& out_rows = result.mutable_get<flex_list>();
+
+        flex_list out_rows = result.get_and_reset<flex_list>();
         for (auto& out_row: out_rows) {
           *output_iter++ = std::move(out_row);
         }
+        result = std::move(out_rows);
       } else if (result.get_type() == flex_type_enum::VECTOR) {
         if (result.get<flex_vec>().size() > 0) {
           std::string message = "Cannot convert " + std::string(result) +

--- a/src/unity/python/turicreate/_cython/cy_flexible_type.pxd
+++ b/src/unity/python/turicreate/_cython/cy_flexible_type.pxd
@@ -66,13 +66,9 @@ cdef extern from "<flexible_type/flexible_type.hpp>" namespace "turi":
         const flex_float& get_double "get<turi::flex_float>"()
         const flex_string& get_string "get<turi::flex_string>"()
         const flex_vec& get_vec "get<turi::flex_vec>"()
-        flex_vec& get_vec_m "mutable_get<turi::flex_vec>"()
         const flex_nd_vec& get_nd_vec "get<turi::flex_nd_vec>"()
-        flex_nd_vec& get_nd_vec_m "mutable_get<turi::flex_nd_vec>"()
         const flex_list& get_list "get<turi::flex_list>"()
-        flex_list& get_list_m "mutable_get<turi::flex_list>"()
         const flex_dict& get_dict "get<turi::flex_dict>"()
-        flex_dict& get_dict_m "mutable_get<turi::flex_dict>"()
         const flex_image& get_img "get<turi::flex_image>"()
 
         flex_float as_double "to<turi::flex_float>"()

--- a/src/unity/toolkits/drawing_classifier/data_preparation.cpp
+++ b/src/unity/toolkits/drawing_classifier/data_preparation.cpp
@@ -195,12 +195,12 @@ flex_list simplify_drawing(flex_list raw_drawing, int row_number) {
     }
     // Align the drawing to top-left corner and scale to [0,255]
     for (size_t i = 0; i < num_strokes; i++) {
-        flex_list &stroke = raw_drawing[i].mutable_get<flex_list>();
+        const flex_list& stroke = raw_drawing[i].get<flex_list>();
         flex_list new_stroke;
         for (size_t j = 0; j < stroke.size(); j++) {
             float new_x;
             float new_y;
-            flex_dict &point = stroke[j].mutable_get<flex_dict>();
+            const flex_dict& point = stroke[j].get<flex_dict>();
             Point P(point);
             if (max_x == min_x) {
                 // vertical straight line

--- a/src/unity/toolkits/graph_analytics/graph_coloring_sgraph.cpp
+++ b/src/unity/toolkits/graph_analytics/graph_coloring_sgraph.cpp
@@ -23,7 +23,7 @@ const std::string COLOR_COLUMN = "color_id";
  * and keep all values in the flex_vec unique.
  */
 void set_insert(flexible_type& set, const flexible_type& value) {
-  flex_vec& vec = set.mutable_get<flex_vec>();
+  flex_vec vec = set.get_and_reset<flex_vec>();
   bool is_unique = true;
   for (auto& v : vec) {
     if (v == (double)(value)) {
@@ -34,6 +34,7 @@ void set_insert(flexible_type& set, const flexible_type& value) {
   if (is_unique) {
     vec.push_back((double)(value));
   }
+  set = std::move(vec); 
 }
 
 /**
@@ -133,12 +134,13 @@ size_t compute_coloring(sgraph& g) {
         ret,          // second argument in lambda is from here.
         flex_type_enum::FLOAT,
         [&](const flexible_type& x, flexible_type& y) { 
-          flex_vec& vec = y.mutable_get<flex_vec>();
+          flex_vec vec = y.get_and_reset<flex_vec>();
           std::sort(vec.begin(), vec.end());
           int new_color = find_min_value_not_in_set(vec);
           if (new_color != (int)(x)) {
             ++num_changed;
           }
+          y = std::move(vec);
           return new_color;
         });
 

--- a/src/unity/toolkits/graph_analytics/triangle_counting_sgraph.cpp
+++ b/src/unity/toolkits/graph_analytics/triangle_counting_sgraph.cpp
@@ -36,7 +36,7 @@ typedef sgraph::edge_direction edge_direction;
  * and keep all values in the flex_vec unique.
  */
 void set_insert(flexible_type& set, const flexible_type& value) {
-  flex_vec& vec = set.mutable_get<flex_vec>();
+  flex_vec vec = set.get_and_reset<flex_vec>();
   bool is_unique = true;
   for (auto& v : vec) {
     if ((size_t)v == (size_t)(value)) {
@@ -47,6 +47,7 @@ void set_insert(flexible_type& set, const flexible_type& value) {
   if (is_unique) {
     vec.push_back((double)(value));
   }
+  set = std::move(vec);
 }
 
 /**
@@ -145,9 +146,10 @@ void make_undirect_graph(sgraph& g) {
       NEIGHBOR_ID_COLUMN,
       flex_type_enum::VECTOR,
       [&](flexible_type& x) {
-        flex_vec& vec = x.mutable_get<flex_vec>();
+        flex_vec vec = x.get_and_reset<flex_vec>();
         std::sort(vec.begin(), vec.end());
-        return vec;
+        x = std::move(vec); 
+        return x.get<flex_vec>();
       });
   g.replace_vertex_field(ret, NEIGHBOR_ID_COLUMN);
 
@@ -230,9 +232,10 @@ size_t compute_triangle_count(sgraph& g) {
       NEIGHBOR_ID_COLUMN,
       flex_type_enum::VECTOR,
       [&](flexible_type& x) {
-        flex_vec& vec = x.mutable_get<flex_vec>();
+        flex_vec vec = x.get_and_reset<flex_vec>();
         std::sort(vec.begin(), vec.end());
-        return vec;
+        x = std::move(vec);
+        return x.get<flex_vec>();
       });
   g.replace_vertex_field(ret, NEIGHBOR_ID_COLUMN);
 

--- a/src/unity/toolkits/ml_data_2/data_storage/ml_data_row_translation.cpp
+++ b/src/unity/toolkits/ml_data_2/data_storage/ml_data_row_translation.cpp
@@ -173,9 +173,10 @@ std::vector<flexible_type> translate_row_to_original(
 
         flexible_type key = m_idx->map_index_to_value(v.index);
 
-        flex_dict& dv = ret[c_idx].mutable_get<flex_dict>();
+        flex_dict dv = ret[c_idx].get_and_reset<flex_dict>();
         dv.push_back(std::make_pair(key, flexible_type(v.value)));
         std::sort(dv.begin(), dv.end());
+        ret[c_idx] = std::move(dv);
 
         break;
       }
@@ -195,11 +196,12 @@ std::vector<flexible_type> translate_row_to_original(
       }
 
       case ml_column_mode::CATEGORICAL_VECTOR: {
-        ret[c_idx].mutable_get<flex_list>().push_back(m_idx->map_index_to_value(v.index));
+        flex_list vl = ret[c_idx].get_and_reset<flex_list>();
+        vl.push_back(m_idx->map_index_to_value(v.index));
+        
+        std::sort(vl.begin(), vl.end());
 
-        std::sort(ret[c_idx].mutable_get<flex_list>().begin(),
-                  ret[c_idx].mutable_get<flex_list>().end());
-
+        ret[c_idx] = std::move(vl);
         break;
       }
 

--- a/test/sframe/sframe_test.cxx
+++ b/test/sframe/sframe_test.cxx
@@ -1716,7 +1716,7 @@ struct sframe_test  {
      TS_ASSERT_EQUALS(sa.size(), values.size());
      // now check for reversibility by reading it back
      for(auto& v: values) {
-       v.mutable_get<flex_nd_vec>() = v.get<flex_nd_vec>().compact();
+       v = v.get<flex_nd_vec>().compact();
      }
      sframe_rows rows;
      sa.get_reader()->read_rows(0, sa.size(), rows);

--- a/test/unity/image_util.cxx
+++ b/test/unity/image_util.cxx
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(test_encode_decode) {
     {
       // encode decode should be lossless
       flexible_type encoded = encode_image(image_wrapped);
-      image_type& encoded_image = encoded.mutable_get<flex_image>();
+      const image_type& encoded_image = encoded.get<flex_image>();
       TS_ASSERT(!encoded_image.is_decoded());
 
       flexible_type decoded = decode_image(encoded);

--- a/test/unity/unity_sarray.cxx
+++ b/test/unity/unity_sarray.cxx
@@ -108,14 +108,24 @@ struct unity_sarray_test {
        case flex_type_enum::STRING:
          flex_val = std::to_string(val);
          break;
-       case flex_type_enum::VECTOR:
-         flex_val.mutable_get<flex_vec>().push_back(val);
+       case flex_type_enum::VECTOR: {
+           flex_vec v = flex_val.get_and_reset<flex_vec>();
+           v.push_back(val);
+           flex_val = std::move(v);
+         }                                    
          break;
-       case flex_type_enum::DICT:
-         flex_val.mutable_get<flex_dict>().push_back({0, val});
+       case flex_type_enum::DICT: {
+           flex_dict d = flex_val.get_and_reset<flex_dict>();
+           d.push_back({0, val});
+           flex_val = std::move(d);
+         }
          break;
        case flex_type_enum::LIST:
-         flex_val.mutable_get<flex_list>().push_back(val);
+         {
+           flex_list l = flex_val.get_and_reset<flex_list>();
+           l.push_back(val);
+           flex_val = std::move(l);
+         }
          break;
        default:
          throw ("Unknown flexible_type");


### PR DESCRIPTION
Eliminating mutable_get access to flexible_type will enable us to better
use memory pools and reference counting to reduce allocations and
copying.  In this PR, it's changed to a private method, and instead a
function, get_and_reset<...>(), returns the object using a move
operation if it's unique and a copy if it's not.