### PR TITLE
Fix mxnet being imported on turicreate import

### DIFF
--- a/src/unity/python/turicreate/toolkits/image_classifier/_annotate.py
+++ b/src/unity/python/turicreate/toolkits/image_classifier/_annotate.py
@@ -19,7 +19,6 @@ import turicreate as __tc
 from sys import platform as __platform
 
 import array as _array
-from mxnet.io import DataBatch as __DataBatch
 
 def _warning_annotations():
     print(


### PR DESCRIPTION
Once again, we are importing mxnet on turicreate import. Seems the place
it's being imported is not even used (at all). Removing it.

We have a unit test for this, but it's flaky due to some lambda worker
issues, so it's not running at the moment.