### PR TITLE
Fixes for bugs in C-API object detector evaluation

### DIFF
--- a/src/unity/toolkits/object_detection/object_detector.cpp
+++ b/src/unity/toolkits/object_detection/object_detector.cpp
@@ -359,13 +359,15 @@ variant_map_type object_detector::perform_evaluation(gl_sframe data,
   
   std::string image_column_name = read_state<flex_string>("feature");
   std::string annotations_column_name = read_state<flex_string>("annotations");
+  flex_list class_labels = read_state<flex_list>("classes");
   size_t batch_size = static_cast<size_t>(options.value("batch_size"));
   float iou_threshold =
       read_state<flex_float>("non_maximum_suppression_threshold");
 
   // Bind the data to a data iterator.
   std::unique_ptr<data_iterator> data_iter = create_iterator(
-      data, annotations_column_name, image_column_name, /* repeat */ false);
+      data, std::vector<std::string>(class_labels.begin(), class_labels.end()),
+      /* repeat */ false);
 
   // Instantiate the compute context.
   std::unique_ptr<compute_context> ctx = create_compute_context();
@@ -384,7 +386,7 @@ variant_map_type object_detector::perform_evaluation(gl_sframe data,
 
   // Instantiate the NN backend.
   // For each anchor box, we have 4 bbox coords + 1 conf + one-hot class labels
-  int num_outputs_per_anchor = 5 + read_state<int>("num_classes");
+  int num_outputs_per_anchor = 5 + static_cast<int>(class_labels.size());
   int num_output_channels = num_outputs_per_anchor * anchor_boxes().size();
   std::unique_ptr<model_backend> model = ctx->create_object_detector(
       /* n */     options.value("batch_size"),
@@ -399,7 +401,7 @@ variant_map_type object_detector::perform_evaluation(gl_sframe data,
 
   // Initialize the metric calculator
   average_precision_calculator calculator(
-      data_iter->class_labels().size(), iou_thresholds_for_evaluation());
+      class_labels.size(), iou_thresholds_for_evaluation());
 
   // To support double buffering, use a queue of pending inference results.
   std::queue<image_augmenter::result> pending_batches;
@@ -470,7 +472,6 @@ variant_map_type object_detector::perform_evaluation(gl_sframe data,
 
   // Compute the average precision (area under the precision-recall curve) for
   // each combination of IOU threshold and class label.
-  flex_list class_labels = read_state<flex_list>("classes");
   std::vector<std::map<float,float>> raw_average_precisions =
       calculator.evaluate();
   ASSERT_EQ(class_labels.size(), raw_average_precisions.size());
@@ -493,11 +494,12 @@ variant_map_type object_detector::perform_evaluation(gl_sframe data,
 
   // Store the requested summary statistics.
   auto create_dict = [&class_labels](const std::vector<float>& v) {
-    variant_map_type class_map;
+    flex_dict class_dict;
+    class_dict.reserve(class_labels.size());
     for (size_t i = 0; i < class_labels.size(); ++i) {
-      class_map[class_labels[i]] = v[i];
+      class_dict.emplace_back(class_labels[i], v[i]);
     }
-    return class_map;
+    return class_dict;
   };
   auto compute_mean = [](const std::vector<float>& v) {
     return std::accumulate(v.begin(), v.end(), 0.f) / v.size();
@@ -679,13 +681,14 @@ std::shared_ptr<MLModelWrapper> object_detector::export_to_coreml(
 }
 
 std::unique_ptr<data_iterator> object_detector::create_iterator(
-    gl_sframe data, std::string annotations_column_name,
-    std::string image_column_name, bool repeat) const {
-
+    gl_sframe data, std::vector<std::string> class_labels, bool repeat) const
+{
   data_iterator::parameters iterator_params;
   iterator_params.data = std::move(data);
-  iterator_params.annotations_column_name = std::move(annotations_column_name);
-  iterator_params.image_column_name = std::move(image_column_name);
+  iterator_params.annotations_column_name =
+      read_state<flex_string>("annotations");
+  iterator_params.image_column_name = read_state<flex_string>("feature");
+  iterator_params.class_labels = std::move(class_labels);
   iterator_params.repeat = repeat;
 
   return std::unique_ptr<data_iterator>(
@@ -701,10 +704,23 @@ void object_detector::init_train(gl_sframe data,
                                  std::string annotations_column_name,
                                  std::string image_column_name,
                                  std::map<std::string, flexible_type> opts) {
+  // Record the relevant column names upfront, for use in create_iterator. Also
+  // values fixed by this version of the toolkit.
+  std::array<flex_int, 3> input_image_shape =  // Using CoreML CHW format.
+      {{3, GRID_SIZE * SPATIAL_REDUCTION, GRID_SIZE * SPATIAL_REDUCTION}};
+  add_or_update_state({
+      { "annotations", annotations_column_name },
+      { "feature", image_column_name },
+      { "input_image_shape", flex_list(input_image_shape.begin(),
+                                       input_image_shape.end()) },
+      { "model", "darknet-yolo" },
+      { "non_maximum_suppression_threshold",
+        DEFAULT_NON_MAXIMUM_SUPPRESSION_THRESHOLD },
+  });
 
   // Bind the data to a data iterator.
   training_data_iterator_ = create_iterator(
-      data, annotations_column_name, image_column_name, /* repeat */ true);
+      data, /* expected class_labels */ {}, /* repeat */ true);
 
   // Instantiate the compute context.
   training_compute_context_ = create_compute_context();
@@ -731,17 +747,8 @@ void object_detector::init_train(gl_sframe data,
   // Set additional model fields.
   const std::vector<std::string>& classes =
       training_data_iterator_->class_labels();
-  std::array<flex_int, 3> input_image_shape =  // Using CoreML CHW format.
-      {{3, GRID_SIZE * SPATIAL_REDUCTION, GRID_SIZE * SPATIAL_REDUCTION}};
   add_or_update_state({
-      { "annotations", annotations_column_name },
       { "classes", flex_list(classes.begin(), classes.end()) },
-      { "feature", image_column_name },
-      { "input_image_shape", flex_list(input_image_shape.begin(),
-                                       input_image_shape.end()) },
-      { "model", "darknet-yolo" },
-      { "non_maximum_suppression_threshold",
-        DEFAULT_NON_MAXIMUM_SUPPRESSION_THRESHOLD },
       { "num_bounding_boxes", training_data_iterator_->num_instances() },
       { "num_classes", training_data_iterator_->class_labels().size() },
       { "num_examples", data.size() },
@@ -945,7 +952,7 @@ void object_detector::update_model_metrics(gl_sframe data,
   if (!validation_data.empty()) {
     variant_map_type validation_metrics = perform_evaluation(validation_data,
                                                              "all");
-    for (const auto& kv : training_metrics) {
+    for (const auto& kv : validation_metrics) {
       metrics["validation_" + kv.first] = kv.second;
     }
   }

--- a/src/unity/toolkits/object_detection/object_detector.hpp
+++ b/src/unity/toolkits/object_detection/object_detector.hpp
@@ -110,8 +110,7 @@ class EXPORT object_detector: public ml_model_base {
 
   // Factory for data_iterator
   virtual std::unique_ptr<data_iterator> create_iterator(
-      gl_sframe data, std::string annotations_column_name,
-      std::string image_column_name, bool repeat) const;
+      gl_sframe data, std::vector<std::string> class_labels, bool repeat) const;
 
   // Factory for compute_context
   virtual


### PR DESCRIPTION
OD data iterators for evaluation must use class labels from training
OD evaluation should return values using flexible_type, not variant_type
OD training was writing incorrect values for validation metrics