### PR TITLE
Read CSV: quote_char value of None should be passed to C++ layer

### DIFF
--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -212,6 +212,8 @@ std::map<std::string, std::shared_ptr<unity_sarray_base>> unity_sframe::construc
   if (csv_parsing_config["quote_char"].get_type() == flex_type_enum::STRING) {
     std::string tmp = (flex_string)csv_parsing_config["quote_char"];
     if (tmp.length() > 0) tokenizer.quote_char = tmp[0];
+  } else if (csv_parsing_config["quote_char"].get_type() == flex_type_enum::UNDEFINED) {
+    tokenizer.quote_char = NULL;
   }
   if (csv_parsing_config.count("skip_initial_space")) {
     tokenizer.skip_initial_space = !csv_parsing_config["skip_initial_space"].is_zero();

--- a/src/unity/python/turicreate/test/test_sarray.py
+++ b/src/unity/python/turicreate/test/test_sarray.py
@@ -31,9 +31,6 @@ import tempfile
 import sys
 import six
 
-#######################################################
-# Metrics tracking tests are in test_usage_metrics.py #
-#######################################################
 
 class SArrayTest(unittest.TestCase):
     def setUp(self):

--- a/src/unity/python/turicreate/test/test_sarray_sketch.py
+++ b/src/unity/python/turicreate/test/test_sarray_sketch.py
@@ -20,9 +20,6 @@ import array
 import time
 import itertools
 
-#######################################################
-# Metrics tracking tests are in test_usage_metrics.py #
-#######################################################
 
 class SArraySketchTest(unittest.TestCase):
 

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -288,6 +288,22 @@ class SFrameTest(unittest.TestCase):
             self.assertEqual(t[0], None)
             self.assertEqual(t[1], "3")
 
+    def test_parse_csv_non_multi_line_unmatched_quotation(self):
+        data = [{'type': 'foo', 'text_string': 'foo foo.'},
+                {'type': 'bar', 'text_string': 'bar " bar.'},
+                {'type': 'foo', 'text_string': 'foo".'}]
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as csvfile:
+            with open(csvfile.name, 'w') as f:
+                f.write("type,text_string\n")     # header
+                for l in data:
+                    f.write(l['type'] + ',' + l['text_string'] + '\n')
+
+            sf = SFrame.read_csv(csvfile.name, quote_char=None)
+            self.assertEqual(len(sf), len(data))
+            for i in range(len(sf)):
+                self.assertEqual(sf[i], data[i])
+
     def test_save_load_file_cleanup(self):
         # when some file is in use, file should not be deleted
         with util.TempDirectory() as f:

--- a/src/unity/python/turicreate/test/test_sframe.py
+++ b/src/unity/python/turicreate/test/test_sframe.py
@@ -35,10 +35,6 @@ import mock
 import sqlite3
 from .dbapi2_mock import dbapi2_mock
 
-#######################################################
-# Metrics tracking tests are in test_usage_metrics.py #
-#######################################################
-
 
 class SFrameTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Without this change, calling `tc.SFrame.read_csv` with `quote_char=None` has no affect. The default value of `"` gets set in the C++ layer. 

This change is necessary to read non-multi line CSV files which have unmatched quotation marks.
