### PR TITLE
Fix utils_tests.cxxtest failure on Linux

### DIFF
--- a/test/annotation/CMakeLists.txt
+++ b/test/annotation/CMakeLists.txt
@@ -8,17 +8,19 @@ make_library(annotation_test_utils
 )
 
 make_boost_test(image_classifier_tests.cxx
-  REQUIRES 
+  REQUIRES
     annotation_test_utils
   COMPILE_FLAGS_EXTRA_GCC
     -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
     -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
 )
 
-make_boost_test(utils_tests.cxx
-  REQUIRES 
-    annotation_test_utils
-  COMPILE_FLAGS_EXTRA_GCC
-    -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
-    -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
-)
+if (APPLE)
+  make_boost_test(utils_tests.cxx
+    REQUIRES
+      annotation_test_utils
+    COMPILE_FLAGS_EXTRA_GCC
+      -Wno-unknown-pragmas  # NOTE: used for auto-generated protobuf source files
+      -Wno-unused-function  # NOTE: used for auto-generated protobuf source files
+  )
+endif()

--- a/test/annotation/utils_tests.cxx
+++ b/test/annotation/utils_tests.cxx
@@ -13,9 +13,6 @@
 
 #include "utils.cpp"
 
-/* The C++ featurizer API only works on Apple platforms. */
-#ifdef __APPLE__
-
 struct utils_test {
 public:
   /*
@@ -88,5 +85,3 @@ BOOST_AUTO_TEST_CASE(test_most_similar_items) {
   utils_test::test_most_similar_items();
 }
 BOOST_AUTO_TEST_SUITE_END()
-
-#endif


### PR DESCRIPTION
The fix in 09802508b4118b82fd1426f28227c0217092168b
was not quite right -- this test still fails, now with:

```
Test setup error: test tree is empty
```

This commit fixes the issue by skipping building that test entirely when
not on an Apple platform.