### PR TITLE
Changed C-API getters of flexible type to be better with numeric types.

### DIFF
--- a/src/capi/impl/capi_flexible_type.cpp
+++ b/src/capi/impl/capi_flexible_type.cpp
@@ -192,13 +192,7 @@ EXPORT double tc_ft_double(const tc_flexible_type* ft, tc_error** error) {
   turi::ensure_server_initialized();
 
   CHECK_NOT_NULL(error, ft, "Flexible type", NULL);
-
-  if(ft->value.get_type() != turi::flex_type_enum::FLOAT) {
-    set_error(error, "Flexible type not a double.");
-    return 0;
-  }
-
-  return ft->value.get<double>();
+  return ft->value.to<double>(); 
 
   ERROR_HANDLE_END(error, NULL);
 }
@@ -209,12 +203,7 @@ EXPORT int64_t tc_ft_int64(const tc_flexible_type* ft, tc_error** error) {
 
   CHECK_NOT_NULL(error, ft, "Flexible type", NULL);
 
-  if(ft->value.get_type() != turi::flex_type_enum::INTEGER) {
-    set_error(error, "Flexible type not an integer.");
-    return 0;
-  }
-
-  return ft->value.get<int64_t>();
+  return ft->value.to<int64_t>();
 
   ERROR_HANDLE_END(error, NULL);
 }


### PR DESCRIPTION
Currently, getting integers and doubles requires the types to match exactly.  This PR allows integers or doubles to be cast to the other type if it can be done exactly.