### PR TITLE
enable recursive dropna for elements in SFrame

### DIFF
--- a/src/core/data/sframe/gl_sframe.cpp
+++ b/src/core/data/sframe/gl_sframe.cpp
@@ -922,14 +922,14 @@ gl_sframe gl_sframe::sort(const std::vector<std::pair<std::string, bool>>& colum
   return get_proxy()->sort(keys, order);
 }
 gl_sframe gl_sframe::dropna(const std::vector<std::string>& columns,
-                            std::string how) const {
-  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false, false);
+                            std::string how, bool recursive) const {
+  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false, recursive);
   ASSERT_EQ(ret.size(), 2);
   return *(ret.begin());
 }
 std::pair<gl_sframe, gl_sframe> gl_sframe::dropna_split(const std::vector<std::string>& columns,
-                                                        std::string how) const {
-  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false, false);
+                                                        std::string how, bool recursive) const {
+  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false, recursive);
   ASSERT_EQ(ret.size(), 2);
   return {*(ret.begin()), *(ret.rbegin())};
 }

--- a/src/core/data/sframe/gl_sframe.cpp
+++ b/src/core/data/sframe/gl_sframe.cpp
@@ -923,13 +923,13 @@ gl_sframe gl_sframe::sort(const std::vector<std::pair<std::string, bool>>& colum
 }
 gl_sframe gl_sframe::dropna(const std::vector<std::string>& columns,
                             std::string how) const {
-  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false);
+  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false, false);
   ASSERT_EQ(ret.size(), 2);
   return *(ret.begin());
 }
 std::pair<gl_sframe, gl_sframe> gl_sframe::dropna_split(const std::vector<std::string>& columns,
                                                         std::string how) const {
-  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false);
+  auto ret = get_proxy()->drop_missing_values(columns, how == "all", false, false);
   ASSERT_EQ(ret.size(), 2);
   return {*(ret.begin()), *(ret.rbegin())};
 }

--- a/src/core/data/sframe/gl_sframe.hpp
+++ b/src/core/data/sframe/gl_sframe.hpp
@@ -2688,7 +2688,7 @@ class gl_sframe {
    * \see dropna_split
    */
   gl_sframe dropna(const std::vector<std::string>& columns = std::vector<std::string>(),
-                   std::string how = "any") const;
+                   std::string how = "any", bool recursive = false) const;
 
   /**
    * Split rows with missing values from this \ref gl_sframe. This function has
@@ -2699,9 +2699,15 @@ class gl_sframe {
    *
    * \param columns Optional. The columns to use when looking for missing values.
    *    By default, all columns are used.
+   *
    * \param how Optional. Specifies whether a row should be dropped if at least
    * one column has missing values, or if all columns have missing values.
    * "any" is default.
+   *
+   * \param recursive Optional. It will recursively check whether a cell contains
+   * nan or not. This is handy for nested data structure like list, dictionary.
+   * For instance, {{FLEX_UNDEFINED, 1}, {1} will be treat as nan and will be removed
+   * if recursive is set to be true. Otherwise it won't be treated as nan-value.
    *
    * Example:
    * \code
@@ -2743,7 +2749,7 @@ class gl_sframe {
    */
   std::pair<gl_sframe, gl_sframe> dropna_split(
       const std::vector<std::string>& columns=std::vector<std::string>(),
-      std::string how = "any") const;
+      std::string how = "any", bool recursive = false) const;
 
   /**
    * Fill all missing values with a given value in a given column. If the
@@ -2754,6 +2760,11 @@ class gl_sframe {
    * \param column The name of the column to modify.
    *
    * \param value The value used to replace all missing values.
+   *
+   * \param recursive The recursive is used to set the manner of nan-value checking.
+   * If this value is true, a cell will be treated as missing value iff it contains nan.
+   * For instance, {{FLEX_UNDEFINED, 1}, {0}} and {FLEX_UNDEFINED, 1} will be all treated
+   * as nan-values.
    *
    * Example:
    * \code

--- a/src/core/storage/sframe_interface/unity_sframe.cpp
+++ b/src/core/storage/sframe_interface/unity_sframe.cpp
@@ -1558,7 +1558,8 @@ bool unity_sframe::_contains_nan(const flexible_type& cell) {
       const auto& nd_arr = cell.get<flex_nd_vec>();
       auto idx = flex_nd_vec::index_range_type(nd_arr.shape().size(), 0);
       do {
-        std::isnan(nd_arr[nd_arr.fast_index(idx)]);
+        if (std::isnan(nd_arr[nd_arr.fast_index(idx)]))
+          return true;
       } while (nd_arr.increment_index(idx));
       break;
     }

--- a/src/core/storage/sframe_interface/unity_sframe.cpp
+++ b/src/core/storage/sframe_interface/unity_sframe.cpp
@@ -382,7 +382,7 @@ size_t unity_sframe::column_index(const std::string &name) {
   Dlog_func_entry();
 
   auto it = std::find(m_column_names.begin(), m_column_names.end(), name);
-  if(it == m_column_names.end()) { 
+  if(it == m_column_names.end()) {
     log_and_throw(std::string("Column '") + name + "' not found.");;
   }
   return std::distance(m_column_names.begin(), it);
@@ -1528,6 +1528,48 @@ unity_sframe::copy_range(size_t start, size_t step, size_t end) {
   return ret;
 }
 
+bool unity_sframe::_contains_nan(const flexible_type& cell) {
+  switch (cell.get_type()) {
+    case flex_type_enum::VECTOR:
+      for (auto cc : cell.get<flex_vec>()) {
+        if (std::isnan(cc)) {
+          return true;
+        }
+      }
+      break;
+    case flex_type_enum::LIST:
+      for (auto& cc : cell.get<flex_list>()) {
+        // recursive call
+        if (_contains_nan(cc)) {
+          return true;
+        }
+      }
+      break;
+    case flex_type_enum::DICT:
+      for (auto& cc : cell.get<flex_dict>()) {
+        // recursive call on key,val pair
+        if (_contains_nan(cc.first) || _contains_nan(cc.second)) {
+          return true;
+        }
+      }
+      break;
+    case flex_type_enum::ND_VECTOR: {
+      // enfore const to use no bound check operator[]
+      const auto& nd_arr = cell.get<flex_nd_vec>();
+      auto idx = flex_nd_vec::index_range_type(nd_arr.shape().size(), 0);
+      do {
+        std::isnan(nd_arr[nd_arr.fast_index(idx)]);
+      } while (nd_arr.increment_index(idx));
+      break;
+    }
+    default:
+      // non-container type case.
+      return cell.is_na();
+  }
+
+  return false;
+}
+
 std::list<std::shared_ptr<unity_sframe_base>> unity_sframe::drop_missing_values(
     const std::vector<std::string> &column_names, bool all, bool split) {
   log_func_entry();
@@ -1545,7 +1587,7 @@ std::list<std::shared_ptr<unity_sframe_base>> unity_sframe::drop_missing_values(
     filter_fn = [column_indices](const sframe_rows::row& row)->flexible_type {
                                   size_t num_missing_values = 0;
                                   for(const auto &i : column_indices) {
-                                    if(row[i].is_na()) {
+                                    if(_contains_nan(row[i])) {
                                       ++num_missing_values;
                                     }
                                   }
@@ -1554,7 +1596,7 @@ std::list<std::shared_ptr<unity_sframe_base>> unity_sframe::drop_missing_values(
   } else {
     filter_fn = [column_indices](const sframe_rows::row& row)->flexible_type {
                                   for(const auto &i : column_indices) {
-                                    if (row[i].is_na())
+                                    if (_contains_nan(row[i]))
                                       return false;
                                   }
                                   return true;

--- a/src/core/storage/sframe_interface/unity_sframe.hpp
+++ b/src/core/storage/sframe_interface/unity_sframe.hpp
@@ -527,10 +527,15 @@ class unity_sframe : public unity_sframe_base {
    * SFrame with missing values dropped, and the second consisting of all the
    * rows removed.
    *
+   * If 'recursive' is true, the `nan`element check will be perfromed in
+   * a recursive manner to check each unit in a container-like flexible-typed
+   * cell in SFrame.
+   *
    * Throws if the column names are not in this SFrame, or if too many are given.
    */
-  std::list<std::shared_ptr<unity_sframe_base>>
-      drop_missing_values(const std::vector<std::string> &column_names, bool all, bool split);
+  std::list<std::shared_ptr<unity_sframe_base>> drop_missing_values(
+      const std::vector<std::string>& column_names, bool all, bool split,
+      bool recursive);
 
   dataframe_t to_dataframe();
 

--- a/src/core/storage/sframe_interface/unity_sframe.hpp
+++ b/src/core/storage/sframe_interface/unity_sframe.hpp
@@ -606,6 +606,13 @@ class unity_sframe : public unity_sframe_base {
   std::vector<size_t> _convert_column_names_to_indices(const std::vector<std::string> &column_names);
 
   /**
+   * a cell is considered to be nan iff it contains nan.
+   * it will be passed to lambda, so declare it as static,
+   * otherwise this pointer needs to be captured.
+   */
+  static inline bool _contains_nan(const flexible_type& cell);
+
+  /**
    * Generate a new column name
    *
    * New column name is in the form of X1, X2, X3 ....
@@ -621,6 +628,8 @@ class unity_sframe : public unity_sframe_base {
    */
   std::string generate_next_column_name();
 };
+
+
 
 }
 

--- a/src/model_server/lib/api/unity_sframe_interface.hpp
+++ b/src/model_server/lib/api/unity_sframe_interface.hpp
@@ -69,7 +69,7 @@ GENERATE_INTERFACE_AND_PROXY(unity_sframe_base, unity_sframe_proxy,
       (std::shared_ptr<unity_sarray_base>, pack_columns, (const std::vector<std::string>&)(const std::vector<std::string>&)(flex_type_enum)(const flexible_type&))
       (std::shared_ptr<unity_sframe_base>, stack,  (const std::string&)(const std::vector<std::string>&)(const std::vector<flex_type_enum>&)(bool))
       (std::shared_ptr<unity_sframe_base>, copy_range, (size_t)(size_t)(size_t))
-      (std::list<std::shared_ptr<unity_sframe_base>>, drop_missing_values, (const std::vector<std::string>&)(bool)(bool))
+      (std::list<std::shared_ptr<unity_sframe_base>>, drop_missing_values, (const std::vector<std::string>&)(bool)(bool)(bool))
       (dataframe_t, to_dataframe, )
       (void, delete_on_close, )
       (void, explore, (const std::string&)(const std::string&))

--- a/src/python/turicreate/_cython/cy_sframe.pxd
+++ b/src/python/turicreate/_cython/cy_sframe.pxd
@@ -63,7 +63,7 @@ cdef extern from "<core/storage/sframe_interface/unity_sframe.hpp>" namespace "t
         unity_sframe_base_ptr stack (const string& , const vector[string]& , const vector[flex_type_enum]&, bint) except +
         unity_sframe_base_ptr sort(const vector[string]&, const vector[int]&) except +
         unity_sframe_base_ptr copy_range(size_t, size_t, size_t) except +
-        cpplist[unity_sframe_base_ptr] drop_missing_values(const vector[string]&, bint, bint) except +
+        cpplist[unity_sframe_base_ptr] drop_missing_values(const vector[string]&, bint, bint, bint) except +
         void delete_on_close() except +
         void explore(const string&, const string&) except +
         void show(const string&) except +
@@ -151,7 +151,7 @@ cdef class UnitySFrameProxy:
 
     cpdef copy_range(self, size_t start, size_t step, size_t end)
 
-    cpdef drop_missing_values(self, columns, bint is_all, bint split)
+    cpdef drop_missing_values(self, columns, bint is_all, bint split, bint recursive)
 
     cpdef __get_object_id(self)
 

--- a/src/python/turicreate/_cython/cy_sframe.pyx
+++ b/src/python/turicreate/_cython/cy_sframe.pyx
@@ -329,11 +329,11 @@ cdef class UnitySFrameProxy:
 
         return create_proxy_wrapper_from_existing_proxy(proxy)
 
-    cpdef drop_missing_values(self, _columns, bint is_all, bint split):
+    cpdef drop_missing_values(self, _columns, bint is_all, bint split, bint recursive):
         cdef vector[string] columns = to_vector_of_strings(_columns)
         cdef cpplist[unity_sframe_base_ptr] sf_array
         with nogil:
-            sf_array = self.thisptr.drop_missing_values(columns, is_all, split)
+            sf_array = self.thisptr.drop_missing_values(columns, is_all, split, recursive)
         assert sf_array.size() == 2
         cdef unity_sframe_base_ptr proxy_first = (sf_array.front())
         cdef unity_sframe_base_ptr proxy_second

--- a/src/python/turicreate/data_structures/sframe.py
+++ b/src/python/turicreate/data_structures/sframe.py
@@ -5556,7 +5556,7 @@ class SFrame(object):
         with cython_context():
             return SFrame(_proxy=self.__proxy__.sort(sort_column_names, sort_column_orders))
 
-    def dropna(self, columns=None, how='any'):
+    def dropna(self, columns=None, how='any', recursive=False):
         """
         Remove missing values from an SFrame. A missing value is either ``None``
         or ``NaN``.  If ``how`` is 'any', a row will be removed if any of the
@@ -5577,6 +5577,11 @@ class SFrame(object):
             Specifies whether a row should be dropped if at least one column
             has missing values, or if all columns have missing values.  'any' is
             default.
+
+        recursive: bool
+            By default is False. If this flag is set to True, then `nan` check will
+            be performed on each element of a sframe cell in a DFS manner if the cell
+            has a nested structure, such as dict, list.
 
         Returns
         -------
@@ -5631,9 +5636,9 @@ class SFrame(object):
         (columns, all_behavior) = self.__dropna_errchk(columns, how)
 
         with cython_context():
-            return SFrame(_proxy=self.__proxy__.drop_missing_values(columns, all_behavior, False))
+            return SFrame(_proxy=self.__proxy__.drop_missing_values(columns, all_behavior, False, recursive))
 
-    def dropna_split(self, columns=None, how='any'):
+    def dropna_split(self, columns=None, how='any', recursive=False):
         """
         Split rows with missing values from this SFrame. This function has the
         same functionality as :py:func:`~turicreate.SFrame.dropna`, but returns a
@@ -5651,6 +5656,12 @@ class SFrame(object):
             Specifies whether a row should be dropped if at least one column
             has missing values, or if all columns have missing values.  'any' is
             default.
+
+        recursive: bool
+            By default is False. If this flag is set to True, then `nan` check will
+            be performed on each element of a sframe cell in a recursive manner if the cell
+            has a nested structure, such as dict, list.
+
 
         Returns
         -------
@@ -5692,7 +5703,7 @@ class SFrame(object):
 
         (columns, all_behavior) = self.__dropna_errchk(columns, how)
 
-        sframe_tuple = self.__proxy__.drop_missing_values(columns, all_behavior, True)
+        sframe_tuple = self.__proxy__.drop_missing_values(columns, all_behavior, True, recursive)
 
         if len(sframe_tuple) != 2:
             raise RuntimeError("Did not return two SFrames!")

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -2976,35 +2976,45 @@ class SFrameTest(unittest.TestCase):
                           'lists':SArray([[1], None, [], [4], [5, 5], [6, np.nan], [7], None], list),
                           'dicts':SArray([{1:2},{2:3},{3:4},{},{5:None},{6:7},{7:[7,[7,np.nan]]},None], dict)})
 
-        # normal dropna
-        self.__test_equal(test_sf.dropna(),
-            pd.DataFrame({'array':[[1,1],[3,3],[4,4]],'lists':[[1],[],[4]],'dicts':[{1:2},{3:4},{}]}))
+        # non-recursive dropna
+        self.__test_equal(test_sf.dropna(how='any'),
+                          test_sf[0:1].append(test_sf[2:7]).to_dataframe())
         test_split = test_sf.dropna_split()
+        self.__test_equal(test_split[0], test_sf[0:1].append(test_sf[2:7]).to_dataframe())
+
+        self.__test_equal(test_sf.dropna(how='all'), test_sf.to_dataframe());
+        test_split = test_sf.dropna_split(how='all')
+        self.assertEqual(len(test_split[1]), 0)
+
+        # recursive dropna
+        self.__test_equal(test_sf.dropna(recursive=True),
+            pd.DataFrame({'array':[[1,1],[3,3],[4,4]],'lists':[[1],[],[4]],'dicts':[{1:2},{3:4},{}]}))
+        test_split = test_sf.dropna_split(recursive=True)
         self.__test_equal(test_split[0], test_sf[0:1].append(test_sf[2:4]).to_dataframe())
         # nan is not comparable, so we don't check the nan part
         # self.__test_equal(test_split[1], test_sf[1:2].append(test_sf[4:8]).to_dataframe())
 
         # the 'all' case
-        self.__test_equal(test_sf.dropna(how='all'), test_sf[0:7].to_dataframe())
-        test_split = test_sf.dropna_split(how='all')
+        self.__test_equal(test_sf.dropna(how='all', recursive=True), test_sf[0:7].to_dataframe())
+        test_split = test_sf.dropna_split(how='all', recursive=True)
         self.__test_equal(test_split[0], test_sf[0:7].to_dataframe())
 
         # test 'split' cases
-        self.__test_equal(test_sf.dropna('array'),
+        self.__test_equal(test_sf.dropna('array', recursive=True),
                           test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
-        test_split = test_sf.dropna_split('array')
+        test_split = test_sf.dropna_split('array', recursive=True)
         self.__test_equal(test_split[0],
                           test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
 
-        self.__test_equal(test_sf.dropna('lists'),
+        self.__test_equal(test_sf.dropna('lists', recursive=True),
                           test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
-        test_split = test_sf.dropna_split('lists')
+        test_split = test_sf.dropna_split('lists', recursive=True)
         self.__test_equal(test_split[0],
                           test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
 
-        self.__test_equal(test_sf.dropna('dicts'),
+        self.__test_equal(test_sf.dropna('dicts', recursive=True),
                           test_sf[0:4].append(test_sf[5:6]).to_dataframe())
-        test_split = test_sf.dropna_split('dicts')
+        test_split = test_sf.dropna_split('dicts', recursive=True)
         self.__test_equal(test_split[0],
                           test_sf[0:4].append(test_sf[5:6]).to_dataframe())
 

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -2971,6 +2971,42 @@ class SFrameTest(unittest.TestCase):
         self.__test_equal(test_split[0], self.employees_sf[0:5].to_dataframe())
         self.__test_equal(test_split[1], self.employees_sf[5:6].to_dataframe())
 
+        # test recursively removing nan
+        test_sf = SFrame({'array':SArray([[1,1],[2,np.nan],[3,3],[4,4],[5,5],[6,np.nan],[7,7],[8, np.nan]], np.ndarray),
+                          'lists':SArray([[1], None, [], [4], [5, 5], [6, np.nan], [7], None], list),
+                          'dicts':SArray([{1:2},{2:3},{3:4},{},{5:None},{6:7},{7:[7,[7,np.nan]]},None], dict)})
+
+        # normal dropna
+        self.__test_equal(test_sf.dropna(),
+            pd.DataFrame({'array':[[1,1],[3,3],[4,4]],'lists':[[1],[],[4]],'dicts':[{1:2},{3:4},{}]}))
+        test_split = test_sf.dropna_split()
+        self.__test_equal(test_split[0], test_sf[0:1].append(test_sf[2:4]).to_dataframe())
+        # nan is not comparable, so we don't check the nan part
+        # self.__test_equal(test_split[1], test_sf[1:2].append(test_sf[4:8]).to_dataframe())
+
+        # the 'all' case
+        self.__test_equal(test_sf.dropna(how='all'), test_sf[0:7].to_dataframe())
+        test_split = test_sf.dropna_split(how='all')
+        self.__test_equal(test_split[0], test_sf[0:7].to_dataframe())
+
+        # test 'split' cases
+        self.__test_equal(test_sf.dropna('array'),
+                          test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
+        test_split = test_sf.dropna_split('array')
+        self.__test_equal(test_split[0],
+                          test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
+
+        self.__test_equal(test_sf.dropna('lists'),
+                          test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
+        test_split = test_sf.dropna_split('lists')
+        self.__test_equal(test_split[0],
+                          test_sf[0:1].append(test_sf[2:5]).append(test_sf[6:7]).to_dataframe())
+
+        self.__test_equal(test_sf.dropna('dicts'),
+                          test_sf[0:4].append(test_sf[5:6]).to_dataframe())
+        test_split = test_sf.dropna_split('dicts')
+        self.__test_equal(test_split[0],
+                          test_sf[0:4].append(test_sf[5:6]).to_dataframe())
 
         # create some other test sframe
         test_sf = SFrame({'ints':SArray([None,None,3,4,None], int),

--- a/src/visualization/annotation/annotation_base.cpp
+++ b/src/visualization/annotation/annotation_base.cpp
@@ -77,7 +77,7 @@ AnnotationBase::returnAnnotations(bool drop_null) {
 
   std::vector<std::string> annotation_column_name = {m_annotation_column};
   std::list<std::shared_ptr<unity_sframe_base>> dropped_missing =
-      copy_data->drop_missing_values(annotation_column_name, false, false);
+      copy_data->drop_missing_values(annotation_column_name, false, false, false);
 
   std::shared_ptr<unity_sframe> final_sf =
       std::static_pointer_cast<unity_sframe>(dropped_missing.front());

--- a/src/visualization/annotation/image_classification.cpp
+++ b/src/visualization/annotation/image_classification.cpp
@@ -368,7 +368,7 @@ void ImageClassification::cast_annotations() {
 
   std::vector<std::string> annotation_column_name = {m_annotation_column};
   std::list<std::shared_ptr<unity_sframe_base>> dropped_missing =
-      copy_data->drop_missing_values(annotation_column_name, false, false);
+      copy_data->drop_missing_values(annotation_column_name, false, false, false);
 
   std::shared_ptr<unity_sframe> filtered_sframe =
       std::static_pointer_cast<unity_sframe>(dropped_missing.front());


### PR DESCRIPTION
feature request #1804 

per user request:
```
import turicreate as tc
import numpy as np
data = tc.SFrame({'a':[[0, np.nan],[1,2]]})
data.dropna()
Columns:
	a	array

Rows: 1

Data:
+------------+
|     a      |
+------------+
| [1.0, 2.0] |
+------------+
[1 rows x 1 columns]

data = tc.SFrame({'a':[[0, None, "sd"],[1,2]]})
data.dropna() # same result
```

when dropna is called, the program will recursively check each cell in sframe whether it contains **nan** for array type, **None** for other types. if it contains, it will be dropped.

==========update on July 11, 2019=============
user can opt in dropna with recursive check on whether nan values are contained in each cell.
```
data.dropna(recursive=True)
```