### PR TITLE
Allow SArray to be created with a map or filter type -- Python 3

### DIFF
--- a/src/unity/python/turicreate/data_structures/sarray.py
+++ b/src/unity/python/turicreate/data_structures/sarray.py
@@ -398,6 +398,8 @@ class SArray(object):
                       (sys.version_info.major < 3 and isinstance(data, unicode))):
                     # if it is a file, we default to string
                     dtype = str
+                elif sys.version_info.major >= 3 and isinstance(data, (filter, map)):
+                    data = list(data)
                 elif isinstance(data, array.array):
                     dtype = pytype_from_array_typecode(data.typecode)
                 elif isinstance(data, collections.Sequence):

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -147,6 +147,10 @@ class SArrayTest(unittest.TestCase):
         self.__test_equal(SArray(np.matrix(self.vec_data)),
                           self.vec_data, array.array)
 
+        # Test python 3
+        self.__test_equal(SArray(filter(lambda x: True, self.int_data)), self.int_data, int)
+        self.__test_equal(SArray(map(lambda x: x, self.int_data)), self.int_data, int)
+
     def test_list_with_none_creation(self):
         tlist=[[2,3,4],[5,6],[4,5,10,None]]
         g=SArray(tlist)

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -875,6 +875,14 @@ class SFrameTest(unittest.TestCase):
         for i in range(len(result)):
             self.assertEqual(i, l[i])
 
+        # map input type
+        toy_data = SFrame({'a': range(100)})
+        map_result = map(lambda x: x+1, [1, 30])
+        result = toy_data.filter_by(map_result, 'a')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['a'], 2)
+        self.assertEqual(result[1]['a'], 31)
+
 
     def test_sample_split(self):
         sf = SFrame(data=self.__create_test_df(100))


### PR DESCRIPTION
Fixes #1140.
