### PR TITLE
Temporarily mark drawing classifier tests as xfail

### DIFF
--- a/src/unity/python/turicreate/test/test_drawing_classifier.py
+++ b/src/unity/python/turicreate/test/test_drawing_classifier.py
@@ -229,6 +229,7 @@ class DrawingClassifierTest(unittest.TestCase):
             with self.assertRaises(_ToolkitError):
                 model.evaluate(sf_without_ground_truth)
 
+    @pytest.mark.xfail(reason='Fails, see https://github.com/apple/turicreate/issues/1973')
     def test_evaluate_with_ground_truth(self):
 
         all_metrics = ["accuracy", "auc", "precision", "recall",


### PR DESCRIPTION
They are tracked by #1973