### PR TITLE
Fixes a hang in CSV parsing when parsing a token of a single '['

### DIFF
--- a/src/core/data/flexible_type/flexible_type_spirit_parser.cpp
+++ b/src/core/data/flexible_type/flexible_type_spirit_parser.cpp
@@ -212,10 +212,10 @@ flexible_type_parser::flexible_type_parser(std::string separator,
                                            const std::unordered_set<std::string>& true_val,
                                            const std::unordered_set<std::string>& false_val,
                                            bool only_raw_string_substitutions):
-    parser(new flexible_type_parser_impl<const char*,
-           decltype(space)>(separator, use_escape_char, escape_char, na_val, true_val, false_val, only_raw_string_substitutions)),
-    non_space_parser(new flexible_type_parser_impl<const char*,
-                     decltype(qi::eoi)>(separator, use_escape_char, escape_char, na_val, true_val, false_val, only_raw_string_substitutions)),
+    parser(new flexible_type_parser_impl<const char*, 
+           decltype(space)>(separator, use_escape_char, escape_char, na_val, true_val, false_val, only_raw_string_substitutions)), 
+    non_space_parser(new flexible_type_parser_impl<const char*, 
+                     decltype(!qi::eps)>(separator, use_escape_char, escape_char, na_val, true_val, false_val, only_raw_string_substitutions)),
     m_delimiter_has_space(delimiter_has_space(parser->delimiter))
     { }
 
@@ -239,7 +239,7 @@ flexible_type_parser::general_flexible_type_parse(const char** str, size_t len) 
   } else {
     ret.second = qi::phrase_parse((*str), (*str) + len,
                                   *non_space_parser,
-                                  qi::eoi,
+                                  !qi::eps,
                                   qi::skip_flag::dont_postskip,
                                   ret.first);
   }

--- a/src/core/data/flexible_type/flexible_type_spirit_parser.hpp
+++ b/src/core/data/flexible_type/flexible_type_spirit_parser.hpp
@@ -108,7 +108,7 @@ class flexible_type_parser {
 
  private:
   std::shared_ptr<flexible_type_parser_impl<const char*, decltype(boost::spirit::iso8859_1::space)> > parser;
-  std::shared_ptr<flexible_type_parser_impl<const char*, decltype(boost::spirit::qi::eoi)> > non_space_parser;
+  std::shared_ptr<flexible_type_parser_impl<const char*, decltype(!boost::spirit::qi::eps)> > non_space_parser;
   bool delimiter_has_space(const std::string& separator);
   bool m_delimiter_has_space;
 };

--- a/test/sframe/sframe_csv_test.cxx
+++ b/test/sframe/sframe_csv_test.cxx
@@ -861,7 +861,18 @@ struct sframe_test  {
      for (auto& row: data.values) row = permute(row, permute_order);
      return data;
    }
+    csv_test test_mismatched_square_brackets() {
+      csv_test ret;
+      std::stringstream strm;
+      strm << "a\n"
+           << "[hello\n";
+      ret.file = strm.str();
+      ret.tokenizer.delimiter = "\t";
+      ret.values.push_back({"[hello"});
 
+      ret.types = {{"a", flex_type_enum::STRING}};
+      return ret;
+    }
    sframe validate_file(const csv_test& data, 
                         std::string filename) {
      csv_line_tokenizer tokenizer = data.tokenizer;
@@ -982,6 +993,7 @@ struct sframe_test  {
      evaluate(single_string_column());
      evaluate(test_missing_tab_values());
      evaluate(tab_delimited_csv_with_list());
+     evaluate(test_mismatched_square_brackets());
    }
 
 


### PR DESCRIPTION
The lost lasting issue is that there doesn't seem to be an easy way to
disble the skip parser in boost spirit. A hack is to use qi::eoi as the
skip parser, but that is not ideal; under certain circumstances when
the parser calls the skip parser at the end of the line, this can cause a hang
since the eoi parser does not consume any characters.

What seems to work is to use !eps as the parser. eps just returns true.
!eps thus returns false. And that works to fully disable the skip
parser.