### PR TITLE
Python 3.7 macOS Support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,6 +128,22 @@ build_wheel_mac_10_14_python36:
     paths:
       - target/
 
+build_wheel_mac_10_14_python37:
+  tags:
+    - macos10.14
+  only:
+    variables:
+      - $TC_HAS_MACOS_RUNNERS == "1"
+  stage: build
+  script:
+    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/3.7/bin/virtualenv"
+    - source scripts/use_ccache.sh
+    - bash scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - target/
+
 build_dylib_macos_10_14:
   tags:
     - macos10.14
@@ -283,23 +299,25 @@ test_python_linux_python36:
     paths:
       - pytest.*
 
-test_python_mac_python27_10_13:
-  tags:
-    - macos10.13
-  only:
-    variables:
-      - $TC_HAS_MACOS_RUNNERS == "1"
-  stage: test
-  dependencies:
-    - build_wheel_mac_10_14_python27
-  script:
-    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
-    - bash scripts/test_wheel.sh
-  artifacts:
-    when: always
-    expire_in: 2 weeks
-    paths:
-      - pytest.*
+# This coremltools issues needs to be resolved before we can run on macOS 10.13
+# https://github.com/apple/coremltools/issues/408
+#test_python_mac_python27_10_13:
+#  tags:
+#    - macos10.13
+#  only:
+#    variables:
+#      - $TC_HAS_MACOS_RUNNERS == "1"
+#  stage: test
+#  dependencies:
+#    - build_wheel_mac_10_14_python27
+#  script:
+#    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
+#    - bash scripts/test_wheel.sh
+#  artifacts:
+#    when: always
+#    expire_in: 2 weeks
+#    paths:
+#      - pytest.*
 
 test_python_mac_python27_10_14:
   tags:
@@ -348,6 +366,24 @@ test_python_mac_python36_10_14:
     - build_wheel_mac_10_14_python36
   script:
     - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/3.6/bin/virtualenv"
+    - bash scripts/test_wheel.sh
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+      - pytest.*
+
+test_python_mac_python37_10_14:
+  tags:
+    - macos10.14
+  only:
+    variables:
+      - $TC_HAS_MACOS_RUNNERS == "1"
+  stage: test
+  dependencies:
+    - build_wheel_mac_10_14_python37
+  script:
+    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/3.7/bin/virtualenv"
     - bash scripts/test_wheel.sh
   artifacts:
     when: always
@@ -406,19 +442,21 @@ scenario_tests_linux_python36:
     - cd scenario-tests
     - ./run_scenario_tests.sh --docker-python3.6 ../target/turicreate-*.whl
 
-scenario_tests_mac_python27_10_13:
-  tags:
-    - macos10.13
-  only:
-    variables:
-      - $TC_HAS_MACOS_RUNNERS == "1"
-  stage: test
-  dependencies:
-    - build_wheel_mac_10_14_python27
-  script:
-    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
-    - cd scenario-tests
-    - ./run_scenario_tests.sh ../target/turicreate-*.whl
+# This coremltools issues needs to be resolved before we can run on macOS 10.13
+# https://github.com/apple/coremltools/issues/408
+#scenario_tests_mac_python27_10_13:
+#  tags:
+#    - macos10.13
+#  only:
+#    variables:
+#      - $TC_HAS_MACOS_RUNNERS == "1"
+#  stage: test
+#  dependencies:
+#    - build_wheel_mac_10_14_python27
+#  script:
+#    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
+#    - cd scenario-tests
+#    - ./run_scenario_tests.sh ../target/turicreate-*.whl
 
 scenario_tests_mac_python27_10_14:
   tags:
@@ -450,6 +488,7 @@ collect_artifacts:
     - build_wheel_mac_10_14_python27
     - build_wheel_mac_10_14_python35
     - build_wheel_mac_10_14_python36
+    - build_wheel_mac_10_14_python37
   script:
     - mv release/src/deployment/*.dylib target/
     - rmdir -p release || find release

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ System Requirements
 
 Turi Create requires:
 
-* Python 2.7, 3.5, 3.6
+* Python 2.7, 3.5, 3.6, 3.7 (macOS only)
 * x86\_64 architecture
 * At least 4 GB of RAM
 
@@ -109,8 +109,8 @@ source ~/venv/bin/activate
 ```
 Alternatively, if you are using [Anaconda](https://www.anaconda.com/what-is-anaconda/), you may use its virtual environment:
 ```shell
-conda create -n venv python=2.7 anaconda
-source activate venv
+conda create -n virtual_environment_name anaconda
+conda activate virtual_environment_name
 ```
 
 To install `Turi Create` within your virtual environment:

--- a/scenario-tests/additional_requirements.txt
+++ b/scenario-tests/additional_requirements.txt
@@ -1,8 +1,0 @@
-beautifulsoup4
-certifi==2015.04.28
-nltk==3.2
-pyscreenshot==0.4
-python-swiftclient
-python-keystoneclient
-testfixtures==4.10.0
-h5py==2.7.1

--- a/scenario-tests/run_scenario_tests.sh
+++ b/scenario-tests/run_scenario_tests.sh
@@ -39,6 +39,8 @@ function print_help {
   echo
   echo "  --docker-python3.6       Use docker to test on Python 3.6 in Ubuntu 18.04."
   echo
+  echo "  --docker-python3.7       Use docker to test on Python 3.7 in Ubuntu 18.04."
+  echo
   exit 0
 } # end of print help
 
@@ -55,6 +57,7 @@ while [ $# -gt 0 ]
     --docker-python2.7)     USE_DOCKER=1;DOCKER_PYTHON=2.7;;
     --docker-python3.5)     USE_DOCKER=1;DOCKER_PYTHON=3.5;;
     --docker-python3.6)     USE_DOCKER=1;DOCKER_PYTHON=3.6;;
+    --docker-python3.7)     USE_DOCKER=1;DOCKER_PYTHON=3.7;;
     --help)                 print_help ;;
     *) TC_WHEEL_UNDER_TEST=$1 ;;
   esac
@@ -86,7 +89,7 @@ if [[ -n "${USE_DOCKER}" ]]; then
       -e "VIRTUALENV=virtualenv --python=python${DOCKER_PYTHON}" \
       ${TC_BUILD_IMAGE_1404} \
       /build/scenario-tests/run_scenario_tests.sh $TC_WHEEL_UNDER_TEST
-  elif [[ "${DOCKER_PYTHON}" == "3.6" ]]; then
+  elif [[ "${DOCKER_PYTHON}" == "3.6" ]] || [[ "${DOCKER_PYTHON}" == "3.7" ]]; then
     docker run --rm -m=4g \
       --mount type=bind,source=$WORKSPACE,target=/build,consistency=delegated \
       -e "VIRTUALENV=virtualenv --python=python${DOCKER_PYTHON}" \

--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -36,20 +36,13 @@ function linux_patch_sigfpe_handler {
 }
 
 $PIP install --upgrade "pip>=8.1"
-
-# numpy needs to be installed before everything else so that installing
-# numba (a dependency of resampy) doesn't fail on Python 3.5. This can
-# be removed once numba publishes a Python 3.5 wheel for their most
-# recent version.
-$PIP install numpy==1.16.4
-
 $PIP install -r scripts/requirements.txt
 
 mkdir -p deps/local/lib
 mkdir -p deps/local/include
 
 pushd deps/local/include
-for f in `ls ../../env/include/$PYTHON_FULL_NAME/*`; do  
+for f in `ls -d ../../env/include/$PYTHON_FULL_NAME/*`; do
   ln -Ffs $f
 done
 popd

--- a/scripts/make_wheel.sh
+++ b/scripts/make_wheel.sh
@@ -44,6 +44,8 @@ print_help() {
   echo
   echo "  --docker-python3.6       Use docker to build for Python 3.6 in Ubuntu 10.04 with GCC 4.8."
   echo
+  echo "  --docker-python3.7       Use docker to build for Python 3.7 in Ubuntu 10.04 with GCC 4.8."
+  echo
   echo "  --num_procs=n            Specify the number of proceses to run in parallel."
   echo
   echo "  --target-dir=[dir]       The directory where the wheel and associated files are put."
@@ -70,6 +72,7 @@ while [ $# -gt 0 ]
     --docker-python2.7)     USE_DOCKER=1;DOCKER_PYTHON=2.7;;
     --docker-python3.5)     USE_DOCKER=1;DOCKER_PYTHON=3.5;;
     --docker-python3.6)     USE_DOCKER=1;DOCKER_PYTHON=3.6;;
+    --docker-python3.7)     USE_DOCKER=1;DOCKER_PYTHON=3.7;;
     --help)                 print_help ;;
     *) unknown_option $1 ;;
   esac

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,26 +1,26 @@
-coremltools==2.1.0
+coremltools==3.0b3
 scipy==1.2.1
 numpy==1.16.4
-cython==0.29.12
+cython==0.29.10
 argparse==1.2.1
-decorator==4.1.2
-mock==2.0.0
-pytest==3.2.5
-pandas==0.22.0
-pillow==5.0.0
+decorator==4.4.0
+mock==3.0.5
+pytest==4.6.3
+pandas==0.24.2
+pillow==6.0.0
 prettytable==0.7.2
-pytz==2016.3
+pytz==2019.1
 resampy==0.2.1
 requests>=2.9.1
-scikit-learn==0.17.1
-six==1.10.0
-statsmodels==0.8.0
+scikit-learn==0.20.3
+six==1.12.0
+statsmodels==0.9.0
 wheel==0.29.0
-mxnet==1.1.0
+mxnet==1.1.0; sys_platform != 'darwin'
 UISoup==2.5.7
-pyobjc==4.2.2; sys_platform == 'darwin'
-future==0.16.0
-pyOpenSSL
-ndg-httpsclient
-pyasn1
-hypothesis==3.76.0
+pyobjc==5.2; sys_platform == 'darwin'
+future==0.17.1
+pyOpenSSL==19.0.0
+ndg-httpsclient==0.5.1
+pyasn1==0.4.5
+hypothesis==4.24.3

--- a/scripts/run_cpp_tests.py
+++ b/scripts/run_cpp_tests.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
     line = ctest_process.stdout.readline()
     if len(line) == 0:
       break
-    sys.stdout.write(line)
+    sys.stdout.write(line.decode())
     sys.stdout.flush()
     lines.append(line)
 
@@ -170,9 +170,9 @@ if __name__ == '__main__':
 
   if args.cache:
     # go through all the tests and see if we have a "Passed" line matching it
-    for i in xrange(len(tests)):
+    for i in range(len(tests)):
       for line in lines:
-        if ('Passed' in line) and ((" " + runtests[i] + " ") in line):
+        if ('Passed' in line.decode()) and ((" " + runtests[i] + " ") in line.decode()):
           # pass!
           cache.add(new_tests[tests[i]])
 

--- a/scripts/test_wheel.sh
+++ b/scripts/test_wheel.sh
@@ -27,6 +27,7 @@ print_help() {
   echo
   echo "  --docker-python3.6       Use docker to test on Python 3.6 in Ubuntu 18.04."
   echo
+  echo "  --docker-python3.7       Use docker to test on Python 3.7 in Ubuntu 18.04."
   exit 1
 } # end of print help
 
@@ -37,6 +38,7 @@ while [ $# -gt 0 ]
     --docker-python2.7)     USE_DOCKER=1;DOCKER_PYTHON=2.7;;
     --docker-python3.5)     USE_DOCKER=1;DOCKER_PYTHON=3.5;;
     --docker-python3.6)     USE_DOCKER=1;DOCKER_PYTHON=3.6;;
+    --docker-python3.7)     USE_DOCKER=1;DOCKER_PYTHON=3.7;;
     --help)                 print_help ;;
     *) unknown_option $1 ;;
   esac
@@ -61,7 +63,7 @@ if [[ -n "${USE_DOCKER}" ]]; then
       -e "VIRTUALENV=virtualenv --python=python${DOCKER_PYTHON}" \
       ${TC_BUILD_IMAGE_1404} \
       /build/scripts/test_wheel.sh
-  elif [[ "${DOCKER_PYTHON}" == "3.6" ]]; then
+  elif [[ "${DOCKER_PYTHON}" == "3.6" ]] || [[ "${DOCKER_PYTHON}" == "3.7" ]]; then
     docker run --rm -m=8g \
       --mount type=bind,source=$WORKSPACE,target=/build,consistency=delegated \
       -e "VIRTUALENV=virtualenv --python=python${DOCKER_PYTHON}" \

--- a/src/python/README.rst
+++ b/src/python/README.rst
@@ -18,6 +18,7 @@ System Requirements
 -------------------
 
 -  Python 2.7, 3.5, or 3.6
+-  Python 3.7 macOS only
 -  x86_64 architecture
 
 Installation

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -7,6 +7,7 @@
 # be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import os
+import subprocess
 import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.dist import Distribution
@@ -38,14 +39,7 @@ class InstallEngine(install):
             sys.stderr.write(msg)
             sys.exit(1)
 
-        # Check correct version of Python
-        if sys.version_info.major == 2 and sys.version_info[:2] < (2, 7):
-            msg = ("Turi Create requires at least Python 2.7, please install using a supported version."
-                   + " Your current Python version is: %s" % sys.version)
-            sys.stderr.write(msg)
-            sys.exit(1)
-
-        # if OSX, verify > 10.7
+        # if OSX, verify >= 10.8
         from distutils.util import get_platform
         from pkg_resources import parse_version
         cur_platform = get_platform()
@@ -94,6 +88,7 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
@@ -116,6 +111,51 @@ if __name__ == '__main__':
 
     with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'rb') as f:
         long_description = f.read().decode('utf-8')
+
+    install_requires = [
+        "coremltools==3.0b3",
+        "decorator >= 4.0.9",
+        "numpy==1.16.4",
+        "pandas >= 0.23.2",
+        "pillow >= 5.2.0",
+        "prettytable == 0.7.2",
+        "resampy == 0.2.1",
+        "requests >= 2.9.1",
+        "scipy >= 1.1.0",
+        "six >= 1.10.0",
+    ]
+
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        if not cur_platform.startswith("macosx"):
+            msg = (
+                "Python 3.7 is only currently supported on macOS."
+            )
+            sys.stderr.write(msg)
+            sys.exit(1)
+
+        # Determine if AVX2 is supported
+        try:
+            p1 = subprocess.Popen(['sysctl', '-a'], stdout=subprocess.PIPE)
+            p2 = subprocess.Popen(['grep', '-E', '^hw\.\w+.avx\w*: 1$'],
+                                  stdin=p1.stdout, stdout=subprocess.PIPE)
+            p1.stdout.close()
+            stdout = p2.communicate()[0]
+        except:
+            msg = (
+                "Error running: sysctl system command"
+            )
+            sys.stderr.write(msg)
+            sys.exit(1)
+        if stdout == b'':
+            msg = (
+                "Error: Python 3.7 requires AVX2 support."
+            )
+            sys.stderr.write(msg)
+            sys.exit(1)
+
+        install_requires.append("mxnet==1.5.0")
+    else:
+        install_requires.append("mxnet >= 1.1.0, < 1.2.0")
 
     setup(
         name="turicreate",
@@ -172,17 +212,5 @@ if __name__ == '__main__':
         description='Turi Create simplifies the development of custom machine learning models.',
         long_description=long_description,
         classifiers=classifiers,
-        install_requires=[
-            "decorator >= 4.0.9",
-            "prettytable == 0.7.2",
-            "requests >= 2.9.1",
-            "mxnet >= 1.1.0, < 1.2.0",
-            "coremltools==2.1.0",
-            "pillow >= 3.3.0",
-            "pandas >= 0.19.0",
-            "scipy >= 0.14.0",
-            "six >= 1.10.0",
-            "resampy == 0.2.1",
-            "numpy"
-        ],
+        install_requires=install_requires
     )

--- a/src/python/turicreate/_sys_util.py
+++ b/src/python/turicreate/_sys_util.py
@@ -358,7 +358,7 @@ for f in server_logs:
         try:
             os.remove(f)
         except Exception:
-            pass
+            print("Could not delete: %s" % f)
 
 
 def dump_directory_structure(out = sys.stdout):

--- a/src/python/turicreate/data_structures/sframe.py
+++ b/src/python/turicreate/data_structures/sframe.py
@@ -2397,7 +2397,10 @@ class SFrame(object):
             else:
                 df[column_name] = list(self[column_name])
             if len(df[column_name]) == 0:
-                df[column_name] = df[column_name].astype(self.column_types()[i])
+                column_type = self.column_types()[i]
+                if column_type in (array.array, type(None)):
+                    column_type = 'object'
+                df[column_name] = df[column_name].astype(column_type)
         return df
 
     def to_numpy(self):

--- a/src/python/turicreate/test/test_object_detector.py
+++ b/src/python/turicreate/test/test_object_detector.py
@@ -386,9 +386,9 @@ class ObjectDetectorGPUTest(unittest.TestCase):
         old_num_gpus = tc.config.get_num_gpus()
         gpu_options = set([old_num_gpus, 0, 1])
         for in_gpus in gpu_options:
+            tc.config.set_num_gpus(in_gpus)
+            model = tc.object_detector.create(self.sf, max_iterations=1)
             for out_gpus in gpu_options:
-                tc.config.set_num_gpus(in_gpus)
-                model = tc.object_detector.create(self.sf, max_iterations=1)
                 with test_util.TempDirectory() as path:
                     model.save(path)
                     tc.config.set_num_gpus(out_gpus)

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -283,9 +283,9 @@ class StyleTransferGPUTest(unittest.TestCase):
         old_num_gpus = tc.config.get_num_gpus()
         gpu_options = set([old_num_gpus, 0, 1])
         for in_gpus in gpu_options:
+            tc.config.set_num_gpus(in_gpus)
+            model = tc.style_transfer.create(self.style_sf, self.content_sf, max_iterations=1)
             for out_gpus in gpu_options:
-                tc.config.set_num_gpus(in_gpus)
-                model = tc.style_transfer.create(self.style_sf, self.content_sf, max_iterations=1)
                 with test_util.TempDirectory() as path:
                     model.save(path)
                     tc.config.set_num_gpus(out_gpus)

--- a/src/python/turicreate/toolkits/_mxnet/__init__.py
+++ b/src/python/turicreate/toolkits/_mxnet/__init__.py
@@ -16,11 +16,18 @@ class _MXNetWrapper(object):
 
         if _mxnet_module is None:
             import mxnet
+            import sys
 
             version_tuple = tuple(int(x) for x in mxnet.__version__.split('.') if x.isdigit())
             lowest_version = (0, 11, 0)
-            not_yet_supported_version = (1, 2, 0)
-            recommended_version_str = '1.1.0'
+
+            if sys.version_info.major == 3 and sys.version_info.minor == 7:
+                not_yet_supported_version = (1, 5, 1)
+                recommended_version_str = '1.5.0'
+            else:
+                not_yet_supported_version = (1, 2, 0)
+                recommended_version_str = '1.1.0'
+
             if not (lowest_version <= version_tuple < not_yet_supported_version):
                 print('WARNING: You are using MXNet', mxnet.__version__, 'which may result in breaking behavior.')
                 print('         To fix this, please install the currently recommended version:')

--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -308,7 +308,7 @@ def create(input_dataset, target, feature=None, validation_set='auto',
 
         # Make one step of parameter update. Trainer needs to know the
         # batch size of data to normalize the gradient by 1/batch_size.
-        trainer.step(train_batch.data[0].shape[0])
+        trainer.step(train_batch.data[0].shape[0], ignore_stale_grad=True)
         # calculate training metrics
         train_loss = loss.mean().asscalar()
 

--- a/src/python/turicreate/toolkits/image_analysis/image_analysis.py
+++ b/src/python/turicreate/toolkits/image_analysis/image_analysis.py
@@ -135,17 +135,18 @@ def resize(image, width, height, channels=None, decode=False,
 
     if height < 0 or width < 0:
         raise ValueError("Cannot resize to negative sizes")
-
-    if resample == 'nearest':
-        resample_method = 0
-    elif resample == 'bilinear':
-        resample_method = 1
-    else:
+    if resample not in ('nearest', 'bilinear'):
         raise ValueError("Unknown resample option: '%s'" % resample)
 
     from ...data_structures.sarray import SArray as _SArray
     from ... import extensions as _extensions
+    import turicreate as _tc
+
     if type(image) is _Image:
+
+        assert resample in ('nearest', 'bilinear')
+        resample_method = 0 if resample == 'nearest' else 1
+
         if channels is None:
             channels = image.channels
         if channels <= 0:
@@ -156,6 +157,6 @@ def resize(image, width, height, channels=None, decode=False,
             channels = 3
         if channels <= 0:
             raise ValueError("cannot resize images to 0 or fewer channels")
-        return image.apply(lambda x: _extensions.resize_image(x, width, height, channels, decode, resample_method))
+        return image.apply(lambda x: _tc.image_analysis.resize(x, width, height, channels, decode, resample))
     else:
         raise ValueError("Cannot call 'resize' on objects that are not either an Image or SArray of Images")

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -282,7 +282,8 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
     batch_size_each = batch_size // max(num_mxnet_gpus, 1)
     if use_mps and _mps_device_memory_limit() < 4 * 1024 * 1024 * 1024:
         # Reduce batch size for GPUs with less than 4GB RAM
-        batch_size_each = 16
+        if batch_size_each > 16:
+            batch_size_each = 16
     # Note, this may slightly alter the batch size to fit evenly on the GPUs
     batch_size = max(num_mxnet_gpus, 1) * batch_size_each
     if verbose:
@@ -574,8 +575,8 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         trainer = _mx.gluon.Trainer(net.collect_params(), 'sgd', options)
 
         for batch in loader:
-            data = _mx.gluon.utils.split_and_load(batch.data[0], ctx_list=ctx, batch_axis=0)
-            label = _mx.gluon.utils.split_and_load(batch.label[0], ctx_list=ctx, batch_axis=0)
+            data = _mx.gluon.utils.split_and_load(batch.data[0], ctx_list=ctx, batch_axis=0, even_split=False)
+            label = _mx.gluon.utils.split_and_load(batch.label[0], ctx_list=ctx, batch_axis=0, even_split=False)
 
             Ls = []
             Zs = []
@@ -589,7 +590,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
                 for L in Ls:
                     L.backward()
 
-            trainer.step(1)
+            trainer.step(1, ignore_stale_grad=True)
             cur_loss = _np.mean([L.asnumpy()[0] for L in Ls])
 
             update_progress(cur_loss, batch.iteration)
@@ -1164,8 +1165,14 @@ class ObjectDetector(_CustomModel):
         # Make sure we are removing the right layers
         assert (self._model[23].name == 'pool5' and
                 self._model[24].name == 'specialcrop5')
-        del net._children[24]
-        net._children[23] = op
+
+        try:
+            del net._children[24]
+            net._children[23] = op
+        except KeyError:
+            # Newer versions of MXNet use string keys
+            del net._children['24']
+            net._children['23'] = op
 
         s_ymap = net(s_image)
         mod = _mx.mod.Module(symbol=s_ymap, label_names=None, data_names=[self.feature])

--- a/src/python/turicreate/toolkits/sound_classifier/_audio_feature_extractor.py
+++ b/src/python/turicreate/toolkits/sound_classifier/_audio_feature_extractor.py
@@ -153,9 +153,10 @@ class VGGishFeatureExtractor(object):
 
         else:
             # Use Core ML
+
             for i, cur_example in enumerate(preprocessed_data):
                 for cur_frame in cur_example:
-                    x = {'input1': [cur_frame]}
+                    x = {'input1': _np.asarray([cur_frame])}
                     y = self.vggish_model.predict(x)
                     deep_features.append(y['output1'])
 

--- a/src/unsupported_python/setup.py
+++ b/src/unsupported_python/setup.py
@@ -26,6 +26,7 @@ class InstallEngine(install):
         * Linux x86_64 (including WSL on Windows 10).
         * macOS 10.12+ x86_64.
         * Python 2.7, 3.5, or 3.6.
+        * Python 3.7 macOS only.
 
         Other possible causes of this error are:
 
@@ -55,6 +56,7 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
I believe this is almost all of the changes we need (in this repository) to support Python 3.7. The only other changes that I know will be needed are in`.gitlab-ci.yml`.

Currently calling `predict(...)` on a coremltools model is broken in Python 3. This is being tracked in [an issue](https://github.com/apple/coremltools/issues/372) in the coremltools repository. We'll need to wait for that to get fixed and for a new version to be released.

All non-CoreML related unit tests pass for Python 3.7 on macOS.

This also fixes #1455