### PR TITLE
Fix OD viz exception error message

### DIFF
--- a/src/python/turicreate/toolkits/object_detector/util/_visualization.py
+++ b/src/python/turicreate/toolkits/object_detector/util/_visualization.py
@@ -152,7 +152,7 @@ def draw_bounding_boxes(images, annotations, confidence_threshold=0):
             if row_number == -1:
                 # indication that it was a single image and not an SFrame
                 raise _ToolkitError(e)
-            raise _ToolkitError("Received exception at row " + str(row_number) + ": " + e)
+            raise _ToolkitError("Received exception at row " + str(row_number) + ": " + str(e))
         return annotated_image
 
     if isinstance(images, _tc.Image) and isinstance(annotations, list):


### PR DESCRIPTION
Format the exception ToolkitError message at [line](https://github.com/apple/turicreate/blob/44556085d01eef01a1188eb13f64487c5ed3b4e1/src/python/turicreate/toolkits/object_detector/util/_visualization.py#L155).

Fixes #2094