### PR TITLE
Add Python 3.7 to docker images

### DIFF
--- a/scripts/Dockerfile-Ubuntu-10.04
+++ b/scripts/Dockerfile-Ubuntu-10.04
@@ -119,6 +119,17 @@ RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enab
     ldconfig && \
     rm -rf /src/Python-3.6.8*
 
+# Install Python 3.7 from source
+WORKDIR /src
+RUN curl -O https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
+RUN tar xf Python-3.7.3.tgz
+WORKDIR /src/Python-3.7.3
+RUN ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared --enable-loadable-sqlite-extensions && \
+    make -j4 --quiet && \
+    make install && \
+    ldconfig && \
+    rm -rf /src/Python-3.7.3*
+
 # Install pip and virtualenv
 WORKDIR /src
 RUN curl -O https://bootstrap.pypa.io/get-pip.py
@@ -128,6 +139,8 @@ RUN python3.5 get-pip.py
 RUN pip3.5 install virtualenv
 RUN python3.6 get-pip.py
 RUN pip3.6 install virtualenv
+RUN python3.7 get-pip.py
+RUN pip3.7 install virtualenv
 RUN rm -rf /src/get-pip.py
 
 # Install llvm 8.0.0 from source with clang (no libc++)

--- a/scripts/Dockerfile-Ubuntu-10.04
+++ b/scripts/Dockerfile-Ubuntu-10.04
@@ -49,7 +49,7 @@ RUN apt-get update && \
                rsync \
                git \
                file \
-               libffi-dev \
+               pkg-config \
                xz-utils && \
     ln -s /usr/bin/gcc-4.8 /usr/bin/gcc && \
     ln -s /usr/bin/g++-4.8 /usr/bin/g++ && \
@@ -86,8 +86,19 @@ RUN tar xf cmake-3.13.4-Linux-x86_64.tar.gz && \
     rm -rf /opt/cmake-3.13.4-Linux-x86_64.tar.gz
 ENV PATH="/opt/cmake-3.13.4-Linux-x86_64/bin:${PATH}"
 
-# Install Python 2.7 from source
+# Install libffi from source
 RUN mkdir -p /src
+WORKDIR /src
+RUN curl -O ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz
+RUN tar xf libffi-3.2.1.tar.gz
+WORKDIR /src/libffi-3.2.1
+RUN ./configure --prefix=/usr/local && \
+    make -j4 --quiet && \
+    make install && \
+    ldconfig && \
+    rm -rf /src/libffi-3.2.1*
+
+# Install Python 2.7 from source
 WORKDIR /src
 RUN curl -O https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz
 RUN tar xf Python-2.7.15.tgz

--- a/scripts/Dockerfile-Ubuntu-10.04
+++ b/scripts/Dockerfile-Ubuntu-10.04
@@ -49,6 +49,7 @@ RUN apt-get update && \
                rsync \
                git \
                file \
+               libffi-dev \
                xz-utils && \
     ln -s /usr/bin/gcc-4.8 /usr/bin/gcc && \
     ln -s /usr/bin/g++-4.8 /usr/bin/g++ && \
@@ -168,10 +169,8 @@ ENV CXX="clang++"
 WORKDIR /build
 
 # Set ccache size to 4GB
-CMD mkdir -p $CCACHE_DIR
-CMD ccache -s
-CMD ccache -M 4G
+RUN mkdir -p $CCACHE_DIR
+RUN ccache -M 4G
 
 # Clean up now-unnecessary paths in image
-CMD apt-get clean
-CMD rm -rf /src
+RUN rm -rf /src

--- a/scripts/Dockerfile-Ubuntu-18.04
+++ b/scripts/Dockerfile-Ubuntu-18.04
@@ -13,13 +13,13 @@ RUN apt-get update
 # Upgrade all possible packages
 RUN apt-get -y upgrade
 
-# Install Python 3.6 with apt, as well as
+# Install Python 3.6 and 3.7 with apt, as well as
 # turicreate and upstream dependencies
-RUN apt-get -y install python3.6 python3.6-distutils libgomp1 lsb-release
+RUN apt-get -y install python3.6 python3.6-distutils python3.7 python3.7-distutils libgomp1 lsb-release
 
-# Install build-essential (needed by numpy==1.11.1, which tries to
-# build itself from source on 3.6)
-RUN apt-get -y install build-essential libpython3.6-dev
+# Install build-essential (needed by numpy, which tries to
+# build itself from source on 3.6 and above)
+RUN apt-get -y install build-essential libpython3.6-dev libpython3.7-dev
 RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 
 # Install pip and virtualenv
@@ -27,3 +27,5 @@ ADD https://bootstrap.pypa.io/get-pip.py /src/get-pip.py
 WORKDIR /src
 RUN python3.6 get-pip.py
 RUN pip3.6 install virtualenv
+RUN python3.7 get-pip.py
+RUN pip3.7 install virtualenv

--- a/scripts/get_docker_image.sh
+++ b/scripts/get_docker_image.sh
@@ -35,7 +35,7 @@ if [[ -z "${UBUNTU_VERSION}" ]]; then
 fi
 
 # The build image version that will be used for building
-TC_BUILD_IMAGE_VERSION="1.0.0"
+TC_BUILD_IMAGE_VERSION="1.0.1"
 
 # The base image name - using Gitlab CI registry
 TC_BUILD_IMAGE="registry.gitlab.com/zach_nation/turicreate/build-image-${UBUNTU_VERSION}:${TC_BUILD_IMAGE_VERSION}"


### PR DESCRIPTION
* Adds Python 3.7 to the Ubuntu 10.04 and 18.04 images
* Adds libffi (installed from source) and pkg-config to the 10.04 image (needed to build Python 3.7 from source)
* Switches some `CMD`s to `RUN` since that seems to have closer to the intended behavior.
* Drops `apt-get clean` since apparently the official Ubuntu images (upon which ours are based) do this automatically: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/