### PR TITLE
Correct handling of quoted "true", "false" values in JSON

### DIFF
--- a/src/flexible_type/flexible_type_spirit_parser.cpp
+++ b/src/flexible_type/flexible_type_spirit_parser.cpp
@@ -39,7 +39,8 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
                             char escape_char = '\\',
                             const std::unordered_set<std::string>& na_val = {},
                             const std::unordered_set<std::string>& true_val = {},
-                            const std::unordered_set<std::string>& false_val = {}) :
+                            const std::unordered_set<std::string>& false_val = {},
+                            bool only_raw_string_substitutions=false) :
       flexible_type_parser_impl::base_type(root_parser), delimiter(delimiter) {
     using qi::long_long;
     using qi::double_;
@@ -64,7 +65,8 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     recursive_element_string_parser.double_quote = true;
     recursive_element_string_parser.na_val = na_val;
     recursive_element_string_parser.true_val = true_val;
-    recursive_element_string_parser.false_val= false_val;
+    recursive_element_string_parser.false_val = false_val;
+    recursive_element_string_parser.only_raw_string_substitutions = only_raw_string_substitutions;
 
     /*
      * A parser which parses strings, and stops at all unquoted delimiters
@@ -78,6 +80,7 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     dictionary_element_string_parser.na_val = na_val;
     dictionary_element_string_parser.true_val = true_val;
     dictionary_element_string_parser.false_val = false_val;
+    dictionary_element_string_parser.only_raw_string_substitutions = only_raw_string_substitutions;
 
     parser_impl::parser_config root_flex_string;
     // when the delimiter is just one character, using the restrictions is faster.
@@ -90,6 +93,7 @@ struct flexible_type_parser_impl: qi::grammar<Iterator, flexible_type(), SpaceTy
     root_flex_string.na_val = na_val;
     root_flex_string.true_val = true_val;
     root_flex_string.false_val = false_val;
+    root_flex_string.only_raw_string_substitutions = only_raw_string_substitutions;
 
     string = 
         (parser_impl::restricted_string(root_flex_string)[_val = _1]);
@@ -206,11 +210,12 @@ flexible_type_parser::flexible_type_parser(std::string separator,
                                            char escape_char,
                                            const std::unordered_set<std::string>& na_val,
                                            const std::unordered_set<std::string>& true_val,
-                                           const std::unordered_set<std::string>& false_val):
+                                           const std::unordered_set<std::string>& false_val,
+                                           bool only_raw_string_substitutions):
     parser(new flexible_type_parser_impl<const char*, 
-           decltype(space)>(separator, use_escape_char, escape_char, na_val, true_val, false_val)), 
+           decltype(space)>(separator, use_escape_char, escape_char, na_val, true_val, false_val, only_raw_string_substitutions)), 
     non_space_parser(new flexible_type_parser_impl<const char*, 
-                     decltype(qi::eoi)>(separator, use_escape_char, escape_char)), 
+                     decltype(qi::eoi)>(separator, use_escape_char, escape_char, na_val, true_val, false_val, only_raw_string_substitutions)), 
     m_delimiter_has_space(delimiter_has_space(parser->delimiter))
     { }
 

--- a/src/flexible_type/flexible_type_spirit_parser.hpp
+++ b/src/flexible_type/flexible_type_spirit_parser.hpp
@@ -39,7 +39,8 @@ class flexible_type_parser {
                        char escape_char = '\\',
                        const std::unordered_set<std::string>& na_val = {},
                        const std::unordered_set<std::string>& true_val = {},
-                       const std::unordered_set<std::string>& false_val = {});
+                       const std::unordered_set<std::string>& false_val = {},
+                       bool only_raw_string_substitutions=false);
   /**
    * Parses a generalized flexible type from a string. The *str pointer will be
    * updated to point to the character after the last character parsed.

--- a/src/sframe/csv_line_tokenizer.hpp
+++ b/src/sframe/csv_line_tokenizer.hpp
@@ -134,6 +134,13 @@ struct csv_line_tokenizer {
   std::unordered_set<std::string> false_values;
 
   /**
+   * If this is set (defaults to false), then
+   * the true/false/na substitutions are only permitted on raw
+   * unparsed strings; that is strings before dequoting, de-escaping, etc.
+   */
+  bool only_raw_string_substitutions = false;
+
+  /**
    * Constructor. Does nothing but set up internal buffers.
    */
   csv_line_tokenizer();
@@ -286,6 +293,7 @@ struct csv_line_tokenizer {
    * (the buffer itself is used to maintain the recursive parse state)
    */
   bool parse_as(char** buf, size_t len, 
+                const char* raw, size_t rawlen,
                 flexible_type& out, bool recursive_parse=false);
 
   /**
@@ -348,6 +356,13 @@ struct csv_line_tokenizer {
   bool delimiter_is_not_empty = true;
   bool empty_string_in_na_values = false;
   bool is_regular_line_terminator = true;
+
+
+
+  /**
+   * Perform substitutions of true/false/na values
+   */
+  bool check_substitutions(const char* buf, size_t len, flexible_type& out);
 };
 /// \}
 } // namespace turi

--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -220,7 +220,11 @@ void unity_sarray::construct_from_json_record_files(std::string url) {
   sarray_ptr->set_type(flex_type_enum::DICT);
   auto output = sarray_ptr->get_output_iterator(0);
 
-  flexible_type_parser parser(",", true, '\\', {"null"}, {"true"}, {"false"});
+  flexible_type_parser parser(",", true, '\\', 
+                              {"null"},  // na values
+                              {"true"},  // true values
+                              {"false"}, // false values
+                              true); // only_raw_string_substitutions
   std::vector<char> buffer;
 
 

--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -216,6 +216,9 @@ std::map<std::string, std::shared_ptr<unity_sarray_base>> unity_sframe::construc
   if (csv_parsing_config.count("skip_initial_space")) {
     tokenizer.skip_initial_space = !csv_parsing_config["skip_initial_space"].is_zero();
   }
+  if (csv_parsing_config.count("only_raw_string_substitutions")) {
+    tokenizer.only_raw_string_substitutions = !csv_parsing_config["only_raw_string_substitutions"].is_zero();
+  }
   if (csv_parsing_config["na_values"].get_type() == flex_type_enum::LIST) {
     flex_list rec = csv_parsing_config["na_values"];
     tokenizer.na_values.clear();

--- a/src/unity/python/turicreate/data_structures/sframe.py
+++ b/src/unity/python/turicreate/data_structures/sframe.py
@@ -884,6 +884,7 @@ class SFrame(object):
                        nrows_to_infer=100,
                        true_values=[],
                        false_values=[],
+                       _only_raw_string_substitutions=False,
                        **kwargs):
         """
         Constructs an SFrame from a CSV file or a path to multiple CSVs, and
@@ -936,6 +937,7 @@ class SFrame(object):
         parsing_config["skip_rows"] =skiprows
         parsing_config["true_values"] = true_values
         parsing_config["false_values"] = false_values
+        parsing_config["only_raw_string_substitutions"] = _only_raw_string_substitutions 
 
         if type(na_values) is str:
           na_values = [na_values]
@@ -969,7 +971,8 @@ class SFrame(object):
                                  skiprows=skiprows,
                                  verbose=verbose,
                                  true_values=true_values,
-                                 false_values=false_values)
+                                 false_values=false_values,
+                                 _only_raw_string_substitutions=_only_raw_string_substitutions)
                 column_type_hints = SFrame._infer_column_types_from_lines(first_rows)
                 typelist = '[' + ','.join(t.__name__ for t in column_type_hints) + ']'
                 if verbose:
@@ -1012,7 +1015,8 @@ class SFrame(object):
                                  skiprows=skiprows,
                                  verbose=verbose,
                                  true_values=true_values,
-                                 false_values=false_values)
+                                 false_values=false_values,
+                                 _only_raw_string_substitutions=_only_raw_string_substitutions)
                 inferred_types = SFrame._infer_column_types_from_lines(first_rows)
                 # make a dict of column_name to type
                 inferred_types = dict(list(zip(first_rows.column_names(), inferred_types)))
@@ -1078,6 +1082,7 @@ class SFrame(object):
                              nrows_to_infer=100,
                              true_values=[],
                              false_values=[],
+                             _only_raw_string_substitutions=False,
                              **kwargs):
         """
         Constructs an SFrame from a CSV file or a path to multiple CSVs, and
@@ -1219,6 +1224,7 @@ class SFrame(object):
                                   nrows_to_infer=nrows_to_infer,
                                   true_values=true_values,
                                   false_values=false_values,
+                                  _only_raw_string_substitutions=_only_raw_string_substitutions,
                                   **kwargs)
     @classmethod
     def read_csv(cls,
@@ -1241,6 +1247,7 @@ class SFrame(object):
                  nrows_to_infer=100,
                  true_values=[],
                  false_values=[],
+                 _only_raw_string_substitutions=False,
                  **kwargs):
         """
         Constructs an SFrame from a CSV file or a path to multiple CSVs.
@@ -1501,6 +1508,7 @@ class SFrame(object):
                                   nrows_to_infer=nrows_to_infer,
                                   true_values=true_values,
                                   false_values=false_values,
+                                  _only_raw_string_substitutions=_only_raw_string_substitutions,
                                   **kwargs)[0]
 
 
@@ -1597,7 +1605,8 @@ class SFrame(object):
             g = SFrame({'X1':g})
             return g.unpack('X1','')
         elif orient == "lines":
-            g = cls.read_csv(url, header=False,na_values=['null'],true_values=['true'],false_values=['false'])
+            g = cls.read_csv(url, header=False,na_values=['null'],true_values=['true'],false_values=['false'], 
+                    _only_raw_string_substitutions=True)
             if g.num_rows() == 0:
                 return SFrame()
             if g.num_columns() != 1:

--- a/src/unity/python/turicreate/test/test_json.py
+++ b/src/unity/python/turicreate/test/test_json.py
@@ -393,3 +393,37 @@ class JSONTest(unittest.TestCase):
                 return
 
             _SFrameComparer._assert_sframe_equal(expected, actual)
+
+
+    def test_true_false_substitutions(self):
+        expecteda = [["a", "b", "c"],["a", "b", "c"]]
+        expectedb = [["d", "false", "e", 0, "true", 1, "a"],["d", "e", "f"]]
+
+        records_json_file = """
+[{"a" : ["a", "b", "c"],
+  "b" : ["d", "false", "e", false, "true", true, "a"]},
+ {"a" : ["a", "b", "c"],
+  "b" : ["d", "e", "f"]}]
+"""
+        lines_json_file = """
+{"a" : ["a", "b", "c"], "b" : ["d", "false", "e", false, "true", true, "a"]}
+{"a" : ["a", "b", "c"], "b" : ["d", "e", "f"]}
+"""
+
+
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write(records_json_file)
+            f.flush()
+            records = SFrame.read_json(f.name, orient='records')
+        self.assertEqual(list(records["a"]), expecteda)
+        self.assertEqual(list(records["b"]), expectedb)
+
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write(lines_json_file)
+            f.flush()
+            lines = SFrame.read_json(f.name, orient='lines')
+
+        self.assertEqual(list(lines["a"]), expecteda)
+        self.assertEqual(list(lines["b"]), expectedb)
+
+

--- a/test/sframe/sframe_csv_test.cxx
+++ b/test/sframe/sframe_csv_test.cxx
@@ -357,6 +357,96 @@ csv_test test_na_values2() {
   return ret;
 }
 
+
+csv_test test_true_values() {
+  csv_test ret;
+  std::stringstream strm;
+  strm << "k,v\n"
+       << "a,1\n"
+       << "b,1\n"
+       << "c,-8\n"
+       << "d,3\n";
+
+  ret.file = strm.str();
+  ret.tokenizer.delimiter = ",";
+  ret.tokenizer.true_values = {"-8"};
+
+  ret.values.push_back({"a", 1});
+  ret.values.push_back({"b", 1});
+  ret.values.push_back({"c", 1});
+  ret.values.push_back({"d", 3});
+
+  ret.types = {{"k", flex_type_enum::STRING},
+               {"v", flex_type_enum::INTEGER}};
+  return ret;
+}
+
+
+csv_test test_false_values() {
+  csv_test ret;
+  std::stringstream strm;
+  strm << "k,v\n"
+       << "a,1\n"
+       << "b,1\n"
+       << "c,-8\n"
+       << "d,3\n";
+
+  ret.file = strm.str();
+  ret.tokenizer.delimiter = ",";
+  ret.tokenizer.false_values = {"-8"};
+
+  ret.values.push_back({"a", 1});
+  ret.values.push_back({"b", 1});
+  ret.values.push_back({"c", 0});
+  ret.values.push_back({"d", 3});
+
+  ret.types = {{"k", flex_type_enum::STRING},
+               {"v", flex_type_enum::INTEGER}};
+  return ret;
+}
+
+csv_test test_substitutions_raw_string_matches1() {
+  csv_test ret;
+  std::stringstream strm;
+  strm << "k,v\n"
+       << "\"true\",true\n"
+       << "\"false\",false\n";
+
+  ret.file = strm.str();
+  ret.tokenizer.delimiter = ",";
+  ret.tokenizer.true_values = {"true"};
+  ret.tokenizer.false_values = {"false"};
+  ret.tokenizer.only_raw_string_substitutions = true;
+
+  ret.values.push_back({"true", 1});
+  ret.values.push_back({"false", 0});
+
+  ret.types = {{"k", flex_type_enum::STRING},
+               {"v", flex_type_enum::INTEGER}};
+  return ret;
+}
+
+csv_test test_substitutions_raw_string_matches2() {
+  csv_test ret;
+  std::stringstream strm;
+  strm << "k,v\n"
+       << "\"true\",true\n"
+       << "\"false\",false\n";
+
+  ret.file = strm.str();
+  ret.tokenizer.delimiter = ",";
+  ret.tokenizer.true_values = {"\"true\""};
+  ret.tokenizer.false_values = {"\"false\""};
+  ret.tokenizer.only_raw_string_substitutions = true;
+
+  ret.values.push_back({1, "true"});
+  ret.values.push_back({0, "false"});
+
+  ret.types = {{"k", flex_type_enum::INTEGER},
+               {"v", flex_type_enum::STRING}};
+  return ret;
+}
+
 csv_test test_missing_tab_values() {
   csv_test ret;
   std::stringstream strm;
@@ -842,9 +932,13 @@ struct sframe_test  {
      unescape_string(s, false, '\\', '\"', false);
      TS_ASSERT_EQUALS(s, "\\world\\");
    }
-   void test_na() {
+   void test_substitutions() {
      evaluate(test_na_values());
      evaluate(test_na_values2());
+     evaluate(test_true_values());
+     evaluate(test_false_values());
+     evaluate(test_substitutions_raw_string_matches1());
+     evaluate(test_substitutions_raw_string_matches2());
    }
 
    void test_csvs() {
@@ -934,8 +1028,8 @@ BOOST_FIXTURE_TEST_SUITE(_sframe_test, sframe_test)
 BOOST_AUTO_TEST_CASE(test_string_escaping) {
   sframe_test::test_string_escaping();
 }
-BOOST_AUTO_TEST_CASE(test_na) {
-  sframe_test::test_na();
+BOOST_AUTO_TEST_CASE(test_substitutions) {
+  sframe_test::test_substitutions();
 }
 BOOST_AUTO_TEST_CASE(test_csvs) {
   sframe_test::test_csvs();


### PR DESCRIPTION
More generally, implements a hidden CSV parsing option called
_only_raw_string_substitutions which forces true,false,na substitutions
to compare *only* on the unprocessed buffer before dequoting, escaping, etc.

This is considered a private option for now since I am unsure how to
document it for public consumption.

Fixes #1695