### PR TITLE
Fix CoreML export for tree classifiers

### DIFF
--- a/src/unity/python/turicreate/test/test_coreml_export.py
+++ b/src/unity/python/turicreate/test/test_coreml_export.py
@@ -22,8 +22,12 @@ import coremltools
 import sys
 import platform
 import array
+import os
 
 import pytest
+
+dirname = os.path.dirname(__file__)
+mushroom_dataset = os.path.join(dirname, 'mushroom.csv')
 
 class CoreMLExportTest(unittest.TestCase):
 
@@ -97,7 +101,7 @@ class CoreMLExportTest(unittest.TestCase):
                 tc_prediction = model.predict(row)[0]
 
                 if (is_regression == False) and (type(model.classes[0]) == str):
-                    if not is_has_probability:
+                    if not has_probability:
                         self.assertEqual(coreml_prediction["target"], tc_prediction)
                 else:
                     self.assertAlmostEqual(coreml_prediction["target"], tc_prediction, delta = 1e-5)
@@ -359,7 +363,6 @@ class CoreMLExportTest(unittest.TestCase):
             self._test_coreml_export(model, test, False)
 
 
-    @pytest.mark.xfail()
     def test_random_forest_multiclass_simple_tiny(self):
         for code_string in ["nnnn", "bns", "sss"]:
             train, test = self.generate_data("multiclass", 8, code_string)
@@ -375,4 +378,14 @@ class CoreMLExportTest(unittest.TestCase):
             model = tc.random_forest_classifier.create(train, "target", validation_set = None, max_depth=3, max_iterations = 5)
             model.evaluate(test)  # Previous classifier -- this caused errors.  
             self._test_coreml_export(model, test, False)
+
+    def test_tree_export_issue_1831(self):
+        SEED = 42
+        data = tc.SFrame.read_csv(mushroom_dataset)
+        data['target'] = data['label']
+        train_data, test_data = data.random_split(0.8,seed=SEED)
+        model = tc.boosted_trees_classifier.create(train_data, target='target',
+                                                   max_iterations=2,
+                                                   max_depth = 3)
+        self._test_coreml_export(model, test_data, False)
 

--- a/src/unity/toolkits/coreml_export/xgboost_exporter.cpp
+++ b/src/unity/toolkits/coreml_export/xgboost_exporter.cpp
@@ -93,11 +93,11 @@ std::shared_ptr<MLModelWrapper> export_xgboost_model(
 
   // set up the pipeline from metadata.
   setup_pipeline_from_mldata(*pipeline, metadata);
-  std::set<size_t> dict_indices;
+  std::map<size_t, size_t> dict_indices;
   for (size_t c = 0; c < metadata->num_columns(); c++) {
     if (metadata->column_type(c) == flex_type_enum::DICT) {
       for (size_t i = 0; i < metadata->index_size(c); i++) {
-          dict_indices.insert(metadata->global_index_offset(c) + i);
+          dict_indices[metadata->global_index_offset(c) + i] = 1;
       }
     }
   }
@@ -184,13 +184,10 @@ std::shared_ptr<MLModelWrapper> export_xgboost_model(
   for(const flexible_type& ft : ft_data.range_iterator()) {
     size_t tree_id = tree_counter; // Start from 0
     ++tree_counter;
-
     for(const flexible_type& node_dict_really_raw : ft.get<flex_list>() ) {
-
       const flex_dict& node_dict_raw = node_dict_really_raw.get<flex_dict>();
 
       std::map<flex_string, flexible_type> node_dict(node_dict_raw.begin(), node_dict_raw.end());
-
       flex_int node_id = node_dict.at("id").get<flex_int>();
       flex_string type = node_dict.at("type").get<flex_string>();
 
@@ -208,7 +205,6 @@ std::shared_ptr<MLModelWrapper> export_xgboost_model(
           }
           exact_value /= num_trees_per_class;
         }
-
         tree_ensemble->setupLeafNode(tree_id, node_id,
                                      { {tree_id % num_dimensions, exact_value} });
       } else {
@@ -223,13 +219,33 @@ std::shared_ptr<MLModelWrapper> export_xgboost_model(
         size_t n = sscanf(feature_name.c_str(), "{%zd}", &feature_index);
         ASSERT_EQ(n, 1);
 
-        tree_ensemble->setupBranchNode(
-            tree_id, node_id, size_t(feature_index),
-            CoreML::BranchMode::BranchOnValueLessThanEqual, exact_value,
-            yes_child, no_child);
-
-        tree_ensemble->setMissingValueBehavior(tree_id, node_id,
-                                               (missing_child != yes_child));
+        // This means that we need to swap out the no and the missing columns.
+        if(feature_type == "indicator") {
+          tree_ensemble->setupBranchNode(
+              tree_id,
+              node_id,
+              size_t(feature_index),
+              CoreML::BranchMode::BranchOnValueEqual,
+              1,
+              yes_child, missing_child);
+        // For dictionaries, set the threshold separately
+        } else if(dict_indices.find(size_t(feature_index)) != dict_indices.end()) {
+          tree_ensemble->setupBranchNode(
+              tree_id,
+              node_id,
+              size_t(feature_index),
+              CoreML::BranchMode::BranchOnValueLessThanEqual,
+              0,
+              missing_child, no_child);
+        } else {
+          tree_ensemble->setupBranchNode(
+              tree_id,
+              node_id,
+              size_t(feature_index),
+              CoreML::BranchMode::BranchOnValueLessThanEqual,
+              exact_value,
+              yes_child, no_child);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #1831

Reverts the changes in `xgboost_exporter.cpp` from #1127. That appeared
to cause wrong predictions in CoreML for some exported classifiers.