### PR TITLE
Allow mps_compute_context to wrap an arbitrary MTLCommandQueue

### DIFF
--- a/src/unity/toolkits/neural_net/mps_cnnmodule.h
+++ b/src/unity/toolkits/neural_net/mps_cnnmodule.h
@@ -12,6 +12,7 @@
 
 #include <unity/toolkits/neural_net/float_array.hpp>
 #include <unity/toolkits/neural_net/model_backend.hpp>
+#include <unity/toolkits/neural_net/mps_command_queue.hpp>
 
 #import "mps_networks.h"
 #import "mps_updater.h"
@@ -25,7 +26,7 @@ namespace neural_net {
 class mps_cnn_module: public model_backend {
 public:
 
-  mps_cnn_module(id <MTLDevice> dev);
+  mps_cnn_module(const mps_command_queue& command_queue);
 
   void init(int network_id, int n, int c_in, int h_in, int w_in, int c_out,
             int h_out, int w_out, int updater_id,

--- a/src/unity/toolkits/neural_net/mps_cnnmodule.mm
+++ b/src/unity/toolkits/neural_net/mps_cnnmodule.mm
@@ -24,10 +24,10 @@ MPSImageBatch * _Nonnull CreateImageBatch(id<MTLDevice> _Nonnull device,
 
 }  // anonymous namespace
 
-mps_cnn_module::mps_cnn_module(id <MTLDevice> dev) {
+mps_cnn_module::mps_cnn_module(const mps_command_queue& command_queue) {
 
-  dev_ = dev;
-  cmd_queue_ = [dev_ newCommandQueue];
+  cmd_queue_ = command_queue.impl;
+  dev_ = cmd_queue_.device;
 
   ASSERT_TRUE(dev_ != nil);
   ASSERT_TRUE(cmd_queue_ != nil);

--- a/src/unity/toolkits/neural_net/mps_command_queue.hpp
+++ b/src/unity/toolkits/neural_net/mps_command_queue.hpp
@@ -1,0 +1,49 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef UNITY_TOOLKITS_NEURAL_NET_MPS_COMMAND_QUEUE_HPP_
+#define UNITY_TOOLKITS_NEURAL_NET_MPS_COMMAND_QUEUE_HPP_
+
+// C++ headers and implementations can include this file for the forward
+// declaration of mps_command_queue, allowing C++ code to pass mps_command_queue
+// pointers and references. Objective C++ implementations can include this file
+// to obtain the MTLCommandQueue that the mps_command_queue wraps.
+
+namespace turi {
+namespace neural_net {
+
+// C++-only files just get this forward declaration.
+struct mps_command_queue;
+
+}  // namespace neural_net
+}  // namespace turi
+
+// Define the mps_command_queue struct for Objective C++ files.
+#ifdef __OBJC__
+
+#import <Metal/Metal.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace turi {
+namespace neural_net {
+
+/**
+ * Simple wrapper around an MTLCommandQueue-conforming Objective C object, so
+ * that pure C++ code can pass these objects around.
+ */
+struct mps_command_queue {
+  id <MTLCommandQueue> impl = nil;
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+NS_ASSUME_NONNULL_END
+
+#endif  // __OBJC__
+
+#endif  // UNITY_TOOLKITS_NEURAL_NET_MPS_COMMAND_QUEUE_HPP_

--- a/src/unity/toolkits/neural_net/mps_compute_context.hpp
+++ b/src/unity/toolkits/neural_net/mps_compute_context.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <unity/toolkits/neural_net/compute_context.hpp>
+#include <unity/toolkits/neural_net/mps_command_queue.hpp>
 
 namespace turi {
 namespace neural_net {
@@ -21,6 +22,11 @@ namespace neural_net {
  */
 class mps_compute_context: public compute_context {
 public:
+
+  /**
+   * Constructs a context wrapping the given Metal command queue.
+   */
+  mps_compute_context(std::unique_ptr<mps_command_queue> command_queue);
 
   /**
    * Constructs a context wrapping the best currently available Metal device.
@@ -55,10 +61,7 @@ public:
 
 private:
 
-  // Use PIMPL pattern to keep Objective C out of this header.
-  struct impl;
-
-  std::unique_ptr<impl> impl_;
+  std::unique_ptr<mps_command_queue> command_queue_;
 };
 
 }  // namespace neural_net

--- a/src/unity/toolkits/neural_net/mps_compute_context.mm
+++ b/src/unity/toolkits/neural_net/mps_compute_context.mm
@@ -16,28 +16,44 @@
 namespace turi {
 namespace neural_net {
 
-struct mps_compute_context::impl {
+mps_compute_context::mps_compute_context(
+    std::unique_ptr<mps_command_queue> command_queue)
+  : command_queue_(std::move(command_queue))
+{}
 
-  id <MTLDevice> dev = nil;
-};
+mps_compute_context::mps_compute_context()
+  : command_queue_(new mps_command_queue)
+{
+  @autoreleasepool {
 
-mps_compute_context::mps_compute_context(): impl_(new impl) {
-
-  impl_->dev = [[TCMPSDeviceManager sharedInstance] preferredDevice];
-  if (impl_->dev == nil) {
+  id <MTLDevice> dev = [[TCMPSDeviceManager sharedInstance] preferredDevice];
+  if (dev == nil) {
     log_and_throw("No valid Metal device found.");
   }
+
+  command_queue_->impl = [dev newCommandQueue];
+
+  }  // @autoreleasepool
 }
 
 mps_compute_context::~mps_compute_context() = default;
 
 size_t mps_compute_context::memory_budget() const {
+  @autoreleasepool {
 
-  return static_cast<size_t>(impl_->dev.recommendedMaxWorkingSetSize);
+  id <MTLDevice> dev = command_queue_->impl.device;
+  return static_cast<size_t>(dev.recommendedMaxWorkingSetSize);
+
+  }  // @autoreleasepool
 }
 
 std::vector<std::string> mps_compute_context::gpu_names() const {
-  return { [impl_->dev.name cStringUsingEncoding:NSUTF8StringEncoding] };
+  @autoreleasepool {
+
+  id <MTLDevice> dev = command_queue_->impl.device;
+  return { [dev.name cStringUsingEncoding:NSUTF8StringEncoding] };
+
+  }  // @autoreleasepool
 }
 
 std::unique_ptr<image_augmenter> mps_compute_context::create_image_augmenter(
@@ -59,7 +75,7 @@ std::unique_ptr<model_backend> mps_compute_context::create_object_detector(
     const float_array_map& config, const float_array_map& weights) {
 
   std::unique_ptr<mps_graph_cnn_module> result(
-      new mps_graph_cnn_module(impl_->dev));
+      new mps_graph_cnn_module(*command_queue_));
 
   result->init(/* network_id */ kODGraphNet, n, c_in, h_in, w_in, c_out, h_out,
                w_out, config, weights);
@@ -71,7 +87,7 @@ std::unique_ptr<model_backend> mps_compute_context::create_activity_classifier(
     int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
     const float_array_map& config, const float_array_map& weights) {
 
-  std::unique_ptr<mps_cnn_module> result(new mps_cnn_module(impl_->dev));
+  std::unique_ptr<mps_cnn_module> result(new mps_cnn_module(*command_queue_));
 
   result->init(/* network_id */ kActivityClassifierNet, n, c_in, h_in, w_in,
                c_out, h_out, w_out, /* updater_id */ 2 /* Adam */,  config);

--- a/src/unity/toolkits/neural_net/mps_graph_cnnmodule.h
+++ b/src/unity/toolkits/neural_net/mps_graph_cnnmodule.h
@@ -13,6 +13,7 @@
 
 #include <unity/toolkits/neural_net/float_array.hpp>
 #include <unity/toolkits/neural_net/model_backend.hpp>
+#include <unity/toolkits/neural_net/mps_command_queue.hpp>
 
 #import "mps_utils.h"
 #import "mps_graph_networks.h"
@@ -26,7 +27,7 @@ class mps_graph_cnn_module: public model_backend {
 public:
 
   mps_graph_cnn_module();
-  mps_graph_cnn_module(id <MTLDevice> dev);
+  mps_graph_cnn_module(const mps_command_queue& command_queue);
 
   void init(int network_id, int n, int c_in, int h_in, int w_in, int c_out,
             int h_out, int w_out,

--- a/src/unity/toolkits/neural_net/mps_graph_cnnmodule.mm
+++ b/src/unity/toolkits/neural_net/mps_graph_cnnmodule.mm
@@ -50,11 +50,12 @@ mps_graph_cnn_module::mps_graph_cnn_module() {
   }
 }
 
-mps_graph_cnn_module::mps_graph_cnn_module(id <MTLDevice> dev) {
+mps_graph_cnn_module::mps_graph_cnn_module(
+    const mps_command_queue& command_queue) {
   @autoreleasepool {
 
-  dev_ = dev;
-  cmd_queue_ = [dev_ newCommandQueue];
+  cmd_queue_ = command_queue.impl;
+  dev_ = cmd_queue_.device;
 
   }  // @autoreleasepool
 }

--- a/src/unity/toolkits/neural_net/mps_trainer.mm
+++ b/src/unity/toolkits/neural_net/mps_trainer.mm
@@ -7,6 +7,7 @@
 
 #include <logger/logger.hpp>
 #include <unity/toolkits/neural_net/float_array.hpp>
+#include <unity/toolkits/neural_net/mps_command_queue.hpp>
 
 #import "mps_cnnmodule.h"
 #import "mps_device_manager.h"
@@ -18,6 +19,7 @@ using turi::neural_net::float_array_map;
 using turi::neural_net::float_array_map_iterator;
 using turi::neural_net::make_array_map;
 using turi::neural_net::mps_cnn_module;
+using turi::neural_net::mps_command_queue;
 using turi::neural_net::shared_float_array;
 
 int TCMPSCreateCNNModule(MPSHandle *out) {
@@ -29,7 +31,9 @@ int TCMPSCreateCNNModule(MPSHandle *out) {
     log_and_throw("No valid Metal device.");
   }
 
-  mps_cnn_module *mps = new mps_cnn_module(dev);
+  mps_command_queue command_queue;
+  command_queue.impl = [dev newCommandQueue];
+  mps_cnn_module *mps = new mps_cnn_module(command_queue);
   *out = (void *)mps;
 
   API_END();


### PR DESCRIPTION
- Facititates better dependency injection for activity_classifier and object_detector
- Use MTLCommandQueue instead of MTLDevice, since the former includes the latter anyway