### PR TITLE
A Fix for the Evaluate Error in Image Classifier.

### DIFF
--- a/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -669,12 +669,14 @@ class ImageClassifier(_CustomModel):
 
         extracted_features = self._extract_features(dataset, verbose=verbose, batch_size=batch_size)
         extracted_features[self.target] = dataset[self.target]
+
+        if metric != 'auto':
+            return self.classifier.evaluate(extracted_features, metric=metric)
         
         metrics = self.classifier.evaluate(extracted_features, metric=metric, with_predictions=True)
         predictions = metrics["predictions"]["probs"]
         state = self.__proxy__.get_state()
         labels = state["classes"]
-
 
         def entropy(probs):
             return _reduce(lambda x, y: x + (y*math.log(1/y, 2) if y > 0 else 0) , probs, 0) / math.log(len(probs),2)


### PR DESCRIPTION
- partially fixes the #1785 Issue of `KeyError: 'predictions'`
- Still have the Issues around the user wanting multiple metrics and not wanting the output of the Evaluation Object.

- Maybe offload this work in a materialize function present on the returned evaluation object? This way unnecessary computation won't occur when the user only wants select metrics.