### PR TITLE
fix for range sequence operation bug

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -102,12 +102,12 @@ If `Ninja` is chosen as the generator in the previous step, you should use comma
 
     cd debug/
     # check ninja -h for more info
-    ninja -j 4
+    ninja
 
 will perform up to 4 build tasks in parallel. When building in release mode,
 Turi Create does require a large amount of memory to compile with the
 heaviest toolkit requiring 1GB of RAM. Where K is the amount of memory you
-have on your machine in GB, we recommend not exceeding `-j K`. Note that
+have on your machine in GB, we recommend not exceeding `make -j K`. Note that
 if you are using ninja, it uses parallelism by default, and builds all targets
 directly from the `debug/` or  `release/` directories.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -71,7 +71,7 @@ If you don't already have it, you can install it with:
 
 Note that you may need to do a system-wide install with `sudo`; this depends on your Python environment and whether your `pip` binary requires sudo permissions. Alternately, you could try `pip install --user` to force a user-local installation if `pip install` gives permission denied errors.
 
-Optionally, set a [generator](https://cmake.org/cmake/help/v3.0/manual/cmake-generators.7.html) for CMake before running `./configure`. Ninja can speed up incremental builds, but is not required.
+Optionally, set a [generator](https://cmake.org/cmake/help/v3.0/manual/cmake-generators.7.html) for CMake **BEFORE** running `./configure`. Ninja can speed up incremental builds, but is not required.
 
     # Optional: set a generator
     # The default is "Unix Makefiles"
@@ -98,10 +98,16 @@ process. For instance:
     cd debug/src/unity
     make -j 4
 
+If `Ninja` is chosen as the generator in the previous step, you should use command listed below instead:
+
+    cd debug/
+    # check ninja -h for more info
+    ninja -j 4
+
 will perform up to 4 build tasks in parallel. When building in release mode,
 Turi Create does require a large amount of memory to compile with the
 heaviest toolkit requiring 1GB of RAM. Where K is the amount of memory you
-have on your machine in GB, we recommend not exceeding `make -j K`. Note that
+have on your machine in GB, we recommend not exceeding `-j K`. Note that
 if you are using ninja, it uses parallelism by default, and builds all targets
 directly from the `debug/` or  `release/` directories.
 
@@ -110,7 +116,7 @@ used for the build:
 
     source <repo root>/scripts/python_env.sh debug
 
-or 
+or
 
     source <repo root>/scripts/python_env.sh release
 

--- a/src/core/storage/query_engine/planning/optimizations/source_transforms.hpp
+++ b/src/core/storage/query_engine/planning/optimizations/source_transforms.hpp
@@ -135,8 +135,8 @@ class opt_merge_all_same_sarrays : public opt_transform {
           // Use this as the key since any range nodes with the same
           // begin and end indices can be merged.
           id.ptr_key = int(planner_node_type::RANGE_NODE);
-          id.begin_index = sn->p("begin_index");
-          id.end_index = sn->p("end_index");
+          id.begin_index = sn->p("start") + sn->p("begin_index");
+          id.end_index = sn->p("start") + sn->p("end_index");
 
           source_out out;
           out.src_node = sn;

--- a/test/capi/capi_sarray.cxx
+++ b/test/capi/capi_sarray.cxx
@@ -1917,6 +1917,41 @@ class capi_test_sarray {
     tc_release(fl);
   }
 
+	void test_range_sequence_division() {
+		/*
+		 * 5/29/19, 12:12 PM Alejandro Isaza:
+		 * Summary:
+		 * Creating two columns with `tc_v1_sarray_create_from_sequence` and dividing them gives invalid results.
+
+		 * Results:
+		 * The result columns is [1, 1, 1, 1], expected it to be [0, 0, 0, 0].
+		 **/
+
+		tc_error *error = nullptr;
+		tc_sarray* col1 = tc_sarray_create_from_sequence(1, 5, &error);
+		CAPI_CHECK_ERROR(error);
+
+		tc_sarray* col2 = tc_sarray_create_from_sequence(2, 6, &error);
+		CAPI_CHECK_ERROR(error);
+
+		tc_sarray* result = tc_binary_op_ss(col1, "/", col2,  &error);
+		CAPI_CHECK_ERROR(error);
+
+
+        using turi::flex_float;
+		for(size_t i = 0; i < 4; ++i) {
+			tc_flexible_type* ft = tc_sarray_extract_element(result, i, &error);
+			CAPI_CHECK_ERROR(error);
+
+            flex_float result = tc_ft_double(ft, &error);
+			CAPI_CHECK_ERROR(error);
+            
+            /* std::cout << tc_ft_type(ft) << " " << result << std::endl; */
+			TS_ASSERT_EQUALS(result, static_cast<flex_float>(i + 1) / (i + 2));
+            
+		}
+	}
+
 };
 
 
@@ -2061,6 +2096,10 @@ BOOST_AUTO_TEST_CASE(test_tc_sarray_materialize) {
 }
 BOOST_AUTO_TEST_CASE(test_sc_sarray_apply) {
   capi_test_sarray::test_tc_sarray_apply();
+}
+
+BOOST_AUTO_TEST_CASE(test_range_sequence_division) {
+  capi_test_sarray::test_range_sequence_division();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/capi/capi_sarray.cxx
+++ b/test/capi/capi_sarray.cxx
@@ -66,7 +66,7 @@ class capi_test_sarray {
       CAPI_CHECK_ERROR(error);
 
       tc_sarray_save(sa_sv, out_name.c_str(), &error);
-    
+
       CAPI_CHECK_ERROR(error);
 
       tc_release(sa_sv);
@@ -1917,41 +1917,54 @@ class capi_test_sarray {
     tc_release(fl);
   }
 
-	void test_range_sequence_division() {
-		/*
-		 * 5/29/19, 12:12 PM Alejandro Isaza:
-		 * Summary:
-		 * Creating two columns with `tc_v1_sarray_create_from_sequence` and dividing them gives invalid results.
+  void test_range_sequence_division() {
+    /*
+     * 5/29/19, 12:12 PM Alejandro Isaza:
+     * Summary:
+     * Creating two columns with `tc_v1_sarray_create_from_sequence` and
+     dividing them gives invalid results.
 
-		 * Results:
-		 * The result columns is [1, 1, 1, 1], expected it to be [0, 0, 0, 0].
-		 **/
+     * Results:
+     * The result columns is [1, 1, 1, 1], expected it to be [0, 0, 0, 0].
+     **/
 
-		tc_error *error = nullptr;
-		tc_sarray* col1 = tc_sarray_create_from_sequence(1, 5, &error);
-		CAPI_CHECK_ERROR(error);
+    tc_error* error = nullptr;
+    tc_sarray* col1 = tc_sarray_create_from_sequence(1, 5, &error);
+    CAPI_CHECK_ERROR(error);
+    tc_sarray* col2 = tc_sarray_create_from_sequence(2, 6, &error);
+    CAPI_CHECK_ERROR(error);
 
-		tc_sarray* col2 = tc_sarray_create_from_sequence(2, 6, &error);
-		CAPI_CHECK_ERROR(error);
+    tc_sarray* result = tc_binary_op_ss(col1, "/", col2, &error);
+    CAPI_CHECK_ERROR(error);
 
-		tc_sarray* result = tc_binary_op_ss(col1, "/", col2,  &error);
-		CAPI_CHECK_ERROR(error);
+    using turi::flex_float;
+    for (size_t i = 0; i < 4; ++i) {
+      tc_flexible_type* ft = tc_sarray_extract_element(result, i, &error);
+      CAPI_CHECK_ERROR(error);
+      TS_ASSERT(tc_ft_type(ft) == tc_ft_type_enum::FT_TYPE_FLOAT);
+      flex_float result = tc_ft_double(ft, &error);
+      CAPI_CHECK_ERROR(error);
 
+      /* std::cout << tc_ft_type(ft) << " " << result << std::endl; */
+      TS_ASSERT_EQUALS(result, static_cast<flex_float>(i + 1) / (i + 2));
+    }
 
-        using turi::flex_float;
-		for(size_t i = 0; i < 4; ++i) {
-			tc_flexible_type* ft = tc_sarray_extract_element(result, i, &error);
-			CAPI_CHECK_ERROR(error);
+    tc_release(result);
 
-            flex_float result = tc_ft_double(ft, &error);
-			CAPI_CHECK_ERROR(error);
-            
-            /* std::cout << tc_ft_type(ft) << " " << result << std::endl; */
-			TS_ASSERT_EQUALS(result, static_cast<flex_float>(i + 1) / (i + 2));
-            
-		}
-	}
+    /* will use the optimizer to fuse 2 identical seq */
+    result = tc_binary_op_ss(col1, "/", col1, &error);
+    CAPI_CHECK_ERROR(error);
 
+    for (size_t i = 0; i < 4; ++i) {
+      tc_flexible_type* ft = tc_sarray_extract_element(result, i, &error);
+      CAPI_CHECK_ERROR(error);
+      TS_ASSERT(tc_ft_type(ft) == tc_ft_type_enum::FT_TYPE_FLOAT);
+      turi::flex_int result = tc_ft_int64(ft, &error);
+      CAPI_CHECK_ERROR(error);
+
+      TS_ASSERT_EQUALS(result, 1);
+    }
+  }
 };
 
 

--- a/test/capi/capi_sarray.cxx
+++ b/test/capi/capi_sarray.cxx
@@ -1952,8 +1952,12 @@ class capi_test_sarray {
     tc_release(result);
 
     /* will use the optimizer to fuse 2 identical seq */
-    result = tc_binary_op_ss(col1, "/", col1, &error);
+    tc_sarray* col3 = tc_sarray_create_from_sequence(1, 5, &error);
     CAPI_CHECK_ERROR(error);
+
+    result = tc_binary_op_ss(col1, "/", col3, &error);
+    CAPI_CHECK_ERROR(error);
+
 
     for (size_t i = 0; i < 4; ++i) {
       tc_flexible_type* ft = tc_sarray_extract_element(result, i, &error);


### PR DESCRIPTION
Big thanks to @hoytak and @ylow for helping me fixing this bug.

[start_val, ....   end_val]
    ^                      ^
 begin_idx.       end_idx

The is issue is caused by the query optimizer will treat two different sequences as the same by only using begin and end index to identify sequence identity. All binary operations are affected by this.

As @ylow points out, head value of a sequence should also be involved to identify whether two sequence are the same and should be fused during the optimization phase.