### PR TITLE
Update Linux build requirements

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -39,7 +39,10 @@ You will need:
 
 * On macOS, [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) with command line tools (tested with Xcode 9 and later)
 * On Linux:
-  * A C++ compiler toolchain with C++11 support (provided by `build-essential` on Ubuntu)
+  * A C++ compiler toolchain with C++11 support (`gcc` >= 4.8 or `clang` >= 3.3)
+  * `git` (typically provided by the `git` package)
+  * `patch` (typically provided by `patch` package)
+  * `rsync` (typically provided by `rsync` package)
   * blas and lapack development libraries (typically provided by the `liblapack-dev` package)
   * `pyfpe.h` (typically provided by the `libpython2.7-dev` package for Python 2.7, or `libpython3.6-dev` for Python 3.6)
   * `gif_lib.h` (typically provided by the `libgif-dev` package)


### PR DESCRIPTION
* Clarifies required compiler toolchain minimum versions.
* Adds some dependencies that aren't installed by default on some Linux
  distributions (but are required).

Fixes #1669