### PR TITLE
Boost Coroutine Removal

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,8 @@ build_wheel_debug_linux_python27:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: build
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -30,8 +30,8 @@ build_wheel_linux_python27:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: build
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -48,8 +48,8 @@ build_wheel_linux_python35:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: build
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -66,8 +66,8 @@ build_wheel_linux_python36:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: build
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -168,8 +168,8 @@ test_cpp_linux:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -223,8 +223,8 @@ test_python_linux_python27:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -244,8 +244,8 @@ test_python_linux_python35:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -265,8 +265,8 @@ test_python_linux_python36:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -359,8 +359,8 @@ scenario_tests_linux_python27:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -376,8 +376,8 @@ scenario_tests_linux_python35:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -393,8 +393,8 @@ scenario_tests_linux_python36:
   tags:
     - docker
   services:
-    - docker:dind
-  image: docker:stable
+    - docker:18.09-dind
+  image: docker:18.09
   stage: test
   variables:
     DOCKER_HOST: tcp://docker:2375/
@@ -438,7 +438,7 @@ collect_artifacts:
   tags:
     - docker
   services:
-    - docker:dind
+    - docker:18.09-dind
   image: alpine:latest
   stage: collect_artifacts
   dependencies:

--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -41,7 +41,7 @@ $PIP install --upgrade "pip>=8.1"
 # numba (a dependency of resampy) doesn't fail on Python 3.5. This can
 # be removed once numba publishes a Python 3.5 wheel for their most
 # recent version.
-$PIP install numpy==1.11.1
+$PIP install numpy==1.16.4
 
 $PIP install -r scripts/requirements.txt
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,7 @@
 coremltools==2.1.0
-scipy==0.19.1
-numpy==1.11.1
-cython==0.24
+scipy==1.2.1
+numpy==1.16.4
+cython==0.29.12
 argparse==1.2.1
 decorator==4.1.2
 mock==2.0.0

--- a/src/core/storage/query_engine/execution/execution_node.cpp
+++ b/src/core/storage/query_engine/execution/execution_node.cpp
@@ -50,76 +50,6 @@ void execution_node::reset() {
   m_output_queue.reset();
 }
 
-struct source_executor {
-  bool supports_skipping;
-  bool is_linear_operator;
-  bool done = false;
-  execution_node* owner;
-  query_context context;
-  emit_state initial_operator_state;
-
-  DECL_CORO_STATE(emit_callback);
-  DECL_CORO_STATE(execute);
-
-  emit_state emit_callback(const std::shared_ptr<sframe_rows>& rows) {
-    owner->add_operator_output(rows);
-    // we are supposed to skip the next block
-    if (owner->m_skip_next_block) {
-      if (supports_skipping) {
-        // operator supports skipping. tell it
-        // we are skipping
-        return emit_state::SKIP_NEXT_BLOCK;
-      } else if (is_linear_operator) {
-        // make it look like the input is shorter
-        // just consume the inputs
-        for (size_t i = 0;i < owner->num_inputs(); ++i) {
-          owner->get_next_from_input(i, true);
-        }
-        // write a fake output, this is the skipped
-        // block. And sink again.
-        return emit_state::NONE;
-      } else {
-        // operator does not support skipping.
-        // read it as usual
-        return emit_state::NONE;
-      }
-    } else {
-      return emit_state::NONE;
-    }
-  }
-
-  void execute() {
-    CORO_BEGIN(execute)
-    initial_operator_state = emit_state::NONE;
-    if (supports_skipping && owner->m_skip_next_block) {
-      initial_operator_state = emit_state::SKIP_NEXT_BLOCK;
-    }
-
-    context = query_context([this](size_t input_id, bool skip) {
-                            auto ret = this->owner->get_next_from_input(input_id, skip);
-                            return ret;
-                          },
-                          [this](const std::shared_ptr<sframe_rows>& rows) {
-                            return this->emit_callback(rows);
-                          },
-                          sframe_config::SFRAME_READ_BATCH_SIZE,
-                          initial_operator_state);
-      do {
-        try {
-          owner->m_operator->execute(context);
-        } catch(...) {
-          owner->m_exception_occured = true;
-          owner->m_exception = std::current_exception();
-        }
-        if (owner->m_operator->coro_running()) {
-          CORO_YIELD();
-        } else {
-          break;
-        }
-      } while(owner->m_operator->coro_running());
-    CORO_END
-  }
-};
 
 void execution_node::start_coroutines() {
   // create the output queue
@@ -129,21 +59,14 @@ void execution_node::start_coroutines() {
   m_coroutines_started = true;
 
   auto attributes = m_operator->attributes();
-  bool supports_skipping =
+  supports_skipping =
       attributes.attribute_bitfield & query_operator_attributes::SUPPORTS_SKIPPING;
 
-  bool is_linear_operator =
+  is_linear_operator =
       attributes.attribute_bitfield & query_operator_attributes::LINEAR;
 
   /*
-   * The mechanism here is somewhat subtle and can be hard to understand.
-   * This ought to be cleaned up a bit.
-   *
-   * The 2nd lambda below, is called whenever the coroutine produces stuff.
-   * Essentially, sink() leaves the current coroutine, sending information
-   * to its consumers.
-   *
-   * The consumers however will request from the current coroutine, whether
+   * The consumers will request from the current coroutine, whether
    * to skip the block or not. This is stored in the state
    * m_skip_next_block.
    *
@@ -161,17 +84,13 @@ void execution_node::start_coroutines() {
    *
    *  - If the operator does not support skipping, but is a linear operator,
    *  we can pull a trick by making it seem like the input is shorter.
-   *  Thus we do not return to the coroutine, but we bypass it,
-   *  Consuming the next inputs blocks, throwing it away, and sinking a nullptr
-   *  value.
+   *  Thus we do not return to the coroutine, but we bypass it, requesting a skip
+   *  from its previous blocks.
    *
    *  - If the operator does not support skipping AND is a non-linear operator
-   *  we need to process it normally.
+   *  we need to proess it normally.
    */
-  m_source = std::make_shared<source_executor>();
-  m_source->owner = this;
-  m_source->supports_skipping = supports_skipping;
-  m_source->is_linear_operator = is_linear_operator;
+  m_context = std::make_shared<query_context>(this, sframe_config::SFRAME_READ_BATCH_SIZE);
 }
 
 std::shared_ptr<sframe_rows> execution_node::get_next(size_t consumer_id, bool skip) {
@@ -181,18 +100,35 @@ std::shared_ptr<sframe_rows> execution_node::get_next(size_t consumer_id, bool s
 
   m_skip_next_block = skip;
 
-  if (m_coroutines_started == false) {
-    start_coroutines();
-    m_source->execute();
-  }
   DASSERT_LT(consumer_id, m_consumer_pos.size());
-
-  // consume from source when queue is empty and there is more in source
-  while (m_output_queue->empty(consumer_id) && CLASS_CORO_RUNNING((*m_source), execute)) {
-    m_source->execute();
+  while (m_coroutines_started == false ||
+         (m_output_queue->empty(consumer_id) && m_operator->coro_running()))  {
+    if (m_coroutines_started == false) {
+      start_coroutines();
+    }
+    try {
+      if (m_skip_next_block) {
+        if (supports_skipping || !is_linear_operator) {
+          m_operator->execute(*m_context);
+        } else {
+          // make it look like the input is shorter
+          // just consume the inputs
+          for (size_t i = 0;i < num_inputs(); ++i) {
+            get_next_from_input(i, true);
+          }
+          add_operator_output(nullptr);
+        }
+      } else {
+        m_operator->execute(*m_context);
+      }
+    } catch(...) {
+      m_exception_occured = true;
+      m_exception = std::current_exception();
+    }
   }
+
   // end of data
-  if (m_output_queue->empty(consumer_id) && CLASS_CORO_DONE((*m_source), execute)) return nullptr;
+  if (m_output_queue->empty(consumer_id) && m_operator->coro_running() == false) return nullptr;
 
   ASSERT_TRUE(!m_output_queue->empty(consumer_id));
 

--- a/src/core/storage/query_engine/execution/execution_node.cpp
+++ b/src/core/storage/query_engine/execution/execution_node.cpp
@@ -9,7 +9,7 @@
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/execution/execution_node.hpp>
 #include <core/system/cppipc/cppipc.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/execution/execution_node.cpp
+++ b/src/core/storage/query_engine/execution/execution_node.cpp
@@ -9,23 +9,10 @@
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/execution/execution_node.hpp>
 #include <core/system/cppipc/cppipc.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
-using boost::coroutines::stack_traits;
-/*
- * Default stack size is 64K or minimum_size() whichever is larger
- */
-int64_t COROUTINE_STACK_SIZE =
-    64*1024 < stack_traits::minimum_size() ?
-        stack_traits::minimum_size() : 64*1024;
-
-REGISTER_GLOBAL_WITH_CHECKS(int64_t, COROUTINE_STACK_SIZE, false,
-            +[](int64_t i){
-              return (i > 0 &&
-                      stack_traits::minimum_size() <= static_cast<size_t>(i) &&
-                      static_cast<size_t>(i) <= stack_traits::maximum_size());
-            ;});
 
 execution_node::execution_node(const std::shared_ptr<query_operator>& op,
                                const std::vector<std::shared_ptr<execution_node> >& inputs) {
@@ -63,13 +50,83 @@ void execution_node::reset() {
   m_output_queue.reset();
 }
 
+struct source_executor {
+  bool supports_skipping;
+  bool is_linear_operator;
+  bool done = false;
+  execution_node* owner;
+  query_context context;
+  emit_state initial_operator_state;
+
+  DECL_CORO_STATE(emit_callback);
+  DECL_CORO_STATE(execute);
+
+  emit_state emit_callback(const std::shared_ptr<sframe_rows>& rows) {
+    owner->add_operator_output(rows);
+    // we are supposed to skip the next block
+    if (owner->m_skip_next_block) {
+      if (supports_skipping) {
+        // operator supports skipping. tell it
+        // we are skipping
+        return emit_state::SKIP_NEXT_BLOCK;
+      } else if (is_linear_operator) {
+        // make it look like the input is shorter
+        // just consume the inputs
+        for (size_t i = 0;i < owner->num_inputs(); ++i) {
+          owner->get_next_from_input(i, true);
+        }
+        // write a fake output, this is the skipped
+        // block. And sink again.
+        return emit_state::NONE;
+      } else {
+        // operator does not support skipping.
+        // read it as usual
+        return emit_state::NONE;
+      }
+    } else {
+      return emit_state::NONE;
+    }
+  }
+
+  void execute() {
+    CORO_BEGIN(execute)
+    initial_operator_state = emit_state::NONE;
+    if (supports_skipping && owner->m_skip_next_block) {
+      initial_operator_state = emit_state::SKIP_NEXT_BLOCK;
+    }
+
+    context = query_context([this](size_t input_id, bool skip) {
+                            auto ret = this->owner->get_next_from_input(input_id, skip);
+                            return ret;
+                          },
+                          [this](const std::shared_ptr<sframe_rows>& rows) {
+                            return this->emit_callback(rows);
+                          },
+                          sframe_config::SFRAME_READ_BATCH_SIZE,
+                          initial_operator_state);
+      do {
+        try {
+          owner->m_operator->execute(context);
+        } catch(...) {
+          owner->m_exception_occured = true;
+          owner->m_exception = std::current_exception();
+        }
+        if (owner->m_operator->coro_running()) {
+          CORO_YIELD();
+        } else {
+          break;
+        }
+      } while(owner->m_operator->coro_running());
+    CORO_END
+  }
+};
+
 void execution_node::start_coroutines() {
   // create the output queue
   m_output_queue.reset(new broadcast_queue<std::shared_ptr<sframe_rows>>(m_consumer_pos.size(), 2));
 
   // restart the coroutine
   m_coroutines_started = true;
-  auto coro_attributes = boost::coroutines::attributes(COROUTINE_STACK_SIZE);
 
   auto attributes = m_operator->attributes();
   bool supports_skipping =
@@ -111,62 +168,10 @@ void execution_node::start_coroutines() {
    *  - If the operator does not support skipping AND is a non-linear operator
    *  we need to process it normally.
    */
-  m_source = boost::coroutines::coroutine<void>::pull_type(
-      [this, supports_skipping, is_linear_operator]
-      (boost::coroutines::coroutine<void>::push_type & sink) {
-
-        emit_state initial_operator_state = emit_state::NONE;
-        if (supports_skipping && m_skip_next_block) {
-          initial_operator_state = emit_state::SKIP_NEXT_BLOCK;
-        }
-
-        query_context context([this](size_t input_id, bool skip) {
-                                auto ret = get_next_from_input(input_id, skip);
-                                return ret;
-                              },
-                              [this, &sink, supports_skipping, is_linear_operator]
-                              (const std::shared_ptr<sframe_rows>& rows)->emit_state{
-                                add_operator_output(rows);
-LABEL_GOTO_SINK_AGAIN:
-                                sink();
-
-                                // we are supposed to skip the next block
-                                if (m_skip_next_block) {
-                                  if (supports_skipping) {
-                                    // operator supports skipping. tell it
-                                    // we are skipping
-                                    return emit_state::SKIP_NEXT_BLOCK;
-                                  } else if (is_linear_operator) {
-                                    // make it look like the input is shorter
-                                    // just consume the inputs
-                                    for (size_t i = 0;i < num_inputs(); ++i) {
-                                      get_next_from_input(i, true);
-                                    }
-                                    // write a fake output, this is the skipped
-                                    // block. And sink again.
-                                    add_operator_output(nullptr);
-                                    goto LABEL_GOTO_SINK_AGAIN;
-                                  } else {
-                                    // operator does not support skipping.
-                                    // read it as usual
-                                    return emit_state::NONE;
-                                  }
-                                }
-                                return emit_state::NONE;
-                              },
-                              sframe_config::SFRAME_READ_BATCH_SIZE,
-                              initial_operator_state);
-        try {
-          m_operator->execute(context);
-        } catch(boost::coroutines::detail::forced_unwind& unwind) {
-          throw;
-        } catch(...) {
-          m_exception_occured = true;
-          m_exception = std::current_exception();
-        }
-
-      },
-      coro_attributes);
+  m_source = std::make_shared<source_executor>();
+  m_source->owner = this;
+  m_source->supports_skipping = supports_skipping;
+  m_source->is_linear_operator = is_linear_operator;
 }
 
 std::shared_ptr<sframe_rows> execution_node::get_next(size_t consumer_id, bool skip) {
@@ -176,15 +181,18 @@ std::shared_ptr<sframe_rows> execution_node::get_next(size_t consumer_id, bool s
 
   m_skip_next_block = skip;
 
-  if (m_coroutines_started == false) start_coroutines();
+  if (m_coroutines_started == false) {
+    start_coroutines();
+    m_source->execute();
+  }
   DASSERT_LT(consumer_id, m_consumer_pos.size());
 
   // consume from source when queue is empty and there is more in source
-  while (m_output_queue->empty(consumer_id) && m_source) {
-    m_source();
+  while (m_output_queue->empty(consumer_id) && CLASS_CORO_RUNNING((*m_source), execute)) {
+    m_source->execute();
   }
   // end of data
-  if (m_output_queue->empty(consumer_id) && !m_source) return nullptr;
+  if (m_output_queue->empty(consumer_id) && CLASS_CORO_DONE((*m_source), execute)) return nullptr;
 
   ASSERT_TRUE(!m_output_queue->empty(consumer_id));
 

--- a/src/core/storage/query_engine/execution/execution_node.hpp
+++ b/src/core/storage/query_engine/execution/execution_node.hpp
@@ -10,8 +10,6 @@
 #include <vector>
 #include <queue>
 
-#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#include <boost/coroutine/coroutine.hpp>
 
 #include <core/data/flexible_type/flexible_type.hpp>
 #include <core/storage/query_engine/operators/operator.hpp>
@@ -35,6 +33,7 @@ namespace query_eval {
 
 
 class query_context;
+struct source_executor;
 
 /**
  * \ingroup sframe_query_engine
@@ -243,7 +242,7 @@ class execution_node  : public std::enable_shared_from_this<execution_node> {
   std::shared_ptr<query_operator> m_operator;
 
   /// The coroutine running the actual function
-  typename boost::coroutines::coroutine<void>::pull_type m_source;
+  std::shared_ptr<source_executor> m_source;
 
   /**
    * The inputs to this execution node:
@@ -269,6 +268,7 @@ class execution_node  : public std::enable_shared_from_this<execution_node> {
   std::exception_ptr m_exception;
 
   friend class query_context;
+  friend struct source_executor;
 };
 
 /// \}

--- a/src/core/storage/query_engine/execution/execution_node.hpp
+++ b/src/core/storage/query_engine/execution/execution_node.hpp
@@ -33,7 +33,6 @@ namespace query_eval {
 
 
 class query_context;
-struct source_executor;
 
 /**
  * \ingroup sframe_query_engine
@@ -230,6 +229,8 @@ class execution_node  : public std::enable_shared_from_this<execution_node> {
   /**
    * Internal utility function what pulls the next batch of rows from a input
    * to this node.
+   * This reads *exactly* one block.
+   * If skip is true, nullptr is always returned.
    */
   std::shared_ptr<sframe_rows> get_next_from_input(size_t input_id, bool skip);
 
@@ -241,8 +242,7 @@ class execution_node  : public std::enable_shared_from_this<execution_node> {
   /// The operator implementation
   std::shared_ptr<query_operator> m_operator;
 
-  /// The coroutine running the actual function
-  std::shared_ptr<source_executor> m_source;
+  std::shared_ptr<query_context> m_context;
 
   /**
    * The inputs to this execution node:
@@ -266,9 +266,10 @@ class execution_node  : public std::enable_shared_from_this<execution_node> {
   /// exception handling
   bool m_exception_occured = false;
   std::exception_ptr m_exception;
+  bool supports_skipping;
+  bool is_linear_operator;
 
   friend class query_context;
-  friend struct source_executor;
 };
 
 /// \}

--- a/src/core/storage/query_engine/execution/query_context.hpp
+++ b/src/core/storage/query_engine/execution/query_context.hpp
@@ -48,6 +48,8 @@ class query_context {
   query_context();
   query_context(const query_context&) = default;
   query_context(query_context&&) = default;
+  query_context& operator=(const query_context&) = default;
+  query_context& operator=(query_context&&) = default;
   ~query_context();
   query_context(std::function<std::shared_ptr<sframe_rows>(size_t, bool)> callback_on_get_input,
                 std::function<emit_state(const std::shared_ptr<sframe_rows>&)> callback_on_emit,

--- a/src/core/storage/query_engine/execution/query_context.hpp
+++ b/src/core/storage/query_engine/execution/query_context.hpp
@@ -10,7 +10,7 @@
 #include <core/storage/sframe_data/sframe_rows.hpp>
 namespace turi {
 namespace query_eval {
-class executor_node;
+class execution_node;
 
 
 /**
@@ -18,15 +18,6 @@ class executor_node;
  * \addtogroup execution Execution
  * \{
  */
-
-/**
- * \ref query_context::emit returns a state, which informs the
- * operator about some execution detail.
- */
-enum class emit_state {
-  NONE, ///< Nothing of interest
-  SKIP_NEXT_BLOCK ///< Caller should skip the next block.
-};
 
 /**
  * This is the object passed to the coroutine which allows the coroutine
@@ -51,10 +42,8 @@ class query_context {
   query_context& operator=(const query_context&) = default;
   query_context& operator=(query_context&&) = default;
   ~query_context();
-  query_context(std::function<std::shared_ptr<sframe_rows>(size_t, bool)> callback_on_get_input,
-                std::function<emit_state(const std::shared_ptr<sframe_rows>&)> callback_on_emit,
-                size_t m_buffer_size,
-                emit_state initial_state);
+  query_context(execution_node* exec_node,
+                size_t m_buffer_size);
 
   /**
    * Requests for the next block for the given input.
@@ -72,16 +61,16 @@ class query_context {
   std::shared_ptr<sframe_rows> get_output_buffer();
 
   /**
-   * Returns the initial state.
-   */
-  emit_state initial_state() const;
-
-  /**
    * Emits a collection of rows. The number of rows emitted
    * MUST be the same as block_size(), except for the very last block
-   * of rows.
+   * of rows. Should yield immediately after emitting a block.
    */
-  emit_state emit(const std::shared_ptr<sframe_rows>& rows);
+  void emit(const std::shared_ptr<sframe_rows>& rows);
+
+  /**
+   * Returns true if the operator should try to skip a block.
+   */
+  bool should_skip();
 
   /**
    * The commmunication block size.
@@ -98,11 +87,7 @@ class query_context {
   // assumption means that at most one buffer may be used or given away at
   // any one point.
   std::shared_ptr<sframe_rows> m_buffers;
-
-  std::function<std::shared_ptr<sframe_rows>(size_t, bool)> m_callback_on_get_input;
-  std::function<emit_state(const std::shared_ptr<sframe_rows>&)> m_callback_on_emit;
-
-  emit_state m_initial_state;
+  execution_node* m_exec_node;
 };
 
 /// \}

--- a/src/core/storage/query_engine/operators/append.hpp
+++ b/src/core/storage/query_engine/operators/append.hpp
@@ -11,7 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 

--- a/src/core/storage/query_engine/operators/append.hpp
+++ b/src/core/storage/query_engine/operators/append.hpp
@@ -11,6 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 
@@ -27,9 +28,18 @@ namespace query_eval {
 template<>
 class operator_impl<planner_node_type::APPEND_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+
+
+  // state
+  std::shared_ptr<sframe_rows> out;
+  size_t outidx;
+  size_t input;
+  std::shared_ptr<const sframe_rows> input_rows;
+  sframe_rows::const_iterator row_iter_begin;
+  sframe_rows::const_iterator row_iter_end;
 
   planner_node_type type() const { return planner_node_type::APPEND_NODE; }
-
   static std::string name() { return "append"; }
 
   inline operator_impl() { };
@@ -46,12 +56,16 @@ class operator_impl<planner_node_type::APPEND_NODE> : public query_operator {
     return std::make_shared<operator_impl>();
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
+
   inline void execute(query_context& context) {
-    std::shared_ptr<sframe_rows> out;
-    size_t outidx = 0;
-    for (size_t input = 0; input < 2; ++input) {
+    CORO_BEGIN(execute)
+    outidx = 0;
+    for (input = 0; input < 2; ++input) {
       // read some input
-      auto input_rows = context.get_next(input);
+      input_rows = context.get_next(input);
       if (input_rows != nullptr && out == nullptr) {
         // we have input, but we don't have an output buffer. Make one
         out = context.get_output_buffer();
@@ -60,16 +74,20 @@ class operator_impl<planner_node_type::APPEND_NODE> : public query_operator {
       }
       // keep looping over this input
       while(input_rows != nullptr) {
-        for (const auto& row: *input_rows) {
-          (*out)[outidx] = row;
+        row_iter_begin = input_rows->cbegin();
+        row_iter_end = input_rows->cend();
+        while(row_iter_begin != row_iter_end) {
+          (*out)[outidx] = *row_iter_begin;
           ++outidx;
           // output buffer is full. give it away and acquire a new one
           if (outidx == context.block_size()) {
             context.emit(out);
+            CORO_YIELD();
             out = context.get_output_buffer();
             out->resize(input_rows->num_columns(), context.block_size());
             outidx = 0;
           }
+          ++row_iter_begin;
         }
         input_rows = context.get_next(input);
       }
@@ -77,7 +95,9 @@ class operator_impl<planner_node_type::APPEND_NODE> : public query_operator {
     if (outidx && out) {
       out->resize(out->num_columns(), outidx);
       context.emit(out);
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/src/core/storage/query_engine/operators/binary_transform.hpp
+++ b/src/core/storage/query_engine/operators/binary_transform.hpp
@@ -12,7 +12,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/binary_transform.hpp
+++ b/src/core/storage/query_engine/operators/binary_transform.hpp
@@ -12,6 +12,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -32,6 +33,12 @@ typedef std::function<flexible_type(const sframe_rows::row&,
 template<>
 class operator_impl<planner_node_type::BINARY_TRANSFORM_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+  std::shared_ptr<const sframe_rows>  rows_left, rows_right;
+  sframe_rows::const_iterator left_iter, right_iter;
+  sframe_rows::iterator out_iter;
+  std::shared_ptr<sframe_rows>  output_buffer;
+
 
   planner_node_type type() const { return planner_node_type::BINARY_TRANSFORM_NODE; }
 
@@ -52,22 +59,26 @@ class operator_impl<planner_node_type::BINARY_TRANSFORM_NODE> : public query_ope
   inline std::shared_ptr<query_operator> clone() const {
     return std::make_shared<operator_impl>(*this);
   }
-
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     while(1) {
-      auto rows_left = context.get_next(0);
-      auto rows_right = context.get_next(1);
+      {
+      rows_left = context.get_next(0);
+      rows_right = context.get_next(1);
       if (rows_left == nullptr && rows_right == nullptr) break;
       ASSERT_TRUE(rows_left != nullptr && rows_right != nullptr);
       ASSERT_EQ(rows_left->num_rows(), rows_right->num_rows());
       ASSERT_EQ(rows_left->num_columns(), 1);
       ASSERT_EQ(rows_right->num_columns(), 1);
-      auto output_buffer = context.get_output_buffer();
+      output_buffer = context.get_output_buffer();
       output_buffer->resize(1, rows_left->num_rows());
 
-      auto left_iter = rows_left->cbegin();
-      auto right_iter = rows_right->cbegin();
-      auto out_iter = output_buffer->begin();
+      left_iter = rows_left->cbegin();
+      right_iter = rows_right->cbegin();
+      out_iter = output_buffer->begin();
       while(left_iter != rows_left->cend()) {
         (*out_iter)[0] = m_transform_fn((*left_iter), (*right_iter));
         ++left_iter;
@@ -75,7 +86,10 @@ class operator_impl<planner_node_type::BINARY_TRANSFORM_NODE> : public query_ope
         ++out_iter;
       }
       context.emit(output_buffer);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/constant.hpp
+++ b/src/core/storage/query_engine/operators/constant.hpp
@@ -10,6 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 namespace turi {
 namespace query_eval {
 
@@ -26,6 +27,11 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::CONSTANT_NODE> : public query_operator {
  public:
+
+  DECL_CORO_STATE(execute);
+  std::shared_ptr<sframe_rows>  retbuf;
+  size_t i;
+  size_t len;
 
   planner_node_type type() const { return planner_node_type::CONSTANT_NODE; }
 
@@ -51,17 +57,23 @@ struct operator_impl<planner_node_type::CONSTANT_NODE> : public query_operator {
     return std::make_shared<operator_impl>(m_value, m_len);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
-    size_t i = 0;
+    CORO_BEGIN(execute)
+    i = 0;
     while(i < m_len) {
-      auto ret = context.get_output_buffer();
-      size_t len = std::min(m_len - i, context.block_size());
+      retbuf = context.get_output_buffer();
+      len = std::min(m_len - i, context.block_size());
 
-      ret->resize(1, len);
-      for (auto& value: *(ret->get_columns()[0])) value = m_value;
-      context.emit(ret);
+      retbuf->resize(1, len);
+      for (auto& value: *(retbuf->get_columns()[0])) value = m_value;
+      context.emit(retbuf);
+      CORO_YIELD();
       i += len;
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(const flexible_type& val,

--- a/src/core/storage/query_engine/operators/constant.hpp
+++ b/src/core/storage/query_engine/operators/constant.hpp
@@ -10,7 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 namespace turi {
 namespace query_eval {
 

--- a/src/core/storage/query_engine/operators/generalized_transform.hpp
+++ b/src/core/storage/query_engine/operators/generalized_transform.hpp
@@ -11,7 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 namespace turi {
 namespace query_eval {
 

--- a/src/core/storage/query_engine/operators/generalized_transform.hpp
+++ b/src/core/storage/query_engine/operators/generalized_transform.hpp
@@ -11,6 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 namespace turi {
 namespace query_eval {
 
@@ -30,6 +31,8 @@ typedef std::function<void (const sframe_rows::row&,
 template<>
 class operator_impl<planner_node_type::GENERALIZED_TRANSFORM_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+
   planner_node_type type() const { return planner_node_type::GENERALIZED_TRANSFORM_NODE; }
 
   static std::string name() { return "generalized_transform";  }
@@ -53,28 +56,35 @@ class operator_impl<planner_node_type::GENERALIZED_TRANSFORM_NODE> : public quer
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     if (m_random_seed != -1){
       random::get_source().seed(m_random_seed + thread::thread_id());
     }
-    std::vector<flexible_type> ret;
     while(1) {
-      auto rows = context.get_next(0);
-      if (rows == nullptr)
-        break;
-      auto output = context.get_output_buffer();
-      output->resize(m_output_types.size(), rows->num_rows());
+      {
+        auto rows = context.get_next(0);
+        if (rows == nullptr)
+          break;
+        auto output = context.get_output_buffer();
+        output->resize(m_output_types.size(), rows->num_rows());
 
-      auto iter = rows->cbegin();
-      auto output_iter = output->begin();
-      while(iter != rows->cend()) {
-        m_transform_fn((*iter), (*output_iter));
-        ++output_iter;
-        ++iter;
+        auto iter = rows->cbegin();
+        auto output_iter = output->begin();
+        while(iter != rows->cend()) {
+          m_transform_fn((*iter), (*output_iter));
+          ++output_iter;
+          ++iter;
+        }
+        output->type_check_inplace(m_output_types);
+        context.emit(output);
       }
-      output->type_check_inplace(m_output_types);
-      context.emit(output);
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/generalized_union_project.hpp
+++ b/src/core/storage/query_engine/operators/generalized_union_project.hpp
@@ -10,7 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/generalized_union_project.hpp
+++ b/src/core/storage/query_engine/operators/generalized_union_project.hpp
@@ -10,6 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -27,6 +28,14 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::GENERALIZED_UNION_PROJECT_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+
+  std::vector<std::shared_ptr<const sframe_rows> > input_v;
+
+  std::vector<
+    std::vector<
+      std::shared_ptr<
+        std::vector<turi::flexible_type> > > > input_columns;
 
   planner_node_type type() const { return planner_node_type::GENERALIZED_UNION_PROJECT_NODE; }
 
@@ -45,15 +54,16 @@ struct operator_impl<planner_node_type::GENERALIZED_UNION_PROJECT_NODE> : public
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
-    std::vector<std::shared_ptr<const sframe_rows> > input_v(num_inputs);
-
-    std::vector<
-      std::vector<
-        std::shared_ptr<
-          std::vector<turi::flexible_type> > > > input_columns(num_inputs);
+    CORO_BEGIN(execute)
+    input_v.resize(num_inputs);
+    input_columns.resize(num_inputs);
 
     while(1) {
+      {
       bool all_null = true, any_null = false;
       for(size_t i = 0; i < num_inputs; ++i) {
         input_v[i] = context.get_next(i);
@@ -81,7 +91,10 @@ struct operator_impl<planner_node_type::GENERALIZED_UNION_PROJECT_NODE> : public
       }
 
       context.emit(out);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
  private:

--- a/src/core/storage/query_engine/operators/lambda_transform.hpp
+++ b/src/core/storage/query_engine/operators/lambda_transform.hpp
@@ -11,6 +11,7 @@
 #include <core/storage/query_engine/operators/operator_properties.hpp>
 #include <core/system/lambda/pylambda_function.hpp>
 #include <core/system/exceptions/error_types.hpp>
+#include <util/coro.hpp>
 namespace turi {
 namespace query_eval {
 
@@ -28,6 +29,7 @@ template<>
 class operator_impl<planner_node_type::LAMBDA_TRANSFORM_NODE> : public query_operator {
 
  public:
+  DECL_CORO_STATE(execute);
   planner_node_type type() const { return planner_node_type::LAMBDA_TRANSFORM_NODE; }
 
   static std::string name() { return "lambda_transform";  }
@@ -50,8 +52,13 @@ class operator_impl<planner_node_type::LAMBDA_TRANSFORM_NODE> : public query_ope
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     while(1) {
+      {
       auto rows = context.get_next(0);
       if (rows == nullptr)
         break;
@@ -73,7 +80,10 @@ class operator_impl<planner_node_type::LAMBDA_TRANSFORM_NODE> : public query_ope
         (*output)[i][0] = convert_value_to_output_type(out[i], m_output_type);
       }
       context.emit(output);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/lambda_transform.hpp
+++ b/src/core/storage/query_engine/operators/lambda_transform.hpp
@@ -11,7 +11,7 @@
 #include <core/storage/query_engine/operators/operator_properties.hpp>
 #include <core/system/lambda/pylambda_function.hpp>
 #include <core/system/exceptions/error_types.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 namespace turi {
 namespace query_eval {
 

--- a/src/core/storage/query_engine/operators/logical_filter.hpp
+++ b/src/core/storage/query_engine/operators/logical_filter.hpp
@@ -9,7 +9,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/logical_filter.hpp
+++ b/src/core/storage/query_engine/operators/logical_filter.hpp
@@ -9,6 +9,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -27,6 +28,14 @@ namespace query_eval {
 template<>
 class operator_impl<planner_node_type::LOGICAL_FILTER_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+  std::shared_ptr<const sframe_rows>  rows_left, rows_right;
+  sframe_rows::const_iterator left_iter, right_iter, out_iter;
+  std::shared_ptr<sframe_rows>  output_buffer;
+  size_t cur_output_index = 0;
+  size_t ncols = 0;
+  size_t nrows = 0;
+  bool has_data = false;
 
   planner_node_type type() const { return planner_node_type::LOGICAL_FILTER_NODE; }
 
@@ -54,18 +63,22 @@ class operator_impl<planner_node_type::LOGICAL_FILTER_NODE> : public query_opera
     return true;
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     // read one block
-    auto rows_left = context.get_next(0);
-    auto rows_right = context.get_next(1);
+    rows_left = context.get_next(0);
+    rows_right = context.get_next(1);
     if (rows_left == nullptr && rows_right == nullptr) return;
     ASSERT_TRUE(rows_left != nullptr && rows_right != nullptr);
 
     // set up the output shape
-    auto output_buffer = context.get_output_buffer();
-    size_t cur_output_index = 0;
-    size_t ncols = rows_left->num_columns();
-    size_t nrows = context.block_size();
+    output_buffer = context.get_output_buffer();
+    cur_output_index = 0;
+    ncols = rows_left->num_columns();
+    nrows = context.block_size();
     output_buffer->resize(ncols, nrows);
 
 
@@ -73,14 +86,15 @@ class operator_impl<planner_node_type::LOGICAL_FILTER_NODE> : public query_opera
       ASSERT_TRUE(rows_left != nullptr && rows_right != nullptr);
       ASSERT_EQ(rows_left->num_rows(), rows_right->num_rows());
 
-      auto left_iter = rows_left->cbegin();
-      auto right_iter = rows_right->cbegin();
+      left_iter = rows_left->cbegin();
+      right_iter = rows_right->cbegin();
       while(left_iter != rows_left->cend()) {
         if (!(*right_iter)[0].is_zero()) {
           (*output_buffer)[cur_output_index] = (*left_iter);
           ++cur_output_index;
           if (cur_output_index == nrows) {
             context.emit(output_buffer);
+            CORO_YIELD();
             output_buffer = context.get_output_buffer();
             output_buffer->resize(ncols, nrows);
             cur_output_index = 0;
@@ -89,7 +103,7 @@ class operator_impl<planner_node_type::LOGICAL_FILTER_NODE> : public query_opera
         ++left_iter;
         ++right_iter;
       }
-      bool has_data = false;
+      has_data = false;
       do {
         // get the binary column first
         rows_right = context.get_next(1);
@@ -108,7 +122,9 @@ class operator_impl<planner_node_type::LOGICAL_FILTER_NODE> : public query_opera
     if (cur_output_index > 0) {
       output_buffer->resize(ncols, cur_output_index);
       context.emit(output_buffer);
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/operator.hpp
+++ b/src/core/storage/query_engine/operators/operator.hpp
@@ -96,6 +96,8 @@ class query_operator {
 
   virtual planner_node_type type() const = 0;
 
+  virtual bool coro_running() const = 0;
+
   /**
    * Basic execution attributes about the query.
    */

--- a/src/core/storage/query_engine/operators/optonly_identity_operator.hpp
+++ b/src/core/storage/query_engine/operators/optonly_identity_operator.hpp
@@ -12,6 +12,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -40,6 +41,10 @@ class operator_impl<planner_node_type::IDENTITY_NODE> : public query_operator {
 
   inline std::shared_ptr<query_operator> clone() const {
     return std::make_shared<operator_impl>(*this);
+  }
+
+  inline bool coro_running() const {
+    return false;
   }
 
   static std::shared_ptr<planner_node> make_planner_node(std::shared_ptr<planner_node> pnode) {

--- a/src/core/storage/query_engine/operators/optonly_identity_operator.hpp
+++ b/src/core/storage/query_engine/operators/optonly_identity_operator.hpp
@@ -12,7 +12,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/project.hpp
+++ b/src/core/storage/query_engine/operators/project.hpp
@@ -10,7 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/project.hpp
+++ b/src/core/storage/query_engine/operators/project.hpp
@@ -10,6 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -27,6 +28,7 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::PROJECT_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
 
   inline planner_node_type type() const { return planner_node_type::PROJECT_NODE; }
 
@@ -53,8 +55,13 @@ struct operator_impl<planner_node_type::PROJECT_NODE> : public query_operator {
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     while (1) {
+      {
       auto rows = context.get_next(0);
       if (rows == nullptr)
         break;
@@ -68,7 +75,10 @@ struct operator_impl<planner_node_type::PROJECT_NODE> : public query_operator {
         out_columns.push_back(rows_columns[m_indices[i]]);
       }
       context.emit(out);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   };
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/range.hpp
+++ b/src/core/storage/query_engine/operators/range.hpp
@@ -9,6 +9,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 namespace turi {
 namespace query_eval {
 
@@ -24,6 +25,8 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::RANGE_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+  flex_int cur;
 
   inline planner_node_type type() const { return planner_node_type::RANGE_NODE; }
 
@@ -43,15 +46,20 @@ struct operator_impl<planner_node_type::RANGE_NODE> : public query_operator {
     ASSERT_LE(m_start, m_end);
   }
 
-
   inline std::shared_ptr<query_operator> clone() const {
     return std::make_shared<operator_impl>(m_start, m_end);
   }
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
 
   inline void execute(query_context& context) {
-    flex_int cur = m_start;
+
+    CORO_BEGIN(execute)
+    cur = m_start;
 
     while(cur < m_end) {
+      {
       auto ret = context.get_output_buffer();
       size_t len = std::min<size_t>(m_end - cur, context.block_size());
 
@@ -61,7 +69,10 @@ struct operator_impl<planner_node_type::RANGE_NODE> : public query_operator {
         ++cur;
       }
       context.emit(ret);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/range.hpp
+++ b/src/core/storage/query_engine/operators/range.hpp
@@ -9,7 +9,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 namespace turi {
 namespace query_eval {
 

--- a/src/core/storage/query_engine/operators/reduce.hpp
+++ b/src/core/storage/query_engine/operators/reduce.hpp
@@ -11,7 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 #include <iostream>
 
 namespace turi {

--- a/src/core/storage/query_engine/operators/reduce.hpp
+++ b/src/core/storage/query_engine/operators/reduce.hpp
@@ -11,6 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 #include <iostream>
 
 namespace turi {
@@ -29,6 +30,7 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::REDUCE_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
 
   planner_node_type type() const { return planner_node_type::REDUCE_NODE; }
 
@@ -51,7 +53,12 @@ struct operator_impl<planner_node_type::REDUCE_NODE> : public query_operator {
     return std::make_shared<operator_impl>(agg, m_output_type);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
+    {
     while(1) {
       auto rows = context.get_next(0);
       if (rows == nullptr)
@@ -66,6 +73,9 @@ struct operator_impl<planner_node_type::REDUCE_NODE> : public query_operator {
     out->resize(1, 1);
     (*out)[0][0] = m_aggregator->emit();
     context.emit(out);
+    }
+    CORO_YIELD();
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/sarray_source.hpp
+++ b/src/core/storage/query_engine/operators/sarray_source.hpp
@@ -14,6 +14,7 @@
 #include <core/storage/query_engine/operators/operator_properties.hpp>
 #include <core/storage/fileio/fs_utils.hpp>
 #include <core/storage/sframe_data/sarray.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -32,6 +33,13 @@ struct operator_impl<planner_node_type::SARRAY_SOURCE_NODE> : public query_opera
  * A "sarray_source" operator generates values from a physical sarray.
  */
  public:
+  DECL_CORO_STATE(execute);
+  size_t start = 0;
+  size_t block_size = 0;
+  bool skip_next_block = false;
+  emit_state state;
+  size_t end;
+  std::shared_ptr<sframe_rows>  rows;
 
   planner_node_type type() const { return planner_node_type::SARRAY_SOURCE_NODE; }
 
@@ -56,25 +64,32 @@ struct operator_impl<planner_node_type::SARRAY_SOURCE_NODE> : public query_opera
     return std::make_shared<operator_impl>(m_source);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     if (!m_reader) m_reader = m_source->get_reader();
-    auto start = m_begin_index;
-    auto block_size = context.block_size();
-    bool skip_next_block = false;
-    emit_state state = context.initial_state();
+    start = m_begin_index;
+    block_size = context.block_size();
+    skip_next_block = false;
+    state = context.initial_state();
 
     while (start != m_end_index) {
-      auto rows = context.get_output_buffer();
-      auto end = std::min(start + block_size, m_end_index);
+      rows = context.get_output_buffer();
+      end = std::min(start + block_size, m_end_index);
       if (skip_next_block == false) {
         m_reader->read_rows(start, end, *rows);
         state = context.emit(rows);
+        CORO_YIELD();
       } else {
         state = context.emit(nullptr);
+        CORO_YIELD();
       }
       skip_next_block = state == emit_state::SKIP_NEXT_BLOCK;
       start = end;
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/sarray_source.hpp
+++ b/src/core/storage/query_engine/operators/sarray_source.hpp
@@ -14,7 +14,7 @@
 #include <core/storage/query_engine/operators/operator_properties.hpp>
 #include <core/storage/fileio/fs_utils.hpp>
 #include <core/storage/sframe_data/sarray.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/sframe_source.hpp
+++ b/src/core/storage/query_engine/operators/sframe_source.hpp
@@ -13,6 +13,7 @@
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
 #include <core/storage/sframe_data/sframe.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -29,6 +30,13 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::SFRAME_SOURCE_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+  size_t start = 0;
+  std::shared_ptr<sframe_rows> rows;
+  size_t block_size = 0;
+  bool skip_next_block = false;
+  emit_state state;
+  size_t end = 0;
 
   planner_node_type type() const { return planner_node_type::SFRAME_SOURCE_NODE; }
 
@@ -53,26 +61,32 @@ struct operator_impl<planner_node_type::SFRAME_SOURCE_NODE> : public query_opera
     return std::make_shared<operator_impl>(m_source);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     if (!m_reader) m_reader = m_source.get_reader();
-    auto start = m_begin_index;
-    std::shared_ptr<sframe_rows> rows;
-    auto block_size = context.block_size();
-    bool skip_next_block = false;
-    emit_state state = context.initial_state();
+    start = m_begin_index;
+    block_size = context.block_size();
+    skip_next_block = false;
+    state = context.initial_state();
 
     while (start != m_end_index) {
-      auto rows = context.get_output_buffer();
-      auto end = std::min(start + block_size, m_end_index);
+      rows = context.get_output_buffer();
+      end = std::min(start + block_size, m_end_index);
       if (skip_next_block == false) {
         m_reader->read_rows(start, end, *rows);
         state = context.emit(rows);
+        CORO_YIELD();
       } else {
         state = context.emit(nullptr);
+        CORO_YIELD();
       }
       skip_next_block = state == emit_state::SKIP_NEXT_BLOCK;
       start = end;
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/sframe_source.hpp
+++ b/src/core/storage/query_engine/operators/sframe_source.hpp
@@ -35,7 +35,6 @@ struct operator_impl<planner_node_type::SFRAME_SOURCE_NODE> : public query_opera
   std::shared_ptr<sframe_rows> rows;
   size_t block_size = 0;
   bool skip_next_block = false;
-  emit_state state;
   size_t end = 0;
 
   planner_node_type type() const { return planner_node_type::SFRAME_SOURCE_NODE; }
@@ -69,21 +68,20 @@ struct operator_impl<planner_node_type::SFRAME_SOURCE_NODE> : public query_opera
     if (!m_reader) m_reader = m_source.get_reader();
     start = m_begin_index;
     block_size = context.block_size();
-    skip_next_block = false;
-    state = context.initial_state();
+    skip_next_block = context.should_skip();
 
     while (start != m_end_index) {
       rows = context.get_output_buffer();
       end = std::min(start + block_size, m_end_index);
       if (skip_next_block == false) {
         m_reader->read_rows(start, end, *rows);
-        state = context.emit(rows);
+        context.emit(rows);
         CORO_YIELD();
       } else {
-        state = context.emit(nullptr);
+        context.emit(nullptr);
         CORO_YIELD();
       }
-      skip_next_block = state == emit_state::SKIP_NEXT_BLOCK;
+      skip_next_block = context.should_skip();
       start = end;
     }
     CORO_END

--- a/src/core/storage/query_engine/operators/sframe_source.hpp
+++ b/src/core/storage/query_engine/operators/sframe_source.hpp
@@ -13,7 +13,7 @@
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
 #include <core/storage/sframe_data/sframe.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/ternary_operator.hpp
+++ b/src/core/storage/query_engine/operators/ternary_operator.hpp
@@ -12,6 +12,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -32,6 +33,7 @@ namespace query_eval {
 template<>
 class operator_impl<planner_node_type::TERNARY_OPERATOR> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
 
   planner_node_type type() const { return planner_node_type::TERNARY_OPERATOR; }
 
@@ -50,11 +52,16 @@ class operator_impl<planner_node_type::TERNARY_OPERATOR> : public query_operator
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
     constexpr size_t CONDITION_INPUT = 0;
     constexpr size_t ISTRUE_INPUT = 1;
     constexpr size_t ISFALSE_INPUT = 2;
+    CORO_BEGIN(execute)
     while(1) {
+      {
       auto condition = context.get_next(CONDITION_INPUT);
 
       if (condition == nullptr) break;
@@ -93,7 +100,6 @@ class operator_impl<planner_node_type::TERNARY_OPERATOR> : public query_operator
 
         out_columns.clear();
         out_columns.push_back(input->cget_columns()[0]);
-        context.emit(output_buffer);
       } else {
 
         auto isfalse = context.get_next(ISFALSE_INPUT);
@@ -120,9 +126,12 @@ class operator_impl<planner_node_type::TERNARY_OPERATOR> : public query_operator
           ++isfalse_iter;
           ++out_iter;
         }
-        context.emit(output_buffer);
       }
+      context.emit(output_buffer);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/ternary_operator.hpp
+++ b/src/core/storage/query_engine/operators/ternary_operator.hpp
@@ -12,7 +12,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/transform.hpp
+++ b/src/core/storage/query_engine/operators/transform.hpp
@@ -11,7 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 namespace turi {
 namespace query_eval {
 

--- a/src/core/storage/query_engine/operators/transform.hpp
+++ b/src/core/storage/query_engine/operators/transform.hpp
@@ -11,6 +11,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 namespace turi {
 namespace query_eval {
 
@@ -29,6 +30,7 @@ typedef std::function<flexible_type(const sframe_rows::row&)> transform_type;
 template<>
 class operator_impl<planner_node_type::TRANSFORM_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
   planner_node_type type() const { return planner_node_type::TRANSFORM_NODE; }
 
   static std::string name() { return "transform";  }
@@ -52,11 +54,16 @@ class operator_impl<planner_node_type::TRANSFORM_NODE> : public query_operator {
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
+    CORO_BEGIN(execute)
     if (m_random_seed != -1){
       random::get_source().seed(m_random_seed + thread::thread_id());
     }
     while(1) {
+      {
       auto rows = context.get_next(0);
       if (rows == nullptr)
         break;
@@ -80,7 +87,10 @@ class operator_impl<planner_node_type::TRANSFORM_NODE> : public query_operator {
         ++iter;
       }
       context.emit(output);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
   static std::shared_ptr<planner_node> make_planner_node(

--- a/src/core/storage/query_engine/operators/union.hpp
+++ b/src/core/storage/query_engine/operators/union.hpp
@@ -10,7 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace query_eval {

--- a/src/core/storage/query_engine/operators/union.hpp
+++ b/src/core/storage/query_engine/operators/union.hpp
@@ -10,6 +10,7 @@
 #include <core/storage/query_engine/operators/operator.hpp>
 #include <core/storage/query_engine/execution/query_context.hpp>
 #include <core/storage/query_engine/operators/operator_properties.hpp>
+#include <util/coro.hpp>
 
 namespace turi {
 namespace query_eval {
@@ -27,6 +28,8 @@ namespace query_eval {
 template <>
 struct operator_impl<planner_node_type::UNION_NODE> : public query_operator {
  public:
+  DECL_CORO_STATE(execute);
+  std::vector<std::shared_ptr<const sframe_rows> > input_v;
 
   planner_node_type type() const { return planner_node_type::UNION_NODE; }
 
@@ -45,10 +48,16 @@ struct operator_impl<planner_node_type::UNION_NODE> : public query_operator {
     return std::make_shared<operator_impl>(*this);
   }
 
+  inline bool coro_running() const {
+    return CORO_RUNNING(execute);
+  }
   inline void execute(query_context& context) {
-    std::vector<std::shared_ptr<const sframe_rows> > input_v(num_inputs);
+
+    CORO_BEGIN(execute)
+    input_v.resize(num_inputs);
 
     while(1) {
+      {
       bool all_null = true, any_null = false;
       for(size_t i = 0; i < num_inputs; ++i) {
         input_v[i] = context.get_next(i);
@@ -73,7 +82,10 @@ struct operator_impl<planner_node_type::UNION_NODE> : public query_operator {
       }
 
       context.emit(out);
+      }
+      CORO_YIELD();
     }
+    CORO_END
   }
 
  private:

--- a/src/core/storage/sframe_data/sarray_file_format_v2.hpp
+++ b/src/core/storage/sframe_data/sarray_file_format_v2.hpp
@@ -23,6 +23,7 @@
 #include <core/storage/sframe_data/sarray_v2_block_manager.hpp>
 #include <core/storage/sframe_data/sarray_v2_block_writer.hpp>
 #include <core/storage/sframe_data/sarray_v2_encoded_block.hpp>
+#include <core/storage/sframe_data/sarray_v2_type_encoding.hpp>
 #include <core/system/cppipc/server/cancel_ops.hpp>
 namespace turi {
 

--- a/src/core/storage/sframe_data/sarray_v2_block_manager.cpp
+++ b/src/core/storage/sframe_data/sarray_v2_block_manager.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include <core/storage/sframe_data/sarray_v2_block_manager.hpp>
 #include <core/storage/sframe_data/sarray_index_file.hpp>
 #include <core/storage/sframe_data/sframe_constants.hpp>
+#include <core/storage/sframe_data/sarray_v2_type_encoding.hpp>
 #include <core/storage/sframe_data/unfair_lock.hpp>
 
 namespace turi {

--- a/src/core/storage/sframe_data/sarray_v2_block_manager.hpp
+++ b/src/core/storage/sframe_data/sarray_v2_block_manager.hpp
@@ -16,8 +16,6 @@
 #include <core/data/flexible_type/flexible_type.hpp>
 #include <core/util/buffer_pool.hpp>
 #include <core/storage/sframe_data/sarray_v2_block_types.hpp>
-#include <core/storage/sframe_data/sarray_v2_type_encoding.hpp>
-
 
 // forward declaration for LZ4. required here annoyingly since I have a template
 // function here which calls it

--- a/src/core/storage/sframe_data/sarray_v2_encoded_block.cpp
+++ b/src/core/storage/sframe_data/sarray_v2_encoded_block.cpp
@@ -5,6 +5,7 @@
  */
 #include <core/storage/sframe_data/sarray_v2_encoded_block.hpp>
 #include <core/storage/sframe_data/sarray_v2_type_encoding.hpp>
+#include <cmath>
 namespace turi {
 namespace v2_block_impl {
 
@@ -32,93 +33,29 @@ void encoded_block::release() {
   m_block.m_block_info = block_info();
 }
 
-encoded_block_range::encoded_block_range(const encoded_block& block) {
-  // initializes the range. Sets up the internal variables
-  m_shared = std::make_shared<coro_shared_data>();
-  m_block = block.m_block;
+encoded_block_range::encoded_block_range(const encoded_block& block)
+ : m_block(block.m_block) {
+   decoder.reset(new typed_decode_stream(m_block.m_block_info,
+                                         m_block.m_data->data(),
+                                         m_block.m_data->size()));
+ }
+
+void encoded_block_range::release() {
+  decoder.reset();
+  m_block.m_data.reset();
 }
 
-void encoded_block_range::coroutine_launch() {
-  // launches the decoding coroutine
-  auto coro_m_shared = m_shared;
-  auto coro_m_block = m_block;
-  coroutine_started = true;
-  source =
-      coroutine_type(
-          // the coroutine function
-          [coro_m_shared, coro_m_block]
-          (boost::coroutines::coroutine<void>::push_type& sink){
-            // coroutine function basically calls the decoder with a callback
-            // which sticks stuff into the buffer.
-            // and triggers the sink when the buffer full.
-            typed_decode_stream_callback(coro_m_block.m_block_info,
-                                         coro_m_block.m_data->data(),
-                                         coro_m_block.m_data->size(),
-                                         [&coro_m_shared, &sink](const flexible_type& val) {
-                                           auto& shared = *coro_m_shared;
-                                           if (shared.terminate) {
-                                             return;
-                                           } else if (shared.m_write_target_numel) {
-                                             // there is an alternative write
-                                             // target rather than the circular
-                                             // buffer.
-                                             (*shared.m_write_target) = val;
-                                             shared.m_write_target++;
-                                             shared.m_write_target_numel--;
-                                             if (shared.m_write_target_numel == 0) sink();
-                                           } else if(shared.m_skip) {
-                                             shared.m_skip--;
-                                             if (shared.m_skip == 0) sink();
-                                           }
-                                         });
-            return;
-      });
-}
+encoded_block_range::~encoded_block_range() {}
 
-void encoded_block_range::call_source() {
-  if (!coroutine_started) coroutine_launch();
-  else source();
+size_t encoded_block_range::decode_to(flexible_type* write_target,
+                                        size_t numel) {
+  if (numel == 0) return 0;
+  return decoder->read({write_target, numel}, 0);
 }
 
 void encoded_block_range::skip(size_t n) {
   if (n == 0) return;
-  if (coroutine_started && !source) return;
-  m_shared->m_skip = n;
-  call_source();
-}
-
-size_t encoded_block_range::fill_buffer(flexible_type* write_target,
-                                        size_t numel) {
-  if (numel == 0) return 0;
-  if (coroutine_started && !source) return 0;
-  m_shared->m_write_target = write_target;
-  m_shared->m_write_target_numel = numel;
-  call_source();
-  // reset the pointers
-  m_shared->m_write_target = nullptr;
-  size_t ctr = numel - m_shared->m_write_target_numel;
-  m_shared->m_write_target_numel = 0;
-  return ctr;
-}
-
-void encoded_block_range::release() {
-  if (source) {
-    // try to unwind the coroutine cleanly.
-    m_shared->terminate = true;
-    source();
-  }
-  source = coroutine_type();
-  m_shared.reset();
-  m_block.m_data.reset();
-}
-
-
-size_t encoded_block_range::decode_to(flexible_type* decode_target, size_t num_elem) {
-  return fill_buffer(decode_target, num_elem);
-}
-
-encoded_block_range::~encoded_block_range() {
-  if (source) release();
+  decoder->read({nullptr, 0}, n);
 }
 
 } // v2_block_impl

--- a/src/core/storage/sframe_data/sarray_v2_encoded_block.hpp
+++ b/src/core/storage/sframe_data/sarray_v2_encoded_block.hpp
@@ -6,9 +6,6 @@
 #ifndef TURI_SFRAME_ENCODED_BLOCK_HPP
 #define TURI_SFRAME_ENCODED_BLOCK_HPP
 
-#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#include <boost/coroutine/coroutine.hpp>
-
 #include <boost/circular_buffer.hpp>
 #include <vector>
 #include <memory>
@@ -30,6 +27,7 @@ namespace turi {
 namespace v2_block_impl {
 
 class encoded_block_range;
+struct typed_decode_stream;
 /**
  * This class provides accessors into a typed v2
  * sarray<flexible_type> encoded column block. It maintains the
@@ -129,13 +127,7 @@ class encoded_block {
 
 /**
  * The range returned by \ref encoded_block::get_range().
- * It provides begin() and end() functions which allows it to be used in:
- *
- * \code
- * for (const flexible_type& i : block.get_range()) {
- *   ...
- * }
- * \endcode
+ * It provides 2 basic methods. \ref decode(target, size) and \ref skip(n)
  *
  * The encoded_block_range provides a one pass reader to the data.
  *
@@ -147,30 +139,14 @@ class encoded_block {
  */
 class encoded_block_range {
  private:
-  /**************************************************************************/
-  /*                                                                        */
-  /*    Buffers and shared datastructures between this and the coroutine    */
-  /*                                                                        */
-  /**************************************************************************/
-  struct coro_shared_data {
-    size_t m_skip = 0;
-    flexible_type* m_write_target = nullptr;
-    size_t m_write_target_numel = 0;
-    bool terminate = false;
-  };
  public:
   encoded_block_range() = default;
   explicit encoded_block_range(const encoded_block& block);
-  encoded_block_range(encoded_block_range&&) = default;
 
+  encoded_block_range(const encoded_block_range&) = delete;
+  encoded_block_range(encoded_block_range&&) = default;
   encoded_block_range& operator=(const encoded_block_range&) = delete;
   encoded_block_range& operator=(encoded_block_range&&) = default;
-
-  /**
-   * Releases the range object and all internal handles.
-   * All iterators are invalidated.
-   */
-  void release();
 
   /**
    * Decodes the next num_elem elements into the decode_target.
@@ -182,46 +158,15 @@ class encoded_block_range {
    * }
    */
   size_t decode_to(flexible_type* decode_target, size_t num_elem);
-
-  /**
-   * Skips some number of elements
-   */
   void skip(size_t n);
+  void release();
 
   ~encoded_block_range();
 
  private:
 
-  /**************************************************************************/
-  /*                                                                        */
-  /*                       The data I am reading from                       */
-  /*                                                                        */
-  /**************************************************************************/
   encoded_block::block m_block;
-
-  /**************************************************************************/
-  /*                                                                        */
-  /*                          The coroutine types                           */
-  /*                                                                        */
-  /**************************************************************************/
-  typedef boost::coroutines::coroutine<void>::pull_type coroutine_type;
-  coroutine_type source;
-
-  void coroutine_launch();
-  void call_source();
-  std::shared_ptr<coro_shared_data> m_shared;
-
-  /**************************************************************************/
-  /*                                                                        */
-  /*                          Iterator management                           */
-  /*                                                                        */
-  /**************************************************************************/
-
-  /// True if there is no more data
-  bool coroutine_started = false;
-
-  /// Fills up to numel elements starting from the pointer at write_target
-  size_t fill_buffer(flexible_type* write_target, size_t numel);
+  std::unique_ptr<typed_decode_stream> decoder;
 
 }; // encoded_block_range
 

--- a/src/core/storage/sframe_data/sarray_v2_type_encoding.cpp
+++ b/src/core/storage/sframe_data/sarray_v2_type_encoding.cpp
@@ -9,7 +9,7 @@
 #include <core/storage/sframe_data/sarray_v2_type_encoding.hpp>
 #include <core/util/dense_bitset.hpp>
 #include <core/storage/sframe_data/integer_pack.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 
 namespace turi {
 namespace v2_block_impl {
@@ -1033,19 +1033,19 @@ size_t typed_decode_stream::read(const std::pair<flexible_type*, size_t>& decode
   if (perform_type_decoding) {
     if (num_types == 1) {
       if (decodebuffer.first && column_type == flex_type_enum::UNDEFINED) {
-        for (size_t i = 0;i < decodebuffer.second; ++i) {
-          decodebuffer.first[i] = FLEX_UNDEFINED;
+        for (size_t idx = 0;idx < decodebuffer.second; ++idx) {
+          decodebuffer.first[idx] = FLEX_UNDEFINED;
         }
       } else {
-        for (size_t i = 0;i < decodebuffer.second; ++i) {
-          decodebuffer.first[i] = flexible_type();
+        for (size_t idx = 0;idx < decodebuffer.second; ++idx) {
+          decodebuffer.first[idx] = flexible_type();
         }
       }
     } else if (num_types == 2) {
       if (skip) {
         size_t effective_skip = 0;
         // compute the effective skip
-        for (i = 0;i < skip; ++i) {
+        for (size_t idx = 0;idx < skip; ++idx) {
           effective_skip += !undefined_bitmap.get(last_id);
           ++last_id;
         }
@@ -1160,11 +1160,11 @@ size_t typed_decode_stream::pad_retbuf_with_undefined_positions(const std::pair<
   // fill the ret buffer with the appropriate undefined values
   // in the right positions
   if (num_undefined && decodebuffer.first) {
-    for (size_t i = 0;i < decodebuffer.second; ++i) {
+    for (size_t idx = 0;idx < decodebuffer.second; ++idx) {
       if (undefined_bitmap.get(last_id)) {
-        decodebuffer.first[i] = FLEX_UNDEFINED;
+        decodebuffer.first[idx] = FLEX_UNDEFINED;
       } else {
-        decodebuffer.first[i] = flexible_type();
+        decodebuffer.first[idx] = flexible_type();
         ++nvals;
       }
       ++last_id;

--- a/src/core/storage/sframe_data/sarray_v2_type_encoding.cpp
+++ b/src/core/storage/sframe_data/sarray_v2_type_encoding.cpp
@@ -9,7 +9,7 @@
 #include <core/storage/sframe_data/sarray_v2_type_encoding.hpp>
 #include <core/util/dense_bitset.hpp>
 #include <core/storage/sframe_data/integer_pack.hpp>
-
+#include <util/coro.hpp>
 
 namespace turi {
 namespace v2_block_impl {
@@ -287,17 +287,9 @@ static void encode_string(block_info& info,
 static void decode_string(iarchive& iarc,
                           std::vector<flexible_type>& ret,
                           size_t num_undefined) {
-  unsigned int last_id = 0;
-  decode_string_stream(ret.size() - num_undefined, iarc,
-                       [&](flexible_type val) {
-                         while(last_id < ret.size() &&
-                               ret[last_id].get_type() == flex_type_enum::UNDEFINED) {
-                           ++last_id;
-                         }
-                         ret[last_id] = val;
-                         DASSERT_LT(last_id, ret.size());
-                         ++last_id;
-                       });
+  decode_string_stream strm;
+  strm.read(ret.size() - num_undefined, iarc,
+            {ret.data(), ret.size()}, 0);
 }
 
 /**
@@ -340,17 +332,11 @@ static void decode_vector(iarchive& iarc,
                           std::vector<flexible_type>& ret,
                           size_t num_undefined,
                           bool new_format) {
-  unsigned int last_id = 0;
-  decode_vector_stream(ret.size() - num_undefined, iarc,
-                       [&](flexible_type val) {
-                         while(last_id < ret.size() &&
-                               ret[last_id].get_type() == flex_type_enum::UNDEFINED) {
-                           ++last_id;
-                         }
-                         ret[last_id] = val;
-                         DASSERT_LT(last_id, ret.size());
-                         ++last_id;
-                       }, new_format);
+  decode_vector_stream strm;
+  strm.read(ret.size() - num_undefined, iarc,
+            {ret.data(), ret.size()},
+            0,
+            new_format);
 }
 
 
@@ -414,17 +400,11 @@ static void decode_nd_vector(iarchive& iarc,
                           std::vector<flexible_type>& ret,
                           size_t num_undefined,
                           bool new_format) {
-  unsigned int last_id = 0;
-  decode_nd_vector_stream(ret.size() - num_undefined, iarc,
-                       [&](flexible_type val) {
-                         while(last_id < ret.size() &&
-                               ret[last_id].get_type() == flex_type_enum::UNDEFINED) {
-                           ++last_id;
-                         }
-                         ret[last_id] = val;
-                         DASSERT_LT(last_id, ret.size());
-                         ++last_id;
-                       }, new_format);
+  decode_ndvector_stream strm;
+  strm.read(ret.size() - num_undefined, iarc,
+            {ret.data(), ret.size()},
+            0,
+            new_format);
 }
 
 void typed_encode(const std::vector<flexible_type>& data,
@@ -597,7 +577,601 @@ bool typed_decode(const block_info& info,
 }
 
 
+/**************************************************************************/
+/*                                                                        */
+/*                             Stream Classes                             */
+/*                                                                        */
+/**************************************************************************/
+/*
+*/
 
+/**
+ * Puts a value into decodebuffer, or skips a value.
+ * These macros here are extremely subtle and should not be messed with.
+ *
+ * Abstractly, this does something very simple.
+ *  - put a value into the decodebuffer, skipping undefined and advancing decode_bufpos
+ *  - OR decrement skip
+ *  - yield when we run out of buffer or run out of skip.
+ *
+ * However, what took a while to get right is that on resumption of
+ * the coroutine, the state of decode_bufpos, decode_buffer and skip can be
+ * arbitrary. We may also not find a place in our buffer to put the new value,
+ * before we have to yield.
+ *
+ * To make this work, the 2 key invariants to keep in mind is that:
+ *  - We yield we when we run out of buffer space
+ *    decode_bufpos >= decodebuffer.second, skip == 0
+ *  - The loop keeps running until we consumed the value.
+ *
+ * Note about the buffer space invariant. Technically, the full form is that
+ * buffer is full if
+ * \code
+ * (decode_buffer.first != nullptr && decode_bufpos == decodebuffer.second) ||
+ * (decode_buffer.first == nullptr && skip == 0)
+ * \endcode
+ *
+ * However, enforcing the following 2 constraints:
+ *   1) IF decode_buffer.first == nullptr THEN decode_buffer.second == 0
+ *   2) IF decode_buffer.first != nullptr THEN skip == 0 on entry
+ *
+ * We can first generalize the constraint as
+ * \code
+ * (decode_buffer.first != nullptr && decode_bufpos == decodebuffer.second) ||
+ * (decode_buffer.first == nullptr && skip == 0)
+ *
+ * <==
+ * // no harm expanding the bounds check
+ * (decode_buffer.first != nullptr && decode_bufpos >= decodebuffer.second) ||
+ * (decode_buffer.first == nullptr && skip == 0)
+ *
+ * <==>
+ *
+ * // adding decode_bufpos >= 0 does nothing here since it is size_t anyway
+ * (decode_buffer.first != nullptr && decode_bufpos >= decodebuffer.second) ||
+ * (decode_buffer.first == nullptr && decode_bufpos >= 0 && skip == 0)
+ *
+ * <==>
+ *
+ * // Constraint 1, decodebuffer.second == 0 if I am skipping. Substitute.
+ * (decode_buffer.first != nullptr && decode_bufpos >= decodebuffer.second) ||
+ * (decode_buffer.first == nullptr && decode_bufpos >= decodebuffer.second && skip == 0)
+ *
+ * <==>
+ *
+ * // Constraint 2, skip == 0 if I am not skipping. So adding useless constraint
+ * (decode_buffer.first != nullptr && decode_bufpos >= decodebuffer.second && skip == 0) ||
+ * (decode_buffer.first == nullptr && decode_bufpos >= decodebuffer.second && skip == 0)
+ *
+ * <==>
+ * // simplify
+ * decode_bufpos >= decodebuffer.second && skip == 0
+ * \endcode
+ *
+ * Funnily it took me a little time to formalize this, but when I wrote it
+ * in code the first time, it was quite intuitive...
+ */
+#define PUT_BUFFER(x) \
+   while(1) { \
+     __brk = false; \
+     if (skip == 0) { \
+       if (decodebuffer.first[decode_bufpos].get_type() != flex_type_enum::UNDEFINED) {  \
+         decodebuffer.first[decode_bufpos] = (x);  \
+         __brk = true; \
+       } \
+       ++decode_bufpos; \
+     } else { \
+       --skip; \
+       ++decode_bufpos;  \
+       __brk = true; \
+     } \
+     if (decode_bufpos >= decodebuffer.second && skip == 0) { CORO_YIELD(decode_bufpos); } \
+     if (__brk) break; \
+   }
+
+/**
+ * Puts a value into decodebuffer and skips multiple values.
+ * These macros here are extremely subtle and should not be messed with.
+ * Also see the documentation in \ref PUT_BUFFER for details.
+ *
+ * This is like \ref PUT_BUFFER, but takes an additional IDX and LIMIT argument
+ * which allows for value skipping. IDX must be a simple variable, as this
+ * may work to increment it.
+ *
+ * Once again the key invariants are
+ *  - We yield we when we run out of buffer space
+ *    decode_bufpos >= decodebuffer.second, skip == 0
+ *  - The loop keeps running until we consumed the value.
+ *
+ *  Note that in the skipping part, we see IDX += elem_to_skip - 1
+ *  The "- 1" is because we expect there to be a normal IDX increment since
+ *  we "consumed" one value. For instance, in the non-skip case, we do not
+ *  advance IDX since we expect the caller to be advancing IDX in a separate
+ *  place. Hence similarly here, we advance IDX by 1 less to account for the
+ *  current element we are supposed to be consuming.
+ *
+ *  An alternative way to write this which makes it clearer is:
+ *  ```
+ *  else {
+ *     // skip one element. Just like in PUT_BUFFER
+ *     skip--;
+ *     decode_bufpos++;
+ *     __brk = true;
+ *
+ *     // calculate how many more we might be able to skip
+ *     size_t more_skip = std::min<size_t>(LIMIT - IDX, skip);
+ *     if (more_skip) {
+ *       IDX += more_skip;
+ *       skip -= more_skip;
+ *       decode_bufpos += more_skip;
+ *     }
+ *  }
+ *  ```
+ */
+#define PUT_BUFFER_SKIP(x, IDX, LIMIT) \
+   while(1) { \
+     __brk = false; \
+     if (skip == 0) { \
+       if (decodebuffer.first[decode_bufpos].get_type() != flex_type_enum::UNDEFINED) {  \
+         decodebuffer.first[decode_bufpos] = (x);  \
+         __brk = true; \
+       } \
+       ++decode_bufpos; \
+     } else { \
+       size_t elem_to_skip = std::min<size_t>(LIMIT - IDX, skip); \
+       if (elem_to_skip > 0) { \
+         IDX += elem_to_skip - 1; \
+         skip -= elem_to_skip; \
+         decode_bufpos += elem_to_skip; \
+         __brk = true; \
+       } \
+     } \
+     if (decode_bufpos >= decodebuffer.second && skip == 0) { CORO_YIELD(decode_bufpos); } \
+     if (__brk) break; \
+   }
+
+
+size_t decode_number_stream::read(size_t _num_elements,
+                                  iarchive& iarc,
+                                  const std::pair<flexible_type*, size_t>& decodebuffer,
+                                  size_t skip) {
+  size_t decode_bufpos = 0;
+  CORO_BEGIN(read)
+  num_elements = _num_elements;
+  while(num_elements > 0) {
+    buflen = std::min<size_t>(num_elements, MAX_INTEGERS_PER_BLOCK);
+    frame_of_reference_decode_128(iarc, buflen, buf);
+    for (i = 0;i < buflen; ++i) {
+      PUT_BUFFER_SKIP(flexible_type(buf[i]), i, buflen);
+    }
+    num_elements -= buflen;
+  }
+  CORO_END;
+  return decode_bufpos;
+}
+
+
+bool decode_double_stream_legacy::read(size_t _num_elements,
+          iarchive& iarc,
+          const std::pair<flexible_type*, size_t>& decodebuffer,
+          size_t skip) {
+  size_t decode_bufpos = 0;
+  CORO_BEGIN(read)
+  num_elements = _num_elements;
+  while(num_elements > 0) {
+    buflen = std::min<size_t>(num_elements, MAX_INTEGERS_PER_BLOCK);
+    frame_of_reference_decode_128(iarc, buflen, buf);
+    for (i = 0;i < buflen; ++i) {
+      {
+        size_t intval = (buf[i] >> 1) | (buf[i] << 63);
+        // make a double flexible_type
+        ret.reinterpret_mutable_get<flex_int>() = intval;
+      }
+      PUT_BUFFER_SKIP(ret,i,buflen);
+    }
+    num_elements -= buflen;
+  }
+  CORO_END;
+  return decode_bufpos;
+}
+
+
+
+bool decode_double_stream::read(size_t _num_elements,
+          iarchive& iarc,
+          const std::pair<flexible_type*, size_t>& decodebuffer,
+          size_t skip) {
+  size_t decode_bufpos = 0;
+  CORO_BEGIN(read)
+  num_elements = _num_elements;
+  // we reserve one character so we can add new encoders as needed in the future
+  reserved = 0;
+  iarc.read(&(reserved), sizeof(reserved));
+  ASSERT_LT(reserved, 3);
+  if (reserved == DOUBLE_RESERVED_FLAGS::LEGACY_ENCODING) {
+    do {
+      decode_bufpos = legacy.read(num_elements, iarc, decodebuffer, skip);
+      CORO_YIELD(decode_bufpos);
+    } while(CLASS_CORO_RUNNING(legacy, read));
+  } else if (reserved == DOUBLE_RESERVED_FLAGS::INTEGER_ENCODING) {
+    while(num_elements > 0) {
+      buflen = std::min<size_t>(num_elements, MAX_INTEGERS_PER_BLOCK);
+      frame_of_reference_decode_128(iarc, buflen, buf);
+      for (i = 0;i < buflen; ++i) {
+        PUT_BUFFER_SKIP(flexible_type((flex_float)(int64_t)(buf[i])), i, buflen);
+      }
+      num_elements -= buflen;
+    }
+  }
+  CORO_END;
+  return decode_bufpos;
+}
+
+
+bool decode_string_stream::read(size_t _num_elements,
+          iarchive& iarc,
+          const std::pair<flexible_type*, size_t>& decodebuffer,
+          size_t skip) {
+  size_t decode_bufpos = 0;
+  CORO_BEGIN(read)
+  num_elements = _num_elements;
+  idx_values.resize(num_elements, flexible_type(flex_type_enum::INTEGER));
+  iarc >> use_dictionary_encoding;
+  if (use_dictionary_encoding) {
+    variable_decode(iarc, num_values);
+    str_values.resize(num_values);
+    for (auto& str: str_values) {
+      std::string new_str;
+      uint64_t str_len;
+      variable_decode(iarc, str_len);
+      new_str.resize(str_len);
+      iarc.read(&(new_str[0]), str_len);
+      str = std::move(new_str);
+    }
+    decode_number(iarc, idx_values, 0);
+    for (i = 0;i < num_elements; ++i) {
+      PUT_BUFFER_SKIP(str_values[idx_values[i].get<flex_int>()], i, num_elements);
+    }
+  } else {
+    // get all the lengths
+    decode_number(iarc, idx_values, 0);
+    for (i = 0;i < num_elements; ++i) {
+      {
+        size_t str_len = idx_values[i].get<flex_int>();
+        ret.mutable_get<std::string>().resize(str_len);
+        iarc.read(&(ret.mutable_get<std::string>()[0]), str_len);
+      }
+      PUT_BUFFER(ret);
+    }
+  }
+  CORO_END;
+  return decode_bufpos;
+}
+
+
+
+bool decode_vector_stream::read(size_t _num_elements,
+          iarchive& iarc,
+          const std::pair<flexible_type*, size_t>& decodebuffer,
+          size_t skip,
+          bool new_format) {
+  size_t decode_bufpos = 0;
+  CORO_BEGIN(read)
+  num_elements = _num_elements;
+  // we reserve one character so we can add new encoders as needed in the future
+  if (new_format) {
+    iarc.read(&(reserved), sizeof(reserved));
+  }
+  // decode the length of each vector
+  lengths.resize(num_elements);
+  decode_number(iarc, lengths, 0);
+  total_num_values = 0;
+  for (const flexible_type& length : lengths) {
+    total_num_values += length.get<flex_int>();
+  }
+
+  // decode the values
+  values.resize(total_num_values);
+  if (new_format) {
+    decode_double(iarc, values, 0);
+  } else {
+    decode_double_legacy(iarc, values, 0);
+  }
+
+  length_ctr = 0;
+  value_ctr = 0;
+  for (i = 0 ;i < num_elements; ++i) {
+    {
+      flex_vec& output_vec = ret.mutable_get<flex_vec>();
+      // resize this to the appropriate length
+      output_vec.resize(lengths[length_ctr].get<flex_int>());
+      ++length_ctr;
+      // fill in the value
+      for(j = 0; j < output_vec.size(); ++j) {
+        output_vec[j] = values[value_ctr].reinterpret_get<flex_float>();
+        ++value_ctr;
+      }
+    }
+    PUT_BUFFER(ret);
+  }
+  CORO_END
+  return decode_bufpos;
+}
+
+
+bool decode_ndvector_stream::read(size_t _num_elements,
+          iarchive& iarc,
+          const std::pair<flexible_type*, size_t>& decodebuffer,
+          size_t skip,
+          bool new_format) {
+  size_t decode_bufpos = 0;
+  CORO_BEGIN(read)
+  num_elements = _num_elements;
+  // new_format is ignored. it should always be true.
+  // one character is reserved so we can add new encoders as needed in the future
+  iarc.read(&(reserved), sizeof(reserved));
+
+  shape_lengths.resize(num_elements);
+  numel.resize(num_elements);
+
+  // decode shape lengths and numel
+  decode_number(iarc, shape_lengths, 0);
+  decode_number(iarc, numel, 0);
+
+  // compute the length of shapes and strides
+  sum_shape_len = 0;
+  for (auto s : shape_lengths) sum_shape_len += s.get<flex_int>();
+  // decode shape and strides
+  shapes.resize(sum_shape_len);
+  strides.resize(sum_shape_len);
+  decode_number(iarc, shapes, 0);
+  decode_number(iarc, strides, 0);
+
+  // compute the length of values
+  sum_values_len = 0;
+  for (auto s : numel) sum_values_len += s.get<flex_int>();
+  values.resize(sum_values_len);
+  decode_double(iarc, values, 0);
+
+  // emit
+  shape_stride_ctr = 0;
+  value_ctr = 0;
+
+  for (i = 0 ;i < num_elements; ++i) {
+    // construct the shape and stride
+    ret_shape.resize(shape_lengths[i]);
+    ret_stride.resize(shape_lengths[i]);
+    for (j = 0;j < shape_lengths[i]; ++j) {
+      ret_shape[j] = shapes[shape_stride_ctr].get<flex_int>();
+      ret_stride[j] = strides[shape_stride_ctr].get<flex_int>();
+      ++shape_stride_ctr;
+    }
+
+    // construct the values
+    ret_numel = numel[i].get<flex_int>();
+    ret_values = std::make_shared<flex_nd_vec::container_type>(ret_numel);
+    for (j = 0;j < ret_numel; ++j) {
+      (*ret_values)[j] = values[j + value_ctr].reinterpret_get<flex_float>();
+    }
+    value_ctr += ret_numel;
+    PUT_BUFFER(flexible_type(flex_nd_vec(ret_values, ret_shape, ret_stride)));
+  }
+  CORO_END
+  return decode_bufpos;
+}
+
+typed_decode_stream::typed_decode_stream(const block_info& info,
+                                         char* start, size_t len)
+  :info(info),start(start),len(len), iarc(start, len), generic_deserializer{iarc} {
+    // some basic block properties which will be filled in
+    // number of elements
+    dsize = info.num_elem;
+    num_undefined = 0;
+    iarc >> num_types;
+    // if it is a multiple type block, we don't perform a type decode
+    perform_type_decoding = !(info.flags & MULTIPLE_TYPE_BLOCK);
+
+
+    if (!(info.flags & IS_FLEXIBLE_TYPE)) {
+      logstream(LOG_ERROR) << "Attempting to decode a non-typed block"
+                           << std::endl;
+      ASSERT_TRUE(info.flags & IS_FLEXIBLE_TYPE);
+    }
+
+    if (perform_type_decoding) {
+      if (num_types == 1) {
+        //  one block of contiguous type.
+        char c;
+        iarc >> c;
+        column_type = (flex_type_enum)c;
+      } else if (num_types == 2) {
+        // two types, but with undefined entries.
+        char c;
+        iarc >> c;
+        column_type = (flex_type_enum)c;
+        // read the bitset and undefine all the flagged entries
+        undefined_bitmap.resize(info.num_elem);
+        undefined_bitmap.clear();
+        iarc.read((char*)undefined_bitmap.array, sizeof(size_t)*undefined_bitmap.arrlen);
+        num_undefined = undefined_bitmap.popcount();
+      } else {
+        logstream(LOG_ERROR) << "Unexpected value for num_types: "
+                             << static_cast<int>(num_types)
+                             << " (expected 0, 1, or 2)" << std::endl;
+        ASSERT_TRUE(false);
+      }
+    }
+    elements_to_decode = dsize - num_undefined;
+  }
+
+typed_decode_stream::~typed_decode_stream() {
+  if (number_decoder) delete number_decoder;
+  if (double_decoder) delete double_decoder;
+  if (double_legacy_decoder) delete double_legacy_decoder;
+  if (string_decoder) delete string_decoder;
+  if (vector_decoder) delete vector_decoder;
+  if (ndvector_decoder) delete ndvector_decoder;
+}
+
+/**
+ * Decodes a collection of flexible_type values. The array must be of
+ * contiguous type, but permitting undefined values.
+ *
+ * See \ref typed_encode() for details.
+ *
+ * \note The coding does not store the number of values stored. This is
+ * stored in the block_info (block.num_elem)
+ */
+size_t typed_decode_stream::read(const std::pair<flexible_type*, size_t>& decodebuffer,
+                                 size_t skip) {
+  if (skip == 0) {
+    ASSERT_TRUE(decodebuffer.first != nullptr && decodebuffer.second > 0);
+  } else {
+    ASSERT_TRUE(decodebuffer.first == nullptr && decodebuffer.second == 0);
+  }
+  size_t decode_bufpos = 0;
+  if (perform_type_decoding) {
+    if (num_types == 1) {
+      if (decodebuffer.first && column_type == flex_type_enum::UNDEFINED) {
+        for (size_t i = 0;i < decodebuffer.second; ++i) {
+          decodebuffer.first[i] = FLEX_UNDEFINED;
+        }
+      } else {
+        for (size_t i = 0;i < decodebuffer.second; ++i) {
+          decodebuffer.first[i] = flexible_type();
+        }
+      }
+    } else if (num_types == 2) {
+      if (skip) {
+        size_t effective_skip = 0;
+        // compute the effective skip
+        for (i = 0;i < skip; ++i) {
+          effective_skip += !undefined_bitmap.get(last_id);
+          ++last_id;
+        }
+        skip = effective_skip;
+        if (skip == 0) return 0;
+      } else {
+        size_t nvals = pad_retbuf_with_undefined_positions(decodebuffer);
+        if (nvals == 0) return 0;
+      }
+    }
+  }
+
+  CORO_BEGIN(read)
+
+  if (perform_type_decoding) {
+    if (num_types == 0) {
+      // empty block
+      return 0;
+    } else if (num_types == 1 && column_type == flex_type_enum::UNDEFINED) {
+      // the CORO_BEGIN(read) prefix has already filled this with
+      // undefined values. So all is good and we just count how
+      // many we should actually be returning and return.
+      // We still use the CORO mechanic here so that CLASS_CORO_RUNNING
+      // can be used to detect if there is still stuff to read.
+      while(dsize > 0) {
+        if (skip) undefined_elem_consumed = std::min(dsize, skip);
+        else undefined_elem_consumed = std::min(dsize, decodebuffer.second);
+        dsize -= undefined_elem_consumed;
+        CORO_YIELD(undefined_elem_consumed);
+      }
+    }
+  } else {
+    iarc >> values;
+    for (i = 0; i < values.size(); ++i) {
+      PUT_BUFFER_SKIP(std::move(values[i]), i, values.size());
+    }
+    return decode_bufpos;
+  }
+
+
+  // the interesting decoder
+  if (perform_type_decoding) {
+
+    if (column_type == flex_type_enum::INTEGER) {
+      number_decoder = new decode_number_stream;
+      do {
+        decode_bufpos = number_decoder->read(elements_to_decode, iarc, decodebuffer, skip);
+        CORO_YIELD(decode_bufpos);
+      } while(CLASS_CORO_RUNNING(*number_decoder, read));
+      delete number_decoder;
+      number_decoder = nullptr;
+
+    } else if (column_type == flex_type_enum::FLOAT) {
+      if (info.flags & BLOCK_ENCODING_EXTENSION) {
+        double_decoder = new decode_double_stream;
+        do {
+          decode_bufpos = double_decoder->read(elements_to_decode, iarc, decodebuffer, skip);
+          CORO_YIELD(decode_bufpos);
+        } while(CLASS_CORO_RUNNING(*double_decoder, read));
+      delete double_decoder;
+      double_decoder = nullptr;
+      } else {
+        double_legacy_decoder = new decode_double_stream_legacy;
+        do {
+          decode_bufpos = double_legacy_decoder->read(elements_to_decode, iarc, decodebuffer, skip);
+          CORO_YIELD(decode_bufpos);
+        } while(CLASS_CORO_RUNNING(*double_legacy_decoder, read));
+      delete double_legacy_decoder;
+      double_legacy_decoder = nullptr;
+      }
+    } else if (column_type == flex_type_enum::STRING) {
+      string_decoder = new decode_string_stream;
+      do {
+        decode_bufpos = string_decoder->read(elements_to_decode, iarc, decodebuffer, skip);
+        CORO_YIELD(decode_bufpos);
+      } while(CLASS_CORO_RUNNING(*string_decoder, read));
+      delete string_decoder;
+      string_decoder = nullptr;
+    } else if (column_type == flex_type_enum::VECTOR) {
+      vector_decoder = new decode_vector_stream;
+      do {
+        decode_bufpos = vector_decoder->read(elements_to_decode, iarc, decodebuffer, skip,
+                                             info.flags & BLOCK_ENCODING_EXTENSION);
+        CORO_YIELD(decode_bufpos);
+      } while(CLASS_CORO_RUNNING(*vector_decoder, read));
+      delete vector_decoder;
+      vector_decoder = nullptr;
+    } else if (column_type == flex_type_enum::ND_VECTOR) {
+      ndvector_decoder = new decode_ndvector_stream;
+      do {
+        decode_bufpos = ndvector_decoder->read(elements_to_decode, iarc, decodebuffer, skip,
+                                               info.flags & BLOCK_ENCODING_EXTENSION);
+        CORO_YIELD(decode_bufpos);
+      } while(CLASS_CORO_RUNNING(*ndvector_decoder, read));
+      delete ndvector_decoder;
+      ndvector_decoder = nullptr;
+    } else {
+      for (i = 0;i < elements_to_decode; ++i) {
+        generic_ret = flexible_type(column_type);
+        generic_ret.apply_mutating_visitor(generic_deserializer);
+        PUT_BUFFER(std::move(generic_ret));
+      }
+    }
+  }
+  CORO_END
+  return decode_bufpos;
+}
+
+
+size_t typed_decode_stream::pad_retbuf_with_undefined_positions(const std::pair<flexible_type*, size_t>& decodebuffer) {
+  size_t nvals = 0;
+  // fill the ret buffer with the appropriate undefined values
+  // in the right positions
+  if (num_undefined && decodebuffer.first) {
+    for (size_t i = 0;i < decodebuffer.second; ++i) {
+      if (undefined_bitmap.get(last_id)) {
+        decodebuffer.first[i] = FLEX_UNDEFINED;
+      } else {
+        decodebuffer.first[i] = flexible_type();
+        ++nvals;
+      }
+      ++last_id;
+    }
+  }
+  return nvals;
+}
 
 } // namespace v2_block_impl
 } // namespace turi

--- a/src/core/storage/sframe_data/sarray_v2_type_encoding.hpp
+++ b/src/core/storage/sframe_data/sarray_v2_type_encoding.hpp
@@ -10,6 +10,7 @@
 #include <core/util/basic_types.hpp>
 #include <core/util/dense_bitset.hpp>
 #include <core/storage/sframe_data/integer_pack.hpp>
+#include <util/coro.hpp>
 namespace turi {
 
 
@@ -118,14 +119,6 @@ bool typed_decode(const block_info& info,
                   char* start, size_t len,
                   std::vector<flexible_type>& ret);
 
-/**
- * Decodes a colelction of flexible_type values calling a callback
- * on each value.
- * Returns false on failure.  See \ref typed_decode()
- */
-bool typed_decode_stream_callback(const block_info& info,
-                                  char* start, size_t len,
-                                  std::function<void(flexible_type)> retcallback);
 
 /**
  * Encodes a collection of flexible_type values. The array must be of
@@ -155,363 +148,265 @@ void typed_encode(const std::vector<flexible_type>& data,
 
 
 /**
- * Decodes num_elements of numbers, calling the callback for each number.
+ * Handle a stream decoding of integers.
+ *
+ * read acts as a coroutine where it is called multiple times to decode
+ * up to num_elements values from the archive. For each call either
+ * decodebuffer is set, or skip is set. At least 1 value must be read/skipped
+ * or there will be problems. num_elements and iarc should be the same on
+ * every call.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static void decode_number_stream(size_t num_elements,
-                                 iarchive& iarc,
-                                 Fn callback) {
+struct decode_number_stream {
+  DECL_CORO_STATE(read);
   uint64_t buf[MAX_INTEGERS_PER_BLOCK];
-  while(num_elements > 0) {
-    size_t buflen = std::min<size_t>(num_elements, MAX_INTEGERS_PER_BLOCK);
-    frame_of_reference_decode_128(iarc, buflen, buf);
-    for (size_t i = 0;i < buflen; ++i) {
-      callback(flexible_type(buf[i]));
-    }
-    num_elements -= buflen;
-  }
-}
+  size_t num_elements;
+  size_t buflen;
+  size_t i;
+  bool __brk;
+
+  size_t read(size_t num_elements,
+              iarchive& iarc,
+              const std::pair<flexible_type*, size_t>& decodebuffer,
+              size_t skip);
+};
 
 
 /**
- * Decodes num_elements of numbers, calling the callback for each number.
+ * Handle a stream decoding of double values (Old format).
+ *
+ * read acts as a coroutine where it is called multiple times to decode
+ * up to num_elements values from the archive. For each call either
+ * decodebuffer is set, or skip is set. At least 1 value must be read/skipped
+ * or there will be problems. num_elements and iarc should be the same on
+ * every call.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static void decode_double_stream_legacy(size_t num_elements,
-                                 iarchive& iarc,
-                                 Fn callback) {
+struct decode_double_stream_legacy{
+  DECL_CORO_STATE(read);
+  size_t num_elements;
   uint64_t buf[MAX_INTEGERS_PER_BLOCK];
-  while(num_elements > 0) {
-    size_t buflen = std::min<size_t>(num_elements, MAX_INTEGERS_PER_BLOCK);
-    frame_of_reference_decode_128(iarc, buflen, buf);
-    for (size_t i = 0;i < buflen; ++i) {
-      size_t intval = (buf[i] >> 1) | (buf[i] << 63);
-      // make a double flexible_type
-      flexible_type ret(0.0);
-      ret.reinterpret_mutable_get<flex_int>() = intval;
-      callback(ret);
-    }
-    num_elements -= buflen;
-  }
-}
+  size_t buflen;
+  size_t i;
+  turi::flexible_type ret;
+  bool __brk;
+
+  inline decode_double_stream_legacy():ret(0.0) { }
+
+  bool read(size_t num_elements,
+            iarchive& iarc,
+            const std::pair<flexible_type*, size_t>& decodebuffer,
+            size_t skip);
+};
 
 
 /**
- * Decodes num_elements of numbers, calling the callback for each number.
+ * Handle a stream decoding of double values (new format).
+ *
+ * read acts as a coroutine where it is called multiple times to decode
+ * up to num_elements values from the archive. For each call either
+ * decodebuffer is set, or skip is set. At least 1 value must be read/skipped
+ * or there will be problems. num_elements and iarc should be the same on
+ * every call.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static void decode_double_stream(size_t num_elements,
-                                 iarchive& iarc,
-                                 Fn callback) {
-  // we reserve one character so we can add new encoders as needed in the future
-  char reserved = 0;
-  iarc.read(&(reserved), sizeof(reserved));
-  ASSERT_LT(reserved, 3);
-  if (reserved == DOUBLE_RESERVED_FLAGS::LEGACY_ENCODING) {
-    decode_double_stream_legacy(num_elements, iarc, callback);
-    return;
-  } else if (reserved == DOUBLE_RESERVED_FLAGS::INTEGER_ENCODING) {
-    decode_number_stream(num_elements, iarc,
-                         [=](const flexible_type& val) {
-                           flex_float ret = flex_float(val.get<flex_int>());
-                           callback(ret);
-                         });
-  }
-}
+struct decode_double_stream{
+  DECL_CORO_STATE(read);
+  size_t num_elements;
 
+  char reserved;
+  decode_double_stream_legacy legacy;
+  uint64_t buf[MAX_INTEGERS_PER_BLOCK];
+  size_t buflen;
+  size_t i;
+  bool __brk;
+
+  bool read(size_t num_elements,
+            iarchive& iarc,
+            const std::pair<flexible_type*, size_t>& decodebuffer,
+            size_t skip);
+};
+
+/**
+ * Handle a stream decoding of string values (new format).
+ *
+ * read acts as a coroutine where it is called multiple times to decode
+ * up to num_elements values from the archive. For each call either
+ * decodebuffer is set, or skip is set. At least 1 value must be read/skipped
+ * or there will be problems. num_elements and iarc should be the same on
+ * every call.
+ */
+struct decode_string_stream{
+  DECL_CORO_STATE(read);
+  size_t num_elements;
+  bool use_dictionary_encoding = false;
+  std::vector<flexible_type> idx_values;
+  uint64_t num_values;
+  std::vector<flexible_type> str_values;
+  flexible_type ret;
+  size_t i;
+  bool __brk;
+
+  inline decode_string_stream():ret(flex_type_enum::STRING) { }
 
 /**
  * Decodes num_elements of strings , calling the callback for each string.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static void decode_string_stream(size_t num_elements,
-                                 iarchive& iarc,
-                                 Fn callback) {
-  bool use_dictionary_encoding = false;
-  std::vector<flexible_type> idx_values;
-  idx_values.resize(num_elements, flexible_type(flex_type_enum::INTEGER));
-  iarc >> use_dictionary_encoding;
-  if (use_dictionary_encoding) {
-    uint64_t num_values;
-    std::vector<flexible_type> str_values;
-    variable_decode(iarc, num_values);
-    str_values.resize(num_values);
-    for (auto& str: str_values) {
-      std::string new_str;
-      uint64_t str_len;
-      variable_decode(iarc, str_len);
-      new_str.resize(str_len);
-      iarc.read(&(new_str[0]), str_len);
-      str = std::move(new_str);
-    }
-    decode_number(iarc, idx_values, 0);
-    for (size_t i = 0;i < num_elements; ++i) {
-      callback(str_values[idx_values[i].get<flex_int>()]);
-    }
-  } else {
-    // get all the lengths
-    decode_number(iarc, idx_values, 0);
-    flexible_type ret(flex_type_enum::STRING);
-    for (size_t i = 0;i < num_elements; ++i) {
-      size_t str_len = idx_values[i].get<flex_int>();
-      ret.mutable_get<std::string>().resize(str_len);
-      iarc.read(&(ret.mutable_get<std::string>()[0]), str_len);
-      callback(ret);
-    }
-  }
-}
+  bool read(size_t num_elements,
+            iarchive& iarc,
+            const std::pair<flexible_type*, size_t>& decodebuffer,
+            size_t skip);
+};
 
 /**
- * Decodes num_elements of vectors, calling the callback for each string.
+ * Handle a stream decoding of vector values.
+ *
+ * read acts as a coroutine where it is called multiple times to decode
+ * up to num_elements values from the archive. For each call either
+ * decodebuffer is set, or skip is set. At least 1 value must be read/skipped
+ * or there will be problems. num_elements and iarc should be the same on
+ * every call.
  *
  * This is the 2nd generation vector decoder. its use is flagged by
  * turning on the block flag BLOCK_ENCODING_EXTENSION.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static void decode_vector_stream(size_t num_elements,
-                                 iarchive& iarc,
-                                 Fn callback,
-                                 bool new_format) {
-  // we reserve one character so we can add new encoders as needed in the future
-  if (new_format) {
-    char reserved = 0;
-    iarc.read(&(reserved), sizeof(reserved));
-  }
-  // decode the length of each vector
-  std::vector<flexible_type> lengths(num_elements);
-  decode_number(iarc, lengths, 0);
+struct decode_vector_stream {
+  DECL_CORO_STATE(read);
+  size_t num_elements;
+  char reserved;
+  std::vector<flexible_type> lengths;
   size_t total_num_values = 0;
-  for (const flexible_type& length : lengths) {
-    total_num_values += length.get<flex_int>();
-  }
-
-  // decode the values
-  std::vector<flexible_type> values(total_num_values);
-  if (new_format) {
-    decode_double(iarc, values, 0);
-  } else {
-    decode_double_legacy(iarc, values, 0);
-  }
-
+  std::vector<flexible_type> values;
   size_t length_ctr = 0;
   size_t value_ctr = 0;
-  flexible_type ret(flex_type_enum::VECTOR);
-  for (size_t i = 0 ;i < num_elements; ++i) {
-    flex_vec& output_vec = ret.mutable_get<flex_vec>();
-    // resize this to the appropriate length
-    output_vec.resize(lengths[length_ctr].get<flex_int>());
-    ++length_ctr;
-    // fill in the value
-    for(size_t j = 0; j < output_vec.size(); ++j) {
-      output_vec[j] = values[value_ctr].reinterpret_get<flex_float>();
-      ++value_ctr;
-    }
-    callback(ret);
-  }
-}
+  flexible_type ret;
+  size_t i,j;
+  bool __brk;
+
+  inline decode_vector_stream():ret(flex_type_enum::VECTOR) { }
+
+  bool read(size_t num_elements,
+            iarchive& iarc,
+            const std::pair<flexible_type*, size_t>& decodebuffer,
+            size_t skip,
+            bool new_format);
+};
+
 
 /**
- * Decodes num_elements of nd_vectors, calling the callback for each string.
+ * Handle a stream decoding of ndvector values.
+ *
+ * read acts as a coroutine where it is called multiple times to decode
+ * up to num_elements values from the archive. For each call either
+ * decodebuffer is set, or skip is set. At least 1 value must be read/skipped
+ * or there will be problems. num_elements and iarc should be the same on
+ * every call.
+ *
+ * This is the 2nd generation vector decoder. its use is flagged by
+ * turning on the block flag BLOCK_ENCODING_EXTENSION.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static void decode_nd_vector_stream(size_t num_elements,
-                                    iarchive& iarc,
-                                    Fn callback,
-                                    bool new_format) {
-  // new_format is ignored. it should always be true.
-  // one character is reserved so we can add new encoders as needed in the future
-  char reserved = 0;
-  iarc.read(&(reserved), sizeof(reserved));
-
-  std::vector<flexible_type> shape_lengths(num_elements);
-  std::vector<flexible_type> numel(num_elements);
+struct decode_ndvector_stream {
+  DECL_CORO_STATE(read);
+  size_t num_elements;
+  char reserved;
+  std::vector<flexible_type> shape_lengths;
+  std::vector<flexible_type> numel;
   std::vector<flexible_type> shapes;
   std::vector<flexible_type> strides;
   std::vector<flexible_type> values;
-
-  // decode shape lengths and numel
-  decode_number(iarc, shape_lengths, 0);
-  decode_number(iarc, numel, 0);
-
-  // compute the length of shapes and strides
   size_t sum_shape_len = 0;
-  for (auto i : shape_lengths) sum_shape_len += i.get<flex_int>();
-  // decode shape and strides
-  shapes.resize(sum_shape_len);
-  strides.resize(sum_shape_len);
-  decode_number(iarc, shapes, 0);
-  decode_number(iarc, strides, 0);
-
-  // compute the length of values
   size_t sum_values_len = 0;
-  for (auto i : numel) sum_values_len += i.get<flex_int>();
-  values.resize(sum_values_len);
-  decode_double(iarc, values, 0);
-
-  // emit
   size_t shape_stride_ctr = 0;
   size_t value_ctr = 0;
-
   std::vector<size_t> ret_shape;
   std::vector<size_t> ret_stride;
+  size_t ret_numel;
+  std::shared_ptr<flex_nd_vec::container_type> ret_values;
+  size_t i, j;
+  bool __brk;
+  /**
+   * Decodes num_elements of nd_vectors, calling the callback for each string.
+   */
+  bool read(size_t num_elements,
+            iarchive& iarc,
+            const std::pair<flexible_type*, size_t>& decodebuffer,
+            size_t skip,
+            bool new_format);
 
-  for (size_t i = 0 ;i < num_elements; ++i) {
-    // construct the shape and stride
-    ret_shape.resize(shape_lengths[i]);
-    ret_stride.resize(shape_lengths[i]);
-    for (size_t j = 0;j < shape_lengths[i]; ++j) {
-      ret_shape[j] = shapes[shape_stride_ctr].get<flex_int>();
-      ret_stride[j] = strides[shape_stride_ctr].get<flex_int>();
-      ++shape_stride_ctr;
-    }
-
-    // construct the values
-    size_t ret_numel = numel[i].get<flex_int>();
-    auto ret_values = std::make_shared<flex_nd_vec::container_type>(ret_numel);
-    for (size_t i = 0;i < ret_numel; ++i) {
-      (*ret_values)[i] = values[i + value_ctr].reinterpret_get<flex_float>();
-    }
-    value_ctr += ret_numel;
-    flexible_type ret(flex_nd_vec(ret_values, ret_shape, ret_stride));
-    callback(ret);
-  }
-}
-
-
-
+};
 
 
 /**
- * Decodes a collection of flexible_type values. The array must be of
- * contiguous type, but permitting undefined values.
+ * Handle a stream decoding of flexible_type values.
  *
- * See \ref typed_encode() for details.
+ * read acts as a coroutine where it is called multiple times to decode
+ * flexible_type values from a block. For each call either
+ * decodebuffer is set, or skip is set.
  *
- * \note The coding does not store the number of values stored. This is
- * stored in the block_info (block.num_elem)
+ * This is the 2nd generation vector decoder. its use is flagged by
+ * turning on the block flag BLOCK_ENCODING_EXTENSION.
  */
-template <typename Fn> // Fn is a function like void(flexible_type)
-static bool typed_decode_stream_callback(const block_info& info,
-                                  char* start, size_t len,
-                                  Fn callback) {
-  if (!(info.flags & IS_FLEXIBLE_TYPE)) {
-    logstream(LOG_ERROR) << "Attempting to decode a non-typed block"
-                         << std::endl;
-    return false;
-  }
-  turi::iarchive iarc(start, len);
+struct typed_decode_stream {
+  DECL_CORO_STATE(read);
+  block_info info;
+  char* start;
+  size_t len;
+  turi::iarchive iarc;
 
-  // some basic block properties which will be filled in
-  // number of elements
-  size_t dsize = info.num_elem;
-  // column type
+  size_t dsize;
   flex_type_enum column_type;
-  // num undefined.
-  size_t num_undefined = 0;
-  // undefined bitmap mapping out where are the undefined values.
-  // only specified if num_undefined > 0
+  size_t num_undefined;
   turi::dense_bitset undefined_bitmap;
-
   char num_types;
-  iarc >> num_types;
-  // if it is a multiple type block, we don't perform a type decode
-  bool perform_type_decoding = !(info.flags & MULTIPLE_TYPE_BLOCK);
-  if (perform_type_decoding) {
-    if (num_types == 0) {
-      // empty block
-      return true;
-    } else if (num_types == 1) {
-      //  one block of contiguous type.
-      char c;
-      iarc >> c;
-      column_type = (flex_type_enum)c;
-      // all undefined. generate and return
-      if (column_type == flex_type_enum::UNDEFINED) {
-        for (size_t i = 0;i < dsize; ++i) callback(FLEX_UNDEFINED);
-        return true;
-      }
-    } else if (num_types == 2) {
-      // two types, but with undefined entries.
-      char c;
-      iarc >> c;
-      column_type = (flex_type_enum)c;
-      // read the bitset and undefine all the flagged entries
-      undefined_bitmap.resize(info.num_elem);
-      undefined_bitmap.clear();
-      iarc.read((char*)undefined_bitmap.array, sizeof(size_t)*undefined_bitmap.arrlen);
-      num_undefined = undefined_bitmap.popcount();
-    } else {
-      logstream(LOG_ERROR) << "Unexpected value for num_types: "
-                           << static_cast<int>(num_types)
-                           << " (expected 0, 1, or 2)" << std::endl;
-      return false;
-    }
-  } else {
-    std::vector<flexible_type> values;
-    iarc >> values;
-    for (const auto& i: values) {
-      callback(i);
-    }
-  }
+  bool perform_type_decoding;
+  size_t i;
+  std::vector<flexible_type> values;
+  size_t last_id = 0;
+  size_t elements_to_decode;
+  size_t undefined_elem_consumed;
+  bool __brk;
 
-  if (perform_type_decoding) {
-    int last_id = 0;
-    auto stream_callback =
-        [&](const flexible_type& val) {
-          // generate all the undefined
-          if (num_undefined) {
-            while(last_id < truncate_check<int64_t>(dsize) &&
-                  undefined_bitmap.get(last_id)) {
-              callback(FLEX_UNDEFINED);
-              ++last_id;
-            }
-          }
-          callback(val);
-          ++last_id;
-        };
-    size_t elements_to_decode = dsize - num_undefined;
-    if (column_type == flex_type_enum::INTEGER) {
-      decode_number_stream(elements_to_decode, iarc, stream_callback);
-    } else if (column_type == flex_type_enum::FLOAT) {
-      if (info.flags & BLOCK_ENCODING_EXTENSION) {
-        decode_double_stream(elements_to_decode, iarc, stream_callback);
-      } else {
-        decode_double_stream_legacy(elements_to_decode, iarc, stream_callback);
-      }
-    } else if (column_type == flex_type_enum::STRING) {
-      decode_string_stream(elements_to_decode, iarc, stream_callback);
-    } else if (column_type == flex_type_enum::VECTOR) {
-      decode_vector_stream(elements_to_decode, iarc, stream_callback,
-                           info.flags & BLOCK_ENCODING_EXTENSION);
-    } else if (column_type == flex_type_enum::ND_VECTOR) {
-      decode_nd_vector_stream(elements_to_decode, iarc, stream_callback,
-                           info.flags & BLOCK_ENCODING_EXTENSION);
-    } else {
-      flexible_type_impl::deserializer s{iarc};
-      flexible_type ret(column_type);
-      for (size_t i = 0;i < dsize; ++i) {
-        if (num_undefined && undefined_bitmap.get(i)) {
-          callback(FLEX_UNDEFINED);
-        } else {
-          ret.apply_mutating_visitor(s);
-          callback(ret);
-        }
-      }
-    }
-    // generate the final undefined values
-    if (num_undefined) {
-      while(last_id < truncate_check<int64_t>(dsize) &&
-            undefined_bitmap.get(last_id)) {
-        callback(FLEX_UNDEFINED);
-        ++last_id;
-      }
-    }
-  }
-  return true;
-}
+  decode_number_stream* number_decoder = nullptr;
+  decode_double_stream* double_decoder = nullptr;
+  decode_double_stream_legacy* double_legacy_decoder = nullptr;
+  decode_string_stream* string_decoder = nullptr;
+  decode_vector_stream* vector_decoder = nullptr;
+  decode_ndvector_stream* ndvector_decoder = nullptr;
+
+  flexible_type_impl::deserializer generic_deserializer;
+  flexible_type generic_ret;
+  typed_decode_stream(const block_info& info,
+                      char* start, size_t len);
+
+  ~typed_decode_stream();
+
+  /**
+   * Decodes a collection of flexible_type values.
+   *
+   * decodebuffer points to a target location and length. skip is the
+   * number of elements to skip. Either
+   *
+   * 1) decodebuffer.first != nullptr, decodebuffer.second > 0, skip == 0
+   * OR
+   * 2) decodebuffer.first == nullptr, decodebuffer.second == 0, skip > 0
+   *
+   * This method can be called repeatedly to extract more values from the
+   * buffer, but note that the buffer is 1 pass only.  caller must make sure
+   * to not read more than the actual number of values in the block, or bad
+   * things will happen.
+   *
+   * \note The coding does not store the number of values stored. This is
+   * stored in the block_info (block.num_elem)
+   *
+   * Returns the number of actual values skipped or decoded
+   * (excluding undefined values).
+   */
+  size_t read(const std::pair<flexible_type*, size_t>& decodebuffer, size_t skip);
+ private:
+  size_t pad_retbuf_with_undefined_positions(const std::pair<flexible_type*, size_t>& decodebuffer);
+
+};
 
 } // namespace v2_block_impl
 
 /// \}
 } // namespace turi
+
 #endif

--- a/src/core/storage/sframe_data/sarray_v2_type_encoding.hpp
+++ b/src/core/storage/sframe_data/sarray_v2_type_encoding.hpp
@@ -10,7 +10,7 @@
 #include <core/util/basic_types.hpp>
 #include <core/util/dense_bitset.hpp>
 #include <core/storage/sframe_data/integer_pack.hpp>
-#include <util/coro.hpp>
+#include <core/util/coro.hpp>
 namespace turi {
 
 

--- a/src/core/storage/sframe_data/sframe_rows.hpp
+++ b/src/core/storage/sframe_data/sframe_rows.hpp
@@ -296,6 +296,10 @@ class sframe_rows {
           const row* m_source = nullptr;
           size_t m_current_idx = 0;
           const_iterator() { }
+          const_iterator(const const_iterator&) = default;
+          const_iterator(const_iterator&&) = default;
+          const_iterator& operator=(const const_iterator&) = default;
+          const_iterator& operator=(const_iterator&&) = default;
           /// default constructor
           explicit const_iterator(const sframe_rows::row& source, size_t current_idx = 0):
               m_source(&source), m_current_idx(current_idx) { };
@@ -356,6 +360,24 @@ class sframe_rows {
     row m_row;
     /// default constructor
     const_iterator() {}
+    const_iterator(const const_iterator& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+    }
+    const_iterator(const_iterator&& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+    }
+    const_iterator& operator=(const const_iterator& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+      return *this;
+    }
+    const_iterator& operator=(const_iterator&& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+      return *this;
+    }
     explicit const_iterator(const sframe_rows* source, size_t current_row_number = 0):
         m_row(source, current_row_number) { };
    private:
@@ -398,6 +420,24 @@ class sframe_rows {
     mutable row m_row;
     /// default constructor
     iterator() {}
+    iterator(const iterator& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+    }
+    iterator(iterator&& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+    }
+    iterator& operator=(const iterator& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+      return *this;
+    }
+    iterator& operator=(iterator&& other) {
+      m_source = other.m_source;
+      m_row.copy_reference(other.m_row);
+      return *this;
+    }
     explicit iterator(sframe_rows* source, size_t current_row_number = 0):
         m_row(source, current_row_number) { };
    private:

--- a/src/core/storage/sframe_data/sframe_rows.hpp
+++ b/src/core/storage/sframe_data/sframe_rows.hpp
@@ -425,8 +425,8 @@ class sframe_rows {
       m_row.copy_reference(other.m_row);
     }
     iterator(iterator&& other) {
-      m_source = other.m_source;
-      m_row.copy_reference(other.m_row);
+      m_source = std::move(other.m_source);
+      m_row = std::move(other.m_row);
     }
     iterator& operator=(const iterator& other) {
       m_source = other.m_source;
@@ -434,8 +434,8 @@ class sframe_rows {
       return *this;
     }
     iterator& operator=(iterator&& other) {
-      m_source = other.m_source;
-      m_row.copy_reference(other.m_row);
+      m_source = std::move(other.m_source);
+      m_row = std::move(other.m_row);
       return *this;
     }
     explicit iterator(sframe_rows* source, size_t current_row_number = 0):

--- a/src/core/storage/sframe_data/sframe_rows.hpp
+++ b/src/core/storage/sframe_data/sframe_rows.hpp
@@ -426,7 +426,7 @@ class sframe_rows {
     }
     iterator(iterator&& other) {
       m_source = std::move(other.m_source);
-      m_row = std::move(other.m_row);
+      m_row.copy_reference(other.m_row);
     }
     iterator& operator=(const iterator& other) {
       m_source = other.m_source;
@@ -435,7 +435,7 @@ class sframe_rows {
     }
     iterator& operator=(iterator&& other) {
       m_source = std::move(other.m_source);
-      m_row = std::move(other.m_row);
+      m_row.copy_reference(other.m_row);
       return *this;
     }
     explicit iterator(sframe_rows* source, size_t current_row_number = 0):

--- a/src/core/util/coro.hpp
+++ b/src/core/util/coro.hpp
@@ -1,5 +1,5 @@
-#ifndef RAMPUDDLE_PUDDLE_CORO_HPP
-#define RAMPUDDLE_PUDDLE_CORO_HPP
+#ifndef TURI_CORO_HPP
+#define TURI_CORO_HPP
 /**
  * \internal
  * \file

--- a/src/python/turicreate/test/test_activity_classifier.py
+++ b/src/python/turicreate/test/test_activity_classifier.py
@@ -41,7 +41,7 @@ def _load_data(self, num_examples = 1000, num_features = 3, max_num_sessions = 4
 
     random_labels = [random.randint(0, self.num_labels - 1) for i in range(self.num_examples)]
 
-    self.data = tc.util.generate_random_sframe(column_codes='r' * self.num_features, num_rows=self.num_examples)
+    self.data = tc.util.generate_random_sframe(column_codes='r' * self.num_features, num_rows=self.num_examples, random_seed=42)
     self.data[self.session_id] = random_session_ids
     self.data[self.target] = random_labels
 

--- a/src/util/coro.hpp
+++ b/src/util/coro.hpp
@@ -1,0 +1,135 @@
+#ifndef RAMPUDDLE_PUDDLE_CORO_HPP
+#define RAMPUDDLE_PUDDLE_CORO_HPP
+/**
+ * \internal
+ * \file
+ * Very limited coroutine implementation.
+ *
+ * Kind of inspired by https://www.chiark.greenend.org.uk/~sgtatham/coroutines.html
+ *
+ * Essentially, DECL_CORO_STATE holds an integer which is a line number of the
+ * function., RESET_CORO resets that value to 0. CORO_YIELD sets the current
+ * line number so that the next time the function is called, a switch is used
+ * to jump to the next line.
+ *
+ * Generally this means that this is not a truly general coroutine mechanic
+ * since it does not remember any stack state between function invocations.
+ * Any stack state has to be maintained outside the function. To some extent
+ * this is automatically checked by the compiler due to the use of switch
+ * statements. Generally extra braces between CORO_YIELDs might be necessary
+ * to get the compiler to accept the code.
+ *
+ * Furthermore, parallel invocations, or multiple simultaneous coroutine
+ * invocations of the function is not allowed since there is a single global
+ * variable which maintains the line number. However, wrapping the
+ * DECL_CORO_STATE and the function in a struct/class will allow for it.
+ *
+ * Example:
+ * \code
+ *  DECL_CORO_STATE(integers)
+ *  int ctr;
+ *
+ *  int integers() {
+ *    // anything before CORO_BEGIN is run *everytime*
+ *    CORO_BEGIN(integers)
+ *    ctr = 0;
+ *    while(1) {
+ *      CORO_YIELD(ctr);
+ *      ++ctr;
+ *    };
+ *    CORO_END
+ *  }
+ *
+ *  int main() {
+ *    while(1) {
+ *      std::cout << CALL_CORO(integers) << "\n";
+ *      getchar();
+ *    }
+ *  }
+ * \endcode
+ *
+ * The behavior of this system is very subtle and takes some care to get right.
+ * A perculiarity is that argument values may be different between successive
+ * calls. Ex:
+ * \code
+ * int ctr = 0;
+ * int integers(int start, int end) {
+ *   CORO_BEGIN(integers)
+ *   for (ctr = start; ctr < end; ++ctr) {
+ *     CORO_YIELD(ctr);
+ *   }
+ *   CORO_END
+ *  }
+ *
+ * do {
+ *   std::cout << integers(1,10) < "\n";
+ * } while(CORO_RUNNING(integers));
+ * \endcode
+ *
+ * User must be careful to call the method with the same input arguments
+ * everytime or interesting behavior might happen. Similarly, this allows input
+ * arguments to be used to transfer information to the coroutine (for instance,
+ * in a producer/consumer model, an argument can be used to transfer a buffer
+ * from the consumer to the producer).
+ *
+ * Example:
+ * \code
+ * int ctr = 0;
+ * void integers(int start, int end, int* out) {
+ *   CORO_BEGIN(integers)
+ *   for (ctr = start; ctr < end; ++ctr) {
+ *     (*out) = ctr;
+ *     CORO_YIELD(ctr);
+ *     // after this, the out pointer may change.
+ *   }
+ *   CORO_END
+ *  }
+ *  \endcode
+ *
+ * But some care must be taken because after a CORO_YIELD, any of the arguments
+ * may have new values. Essentially, CORO_YIELD itself is an entry point to
+ * the function and has to be treated that way.
+ *
+ * To help in closure maintenance, a struct/class version of the macros are
+ * provided.
+ * \code
+ * struct integers {
+ *  DECL_CORO_STATE(call)
+ *  int start, int end;
+ *  int ctr;
+ *  integers(int start, int end):start(start),end(end), ctr(0) {}
+ *
+ *  int read() {
+ *    CORO_BEGIN(integers)
+ *    for (ctr = start; ctr < end; ++ctr) {
+ *      CORO_YIELD(ctr);
+ *    }
+ *    CORO_END
+ *   }
+ * };
+ *
+ *
+ * integers counter(1, 10);
+ * do {
+ *   std::cout << counter.read() < "\n";
+ * } while(CLASS_CORO_RUNNING(counter, read));
+ * \endcode
+ */
+
+#define DECL_CORO_STATE(f) int _coro_state ## f = 0;
+
+#define RESET_CORO(f) _coro_state ## f = 0;
+#define RESET_CLASS_CORO(obj, f) obj._coro_state ## f = 0;
+#define CALL_CORO(f, ...) f(__VA_ARGS__)
+#define CALL_CORO_RESET(f, ...) {_coro_state ## f = 0; f(__VA_ARGS__);}
+#define CORO_BEGIN(f) int& _coro_state = _coro_state ## f; switch(_coro_state) { case 0:
+#define CORO_YIELD(x) _coro_state=__LINE__; return x; \
+ case __LINE__:
+#define CORO_END _coro_state = 0; break; }
+#define CORO_DONE(f) (_coro_state ##f == 0)
+#define CORO_RUNNING(f) (_coro_state ##f != 0)
+#define CLASS_CALL_CORO(obj, f, ...) (obj).f(__VA_ARGS__)
+#define CLASS_CORO_DONE(obj, f) ((obj)._coro_state ##f == 0)
+#define CLASS_CORO_RUNNING(obj, f) ((obj)._coro_state ##f != 0)
+
+#endif

--- a/test/sframe/sarray_file_format_v2_test.cxx
+++ b/test/sframe/sarray_file_format_v2_test.cxx
@@ -134,6 +134,7 @@ struct sarray_file_format_v2_test {
 
 
   static const size_t VERY_LARGE_SIZE = 4*1024*1024;
+  //static const size_t VERY_LARGE_SIZE = 128*1024;
   void test_random_access(void) {
     // write a file
     sarray_group_format_writer_v2<size_t> group_writer;
@@ -246,117 +247,117 @@ struct sarray_file_format_v2_test {
               << ti.current_time() << " seconds \n";
 
 
-// random reads
-{
-  ti.start();
-  // now see if I can read it
-  sarray_format_reader_v2<flexible_type> reader;
-  reader.open(test_file_name + ":0");
-  random::seed(10001);
-  for (size_t i = 0;i < 1600; ++i) {
-    size_t len = 4096;
-    size_t start = random::fast_uniform<size_t>(0, 16 * VERY_LARGE_SIZE - 4097);
-    std::vector<flexible_type> vals;
-    reader.read_rows(start, start + len, vals);
-    TS_ASSERT_EQUALS(vals.size(), len);
-    for (size_t i = 0; i < len; ++i) {
-      if ((size_t)(vals[i]) != start + i) TS_ASSERT_EQUALS((size_t)(vals[i]), start + i);
-    }
-  }
-  std::cout << "1600 random seeks of 4096 flexible_type values in " 
-            << ti.current_time() << " seconds\n" << std::endl;
+    // random reads
+    {
+      ti.start();
+      // now see if I can read it
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      random::seed(10001);
+      for (size_t i = 0;i < 1600; ++i) {
+        size_t len = 4096;
+        size_t start = random::fast_uniform<size_t>(0, 16 * VERY_LARGE_SIZE - 4097);
+        std::vector<flexible_type> vals;
+        reader.read_rows(start, start + len, vals);
+        TS_ASSERT_EQUALS(vals.size(), len);
+        for (size_t i = 0; i < len; ++i) {
+          if ((size_t)(vals[i]) != start + i) TS_ASSERT_EQUALS((size_t)(vals[i]), start + i);
+        }
+      }
+      std::cout << "1600 random seeks of 4096 flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
 
-  // test some edge cases. Read past the end
-  size_t end = 16*VERY_LARGE_SIZE;
-  std::vector<flexible_type> vals;
-  size_t ret = reader.read_rows(end - 5, 2*end, vals);
-  TS_ASSERT_EQUALS(ret, 5);
-  TS_ASSERT_EQUALS(vals.size(), 5);
-  for (size_t i = 0;i < vals.size(); ++i) {
-    if ((size_t)vals[i] != end - (5 - i)) TS_ASSERT_EQUALS((size_t)vals[i], end - (5 - i));
-  }
-}
-
-// random sequential reads
-{
-  ti.start();
-  // now see if I can read it
-  sarray_format_reader_v2<flexible_type> reader;
-  reader.open(test_file_name + ":0");
-  random::seed(10001);
-  std::vector<size_t> start_points;
-  for (size_t i = 0;i < 16; ++i) {
-    start_points.push_back(
-        random::fast_uniform<size_t>(0, 
-                                     15 * VERY_LARGE_SIZE));
-                                     // 15 so as to give some gap for reading
-  }
-  for (size_t i = 0;i < 100; ++i) {
-    for (size_t j = 0;j < start_points.size(); ++j) {
-      size_t len = 4096;
+      // test some edge cases. Read past the end
+      size_t end = 16*VERY_LARGE_SIZE;
       std::vector<flexible_type> vals;
-      reader.read_rows(start_points[j], start_points[j] + len, vals);
-      TS_ASSERT_EQUALS(vals.size(), len);
-      for (size_t k = 0; k < len; ++k) {
-        if ((size_t)vals[k] != start_points[j] + k) TS_ASSERT_EQUALS((size_t)vals[k], start_points[j] + k);
+      size_t ret = reader.read_rows(end - 5, 2*end, vals);
+      TS_ASSERT_EQUALS(ret, 5);
+      TS_ASSERT_EQUALS(vals.size(), 5);
+      for (size_t i = 0;i < vals.size(); ++i) {
+        if ((size_t)vals[i] != end - (5 - i)) TS_ASSERT_EQUALS((size_t)vals[i], end - (5 - i));
       }
-      start_points[j] += len;
     }
-  }
-  std::cout << "1600 semi-sequential seeks of average 4096 flexible_type values in " 
-            << ti.current_time() << " seconds\n" << std::endl;
-}
 
-{
-  ti.start();
-  sarray_format_reader_v2<flexible_type> reader;
-  reader.open(test_file_name + ":0");
-  random::seed(10001);
-  std::vector<size_t> start_points;
-  for (size_t i = 0;i < 16; ++i) {
-    start_points.push_back(
-        random::fast_uniform<size_t>(0, 
-                                     15 * VERY_LARGE_SIZE));
-                                     // 15 so as to give some gap for reading
-  }
-  for (size_t i = 0;i < 100; ++i) {
-    sframe_rows rows;
-    for (size_t j = 0;j < start_points.size(); ++j) {
-      size_t len = 4096;
-      reader.read_rows(start_points[j], start_points[j] + len, rows);
-      size_t k = 0;
-      TS_ASSERT_EQUALS(rows.num_rows(), len);
-      TS_ASSERT_EQUALS(rows.num_columns(), 1);
-      for (const auto& val: rows) {
-        if ((size_t)val[0] != start_points[j] + k) TS_ASSERT_EQUALS((size_t)val[0], start_points[j] + k);
-        ++k;
+    // random sequential reads
+    {
+      ti.start();
+      // now see if I can read it
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      random::seed(10001);
+      std::vector<size_t> start_points;
+      for (size_t i = 0;i < 16; ++i) {
+        start_points.push_back(
+            random::fast_uniform<size_t>(0,
+                                         15 * VERY_LARGE_SIZE));
+        // 15 so as to give some gap for reading
       }
-      TS_ASSERT_EQUALS(k, len);
-      start_points[j] += len;
+      for (size_t i = 0;i < 100; ++i) {
+        for (size_t j = 0;j < start_points.size(); ++j) {
+          size_t len = 4096;
+          std::vector<flexible_type> vals;
+          reader.read_rows(start_points[j], start_points[j] + len, vals);
+          TS_ASSERT_EQUALS(vals.size(), len);
+          for (size_t k = 0; k < len; ++k) {
+            if ((size_t)vals[k] != start_points[j] + k) TS_ASSERT_EQUALS((size_t)vals[k], start_points[j] + k);
+          }
+          start_points[j] += len;
+        }
+      }
+      std::cout << "1600 semi-sequential seeks of average 4096 flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
     }
-  }
-  std::cout << "1600 sframe_rows semi-sequential seeks of average 4096 flexible_type values in " 
-            << ti.current_time() << " seconds\n" << std::endl;
-}
 
-{
-  sarray_format_reader_v2<flexible_type> reader;
-  reader.open(test_file_name + ":0");
-  ti.start();
-  std::vector<flexible_type> rows;
-  for (size_t j = 0;j < 64; ++j) {
-    size_t len = 1*1024*1024;
-    reader.read_rows(j * len, (j+1)*len, rows);
-    size_t k = 0;
-    for (const auto& val: rows) {
-      if ((size_t)val != j * len + k) TS_ASSERT_EQUALS((size_t)val, j * len + k);
-      ++k;
+    {
+      ti.start();
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      random::seed(10001);
+      std::vector<size_t> start_points;
+      for (size_t i = 0;i < 16; ++i) {
+        start_points.push_back(
+            random::fast_uniform<size_t>(0,
+                                         15 * VERY_LARGE_SIZE));
+        // 15 so as to give some gap for reading
+      }
+      for (size_t i = 0;i < 100; ++i) {
+        sframe_rows rows;
+        for (size_t j = 0;j < start_points.size(); ++j) {
+          size_t len = 4096;
+          reader.read_rows(start_points[j], start_points[j] + len, rows);
+          size_t k = 0;
+          TS_ASSERT_EQUALS(rows.num_rows(), len);
+          TS_ASSERT_EQUALS(rows.num_columns(), 1);
+          for (const auto& val: rows) {
+            if ((size_t)val[0] != start_points[j] + k) TS_ASSERT_EQUALS((size_t)val[0], start_points[j] + k);
+            ++k;
+          }
+          TS_ASSERT_EQUALS(k, len);
+          start_points[j] += len;
+        }
+      }
+      std::cout << "1600 sframe_rows semi-sequential seeks of average 4096 flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
     }
-    TS_ASSERT_EQUALS(k, len);
-  }
-  std::cout << "64 vector read sequential seeks of 1M flexible_type values in " 
-            << ti.current_time() << " seconds\n" << std::endl;
-}
+
+    {
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      ti.start();
+      std::vector<flexible_type> rows;
+      for (size_t j = 0;j < 64; ++j) {
+        size_t len = 1*1024*1024;
+        reader.read_rows(j * len, (j+1)*len, rows);
+        size_t k = 0;
+        for (const auto& val: rows) {
+          if ((size_t)val != j * len + k) TS_ASSERT_EQUALS((size_t)val, j * len + k);
+          ++k;
+        }
+        TS_ASSERT_EQUALS(k, len);
+      }
+      std::cout << "64 vector read sequential seeks of 1M flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
+    }
 
 
     {
@@ -371,7 +372,194 @@ struct sarray_file_format_v2_test {
         TS_ASSERT_EQUALS(rows.num_rows(), len);
         TS_ASSERT_EQUALS(rows.num_columns(), 1);
         for (const auto& val: rows) {
-           if ((size_t)val[0] != j * len + k) TS_ASSERT_EQUALS((size_t)val[0], j * len + k);
+          if ((size_t)val[0] != j * len + k) TS_ASSERT_EQUALS((size_t)val[0], j * len + k);
+          ++k;
+        }
+        TS_ASSERT_EQUALS(k, len);
+      }
+      std::cout << "64 sframe_rows sequential seeks of average 1M flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
+    }
+  }
+
+  void test_missing_values_random_access(void) {
+    // write a file
+    sarray_group_format_writer_v2<flexible_type> group_writer;
+
+    timer ti;
+    ti.start();
+    // open with 4 segments
+    std::string test_file_name = get_temp_name() + ".sidx";
+    group_writer.open(test_file_name, 16, 1);
+
+    TS_ASSERT_EQUALS(group_writer.num_segments(), 16);
+    // open all segments, write one sequential value spanning all segments
+    size_t v = 0;
+    for (size_t i = 0;i < 16; ++i) {
+      for (size_t j = 0;j < VERY_LARGE_SIZE; ++j) {
+        if (v % 4 != 0) group_writer.write_segment(0, i, v);
+        else group_writer.write_segment(0, i, FLEX_UNDEFINED);
+        ++v;
+      }
+    }
+    group_writer.close();
+    group_writer.write_index_file();
+    std::cout << "Written 16*4M = 64M flexible_type integers to disk sequentially in: "
+              << ti.current_time() << " seconds \n";
+
+
+    // random reads
+    {
+      ti.start();
+      // now see if I can read it
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      random::seed(10001);
+      for (size_t i = 0;i < 1600; ++i) {
+        size_t len = 4096;
+        size_t start = random::fast_uniform<size_t>(0, 16 * VERY_LARGE_SIZE - 4097);
+        std::vector<flexible_type> vals;
+        reader.read_rows(start, start + len, vals);
+        TS_ASSERT_EQUALS(vals.size(), len);
+        for (size_t i = 0; i < len; ++i) {
+          if ((start + i) % 4 != 0) {
+            if ((size_t)(vals[i]) != start + i) TS_ASSERT_EQUALS((size_t)(vals[i]), start + i);
+          } else {
+            TS_ASSERT_EQUALS((int)(vals[i].get_type()), (int)flex_type_enum::UNDEFINED);
+          }
+        }
+      }
+      std::cout << "1600 random seeks of 4096 flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
+
+      // test some edge cases. Read past the end
+      size_t end = 16*VERY_LARGE_SIZE;
+      std::vector<flexible_type> vals;
+      size_t ret = reader.read_rows(end - 5, 2*end, vals);
+      TS_ASSERT_EQUALS(ret, 5);
+      TS_ASSERT_EQUALS(vals.size(), 5);
+      for (size_t i = 0;i < vals.size(); ++i) {
+        if ((end - (5 - i)) % 4 != 0) {
+          if ((size_t)vals[i] != end - (5 - i)) TS_ASSERT_EQUALS((size_t)vals[i], end - (5 - i));
+        } else {
+          TS_ASSERT_EQUALS((int)(vals[i].get_type()), (int)flex_type_enum::UNDEFINED);
+        }
+      }
+    }
+
+    // random sequential reads
+    {
+      ti.start();
+      // now see if I can read it
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      random::seed(10001);
+      std::vector<size_t> start_points;
+      for (size_t i = 0;i < 16; ++i) {
+        start_points.push_back(
+            random::fast_uniform<size_t>(0,
+                                         15 * VERY_LARGE_SIZE));
+        // 15 so as to give some gap for reading
+      }
+      for (size_t i = 0;i < 100; ++i) {
+        for (size_t j = 0;j < start_points.size(); ++j) {
+          size_t len = 4096;
+          std::vector<flexible_type> vals;
+          reader.read_rows(start_points[j], start_points[j] + len, vals);
+          TS_ASSERT_EQUALS(vals.size(), len);
+          for (size_t k = 0; k < len; ++k) {
+            if ((start_points[j] + k) % 4 != 0) {
+              if ((size_t)vals[k] != start_points[j] + k) TS_ASSERT_EQUALS((size_t)vals[k], start_points[j] + k);
+            } else {
+              TS_ASSERT_EQUALS((int)(vals[k].get_type()), (int)flex_type_enum::UNDEFINED);
+            }
+          }
+          start_points[j] += len;
+        }
+      }
+      std::cout << "1600 semi-sequential seeks of average 4096 flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
+    }
+
+    {
+      ti.start();
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      random::seed(10001);
+      std::vector<size_t> start_points;
+      for (size_t i = 0;i < 16; ++i) {
+        start_points.push_back(
+            random::fast_uniform<size_t>(0,
+                                         15 * VERY_LARGE_SIZE));
+        // 15 so as to give some gap for reading
+      }
+      for (size_t i = 0;i < 100; ++i) {
+        sframe_rows rows;
+        for (size_t j = 0;j < start_points.size(); ++j) {
+          size_t len = 4096;
+          reader.read_rows(start_points[j], start_points[j] + len, rows);
+          size_t k = 0;
+          TS_ASSERT_EQUALS(rows.num_rows(), len);
+          TS_ASSERT_EQUALS(rows.num_columns(), 1);
+          for (const auto& val: rows) {
+            if ((start_points[j] + k) % 4 != 0) {
+              if ((size_t)val[0] != start_points[j] + k) {
+                TS_ASSERT_EQUALS((size_t)val[0], start_points[j] + k);
+              }
+            } else {
+              TS_ASSERT_EQUALS((int)(val[0].get_type()), (int)flex_type_enum::UNDEFINED);
+            }
+            ++k;
+          }
+          TS_ASSERT_EQUALS(k, len);
+          start_points[j] += len;
+        }
+      }
+      std::cout << "1600 sframe_rows semi-sequential seeks of average 4096 flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
+    }
+
+    {
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      ti.start();
+      std::vector<flexible_type> rows;
+      for (size_t j = 0;j < 64; ++j) {
+        size_t len = 1*1024*1024;
+        reader.read_rows(j * len, (j+1)*len, rows);
+        size_t k = 0;
+        for (const auto& val: rows) {
+          if ((j * len + k) % 4 != 0) {
+            if ((size_t)val != j * len + k) TS_ASSERT_EQUALS((size_t)val, j * len + k);
+          } else {
+            TS_ASSERT_EQUALS((int)(val.get_type()), (int)flex_type_enum::UNDEFINED);
+          }
+          ++k;
+        }
+        TS_ASSERT_EQUALS(k, len);
+      }
+      std::cout << "64 vector read sequential seeks of 1M flexible_type values in "
+                << ti.current_time() << " seconds\n" << std::endl;
+    }
+
+
+    {
+      sarray_format_reader_v2<flexible_type> reader;
+      reader.open(test_file_name + ":0");
+      ti.start();
+      sframe_rows rows;
+      for (size_t j = 0;j < 64; ++j) {
+        size_t len = 1*1024*1024;
+        reader.read_rows(j * len, (j+1)*len, rows);
+        size_t k = 0;
+        TS_ASSERT_EQUALS(rows.num_rows(), len);
+        TS_ASSERT_EQUALS(rows.num_columns(), 1);
+        for (const auto& val: rows) {
+          if ((j * len + k) % 4 != 0) {
+            if ((size_t)val[0] != j * len + k) TS_ASSERT_EQUALS((size_t)val[0], j * len + k);
+          } else {
+            TS_ASSERT_EQUALS((int)(val[0].get_type()), (int)flex_type_enum::UNDEFINED);
+          }
           ++k;
         }
         TS_ASSERT_EQUALS(k, len);
@@ -395,5 +583,8 @@ BOOST_AUTO_TEST_CASE(test_random_access) {
 }
 BOOST_AUTO_TEST_CASE(test_typed_random_access) {
   sarray_file_format_v2_test::test_typed_random_access();
+}
+BOOST_AUTO_TEST_CASE(test_missing_values_random_access) {
+  sarray_file_format_v2_test::test_missing_values_random_access();
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/sframe/sframe_test.cxx
+++ b/test/sframe/sframe_test.cxx
@@ -23,6 +23,9 @@ struct sframe_test  {
   std::string test_writer_dbl_prefix;
   std::string test_writer_str_prefix;
   std::string test_writer_add_col_prefix;
+  std::string test_writer_arr_prefix;
+  std::string test_writer_dt_prefix;
+  std::string test_writer_ndarr_prefix;
   std::string test_writer_seg_size_err_prefix;
 
   public:
@@ -32,11 +35,17 @@ struct sframe_test  {
       sarray<flexible_type> test_writer_str;
       sarray<flexible_type> test_writer_add_col;
       sarray<flexible_type> test_writer_seg_size_err;
+      sarray<flexible_type> test_writer_arr;
+      sarray<flexible_type> test_writer_dt;
+      sarray<flexible_type> test_writer_ndarr;
 
       this->test_writer_prefix = get_temp_name() + ".sidx";
       this->test_writer_dbl_prefix = get_temp_name() + ".sidx";
       this->test_writer_str_prefix = get_temp_name() + ".sidx";
       this->test_writer_add_col_prefix = get_temp_name() + ".sidx";
+      this->test_writer_arr_prefix = get_temp_name() + ".sidx";
+      this->test_writer_dt_prefix = get_temp_name() + ".sidx";
+      this->test_writer_ndarr_prefix = get_temp_name() + ".sidx";
       this->test_writer_seg_size_err_prefix = get_temp_name() + ".sidx";
 
       std::vector<std::vector<size_t> > data{{1,2,3,4,5},
@@ -44,31 +53,45 @@ struct sframe_test  {
                                              {11,12,13,14,15},
                                              {16,17,18,19,20}};
 
-      //TODO: Make better!
       test_writer.open_for_write(this->test_writer_prefix, 4);
       test_writer_dbl.open_for_write(this->test_writer_dbl_prefix, 4);
       test_writer_str.open_for_write(this->test_writer_str_prefix, 4);
       test_writer_add_col.open_for_write(this->test_writer_add_col_prefix, 4);
+      test_writer_arr.open_for_write(this->test_writer_arr_prefix, 4);
+      test_writer_dt.open_for_write(this->test_writer_dt_prefix, 4);
+      test_writer_ndarr.open_for_write(this->test_writer_ndarr_prefix, 4);
 
       test_writer.set_type(flex_type_enum::INTEGER);
       test_writer_dbl.set_type(flex_type_enum::FLOAT);
       test_writer_str.set_type(flex_type_enum::STRING);
       test_writer_add_col.set_type(flex_type_enum::FLOAT);
+      test_writer_arr.set_type(flex_type_enum::VECTOR);
+      test_writer_dt.set_type(flex_type_enum::DATETIME);
+      test_writer_ndarr.set_type(flex_type_enum::ND_VECTOR);
 
       for (size_t i = 0; i < 4; ++i) {
         auto iter = test_writer.get_output_iterator(i);
         auto iter_dbl = test_writer_dbl.get_output_iterator(i);
         auto iter_str = test_writer_str.get_output_iterator(i);
         auto iter_add_col = test_writer_add_col.get_output_iterator(i);
+        auto iter_arr = test_writer_arr.get_output_iterator(i);
+        auto iter_dt = test_writer_dt.get_output_iterator(i);
+        auto iter_ndarr = test_writer_ndarr.get_output_iterator(i);
         for(auto val: data[i]) {
           *iter = val;
           *iter_dbl = val;
           *iter_str = std::to_string(val);
           *iter_add_col = val;
+          *iter_dt = flex_date_time(val);
+          *iter_arr = flex_vec(10,val);
+          *iter_ndarr = flex_nd_vec(std::vector<double>(10,val), {2,5});
           ++iter;
           ++iter_dbl;
           ++iter_str;
           ++iter_add_col;
+          ++iter_arr;
+          ++iter_dt;
+          ++iter_ndarr;
         }
       }
 
@@ -76,6 +99,9 @@ struct sframe_test  {
       test_writer_dbl.close();
       test_writer_str.close();
       test_writer_add_col.close();
+      test_writer_arr.close();
+      test_writer_dt.close();
+      test_writer_ndarr.close();
 
       std::vector<std::vector<size_t> > data2{{1,2,3,4},
                                              {5, 6,7,8,9,10,11,12},
@@ -543,9 +569,14 @@ struct sframe_test  {
       std::vector<std::shared_ptr<sarray<flexible_type>>>
         v{std::make_shared<sarray<flexible_type>>(test_writer_prefix),
           std::make_shared<sarray<flexible_type>>(test_writer_dbl_prefix),
-          std::make_shared<sarray<flexible_type>>(test_writer_str_prefix)};
+          std::make_shared<sarray<flexible_type>>(test_writer_str_prefix),
+          std::make_shared<sarray<flexible_type>>(test_writer_arr_prefix),
+          std::make_shared<sarray<flexible_type>>(test_writer_dt_prefix),
+          std::make_shared<sarray<flexible_type>>(test_writer_ndarr_prefix)
+        };
 
       sframe sf(v);
+      size_t nrows = sf.num_rows();
 
       auto reader = sf.get_reader();
 
@@ -562,7 +593,10 @@ struct sframe_test  {
         while(iter != end_iter) {
           std::vector<flexible_type> expected {flex_int(rowid+1),
                                                flex_float(rowid+1),
-                                               flex_string(std::to_string(rowid+1))};
+                                               flex_string(std::to_string(rowid+1)),
+                                               flex_vec(10, rowid+1),
+                                               flex_date_time(rowid+1),
+                                               flex_nd_vec(std::vector<double>(10, rowid+1), {2,5})};
           sframe::value_type actual = *iter;
           TS_ASSERT_EQUALS(actual.size(), expected.size());
           for (size_t j = 0; j < actual.size(); ++j) {
@@ -590,7 +624,12 @@ struct sframe_test  {
             }
             size_t rowid = startrow;
             while(iter != end_iter) {
-              std::vector<flexible_type> expected {flex_int(rowid+1), flex_float(rowid+1), flex_string(std::to_string(rowid+1))};
+            std::vector<flexible_type> expected {flex_int(rowid+1),
+                                                 flex_float(rowid+1),
+                                                 flex_string(std::to_string(rowid+1)),
+                                                 flex_vec(10, rowid+1),
+                                                 flex_date_time(rowid+1),
+                                                 flex_nd_vec(std::vector<double>(10, rowid+1), {2,5})};
               TS_ASSERT_EQUALS(iter->size(), expected.size());
               for (size_t j = 0; j < iter->size(); ++j) {
                 TS_ASSERT_EQUALS(iter->at(j), expected[j]);
@@ -610,7 +649,12 @@ struct sframe_test  {
             TS_ASSERT_EQUALS(ret.size(), 5);
             for (size_t i = 0;i < ret.size(); ++i) {
               size_t rowid = i + startrow;
-              std::vector<flexible_type> expected {flex_int(rowid+1), flex_float(rowid+1), flex_string(std::to_string(rowid+1))};
+              std::vector<flexible_type> expected {flex_int(rowid+1),
+                                                   flex_float(rowid+1),
+                                                   flex_string(std::to_string(rowid+1)),
+                                                   flex_vec(10, rowid+1),
+                                                   flex_date_time(rowid+1),
+                                                   flex_nd_vec(std::vector<double>(10, rowid+1), {2,5})};
               TS_ASSERT_EQUALS(ret[i].size(), expected.size());
               for (size_t j = 0; j < ret[i].size(); ++j) {
                 TS_ASSERT_EQUALS(ret[i].at(j), expected[j]);
@@ -626,11 +670,44 @@ struct sframe_test  {
             size_t nrows = reader->read_rows(startrow, startrow + 5, rows);
             TS_ASSERT_EQUALS(nrows, 5);
             TS_ASSERT_EQUALS(rows.num_rows(), 5);
-            TS_ASSERT_EQUALS(rows.num_columns(), 3);
+            TS_ASSERT_EQUALS(rows.num_columns(), 6);
             size_t i = 0;
             for (const auto& ret: rows) {
               size_t rowid = i + startrow;
-              std::vector<flexible_type> expected {flex_int(rowid+1), flex_float(rowid+1), flex_string(std::to_string(rowid+1))};
+              std::vector<flexible_type> expected {flex_int(rowid+1),
+                                                   flex_float(rowid+1),
+                                                   flex_string(std::to_string(rowid+1)),
+                                                   flex_vec(10, rowid+1),
+                                                   flex_date_time(rowid+1),
+                                                   flex_nd_vec(std::vector<double>(10, rowid+1), {2,5})};
+              TS_ASSERT_EQUALS(ret.size(), expected.size());
+              for (size_t j = 0; j < ret.size(); ++j) {
+                TS_ASSERT_EQUALS(ret.at(j), expected[j]);
+              }
+              ++i;
+            }
+          });
+
+      // randomaccess
+      // once again using the sframe_rows datastructure
+      // make 15 threads, each read 5 rows
+      parallel_for(0, (size_t)15,
+          [&](size_t seed) {
+            size_t startrow = (std::hash<unsigned long>()((unsigned long)seed)) % nrows;
+            sframe_rows rows;
+            size_t nrows = reader->read_rows(startrow, startrow + 5, rows);
+            TS_ASSERT_EQUALS(nrows, 5);
+            TS_ASSERT_EQUALS(rows.num_rows(), 5);
+            TS_ASSERT_EQUALS(rows.num_columns(), 6);
+            size_t i = 0;
+            for (const auto& ret: rows) {
+              size_t rowid = i + startrow;
+              std::vector<flexible_type> expected {flex_int(rowid+1),
+                                                   flex_float(rowid+1),
+                                                   flex_string(std::to_string(rowid+1)),
+                                                   flex_vec(10, rowid+1),
+                                                   flex_date_time(rowid+1),
+                                                   flex_nd_vec(std::vector<double>(10, rowid+1), {2,5})};
               TS_ASSERT_EQUALS(ret.size(), expected.size());
               for (size_t j = 0; j < ret.size(); ++j) {
                 TS_ASSERT_EQUALS(ret.at(j), expected[j]);


### PR DESCRIPTION
This patch removes the use of boost coroutines from everywhere, instead
using a simple stackless coroutine implementation in src/util/coro.hpp
which uses a switch statement (like the Duff's device) to resume function
execution.

The 2 main places where coroutines are used are in the query execution
engine and in the sarray decoder.

The query execution required minimal changes to switch to the new
mechanism since the operators are already cleanly isolated in classes.
Simply moving stack state to class members suffices (as well as some
slightly more interesting changes in the driver code).

The sarray decoder required significant surgery since there coroutines
are used as a convenience mechanic to make a regular stateful decoder
(for loop which decodes all values in a block) act in a streaming
fashion. The changes here are more involving requiring wrapping each
type decoder in a struct; correctly handling "recursive" cases (where
one stream decoder calls another stream decoder), and the various
decoding paths we can go through based on various flags in the block.

However, switching to a "proper" use of a consumer/producer coroutine
mechanic allowed value skipping to be pushed deeper into the decoder
speeding up random access significantly (up to 4x for integers).
There are certainly more optimization that can be done here.

Since this change impacts the sarray decoder at a deep level, exhaustive
testing is recommended; in particular on old previously saved sframes to
ensure that the "legacy" decoding paths are implemented correctly.