### PR TITLE
Workaround for virtualenv issue.

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -7,7 +7,7 @@ if [[ -z $VIRTUALENV ]]; then
   VIRTUALENV=virtualenv
 fi
 
-$VIRTUALENV deps/env
+$VIRTUALENV `pwd`/deps/env
 source deps/env/bin/activate
 
 PYTHON="${PWD}/deps/env/bin/python"


### PR DESCRIPTION
Turns out there’s a weird issue with virtualenv that, when given a
relative path, actually resolves the rest of it to
include the `/Volumes/Macintosh HD` with the space in it.  the fix
is to give it an absolute path on setup.