### PR TITLE
Adding export_coreml and fixed evaluate for One Shot Object Detector

### DIFF
--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -933,7 +933,7 @@ class ObjectDetector(_CustomModel):
 
     def predict(self, dataset, confidence_threshold=0.25, iou_threshold=None, verbose=True):
         """
-        Predict object instances in an sframe of images.
+        Predict object instances in an SFrame of images.
 
         Parameters
         ----------
@@ -1631,7 +1631,7 @@ class ObjectDetector(_CustomModel):
         --------
         >>> model.export_coreml('detector.mlmodel')
         """
+        from coremltools.models.utils import save_spec as _save_spec
         model = self._create_coreml_model(include_non_maximum_suppression=include_non_maximum_suppression, 
             iou_threshold=iou_threshold, confidence_threshold=confidence_threshold)
-        from coremltools.models.utils import save_spec as _save_spec
         _save_spec(model, filename)

--- a/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/unity/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1133,68 +1133,8 @@ class ObjectDetector(_CustomModel):
 
         return ret
 
-    def export_coreml(self, filename, 
-            include_non_maximum_suppression = True,
-            iou_threshold = None,
-            confidence_threshold = None):
-        """
-        Save the model in Core ML format. The Core ML model takes an image of
-        fixed size as input and produces two output arrays: `confidence` and
-        `coordinates`.
-
-        The first one, `confidence` is an `N`-by-`C` array, where `N` is the
-        number of instances predicted and `C` is the number of classes. The
-        number `N` is fixed and will include many low-confidence predictions.
-        The instances are not sorted by confidence, so the first one will
-        generally not have the highest confidence (unlike in `predict`). Also
-        unlike the `predict` function, the instances have not undergone
-        what is called `non-maximum suppression`, which means there could be
-        several instances close in location and size that have all discovered
-        the same object instance. Confidences do not need to sum to 1 over the
-        classes; any remaining probability is implied as confidence there is no
-        object instance present at all at the given coordinates. The classes
-        appear in the array alphabetically sorted.
-
-        The second array `coordinates` is of size `N`-by-4, where the first
-        dimension `N` again represents instances and corresponds to the
-        `confidence` array. The second dimension represents `x`, `y`, `width`,
-        `height`, in that order.  The values are represented in relative
-        coordinates, so (0.5, 0.5) represents the center of the image and (1,
-        1) the bottom right corner. You will need to multiply the relative
-        values with the original image size before you resized it to the fixed
-        input size to get pixel-value coordinates similar to `predict`.
-
-        See Also
-        --------
-        save
-
-        Parameters
-        ----------
-        filename : string
-            The path of the file where we want to save the Core ML model.
-       
-        include_non_maximum_suppression : bool
-            Non-maximum suppression is only available in iOS 12+.
-            A boolean parameter to indicate whether the Core ML model should be
-            saved with built-in non-maximum suppression or not. 
-            This parameter is set to True by default.
-
-        iou_threshold : float
-            Threshold value for non-maximum suppression. Non-maximum suppression
-            prevents multiple bounding boxes appearing over a single object. 
-            This threshold, set between 0 and 1, controls how aggressive this 
-            suppression is. A value of 1 means no maximum suppression will 
-            occur, while a value of 0 will maximally suppress neighboring 
-            boxes around a prediction.
-
-        confidence_threshold : float
-            Only return predictions above this level of confidence. The
-            threshold can range from 0 to 1. 
-
-        Examples
-        --------
-        >>> model.export_coreml('detector.mlmodel')
-        """
+    def _create_coreml_model(self, include_non_maximum_suppression,
+            iou_threshold, confidence_threshold):
         import mxnet as _mx
         from .._mxnet._mxnet_to_coreml import _mxnet_converter
         import coremltools
@@ -1627,5 +1567,71 @@ class ObjectDetector(_CustomModel):
             partial_user_defined_metadata,
             version)
         model.description.metadata.userDefined.update(user_defined_metadata)
+        return model
+
+    def export_coreml(self, filename, 
+            include_non_maximum_suppression = True,
+            iou_threshold = None,
+            confidence_threshold = None):
+        """
+        Save the model in Core ML format. The Core ML model takes an image of
+        fixed size as input and produces two output arrays: `confidence` and
+        `coordinates`.
+
+        The first one, `confidence` is an `N`-by-`C` array, where `N` is the
+        number of instances predicted and `C` is the number of classes. The
+        number `N` is fixed and will include many low-confidence predictions.
+        The instances are not sorted by confidence, so the first one will
+        generally not have the highest confidence (unlike in `predict`). Also
+        unlike the `predict` function, the instances have not undergone
+        what is called `non-maximum suppression`, which means there could be
+        several instances close in location and size that have all discovered
+        the same object instance. Confidences do not need to sum to 1 over the
+        classes; any remaining probability is implied as confidence there is no
+        object instance present at all at the given coordinates. The classes
+        appear in the array alphabetically sorted.
+
+        The second array `coordinates` is of size `N`-by-4, where the first
+        dimension `N` again represents instances and corresponds to the
+        `confidence` array. The second dimension represents `x`, `y`, `width`,
+        `height`, in that order.  The values are represented in relative
+        coordinates, so (0.5, 0.5) represents the center of the image and (1,
+        1) the bottom right corner. You will need to multiply the relative
+        values with the original image size before you resized it to the fixed
+        input size to get pixel-value coordinates similar to `predict`.
+
+        See Also
+        --------
+        save
+
+        Parameters
+        ----------
+        filename : string
+            The path of the file where we want to save the Core ML model.
+       
+        include_non_maximum_suppression : bool
+            Non-maximum suppression is only available in iOS 12+.
+            A boolean parameter to indicate whether the Core ML model should be
+            saved with built-in non-maximum suppression or not. 
+            This parameter is set to True by default.
+
+        iou_threshold : float
+            Threshold value for non-maximum suppression. Non-maximum suppression
+            prevents multiple bounding boxes appearing over a single object. 
+            This threshold, set between 0 and 1, controls how aggressive this 
+            suppression is. A value of 1 means no maximum suppression will 
+            occur, while a value of 0 will maximally suppress neighboring 
+            boxes around a prediction.
+
+        confidence_threshold : float
+            Only return predictions above this level of confidence. The
+            threshold can range from 0 to 1. 
+
+        Examples
+        --------
+        >>> model.export_coreml('detector.mlmodel')
+        """
+        model = self._create_coreml_model(include_non_maximum_suppression=include_non_maximum_suppression, 
+            iou_threshold=iou_threshold, confidence_threshold=confidence_threshold)
         from coremltools.models.utils import save_spec as _save_spec
         _save_spec(model, filename)

--- a/src/unity/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
+++ b/src/unity/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
@@ -86,7 +86,7 @@ class OneShotObjectDetector(_CustomModel):
 
     def predict(self, dataset, confidence_threshold=0.25, iou_threshold=None, verbose=True):
         """
-        Predict object instances in an sframe of images.
+        Predict object instances in an SFrame of images.
 
         Parameters
         ----------
@@ -198,8 +198,8 @@ class OneShotObjectDetector(_CustomModel):
         --------
         >>> model.export_coreml('one_shot.mlmodel')
         """
-        model = self.__proxy__['detector']._create_coreml_model(include_non_maximum_suppression=include_non_maximum_suppression, iou_threshold=iou_threshold, confidence_threshold=confidence_threshold)
         from coremltools.models.utils import save_spec as _save_spec
+        model = self.__proxy__['detector']._create_coreml_model(include_non_maximum_suppression=include_non_maximum_suppression, iou_threshold=iou_threshold, confidence_threshold=confidence_threshold)
         model.description.metadata.shortDescription = 'One Shot ' + model.description.metadata.shortDescription
         model.description.metadata.userDefined["type"] = 'OneShotObjectDetector'
         _save_spec(model, filename)

--- a/src/unity/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
+++ b/src/unity/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
@@ -13,6 +13,7 @@ from turicreate.toolkits.object_detector.object_detector import ObjectDetector a
 from turicreate.toolkits.one_shot_object_detector.util._augmentation import preview_synthetic_training_data as _preview_synthetic_training_data
 import turicreate.toolkits._internal_utils as _tkutl
 
+
 def create(data,
            target,
            backgrounds=None,
@@ -83,11 +84,125 @@ class OneShotObjectDetector(_CustomModel):
         # We use PythonProxy here so that we get tab completion
         self.__proxy__ = _PythonProxy(state)
 
-    def predict(self, dataset):
-        return self.__proxy__['detector'].predict(dataset)
+    def predict(self, dataset, confidence_threshold=0.25, iou_threshold=None, verbose=True):
+        """
+        Predict object instances in an sframe of images.
 
-    def evaluate(self, dataset, metric="auto"):
-        return self.__proxy__['detector'].evaluate(dataset, metric)
+        Parameters
+        ----------
+        dataset : SFrame | SArray | turicreate.Image
+            The images on which to perform object detection.
+            If dataset is an SFrame, it must have a column with the same name
+            as the feature column during training. Additional columns are
+            ignored.
+
+        confidence_threshold : float
+            Only return predictions above this level of confidence. The
+            threshold can range from 0 to 1.
+
+        iou_threshold : float
+            Threshold value for non-maximum suppression. Non-maximum suppression
+            prevents multiple bounding boxes appearing over a single object. 
+            This threshold, set between 0 and 1, controls how aggressive this 
+            suppression is. A value of 1 means no maximum suppression will 
+            occur, while a value of 0 will maximally suppress neighboring 
+            boxes around a prediction.
+
+        verbose : bool
+            If True, prints prediction progress.
+
+
+        Returns
+        -------
+        out : SArray
+            An SArray with model predictions. Each element corresponds to
+            an image and contains a list of dictionaries. Each dictionary
+            describes an object instances that was found in the image. If
+            `dataset` is a single image, the return value will be a single
+            prediction.
+
+        See Also
+        --------
+        evaluate
+
+        Examples
+        --------
+        .. sourcecode:: python
+
+            # Make predictions
+            >>> pred = model.predict(data)
+
+        """
+        return self.__proxy__['detector'].predict(dataset=dataset, 
+            confidence_threshold=confidence_threshold, iou_threshold=iou_threshold, verbose=verbose)
+
+    def export_coreml(self, filename, 
+            include_non_maximum_suppression = True,
+            iou_threshold = None,
+            confidence_threshold = None):
+        """
+        Save the model in Core ML format. The Core ML model takes an image of
+        fixed size as input and produces two output arrays: `confidence` and
+        `coordinates`.
+
+        The first one, `confidence` is an `N`-by-`C` array, where `N` is the
+        number of instances predicted and `C` is the number of classes. The
+        number `N` is fixed and will include many low-confidence predictions.
+        The instances are not sorted by confidence, so the first one will
+        generally not have the highest confidence (unlike in `predict`). Also
+        unlike the `predict` function, the instances have not undergone
+        what is called `non-maximum suppression`, which means there could be
+        several instances close in location and size that have all discovered
+        the same object instance. Confidences do not need to sum to 1 over the
+        classes; any remaining probability is implied as confidence there is no
+        object instance present at all at the given coordinates. The classes
+        appear in the array alphabetically sorted.
+
+        The second array `coordinates` is of size `N`-by-4, where the first
+        dimension `N` again represents instances and corresponds to the
+        `confidence` array. The second dimension represents `x`, `y`, `width`,
+        `height`, in that order.  The values are represented in relative
+        coordinates, so (0.5, 0.5) represents the center of the image and (1,
+        1) the bottom right corner. You will need to multiply the relative
+        values with the original image size before you resized it to the fixed
+        input size to get pixel-value coordinates similar to `predict`.
+
+        See Also
+        --------
+        save
+
+        Parameters
+        ----------
+        filename : string
+            The path of the file where we want to save the Core ML model.
+
+        include_non_maximum_suppression : bool
+            Non-maximum suppression is only available in iOS 12+.
+            A boolean parameter to indicate whether the Core ML model should be
+            saved with built-in non-maximum suppression or not. 
+            This parameter is set to True by default.
+
+        iou_threshold : float
+            Threshold value for non-maximum suppression. Non-maximum suppression
+            prevents multiple bounding boxes appearing over a single object. 
+            This threshold, set between 0 and 1, controls how aggressive this 
+            suppression is. A value of 1 means no maximum suppression will 
+            occur, while a value of 0 will maximally suppress neighboring 
+            boxes around a prediction.
+
+        confidence_threshold : float
+            Only return predictions above this level of confidence. The
+            threshold can range from 0 to 1. 
+
+        Examples
+        --------
+        >>> model.export_coreml('one_shot.mlmodel')
+        """
+        model = self.__proxy__['detector']._create_coreml_model(include_non_maximum_suppression=include_non_maximum_suppression, iou_threshold=iou_threshold, confidence_threshold=confidence_threshold)
+        from coremltools.models.utils import save_spec as _save_spec
+        model.description.metadata.shortDescription = 'One Shot ' + model.description.metadata.shortDescription
+        model.description.metadata.userDefined["type"] = 'OneShotObjectDetector'
+        _save_spec(model, filename)
 
     def _get_version(self):
         return self._PYTHON_ONE_SHOT_OBJECT_DETECTOR_VERSION


### PR DESCRIPTION
```
[[model.evaluate(data,"label")
Predicting 3/3
Out[10]: 
{'average_precision_50': {'[{"coordinates":{"y":158.92, "x":171.362, "height":217.371, "width":258.216}, "label":"Waffle"}]': 0.0,
  '[{"coordinates":{"y":194.416, "x":206.98, "height":211.006, "width":386.04}, "label":"Waffle"}]': 0.0,
  '[{"coordinates":{"y":222.581, "x":166.935, "height":154.399, "width":164.956}, "label":"Waffle"}]': 0.0},
 'mean_average_precision_50': 0.0}]]
```