### PR TITLE
Data Augmentation for C-API activity classifier

### DIFF
--- a/src/toolkits/activity_classification/ac_data_iterator.cpp
+++ b/src/toolkits/activity_classification/ac_data_iterator.cpp
@@ -40,25 +40,26 @@ static std::map<std::string,size_t> generate_column_index_map(const std::vector<
  * \return    The most frequent value within the given vector.
  */
 
-static double vec_mode(const flex_vec& input_vec) {
-    std::vector<int> histogram;
-    for (size_t i = 0; i < input_vec.size(); ++i) {
-        size_t value = static_cast<size_t>(input_vec[i]);
+static double vec_mode(flex_vec::const_iterator first,
+                       flex_vec::const_iterator last) {
+  std::vector<int> histogram;
+  for (flex_vec::const_iterator i = first; i < last; ++i) {
+    size_t value = static_cast<size_t>(*i);
 
-        // Each value should be in the index of a class label
-        DASSERT_EQ(static_cast<double>(static_cast<size_t>(input_vec[i])), input_vec[i]);
+    // Each value should be in the index of a class label
+    DASSERT_EQ(static_cast<double>(static_cast<size_t>(*i)), *i);
 
-        if(histogram.size() < (value + 1)){
-          histogram.resize(value + 1);
-        }
-
-        histogram[value]++;
+    if (histogram.size() < (value + 1)) {
+      histogram.resize(value + 1);
     }
 
-    auto majority = std::max_element(histogram.begin(), histogram.end());
+    histogram[value]++;
+  }
 
-    // return index to mode majority value
-    return std::distance(histogram.begin(), majority);
+  auto majority = std::max_element(histogram.begin(), histogram.end());
+
+  // return index to mode majority value
+  return std::distance(histogram.begin(), majority);
 }
 
 /**
@@ -97,7 +98,7 @@ static void finalize_chunk(flex_vec&            curr_chunk_features,
 
     if (use_target) {
         if (curr_window_targets.size() > 0) {
-            curr_chunk_targets.push_back(vec_mode(curr_window_targets));
+            curr_chunk_targets.push_back(vec_mode(curr_window_targets.begin(), curr_window_targets.end()));
             curr_window_targets.clear();
         }
 
@@ -222,7 +223,7 @@ variant_map_type _activity_classifier_prepare_data_impl(const gl_sframe &data,
             curr_window_targets.push_back(line[column_index_map[target]]);
 
             if (curr_window_targets.size() == static_cast<size_t>(prediction_window)) {
-                auto target_val = vec_mode(curr_window_targets);
+                auto target_val = vec_mode(curr_window_targets.begin(), curr_window_targets.end());
                 curr_chunk_targets.push_back(target_val);
                 curr_window_targets.clear();
             }

--- a/src/toolkits/activity_classification/ac_data_iterator.hpp
+++ b/src/toolkits/activity_classification/ac_data_iterator.hpp
@@ -61,8 +61,11 @@ public:
      */
     flex_list class_labels;
 
-    /**  Generates verbose output when set to true. */
-    bool verbose;
+    /**  Set to true, when the data is used for training. */
+    bool is_train = false;
+
+    /** Augments training data when set to true*/
+    bool use_data_augmentation = false;
   };
 
   /** Defines the output of a data_iterator. */
@@ -79,7 +82,7 @@ public:
     };
 
     /**
-     * An array with shape: (requested_batch_size,
+     * An array with shape: (requested_batch_size, 
      * 1, prediction_window * predictions_in_chunk, num_feature_columns)
      *
      * Each row is a chunk of feature values from one session.
@@ -179,6 +182,9 @@ private:
   gl_sframe_range range_iterator_;
   gl_sframe_range::iterator next_row_;
   gl_sframe_range::iterator end_of_rows_;
+  size_t sample_in_row_ = 0;
+  bool is_train_ = false;
+  bool use_data_augmentation_ = false;
 };
 
 /**

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -163,6 +163,12 @@ void activity_classifier::init_options(
       10,
       1,
       std::numeric_limits<int>::max());
+  options.create_boolean_option(
+      "use_data_augmentation",
+      "Data augmentation helps use prediction window started with random "
+      "offset."
+      " If set to True, the trained model uses augmented data.",
+      false);
 
   // Validate user-provided options.
   options.set_options(opts);
@@ -289,12 +295,10 @@ void activity_classifier::init_table_printer(bool has_validation) {
   }
 }
 
-void activity_classifier::train(gl_sframe data, const std::string& target_column_name,
-                                const std::string& session_id_column_name,
-                                variant_type validation_data,
-                                const std::map<std::string, flexible_type>& opts)
-{
-
+void activity_classifier::train(
+    gl_sframe data, const std::string& target_column_name,
+    const std::string& session_id_column_name, variant_type validation_data,
+    const std::map<std::string, flexible_type>& opts) {
   gl_sframe train_data;
   gl_sframe val_data;
   std::tie(train_data, val_data) =
@@ -349,8 +353,6 @@ void activity_classifier::train(gl_sframe data, const std::string& target_column
   add_or_update_state(state_update);
 }
 
-
-
 gl_sarray activity_classifier::predict(gl_sframe data,
                                        std::string output_type) {
   if (output_type.empty()) {
@@ -362,7 +364,8 @@ gl_sarray activity_classifier::predict(gl_sframe data,
 
   // Bind the data to a data iterator.
   std::unique_ptr<data_iterator> data_it =
-      create_iterator(data, /* requires_labels */ false, /* is_train */ false);
+      create_iterator(data, /* requires_labels */ false, /* is_train */ false,
+                      /* use_data_augmentation */ false);
 
   // Accumulate the class probabilities for each prediction window.
   gl_sframe raw_preds_per_window = perform_inference(data_it.get());
@@ -407,7 +410,8 @@ gl_sframe activity_classifier::predict_per_window(gl_sframe data,
 
   // Bind the data to a data iterator.
   std::unique_ptr<data_iterator> data_it =
-      create_iterator(data, /* requires_labels */ false, /* is_train */ false);
+      create_iterator(data, /* requires_labels */ false, /* is_train */ false,
+                      /* use_data_augmentation */ false);
 
   // Accumulate the class probabilities for each prediction window.
   gl_sframe raw_preds_per_window = perform_inference(data_it.get());
@@ -582,10 +586,9 @@ void activity_classifier::import_from_custom_model(
   nn_spec_->update_params(nn_params);
 }
 
-std::unique_ptr<data_iterator>
-activity_classifier::create_iterator(gl_sframe data, bool requires_labels,
-                                     bool is_train) const {
-
+std::unique_ptr<data_iterator> activity_classifier::create_iterator(
+    gl_sframe data, bool requires_labels, bool is_train,
+    bool use_data_augmentation) const {
   data_iterator::parameters data_params;
   data_params.data = std::move(data);
 
@@ -593,10 +596,11 @@ activity_classifier::create_iterator(gl_sframe data, bool requires_labels,
     data_params.class_labels = read_state<flex_list>("classes");
   }
 
-  data_params.verbose = is_train;
+  data_params.is_train = is_train;
   if (requires_labels) {
     data_params.target_column_name = read_state<flex_string>("target");
   }
+  data_params.use_data_augmentation = use_data_augmentation;
   data_params.session_id_column_name = read_state<flex_string>("session_id");
   flex_list features = read_state<flex_list>("features");
   data_params.feature_column_names =
@@ -722,7 +726,6 @@ void activity_classifier::init_train(
     gl_sframe data, std::string target_column_name,
     std::string session_id_column_name, gl_sframe validation_data,
     std::map<std::string, flexible_type> opts) {
-
   // Begin printing progress.
   // TODO: Make progress printing optional.
   init_table_printer(!validation_data.empty());
@@ -746,15 +749,18 @@ void activity_classifier::init_train(
                                               feature_column_names.end())}});
 
   // Bind the data to a data iterator.
+  bool use_data_augmentation = read_state<bool>("use_data_augmentation");
   training_data_iterator_ =
-      create_iterator(data, /* requires_labels */ true, /* is_train */ true);
+      create_iterator(data, /* requires_labels */ true, /* is_train */ true,
+                      use_data_augmentation);
 
   add_or_update_state({{"classes", training_data_iterator_->class_labels()}});
 
   // Bind the validation data to a data iterator.
   if (!validation_data.empty()) {
     validation_data_iterator_ = create_iterator(
-        validation_data, /* requires_labels */ true, /* is_train */ false);
+        validation_data, /* requires_labels */ true, /* is_train */ false,
+        /* use_data_augmentation */ false);
   } else {
     validation_data_iterator_ = nullptr;
   }

--- a/src/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/toolkits/activity_classification/activity_classifier.hpp
@@ -179,9 +179,9 @@ class EXPORT activity_classifier: public ml_model_base {
   // Override points allowing subclasses to inject dependencies
 
   // Factory for data_iterator
-  virtual std::unique_ptr<data_iterator> create_iterator(gl_sframe data,
-                                                         bool requires_labels,
-                                                         bool is_train) const;
+  virtual std::unique_ptr<data_iterator> create_iterator(
+      gl_sframe data, bool requires_labels, bool is_train,
+      bool use_data_augmentation) const;
 
   // Factory for compute_context
   virtual std::unique_ptr<neural_net::compute_context> create_compute_context()


### PR DESCRIPTION
In activity classification, say prediction window is 100 and lstm sequence length is 20, so the batch row is 20 x 100 = 2000 and there are 32 batch rows in a batch (if the batch size is 32). So per batch we have 32 x 100 x 20 x #features for features and 32 x 20 labels (majority voting done in every prediction window). Originally (without data augmentation), we would preprocess it in chunks of 100 x 20 x #features features and 20 labels. Now, the number of rows (=batch size) were picked up and passed as a batch by the iterator. So here in every epoch we were going to pick up the same chunked up data 0-1999, 2000-3999, 4000-5999 and so on.

The goal of data augmentation was to have different prediction windows in each iteration. To implement data augmentation, we have chunked up data to save it as the whole session features and the whole session labels. Let's assume number of data points in session 1 are n and in session 2 are m. Then, the converted sframe would look like this -

| features                |      labels   |
| n x #features.       |       n         |
| m x #features       |        m       |
and so on..

For example let's say prediction window = 100, then we would chunk this session row once with a random offset between 0-99. In each iteration, each session is picked up with a different random offset. Assuming we picked up 23, then the data picked up is 23-2022, 2023-4022, and so on. For next session, a new random offset is picked.