### PR TITLE
Automatically splitting data into train and validation for C-API Object Detector

### DIFF
--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -22,6 +22,7 @@
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 #include <toolkits/object_detection/od_evaluation.hpp>
 #include <toolkits/object_detection/od_yolo.hpp>
+#include <toolkits/supervised_learning/automatic_model_creation.hpp>
 
 using turi::coreml::MLModelWrapper;
 using turi::neural_net::compute_context;
@@ -273,6 +274,9 @@ void object_detector::train(gl_sframe data,
   training_table_printer_.reset(new table_printer(
       {{ "Iteration", 12}, {"Loss", 12}, {"Elapsed Time", 12}}));
 
+  gl_sframe val_data;
+  std::tie(data, val_data) = supervised::create_validation_data(data, validation_data); 
+
   // Instantiate the training dependencies: data iterator, image augmenter,
   // backend NN model.
   init_train(std::move(data), std::move(annotations_column_name),
@@ -305,10 +309,6 @@ void object_detector::train(gl_sframe data,
   nn_spec_->update_params(trained_weights);
 
   // Compute training and validation metrics.
-  gl_sframe val_data;
-  if (variant_is<gl_sframe>(validation_data)) {
-    val_data = variant_get_value<gl_sframe>(validation_data);
-  }
   update_model_metrics(data, val_data);
 }
 

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -635,6 +635,7 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   auto create_iterator_impl = [&](gl_sframe data,
                                   std::vector<std::string> class_labels,
                                   bool repeat) {
+    // The train data is smaller than the original dataset
     TS_ASSERT(test_num_examples > data.size());
     TS_ASSERT(class_labels.empty());  // Should infer class labels from data.
     TS_ASSERT(repeat);
@@ -708,6 +709,9 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
     result["mean_average_precision"] = 0.80f;
     return result;
   };
+
+  // The two evaluation calls are performed for train data as well as validation
+  // data.
   model.perform_evaluation_calls_.resize(2, perform_evaluation_impl);
 
   // Create an arbitrary SFrame with test_num_examples rows, since

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -511,7 +511,241 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
   // Deconstructing `model` here will assert that every expected call to a
   // mocked-out method has been called.
 }
-    
+  
+BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
+
+  // Most of this test body will be spent setting up the mock objects that we'll
+  // inject into the object_detector implementation. These mock objects will
+  // make assertions about their inputs along the way and provide the outputs
+  // that we manually pre-program. At the end will be a single call to
+  // object_detector::train that will trigger all the actual testing.
+  test_object_detector model;
+
+  // Allocate the mock dependencies. We'll transfer ownership when the toolkit
+  // code attempts to instantiate these dependencies.
+  std::unique_ptr<mock_data_iterator> mock_iterator(new mock_data_iterator);
+  std::unique_ptr<mock_image_augmenter> mock_augmenter(
+      new mock_image_augmenter);
+  std::unique_ptr<mock_model_backend> mock_nn_model(
+      new mock_model_backend);
+  std::unique_ptr<mock_compute_context> mock_context(new mock_compute_context);
+
+  // We'll request 4 training iterations, since the learning rate schedule
+  // kicks in at the 50% and 75% points.
+  static constexpr size_t test_max_iterations = 4;
+  static constexpr size_t test_batch_size = 2;
+  const std::vector<std::string> test_class_labels = { "label1", "label2" };
+  static constexpr size_t test_num_instances = 123;
+  static constexpr size_t test_num_examples = 200;
+  static constexpr float test_loss = 5.f;
+
+  mock_iterator->class_labels_ = test_class_labels;
+  mock_iterator->num_instances_ = test_num_instances;
+
+  auto num_iterations_submitted = std::make_shared<size_t>(0);
+  for (size_t i = 0; i < test_max_iterations; ++i) {
+
+    // Program the mock_iterator to return two arbitrary images, each with one
+    // unique annotation. We'll store a copy of the annotations for later
+    // comparison.
+    auto test_annotations =
+        std::make_shared<std::vector<std::vector<image_annotation>>>();
+    auto next_batch_impl = [=](size_t batch_size) {
+
+      TS_ASSERT_EQUALS(batch_size, test_batch_size);
+
+      std::vector<labeled_image> result(test_batch_size);
+      for (size_t j = 0; j < result.size(); ++j) {
+
+        // The actual contents of the image and the annotations are irrelevant
+        // for the purposes of this test. But encode the batch index and row
+        // index into the bounding box so that we can verify this data is passed
+        // into the image augmenter.
+        image_annotation annotation;
+        annotation.bounding_box.x = i;
+        annotation.bounding_box.y = j;
+
+        result[j].annotations.push_back(annotation);
+        test_annotations->push_back(result[j].annotations);
+      }
+
+      return result;
+    };
+    mock_iterator->next_batch_calls_.push_back(next_batch_impl);
+
+    // Program the mock_augmenter to return an arbitrary float_array, and to
+    // pass through the annotations.
+    auto test_image_batch = std::make_shared<shared_float_array>();
+    auto prepare_images_impl = [=](std::vector<labeled_image> source_batch) {
+
+      // The source batch should batch what we returned from the mock_iterator.
+      TS_ASSERT_EQUALS(source_batch.size(), test_batch_size);
+      for (size_t j = 0; j < source_batch.size(); ++j) {
+        TS_ASSERT_EQUALS(source_batch[j].annotations, (*test_annotations)[j]);
+      }
+
+      // Return an arbitrary float_array, just a scalar encoding the iteration
+      // index.
+      image_augmenter::result res;
+      res.image_batch = shared_float_array::wrap(static_cast<float>(i));
+      res.annotations_batch = *test_annotations;
+
+      // Save the image_batch for downstream validation.
+      *test_image_batch = res.image_batch;
+
+      return res;
+    };
+    mock_augmenter->prepare_images_calls_.push_back(prepare_images_impl);
+
+    // The mock_model_backend should expect calls to set_learning_rate just at
+    // the 50% and 75% marks.
+    if (i == test_max_iterations / 2 || i == test_max_iterations * 3 / 4) {
+
+      auto set_learning_rate_impl = [=](float lr) {
+        TS_ASSERT_EQUALS(*num_iterations_submitted, i);
+      };
+      mock_nn_model->set_learning_rate_calls_.push_back(set_learning_rate_impl);
+    }
+
+    // The mock_model_backend should expect `train` calls on every iteration.
+    auto train_impl = [=](const float_array_map& inputs) {
+
+      // The input_batch should just be whatever the image_augmenter returned.
+      shared_float_array input_batch = inputs.at("input");
+      TS_ASSERT_EQUALS(input_batch.data(), test_image_batch->data());
+
+      // Track how many calls we've had.
+      *num_iterations_submitted += 1;
+
+      // Multiply loss by 8 to offset the "mps_loss_mult" factor currently
+      // hardwired in to avoid fp16 underflow in MPS.
+      std::map<std::string, shared_float_array> result;
+      result["loss"] = shared_float_array::wrap(8 * test_loss);
+      return result;
+    };
+    mock_nn_model->train_calls_.push_back(train_impl);
+  }
+
+  const std::string test_annotations_name = "test_annotations";
+  const std::string test_image_name = "test_image";
+
+  // The following callbacks capture by reference so that they can transfer
+  // ownership of the mocks created above.
+
+  auto create_iterator_impl = [&](gl_sframe data,
+                                  std::vector<std::string> class_labels,
+                                  bool repeat) {
+    TS_ASSERT(test_num_examples > data.size());
+    TS_ASSERT(class_labels.empty());  // Should infer class labels from data.
+    TS_ASSERT(repeat);
+
+    return std::move(mock_iterator);
+  };
+  model.create_iterator_calls_.push_back(create_iterator_impl);
+
+  auto create_augmenter_impl = [&](const image_augmenter::options& opts) {
+
+    TS_ASSERT_EQUALS(opts.output_height, 416);
+    TS_ASSERT_EQUALS(opts.output_width, 416);
+    return std::move(mock_augmenter);
+  };
+  mock_context->create_augmenter_calls_.push_back(create_augmenter_impl);
+
+  // We'll provide this path for the "mlmodel_path" option. When the
+  // object_detector attempts to initialize weights from that path, just return
+  // some arbitrary dummy params.
+  const std::string test_mlmodel_path = "/test/foo.mlmodel";
+  model.init_model_calls_.emplace_back([=](const std::string& model_path) {
+    TS_ASSERT_EQUALS(model_path, test_mlmodel_path);
+
+    std::unique_ptr<model_spec> nn_spec(new model_spec);
+    nn_spec->add_convolution("test_layer", "test_input", 16, 16, 3, 3, 1, 1,
+                             model_spec::padding_type::SAME,
+                             /* weight_init_fn */ [](float*w , float* w_end) {
+                               for (int i = 0; i < w_end - w; ++i) {
+                                 w[i] = static_cast<float>(i);
+                               }
+                             });
+    return nn_spec;
+  });
+
+
+  auto create_object_detector_impl = [&](int n, int c_in, int h_in, int w_in,
+                                    int c_out, int h_out, int w_out,
+                                    const float_array_map& config,
+                                    const float_array_map& weights) {
+
+    TS_ASSERT_EQUALS(n, test_batch_size);
+    TS_ASSERT_EQUALS(c_in, 3);
+    TS_ASSERT_EQUALS(h_in, 416);
+    TS_ASSERT_EQUALS(w_in, 416);
+    TS_ASSERT_EQUALS(c_out, 15 * (5 + test_class_labels.size()));
+    TS_ASSERT_EQUALS(h_out, 13);
+    TS_ASSERT_EQUALS(w_out, 13);
+
+    // weights should be what we returned from init_model, as copied by
+    // neural_net::wrap_network_params
+    TS_ASSERT_EQUALS(weights.size(), 1);
+    auto it = weights.find("test_layer_weight");
+    TS_ASSERT(it != weights.end());
+    for (size_t i = 0; i < it->second.size(); ++i) {
+      TS_ASSERT_EQUALS(it->second.data()[i], static_cast<float>(i));
+    }
+
+    // TODO: Assert the config values?
+
+    return std::move(mock_nn_model);
+  };
+  mock_context->create_object_detector_calls_.push_back(
+      create_object_detector_impl);
+
+  auto create_compute_context_impl = [&] { return std::move(mock_context); };
+  model.create_compute_context_calls_.push_back(create_compute_context_impl);
+
+  // Training will trigger a call to evaluation, to compute training metrics.
+  auto perform_evaluation_impl = [&](gl_sframe data, std::string metric) {
+    std::map<std::string, variant_type> result;
+    result["mean_average_precision"] = 0.80f;
+    return result;
+  };
+  model.perform_evaluation_calls_.resize(2, perform_evaluation_impl);
+
+  // Create an arbitrary SFrame with test_num_examples rows, since
+  // object_detector uses the number of rows to compute num_examples, which is
+  // used as a normalizer.
+  gl_sframe data({{"ignored", gl_sarray::from_sequence(0, test_num_examples)}});
+
+  // Now, actually invoke object_detector::train. This will trigger all the
+  // assertions registered above.
+  model.train(data, test_annotations_name, test_image_name, "auto",
+              { { "mlmodel_path",   test_mlmodel_path   },
+                { "batch_size",     test_batch_size     },
+                { "max_iterations", test_max_iterations }, });
+
+  // Verify model fields.
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("batch_size"), test_batch_size);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("max_iterations"),
+                   test_max_iterations);
+  TS_ASSERT_EQUALS(model.get_field<flex_string>("annotations"),
+                   test_annotations_name);
+  TS_ASSERT_EQUALS(model.get_field<flex_string>("feature"), test_image_name);
+  TS_ASSERT_EQUALS(model.get_field<flex_string>("model"), "darknet-yolo");
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("num_bounding_boxes"),
+                   test_num_instances);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("num_classes"),
+                   test_class_labels.size());
+  TS_ASSERT_LESS_THAN_EQUALS(model.get_field<flex_int>("num_examples"),
+                   test_num_examples);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"),
+                   test_max_iterations);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_epochs"),
+                   test_max_iterations * test_batch_size / test_num_examples);
+  TS_ASSERT_EQUALS(
+      model.get_field<flex_float>("training_mean_average_precision"), 0.8f);
+
+  // Deconstructing `model` here will assert that every expected call to a
+  // mocked-out method has been called.
+}  
 }  // namespace
 }  // namespace object_detection
 }  // namespace turi


### PR DESCRIPTION
Adding the functionality to split provided dataset into validation in C-API Object Detector. A test is also added to check its functionality.