### PR TITLE
Added extract_label option to load_images

### DIFF
--- a/src/unity/lib/image_util.hpp
+++ b/src/unity/lib/image_util.hpp
@@ -39,7 +39,8 @@ flexible_type generate_mean(std::shared_ptr<unity_sarray> unity_data);
  * Construct an sframe of flex_images, with url pointing to directory where images reside. 
  */
 std::shared_ptr<unity_sframe> load_images(std::string url, std::string format,
-    bool with_path, bool recursive, bool ignore_failure, bool random_order);
+    bool with_path, bool recursive, bool ignore_failure, bool random_order,
+    bool extract_label);
 
 /**
  * Construct a single image from url, and format hint.

--- a/src/unity/python/turicreate/toolkits/image_analysis/image_analysis.py
+++ b/src/unity/python/turicreate/toolkits/image_analysis/image_analysis.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import as _
 from ...data_structures.image import Image as _Image
 
 
-def load_images(url, format='auto', with_path=True, recursive=True, ignore_failure=True, random_order=False):
+def load_images(url, format='auto', with_path=True, recursive=True, ignore_failure=True, random_order=False, extract_label=False):
     """
     Loads images from a directory. JPEG and PNG images are supported.
 
@@ -39,13 +39,19 @@ def load_images(url, format='auto', with_path=True, recursive=True, ignore_failu
     random_order : bool, optional
         Load images in random order.
 
+    extract_label : bool, optional
+        Extract the label from the path assuming the path is of the form 
+        ...../label.EXTENSION
+
     Returns
     -------
     out : SFrame
         Returns an SFrame with either an 'image' column or both an 'image' and
-        a 'path' column. The 'image' column is a column of Image objects. If
-        with_path is True, there is also a 'path' column which contains the image
-        path for each of each corresponding Image object.
+        a 'path' column. The 'image' column is a column of Image objects.
+        If 'with_path' is True, there is also a 'path' column which contains
+        the image path for each of each corresponding Image object.
+        If 'extract_label' is True, there is also a 'label' column which
+        contains the 'label' column for each corresponding Image object.
 
     Examples
     --------
@@ -57,7 +63,8 @@ def load_images(url, format='auto', with_path=True, recursive=True, ignore_failu
     from ... import extensions as _extensions
     from ...util import _make_internal_url
     return _extensions.load_images(url, format, with_path,
-                                     recursive, ignore_failure, random_order)
+                                    recursive, ignore_failure, random_order, 
+                                    extract_label)
 
 
 def _decode(image_data):

--- a/src/unity/toolkits/image/image_fn_export.cpp
+++ b/src/unity/toolkits/image/image_fn_export.cpp
@@ -13,7 +13,7 @@ namespace image_util{
 
 BEGIN_FUNCTION_REGISTRATION
 REGISTER_FUNCTION(load_image, "url", "format")
-REGISTER_FUNCTION(load_images, "url", "format", "with_path", "recursive", "ignore_failure", "random_order")
+REGISTER_FUNCTION(load_images, "url", "format", "with_path", "recursive", "ignore_failure", "random_order", "extract_label")
 REGISTER_FUNCTION(decode_image, "image")
 REGISTER_FUNCTION(decode_image_sarray, "image_sarray")
 REGISTER_FUNCTION(resize_image, "image",  "resized_width", "resized_height", "resized_channels", "decode", "resample_method")


### PR DESCRIPTION
Extracts the label from the path (assuming that the path is of the form ..././../../../label.png) if `extract_label=True` is passed into `load_images`.

This should be very a very useful feature for One Shot OD.