### PR TITLE
Fix key press handler in tcviz app

### DIFF
--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -20,6 +20,7 @@ if(${TC_BUILD_VISUALIZATION_CLIENT})
       "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/Pipe.swift"
       "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/AppDelegate.swift"
       "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/JSON.swift"
+      "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/CustomWebKitView.swift"
       "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/VegaContainer.swift"
       "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/ViewController.swift"
       "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization/src/NSWindowWorkaround.swift"

--- a/src/visualization/Turi Create Visualization/src/CustomWebKitView.swift
+++ b/src/visualization/Turi Create Visualization/src/CustomWebKitView.swift
@@ -8,7 +8,15 @@ import WebKit
 
 class CustomWebKitView: WKWebView {
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        super.performKeyEquivalent(with: event)
-        return true
+        let ret = super.performKeyEquivalent(with: event)
+        if (event.modifierFlags.contains(.command) &&
+            (event.charactersIgnoringModifiers == "=" ||
+                event.charactersIgnoringModifiers == "-" ||
+                event.charactersIgnoringModifiers == "+")) {
+            // if cmd+ or cmd- are pressed, those will zoom in the
+            // browser pane and are handled.
+            return true
+        }
+        return ret
     }
 }


### PR DESCRIPTION
Fixes #1803

* In the key handler code, always return the value from the super class
  (default handler), unless the key combination pressed is Cmd+/Cmd-.
* Adds CustomWebKitView to the CMake build tracking (fixes incremental
  build of tcviz app when this file is changed).