### PR TITLE
flex_image constructor from Boost GIL Image Types

### DIFF
--- a/src/image/CMakeLists.txt
+++ b/src/image/CMakeLists.txt
@@ -13,7 +13,6 @@ make_library(image_type OBJECT
   REQUIRES
     logger
     image_io
-    boost
   EXTERNAL_VISIBILITY
 )
 
@@ -34,7 +33,6 @@ make_library(image_io OBJECT
     libjpeg
     logger
     fileio
-    boost
   EXTERNAL_VISIBILITY
 )
 

--- a/src/image/CMakeLists.txt
+++ b/src/image/CMakeLists.txt
@@ -13,6 +13,7 @@ make_library(image_type OBJECT
   REQUIRES
     logger
     image_io
+    boost
   EXTERNAL_VISIBILITY
 )
 
@@ -29,10 +30,11 @@ make_library(image_io OBJECT
     jpeg_io.cpp
     png_io.cpp
   REQUIRES
-    libpng		
-    libjpeg		
-    logger		
-    fileio		
+    libpng
+    libjpeg
+    logger
+    fileio
+    boost
   EXTERNAL_VISIBILITY
 )
 

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -20,16 +20,16 @@ image_type::image_type(const char* image_data, size_t height, size_t width, size
   std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
 }
 
-template<typename gil_image_type>
-image_type::image_type(const gil_image_type &gil_image)
+// template<typename gil_image_type>
+image_type::image_type(const boost::gil::rgb8_image_t &gil_image)
 : m_height(gil_image.height())
 , m_width(gil_image.width())
-, m_channels(boost::gil::num_channels<gil_image_type>())
-, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<gil_image_type>())
+, m_channels(boost::gil::num_channels<boost::gil::rgb8_image_t>())
+, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>())
 , m_version(IMAGE_TYPE_CURRENT_VERSION)
 , m_format(Format::RAW_ARRAY)
 {
-  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<gil_image_type>();
+  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>();
   auto it = const_view(gil_image).begin();
   const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
   m_image_data.reset(new char[image_data_size]);

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -17,12 +17,12 @@ image_type::image_type(const boost::gil::rgb8_image_t &gil_image) {
   auto it = view(gil_image).begin();
   const uint8_t* data = reinterpret_cast<const uint8_t*>(&boost::gil::at_c<0>(*it));
   m_image_data.reset(new char[m_image_data_size]);
-  memcpy(&m_image_data[0], data, m_image_data_size);
+  std::copy(data, data + m_image_data_size, &m_image_data[0]);
 }
 
 image_type::image_type(const char* image_data, size_t height, size_t width, size_t channels, size_t image_data_size, int version, int format){
   m_image_data.reset(new char[image_data_size]);
-  memcpy(&m_image_data[0], image_data, image_data_size);
+  std::copy(data, data + image_data_size, &m_image_data[0]);
   m_height = height;
   m_width = width;
   m_channels = channels;

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -20,15 +20,16 @@ image_type::image_type(const char* image_data, size_t height, size_t width, size
   std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
 }
 
-image_type::image_type(const boost::gil::rgb8_image_t &gil_image)
+template<typename image_type>
+image_type::image_type(const image_type &gil_image)
 : m_height(gil_image.height())
 , m_width(gil_image.width())
-, m_channels(boost::gil::num_channels<boost::gil::rgb8_image_t>())
-, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>())
+, m_channels(boost::gil::num_channels<image_type>())
+, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<image_type>())
 , m_version(IMAGE_TYPE_CURRENT_VERSION)
 , m_format(Format::RAW_ARRAY)
 {
-  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>();
+  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<image_type>();
   auto it = const_view(gil_image).begin();
   const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
   m_image_data.reset(new char[image_data_size]);

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -8,7 +8,7 @@
 namespace turi{
 
 image_type::image_type(const boost::gil::rgb8_image_t &gil_image) {
-  auto it = view(gil_image).begin();
+  rgb8_image_t::view_t::iterator it = view(gil_image).begin();
   const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
   size_t num_channels = boost::gil::num_channels<boost::gil::rgb8_image_t>();
   image_type::image_type( data, 

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -20,16 +20,16 @@ image_type::image_type(const char* image_data, size_t height, size_t width, size
   std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
 }
 
-template<typename image_type>
-image_type::image_type(const image_type &gil_image)
+template<typename gil_image_type>
+image_type::image_type(const gil_image_type &gil_image)
 : m_height(gil_image.height())
 , m_width(gil_image.width())
-, m_channels(boost::gil::num_channels<image_type>())
-, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<image_type>())
+, m_channels(boost::gil::num_channels<gil_image_type>())
+, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<gil_image_type>())
 , m_version(IMAGE_TYPE_CURRENT_VERSION)
 , m_format(Format::RAW_ARRAY)
 {
-  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<image_type>();
+  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<gil_image_type>();
   auto it = const_view(gil_image).begin();
   const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
   m_image_data.reset(new char[image_data_size]);

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -7,6 +7,19 @@
 
 namespace turi{
 
+image_type::image_type(boost::gil::rgb8_image_t gil_image) {
+  auto it = view(gil_image).begin();
+  auto data = (uint8_t*) &boost::gil::at_c<0>(*it);
+  m_height = gil_image.height();
+  m_width = gil_image.width();
+  m_channels = boost::gil::num_channels<boost::gil::rgb8_image_t>();
+  m_image_data_size = m_height * m_width * m_channels;
+  m_version = IMAGE_TYPE_CURRENT_VERSION;
+  m_format = Format::RAW_ARRAY;
+  m_image_data.reset(new char[m_image_data_size]);
+  memcpy(&m_image_data[0], data, m_image_data_size);
+}
+
 image_type::image_type(const char* image_data, size_t height, size_t width, size_t channels, size_t image_data_size, int version, int format){
   m_image_data.reset(new char[image_data_size]);
   memcpy(&m_image_data[0], image_data, image_data_size);

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -28,7 +28,7 @@ image_type::image_type(const boost::gil::rgb8_image_t &gil_image)
 , m_format(Format::RAW_ARRAY)
 {
   size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>();
-  boost::gil::rgb8_image_t::view_t::iterator it = const_view(gil_image).begin();
+  auto it = const_view(gil_image).begin();
   const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
   m_image_data.reset(new char[image_data_size]);
   std::copy(data, data + image_data_size, &m_image_data[0]);

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -4,6 +4,7 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 #include <image/image_type.hpp>
+#include <boost/gil/gil_all.hpp>
 
 namespace turi{
 

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -20,15 +20,16 @@ image_type::image_type(const boost::gil::rgb8_image_t &gil_image) {
                           Format::RAW_ARRAY);
 }
 
-image_type::image_type(const char* image_data, size_t height, size_t width, size_t channels, size_t image_data_size, int version, int format){
+image_type::image_type(const char* image_data, size_t height, size_t width, size_t channels, size_t image_data_size, int version, int format)
+: m_height(height)
+, m_width(width)
+, m_channels(channels)
+, m_image_data_size(image_data_size)
+, m_version(version)
+, m_format(static_cast<Format>(format))
+{
   m_image_data.reset(new char[image_data_size]);
   std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
-  m_height = height;
-  m_width = width;
-  m_channels = channels;
-  m_image_data_size = image_data_size;
-  m_version = (char)version;
-  m_format = static_cast<Format>(format);
 }
 
 

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -8,21 +8,21 @@
 namespace turi{
 
 image_type::image_type(const boost::gil::rgb8_image_t &gil_image) {
-  m_height = gil_image.height();
-  m_width = gil_image.width();
-  m_channels = boost::gil::num_channels<boost::gil::rgb8_image_t>();
-  m_image_data_size = m_height * m_width * m_channels;
-  m_version = IMAGE_TYPE_CURRENT_VERSION;
-  m_format = Format::RAW_ARRAY;
   auto it = view(gil_image).begin();
-  const uint8_t* data = reinterpret_cast<const uint8_t*>(&boost::gil::at_c<0>(*it));
-  m_image_data.reset(new char[m_image_data_size]);
-  std::copy(data, data + m_image_data_size, &m_image_data[0]);
+  const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
+  size_t num_channels = boost::gil::num_channels<boost::gil::rgb8_image_t>();
+  image_type::image_type( data, 
+                          gil_image.height(),
+                          gil_image.width(),
+                          num_channels,
+                          gil_image.height() * gil_image.width() * num_channels,
+                          IMAGE_TYPE_CURRENT_VERSION,
+                          Format::RAW_ARRAY);
 }
 
 image_type::image_type(const char* image_data, size_t height, size_t width, size_t channels, size_t image_data_size, int version, int format){
   m_image_data.reset(new char[image_data_size]);
-  std::copy(data, data + image_data_size, &m_image_data[0]);
+  std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
   m_height = height;
   m_width = width;
   m_channels = channels;

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -7,15 +7,15 @@
 
 namespace turi{
 
-image_type::image_type(boost::gil::rgb8_image_t gil_image) {
-  auto it = view(gil_image).begin();
-  auto data = (uint8_t*) &boost::gil::at_c<0>(*it);
+image_type::image_type(const boost::gil::rgb8_image_t &gil_image) {
   m_height = gil_image.height();
   m_width = gil_image.width();
   m_channels = boost::gil::num_channels<boost::gil::rgb8_image_t>();
   m_image_data_size = m_height * m_width * m_channels;
   m_version = IMAGE_TYPE_CURRENT_VERSION;
   m_format = Format::RAW_ARRAY;
+  auto it = view(gil_image).begin();
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(&boost::gil::at_c<0>(*it));
   m_image_data.reset(new char[m_image_data_size]);
   memcpy(&m_image_data[0], data, m_image_data_size);
 }

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -20,7 +20,6 @@ image_type::image_type(const char* image_data, size_t height, size_t width, size
   std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
 }
 
-// template<typename gil_image_type>
 image_type::image_type(const boost::gil::rgb8_image_t &gil_image)
 : m_height(gil_image.height())
 , m_width(gil_image.width())

--- a/src/image/image_type.cpp
+++ b/src/image/image_type.cpp
@@ -7,19 +7,6 @@
 
 namespace turi{
 
-image_type::image_type(const boost::gil::rgb8_image_t &gil_image) {
-  rgb8_image_t::view_t::iterator it = view(gil_image).begin();
-  const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
-  size_t num_channels = boost::gil::num_channels<boost::gil::rgb8_image_t>();
-  image_type::image_type( data, 
-                          gil_image.height(),
-                          gil_image.width(),
-                          num_channels,
-                          gil_image.height() * gil_image.width() * num_channels,
-                          IMAGE_TYPE_CURRENT_VERSION,
-                          Format::RAW_ARRAY);
-}
-
 image_type::image_type(const char* image_data, size_t height, size_t width, size_t channels, size_t image_data_size, int version, int format)
 : m_height(height)
 , m_width(width)
@@ -30,6 +17,21 @@ image_type::image_type(const char* image_data, size_t height, size_t width, size
 {
   m_image_data.reset(new char[image_data_size]);
   std::copy(image_data, image_data + image_data_size, &m_image_data[0]);
+}
+
+image_type::image_type(const boost::gil::rgb8_image_t &gil_image)
+: m_height(gil_image.height())
+, m_width(gil_image.width())
+, m_channels(boost::gil::num_channels<boost::gil::rgb8_image_t>())
+, m_image_data_size(gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>())
+, m_version(IMAGE_TYPE_CURRENT_VERSION)
+, m_format(Format::RAW_ARRAY)
+{
+  size_t image_data_size = gil_image.height() * gil_image.width() * boost::gil::num_channels<boost::gil::rgb8_image_t>();
+  boost::gil::rgb8_image_t::view_t::iterator it = const_view(gil_image).begin();
+  const char* data = reinterpret_cast<const char*>(&boost::gil::at_c<0>(*it));
+  m_image_data.reset(new char[image_data_size]);
+  std::copy(data, data + image_data_size, &m_image_data[0]);
 }
 
 

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -10,12 +10,6 @@
 #include <serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
 
-namespace boost {
-namespace gil {
-  class rgb8_image_t;
-} // gil
-} // boost
-
 const char IMAGE_TYPE_CURRENT_VERSION = 0;
 
 namespace turi {
@@ -60,7 +54,9 @@ public:
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);
   /// Construct from a Boost GIL Image
-  explicit image_type(const boost::gil::rgb8_image_t &boost_image);
+  /// Note: image_type can be any of the Boost GIL image types.
+  template<typename image_type>
+  explicit image_type(const image_type &gil_image);
   /// Check whether image is decoded
   inline bool is_decoded() const { return m_format == Format::RAW_ARRAY; }
   /// Serialization

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -10,10 +10,6 @@
 #include <serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/gil/gil_all.hpp>
-#include <boost/gil/rgb.hpp>
-// #include <boost/gil/utilities.hpp>
-// #include <boost/gil/extension/toolbox/metafunctions.hpp>
-// #include <boost/gil/extension/toolbox/metafunctions/gil_extensions.hpp>
 
 const char IMAGE_TYPE_CURRENT_VERSION = 0;
 
@@ -55,10 +51,10 @@ public:
   Format m_format = Format::UNDEFINED; 
   /// Constructor
   image_type() = default;
-  /// Construct from a Boost GIL Image
   /// Construct from existing data
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);
+  /// Construct from a Boost GIL Image
   explicit image_type(const boost::gil::rgb8_image_t &boost_image);
   /// Check whether image is decoded
   inline bool is_decoded() const { return m_format == Format::RAW_ARRAY; }

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -52,7 +52,7 @@ public:
   /// Constructor
   image_type() = default;
   /// Construct from a Boost GIL Image
-  explicit image_type(boost::gil::rgb8_image_t boost_image);
+  explicit image_type(const boost::gil::rgb8_image_t &boost_image);
   /// Construct from existing data
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -55,8 +55,8 @@ public:
              size_t channels, size_t image_data_size, int version, int format);
   /// Construct from a Boost GIL Image
   /// Note: image_type can be any of the Boost GIL image types.
-  template<typename image_type>
-  explicit image_type(const image_type &gil_image);
+  template<typename gil_image_type>
+  explicit image_type(const gil_image_type &gil_image);
   /// Check whether image is decoded
   inline bool is_decoded() const { return m_format == Format::RAW_ARRAY; }
   /// Serialization

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -50,6 +50,8 @@ public:
   Format m_format = Format::UNDEFINED; 
   /// Constructor
   image_type() = default;
+  /// Construct from a Boost GIL Image
+  explicit image_type(boost::gil::rgb8_image_t boost_image);
   /// Construct from existing data
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -9,7 +9,12 @@
 #include <string>
 #include <serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/gil/gil_all.hpp>
+
+namespace boost {
+namespace gil {
+  class rgb8_image_t;
+} // gil
+} // boost
 
 const char IMAGE_TYPE_CURRENT_VERSION = 0;
 

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -10,6 +10,10 @@
 #include <serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/gil/gil_all.hpp>
+#include <boost/gil/rgb.hpp>
+// #include <boost/gil/utilities.hpp>
+// #include <boost/gil/extension/toolbox/metafunctions.hpp>
+// #include <boost/gil/extension/toolbox/metafunctions/gil_extensions.hpp>
 
 const char IMAGE_TYPE_CURRENT_VERSION = 0;
 
@@ -52,10 +56,10 @@ public:
   /// Constructor
   image_type() = default;
   /// Construct from a Boost GIL Image
-  explicit image_type(const boost::gil::rgb8_image_t &boost_image);
   /// Construct from existing data
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);
+  explicit image_type(const boost::gil::rgb8_image_t &boost_image);
   /// Check whether image is decoded
   inline bool is_decoded() const { return m_format == Format::RAW_ARRAY; }
   /// Serialization

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -54,8 +54,7 @@ public:
   /// Construct from existing data
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);
-  /// Construct from a Boost GIL Image
-  /// Note: gil_image_type can be any of the Boost GIL image types.
+  /// Construct from a Boost GIL rgb8 Image
   explicit image_type(const boost::gil::rgb8_image_t& gil_image);
   /// Check whether image is decoded
   inline bool is_decoded() const { return m_format == Format::RAW_ARRAY; }

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/gil/typedefs.hpp>
 
 const char IMAGE_TYPE_CURRENT_VERSION = 0;
 
@@ -55,8 +56,7 @@ public:
              size_t channels, size_t image_data_size, int version, int format);
   /// Construct from a Boost GIL Image
   /// Note: gil_image_type can be any of the Boost GIL image types.
-  template<typename gil_image_type>
-  explicit image_type(const gil_image_type &gil_image);
+  explicit image_type(const boost::gil::rgb8_image_t& gil_image);
   /// Check whether image is decoded
   inline bool is_decoded() const { return m_format == Format::RAW_ARRAY; }
   /// Serialization

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/gil/gil_all.hpp>
 
 const char IMAGE_TYPE_CURRENT_VERSION = 0;
 

--- a/src/image/image_type.hpp
+++ b/src/image/image_type.hpp
@@ -54,7 +54,7 @@ public:
   image_type(const char* image_data, size_t height, size_t width,
              size_t channels, size_t image_data_size, int version, int format);
   /// Construct from a Boost GIL Image
-  /// Note: image_type can be any of the Boost GIL image types.
+  /// Note: gil_image_type can be any of the Boost GIL image types.
   template<typename gil_image_type>
   explicit image_type(const gil_image_type &gil_image);
   /// Check whether image is decoded


### PR DESCRIPTION
This will be useful for the One Shot Object Detection functionality when we want to construct a `flex_image` from Boost GIL Image Types.

Only fixes #1828