### PR TITLE
Fix linux-only test build break

### DIFF
--- a/test/annotation/utils_tests.cxx
+++ b/test/annotation/utils_tests.cxx
@@ -13,6 +13,9 @@
 
 #include "utils.cpp"
 
+/* The C++ featurizer API only works on Apple platforms. */
+#ifdef __APPLE__
+
 struct utils_test {
 public:
   /*
@@ -78,12 +81,12 @@ public:
 };
 
 BOOST_FIXTURE_TEST_SUITE(_utils_test, utils_test)
-#ifdef __APPLE__
 BOOST_AUTO_TEST_CASE(test_featurize_images) {
   utils_test::test_featurize_images();
 }
 BOOST_AUTO_TEST_CASE(test_most_similar_items) {
   utils_test::test_most_similar_items();
 }
-#endif
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif


### PR DESCRIPTION
The use of the C++ featurizer API will only compile on Apple platforms,
it seems. The test execution was scoped to `ifdef __APPLE__` but probably
the definition of the tests should be as well.

Otherwise we get:
```
../test/annotation/utils_tests.cxx: In member function ‘void utils_test::test_featurize_images()’:
../test/annotation/utils_tests.cxx:41:9: error: ‘featurize_images’ is not a member of ‘turi::annotate’
         turi::annotate::featurize_images(image_gl_sarray);
         ^
../test/annotation/utils_tests.cxx: In member function ‘void utils_test::test_most_similar_items()’:
../test/annotation/utils_tests.cxx:71:9: error: ‘featurize_images’ is not a member of ‘turi::annotate’
         turi::annotate::featurize_images(image_gl_sarray);
         ^
```