### PR TITLE
Updated syntax for Python 2.7 and 3.6 Build Breaks

### DIFF
--- a/src/python/turicreate/test/test_sframe_builder.py
+++ b/src/python/turicreate/test/test_sframe_builder.py
@@ -62,7 +62,7 @@ class SFrameBuilderTest(unittest.TestCase):
             sb.append(extra_data)
 
         sb = SFrameBuilder(self.all_types)
-        sf_data_extra = list(zip(*self.all_type_cols, self.int_data))
+        sf_data_extra = list(zip(*(self.all_type_cols + [self.int_data])))
         with self.assertRaises(RuntimeError):
             sb.append_multiple(sf_data_extra)
 


### PR DESCRIPTION
- Updated the testing syntax for Python 2.7 and 3.6 Build Breaks in master.