### PR TITLE
Fix broken build with `--no-python`

### DIFF
--- a/src/unity/CMakeLists.txt
+++ b/src/unity/CMakeLists.txt
@@ -44,6 +44,18 @@ if(APPLE AND HAS_MLCUSTOMMODEL)
   )
 endif()
 
+make_library(unity_shared
+  SOURCES
+    ${unity_shared_deps}
+    ${_TC_DEFAULT_SERVER_INITIALIZER}
+    ${_TC_COMMON_OBJECTS}
+  REQUIRES
+    ${_TC_COMMON_REQUIREMENTS}
+  SHARED
+  SHARED_ALL_DEFINED
+  DEAD_STRIP
+)
+
 # same as unity_shared, but all symbols exported
 # uses add_library instead of make_library so dependencies' symbols can be exported.
 add_library(unity_shared_for_testing SHARED

--- a/src/unity/python/turicreate/CMakeLists.txt
+++ b/src/unity/python/turicreate/CMakeLists.txt
@@ -20,17 +20,11 @@ foreach(loop_var ${EXTENSIONS_LIST})
   list(APPEND INSTALLATION_EXTENSIONS ${loop_var})
 endforeach()
 
-make_library(unity_shared
-  SOURCES
-    ${unity_shared_deps}
-    ${_TC_DEFAULT_SERVER_INITIALIZER}
-    ${_TC_COMMON_OBJECTS}
-  REQUIRES
-    ${_TC_COMMON_REQUIREMENTS}
-  SHARED
-  SHARED_ALL_DEFINED
-  DEAD_STRIP
+make_copy_target(copy_unity_shared
+  FILES
+  $<TARGET_FILE:unity_shared>
 )
+add_dependencies(copy_unity_shared unity_shared)
 
 make_copy_target(release_binaries
         TARGETS


### PR DESCRIPTION
The big CMake refactor that went in recently seems to have broken
the build for non-Python builds (./configure --no-python). The problem
is that unity_shared now only builds in the python directory (which
makes sense, since it's only used in Python), but the extensions all
depended on it and all were expected to build even without Python.

The fix is to move the `unity_shared` target back up from
`src/unity/python/turicreate` into `src/unity`. Now it builds with
non-Python builds again.