### PR TITLE
Implement model save/load for C++ activity classifier

### DIFF
--- a/src/unity/python/turicreate/toolkits/_mps_utils.py
+++ b/src/unity/python/turicreate/toolkits/_mps_utils.py
@@ -117,7 +117,7 @@ def ac_weights_mxnet_to_mps(arg_params, aux_params, lstm_h_size):
             w = mxnet_weights[key].asnumpy()
             mps_weights[key] = w[..., _np.newaxis, :]
         elif key.startswith('dense') and key.endswith('weight'):
-            mps_weights[key] = w[:, _np.newaxis, _np.newaxis]
+            mps_weights[key] = w[..., _np.newaxis, _np.newaxis]
         else:
             mps_weights[key] = w
 

--- a/src/unity/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/unity/toolkits/activity_classification/activity_classifier.cpp
@@ -13,6 +13,7 @@
 
 #include <logger/assertions.hpp>
 #include <logger/logger.hpp>
+#include <unity/lib/variant_deep_serialize.hpp>
 #include <unity/toolkits/coreml_export/neural_net_models_exporter.hpp>
 #include <unity/toolkits/evaluation/metrics.hpp>
 #include <util/string_util.hpp>
@@ -34,6 +35,9 @@ using neural_net::xavier_weight_initializer;
 using neural_net::zero_weight_initializer;
 
 using padding_type = model_spec::padding_type;
+
+// The last Python version was 2.
+constexpr size_t ACTIVITY_CLASSIFIER_VERSION = 3;
 
 constexpr size_t NUM_PREDICTIONS_PER_CHUNK = 20;
 
@@ -144,6 +148,28 @@ struct result {
 
 }  // namespace
 
+size_t activity_classifier::get_version() const {
+  return ACTIVITY_CLASSIFIER_VERSION;
+}
+
+void activity_classifier::save_impl(oarchive& oarc) const {
+  // Save model attributes.
+  variant_deep_save(state, oarc);
+
+  // Save neural net weights.
+  oarc << nn_spec_->export_params_view();
+}
+
+void activity_classifier::load_version(iarchive& iarc, size_t version) {
+  // Load model attributes.
+  variant_deep_load(state, iarc);
+
+  // Load neural net weights.
+  float_array_map nn_params;
+  iarc >> nn_params;
+  nn_spec_ = init_model();
+  nn_spec_->update_params(nn_params);
+}
 
 void activity_classifier::init_options(
     const std::map<std::string, flexible_type>& opts)
@@ -457,6 +483,102 @@ std::shared_ptr<MLModelWrapper> activity_classifier::export_to_coreml(
   }
 
   return model_wrapper;
+}
+
+// Converts a model saved from the original Python (CustomModel) toolkit.
+void activity_classifier::import_from_custom_model(
+    variant_map_type model_data, size_t version) {
+
+  // Extract the neural net weights from the model data.
+  auto it = model_data.find("_pred_model");
+  flex_dict pred_model = variant_get_value<flex_dict>(it->second);
+  model_data.erase(it);
+
+  // The remaining model data should be interpreted as model attributes (state).
+  state.clear();
+  state.insert(model_data.begin(), model_data.end());
+
+  // Migrate the MXNet weights from pred_model, which is a nested dictionary
+  // with three layers. The weights we want are spread among two top-level keys:
+  // "arg_params" and "aux_params". The mid-level keys are "data" and "shapes".
+  // The bottom-level keys are the layer names.
+  float_array_map nn_params;
+  auto import_mxnet_params = [&](const flex_dict& params) {
+    // Here, params is the value for either "arg_params" or "aux_params" in the
+    // top-level dictionary. Extract the data dictionary and shape dictionary.
+    flex_dict mxnet_data_dict;
+    flex_dict mxnet_shape_dict;
+    for (const auto& params_kv : params) {
+      if (params_kv.first == "data") {
+        mxnet_data_dict = params_kv.second;
+      } else if (params_kv.first == "shapes") {
+        mxnet_shape_dict = params_kv.second;
+      }
+    }
+
+    // Sort the two dictionaries, assuming that they contain the same keys.
+    auto cmp = [](const flex_dict::value_type& a, const flex_dict::value_type& b) {
+      return a.first < b.first;
+    };
+    std::sort(mxnet_data_dict.begin(), mxnet_data_dict.end(), cmp);
+    std::sort(mxnet_shape_dict.begin(), mxnet_shape_dict.end(), cmp);
+    ASSERT_EQ(mxnet_data_dict.size(), mxnet_shape_dict.size());
+
+    // Iterate through the shapes and data simultaneously, one layer at a time.
+    for (size_t i = 0; i < mxnet_data_dict.size(); ++i) {
+      // Copy/convert to std::vector of float (for data) and size_t (for shape).
+      std::string name = mxnet_data_dict[i].first;
+      flex_nd_vec mxnet_data_nd = mxnet_data_dict[i].second.to<flex_nd_vec>();
+      flex_nd_vec mxnet_shape_nd = mxnet_shape_dict[i].second.to<flex_nd_vec>();
+      const std::vector<double>& mxnet_data = mxnet_data_nd.elements();
+      const std::vector<double>& mxnet_shape = mxnet_shape_nd.elements();
+      std::vector<float> data(mxnet_data.size());
+      std::vector<size_t> shape(mxnet_shape.size());
+      std::copy(mxnet_data.begin(), mxnet_data.end(), data.begin());
+      std::copy(mxnet_shape.begin(), mxnet_shape.end(), shape.begin());
+
+      // Replace "moving" with "running" in layer names.
+      auto moving_pos = name.find("moving");
+      if (moving_pos != std::string::npos) {
+        name.replace(moving_pos, 6, "running");
+      }
+
+      if (name.find("lstm") == 0) {
+        // MXNet packs the parameters for a LSTM layer into a single block,
+        // concatenating the input gate, forget gate, cell, and output gate
+        // weights. CoreML expects these to be split into separate names.
+        shape[0] /= 4;
+        std::string prefix = name.substr(0, 8);  // "lstm_i2h" or "lstm_h2h"
+        std::string suffix = name.substr(9);     // "weight" or "bias"
+        size_t size = data.size() / 4;
+        nn_params[prefix + "_i_" + suffix] = shared_float_array::wrap(
+            std::vector<float>(data.begin(), data.begin() + size), shape);
+        nn_params[prefix + "_f_" + suffix] = shared_float_array::wrap(
+            std::vector<float>(data.begin() + size, data.begin() + size*2),
+            shape);
+        nn_params[prefix + "_c_" + suffix] = shared_float_array::wrap(
+            std::vector<float>(data.begin() + size*2, data.begin() + size*3),
+            shape);
+        nn_params[prefix + "_o_" + suffix] = shared_float_array::wrap(
+            std::vector<float>(data.begin() + size*3, data.end()), shape);
+      } else {
+        nn_params[name] =
+            shared_float_array::wrap(std::move(data), std::move(shape));
+      }
+    }
+  };
+
+  // Migrate all the weights found under the "arg_params" or "aux_params" keys.
+  for (const auto& pred_model_kv : pred_model) {
+    const std::string& key = pred_model_kv.first;
+    if (key == "arg_params" || key == "aux_params") {
+      import_mxnet_params(pred_model_kv.second.get<flex_dict>());
+    }
+  }
+
+  // Load the migrated weights.
+  nn_spec_ = init_model();
+  nn_spec_->update_params(nn_params);
 }
 
 std::unique_ptr<data_iterator>

--- a/src/unity/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/unity/toolkits/activity_classification/activity_classifier.hpp
@@ -25,6 +25,9 @@ class EXPORT activity_classifier: public ml_model_base {
   // ml_model_base interface
 
   void init_options(const std::map<std::string, flexible_type>& opts) override;
+  size_t get_version() const override;
+  void save_impl(oarchive& oarc) const override;
+  void load_version(iarchive& iarc, size_t version) override;
 
   // Interface exposed via Unity server
 
@@ -37,8 +40,7 @@ class EXPORT activity_classifier: public ml_model_base {
   variant_map_type evaluate(gl_sframe data, std::string metric);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename);
-
-  // TODO: Remainder of public interface: export, evaluate, predict, save/load
+  void import_from_custom_model(variant_map_type model_data, size_t version);
 
   BEGIN_CLASS_MEMBER_REGISTRATION("activity_classifier")
 
@@ -163,6 +165,9 @@ class EXPORT activity_classifier: public ml_model_base {
   );
   REGISTER_CLASS_MEMBER_FUNCTION(activity_classifier::export_to_coreml,
                                  "filename");
+
+  REGISTER_CLASS_MEMBER_FUNCTION(activity_classifier::import_from_custom_model,
+                                 "model_data", "version");
 
   END_CLASS_MEMBER_REGISTRATION
 

--- a/src/unity/toolkits/neural_net/float_array.cpp
+++ b/src/unity/toolkits/neural_net/float_array.cpp
@@ -83,6 +83,27 @@ shared_float_array shared_float_array::operator[](size_t idx) const {
   return shared_float_array(impl_, offset_ + offset, shape_ + 1, dim_ - 1);
 }
 
+void shared_float_array::save(oarchive& oarc) const {
+  // Write shape.
+  serialize_iterator(oarc, shape(), shape() + dim(), dim());
+
+  // Write data.
+  serialize_iterator(oarc, data(), data() + size(), size());
+}
+
+void shared_float_array::load(iarchive& iarc) {
+  // Read shape.
+  std::vector<size_t> shape;
+  iarc >> shape;
+
+  // Read data.
+  std::vector<float> data;
+  iarc >> data;
+
+  // Overwrite self with a new float_array wrapping the deserialized data.
+  *this = wrap(std::move(data), std::move(shape));
+}
+
 // static
 std::shared_ptr<float_array> shared_float_array::default_value() {
   // n.b. static variables should have trivial destructors

--- a/src/unity/toolkits/neural_net/float_array.hpp
+++ b/src/unity/toolkits/neural_net/float_array.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include <serialization/serialization_includes.hpp>
+
 namespace turi {
 namespace neural_net {
 
@@ -157,6 +159,10 @@ public:
   shared_float_array operator[](size_t idx) const;
 
   // TODO: Operations such as reshape, slice, etc.?
+
+  // Serialization.
+  void save(oarchive& oarc) const;
+  void load(iarchive& iarc);
 
 protected:
   shared_float_array(std::shared_ptr<float_array> impl, size_t offset,


### PR DESCRIPTION
This functionality is not wired into turicreate.load_model() yet, since the Python toolkit is still the default. Eventually, we'll need to wire in two paths there, one for loading models saved by the original Python CustomModel implementation, and one for loading models saved from C++. For now, this code should aid in developing the C++ toolkit by comparing the behavior of a model trained from Python, loaded into each implementation.

Fixes #1710 

For now, loading a model saved from Python as `ac.model`:
```
import turicreate as tc
m = tc.extensions.activity_classifier()
m.import_from_custom_model(tc._connect.main.get_unity().load_model('ac.model')['side_data'], 2)
```

Saving a model:
```
import turicreate as tc
m = tc.extensions.activity_classifier()
m.train(...)
class Wrapper:
    def __init__(self, m):
        self.__proxy__ = m
tc._connect.main.get_unity().save_model(Wrapper(m), 'ac.model')
```

Loading a saved model:
```
import turicreate as tc
m = tc.extensions._wrap_function_return(tc._connect.main.get_unity().load_model('ac.model')['model'])
```
