### PR TITLE
bug fix for sarray constructor not accepting map/filter if dtype is explicitly set

### DIFF
--- a/src/python/turicreate/data_structures/sarray.py
+++ b/src/python/turicreate/data_structures/sarray.py
@@ -355,6 +355,11 @@ class SArray(object):
                 self.__proxy__ = data.astype(dtype).__proxy__
         else:
             self.__proxy__ = UnitySArrayProxy()
+
+            ## data transfromation from generator to list
+            if sys.version_info.major >= 3 and isinstance(data, (filter, map)):
+                data = list(data)
+
             # we need to perform type inference
             if dtype is None:
                 if HAS_PANDAS and isinstance(data, pandas.Series):
@@ -398,8 +403,6 @@ class SArray(object):
                       (sys.version_info.major < 3 and isinstance(data, unicode))):
                     # if it is a file, we default to string
                     dtype = str
-                elif sys.version_info.major >= 3 and isinstance(data, (filter, map)):
-                    data = list(data)
                 elif isinstance(data, array.array):
                     dtype = pytype_from_array_typecode(data.typecode)
                 elif isinstance(data, collections.Sequence):

--- a/src/python/turicreate/data_structures/sarray.py
+++ b/src/python/turicreate/data_structures/sarray.py
@@ -34,6 +34,7 @@ import datetime
 import warnings
 import numbers
 import six
+import types
 
 __all__ = ['SArray']
 
@@ -357,7 +358,7 @@ class SArray(object):
             self.__proxy__ = UnitySArrayProxy()
 
             ## data transfromation from generator to list
-            if sys.version_info.major >= 3 and isinstance(data, (filter, map)):
+            if (isinstance(data, types.GeneratorType)) or (sys.version_info.major >= 3 and isinstance(data, (filter, map))):
                 data = list(data)
 
             # we need to perform type inference

--- a/src/python/turicreate/data_structures/sarray.py
+++ b/src/python/turicreate/data_structures/sarray.py
@@ -96,8 +96,9 @@ class SArray(object):
 
     Parameters
     ----------
-    data : list | numpy.ndarray | pandas.Series | string
-        The input data. If this is a list, numpy.ndarray, or pandas.Series,
+    data : list | numpy.ndarray | pandas.Series | string | generator | map | range | filter
+        The input data. If this is a list or can generate a list from map,
+        filter, and generator, numpy.ndarray, or pandas.Series,
         the data in the list is converted and stored in an SArray.
         Alternatively if this is a string, it is interpreted as a path (or
         url) to a text file. Each line of the text file is loaded as a
@@ -142,6 +143,38 @@ class SArray(object):
     >>> sa = SArray(data=pd.Series([1,2,3,4,5]), dtype=int)
     or:
     >>> sa = SArray(pd.Series([1,2,3,4,5]), int)
+
+    Construct an SArray from range (xrange for py2):
+    .. warning::
+        if no step is provided from range, SArray.from_sequence is preferred in terms of performance.
+
+    >>> sa = SArray(data=range(1, 100, 2), dtype=int)
+    or:
+    >>> sa = SArray(data=range(1, 100, 2))
+
+    Construct an SArray from map:
+
+    >>> sa = SArray(data=map(lambda x : x**2, [1, 2, 3]), dtype=int)
+    or:
+    >>> sa = SArray(data=map(lambda x : x**2, [1, 2, 3]))
+
+    Construct an SArray from filter:
+
+    >>> sa = SArray(data=filter(lambda x : x > 2, [1, 2, 3]), dtype=int)
+    or:
+    >>> sa = SArray(data=filter(lambda x : x > 2, [1, 2, 3]))
+
+    Construct an SArray from generator:
+
+    def gen():
+        x = 0
+        while x < 10:
+            yield x
+            x += 1
+
+    >>> sa = SArray(data=gen(), dtype=int)
+    or:
+    >>> sa = SArray(data=gen())
 
     If the type is not specified, automatic inference is attempted:
 
@@ -336,12 +369,21 @@ class SArray(object):
 
     __slots__ = ["__proxy__", "_getitem_cache"]
 
+    # assume obj is aready an iterable
+    @classmethod
+    def _is_iterable_required_to_listify(cls, obj):
+        # In Python 3, str implements '__iter__'.
+        return (isinstance(obj, types.GeneratorType) or
+                (sys.version_info.major < 3 and isinstance(obj, six.moves.xrange)) or
+                sys.version_info.major >= 3 and isinstance(obj, (range, filter, map)))
+
+
     def __init__(self, data=[], dtype=None, ignore_cast_failure=False, _proxy=None):
         """
         __init__(data=list(), dtype=None, ignore_cast_failure=False)
 
         Construct a new SArray. The source of data includes: list,
-        numpy.ndarray, pandas.Series, and urls.
+        range, generators, map, filter, numpy.ndarray, pandas.Series, and urls.
         """
 
         if dtype is not None and type(dtype) != type:
@@ -357,8 +399,8 @@ class SArray(object):
         else:
             self.__proxy__ = UnitySArrayProxy()
 
-            ## data transfromation from generator to list
-            if (isinstance(data, types.GeneratorType)) or (sys.version_info.major >= 3 and isinstance(data, (filter, map))):
+            ## data transfromation from generator and other iterable to list
+            if self._is_iterable_required_to_listify(data):
                 data = list(data)
 
             # we need to perform type inference

--- a/src/python/turicreate/data_structures/sframe.py
+++ b/src/python/turicreate/data_structures/sframe.py
@@ -4361,7 +4361,8 @@ class SFrame(object):
 
         Parameters
         ----------
-        values : SArray | list | numpy.ndarray | pandas.Series | str
+        values : SArray | list | numpy.ndarray | pandas.Series | str | map
+        | generator | filter | None | range
             The values to use to filter the SFrame.  The resulting SFrame will
             only include rows that have one of these values in the given
             column.
@@ -4400,6 +4401,35 @@ class SFrame(object):
         |     cow     | 3  | jimbob |
         +-------------+----+--------+
         [2 rows x 3 columns]
+
+        >>> sf.filter_by(None, 'name', exclude=True)
+        +-------------+----+--------+
+        | animal_type | id |  name  |
+        +-------------+----+--------+
+        |     dog     | 1  |  bob   |
+        |     cat     | 2  |  jim   |
+        |     cow     | 3  | jimbob |
+        |    horse    | 4  | bobjim |
+        +-------------+----+--------+
+        [4 rows x 3 columns]
+
+        >>> sf.filter_by(filter(lambda x : len(x) > 3, sf['name']), 'name', exclude=True)
+        +-------------+----+--------+
+        | animal_type | id |  name  |
+        +-------------+----+--------+
+        |     dog     | 1  |  bob   |
+        |     cat     | 2  |  jim   |
+        +-------------+----+--------+
+        [2 rows x 3 columns]
+
+        >>> sf.filter_by(range(3), 'id', exclude=True)
+        +-------------+----+--------+
+        | animal_type | id |  name  |
+        +-------------+----+--------+
+        |     cow     | 3  | jimbob |
+        |    horse    | 4  | bobjim |
+        +-------------+----+--------+
+        [2 rows x 3 columns]
         """
         if type(column_name) is not str:
             raise TypeError("Must pass a str as column_name")
@@ -4415,6 +4445,15 @@ class SFrame(object):
             # to SArray
             if not _is_non_string_iterable(values):
                 values = [values]
+            else:
+                # is iterable
+                # if `values` is a map/filter/generator, then we need to convert it to list
+                # so we can repeatedly iterate through the iterable object through `all`.
+                # true that, we don't cover use defined iterators.
+                # I find it's too hard to check whether an iterable can be used repeatedly.
+                # just let em not use.
+                if SArray._is_iterable_required_to_listify(values):
+                    values = list(values)
 
             # if all vals are None, cast the sarray to existing type
             # this will enable filter_by(None, column_name) to remove missing vals
@@ -4428,8 +4467,8 @@ class SFrame(object):
 
         given_type = value_sf.column_types()[0]
         if given_type != existing_type:
-            raise TypeError("Type of given values does not match type of column '" +
-                column_name + "' in SFrame.")
+            raise TypeError(("Type of given values ({0}) does not match type of column '" +
+                column_name + "' ({1}) in SFrame.").format(given_type, existing_type))
 
         # Make sure the values list has unique values, or else join will not
         # filter.

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -1887,6 +1887,28 @@ class SFrameTest(unittest.TestCase):
         res = sf_none.filter_by(None, "strings", exclude=True)
         self.__assert_join_results_equal(res, sf)
 
+        # by generator, filter, map, range
+        res = sf.filter_by(range(10), "ints")
+        self.assertEqual(len(res), 9)
+        self.assertEqual(res["ints"][0], 1)
+        res = sf.filter_by(range(10), "ints", exclude=True)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res["ints"][0], 10)
+
+        res = sf.filter_by(map(lambda x : x - 5., self.float_data), "floats")
+        self.assertEqual(len(res), 5)
+        self.assertEqual(res["floats"][0], self.float_data[0])
+        res = sf.filter_by(map(lambda x : x - 5., self.float_data), "floats", exclude=True)
+        self.assertEqual(len(res), 5)
+        self.assertEqual(res["floats"][0], self.float_data[5])
+
+        res = sf.filter_by(filter(lambda x : len(x) > 1, self.string_data), "strings")
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res["strings"][0], self.string_data[-1])
+        res = sf.filter_by(filter(lambda x : len(x) > 1, self.string_data), "strings", exclude=True)
+        self.assertEqual(len(res), 9)
+        self.assertEqual(res["strings"][0], self.string_data[0])
+
         # Normal cases
         res = sf.filter_by(SArray(self.int_data), "ints")
         self.__assert_join_results_equal(res, sf)


### PR DESCRIPTION
bug fix for issue #2088

this pr also supports generator types; before any type inference and passing data to the cpp proxy, transform the data from generator/map/filter to a valid list first.

This issue is caused by a patch for #1716. The internal test is triggered.