### PR TITLE
Remove jinja2 dependency

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,7 +2,6 @@ coremltools==2.1.0
 scipy==0.19.1
 numpy==1.11.1
 cython==0.24
-Jinja2==2.8
 argparse==1.2.1
 decorator==4.1.2
 mock==2.0.0

--- a/src/external/coremltools_wrap/coremltools/docs_requirements.txt
+++ b/src/external/coremltools_wrap/coremltools/docs_requirements.txt
@@ -5,7 +5,6 @@ chardet==3.0.4
 docutils==0.14
 idna==2.6
 imagesize==0.7.1
-Jinja2==2.10
 MarkupSafe==1.0
 numpy==1.14.0
 numpydoc==0.7.0

--- a/src/external/coremltools_wrap/coremltools/mlmodel/Requirements.txt
+++ b/src/external/coremltools_wrap/coremltools/mlmodel/Requirements.txt
@@ -3,7 +3,6 @@ Babel==2.4.0
 docutils==0.13.1
 imagesize==0.7.1
 inflection==0.3.1
-Jinja2==2.9.6
 MarkupSafe==1.0
 Pygments==2.2.0
 pytz==2017.2

--- a/src/unity/python/doc/Makefile
+++ b/src/unity/python/doc/Makefile
@@ -47,11 +47,6 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-jinja2:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	@echo
-	@echo "Build finished. The Jinja2 templates are in $(BUILDDIR)/html."
-
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo


### PR DESCRIPTION
Turns out we (apparently) aren't using it anywhere. The only place it
might be used is by sphinx, in the optional `make jinja2` for sphinx
docs, but I don't think we normally run this as part of our
documentation generation process.