### PR TITLE
Add support for fillRect() to JSCanvas

### DIFF
--- a/src/visualization/vega_renderer/JSCanvas.h
+++ b/src/visualization/vega_renderer/JSCanvas.h
@@ -119,6 +119,12 @@ JSExportAs(fillText,
            x:(double)x
            y:(double)y
            );
+JSExportAs(fillRect,
+            - (void)fillRectWithX:(double)x
+            y:(double)y
+            width:(double)width
+            height:(double)height
+            );
 JSExportAs(lineTo,
            - (void)lineToX:(double)x
            y:(double)y

--- a/src/visualization/vega_renderer/JSCanvas.m
+++ b/src/visualization/vega_renderer/JSCanvas.m
@@ -588,6 +588,11 @@
     CFRelease(line);
 }
 
+- (void)fillRectWithX:(double)x y:(double)y width:(double)width height:(double)height {
+    [self rectWithX:x y:y width:width height:height];
+    [self fill];
+}
+
 - (void)rectWithX:(double)x y:(double)y width:(double)width height:(double)height {
     CGContextAddRect(self.context, CGRectMake(x, y, width, height));
 }

--- a/test/vega_renderer/CMakeLists.txt
+++ b/test/vega_renderer/CMakeLists.txt
@@ -4,6 +4,7 @@ if(APPLE AND NOT TC_BUILD_IOS)
 
     # sets XCTest_LIBRARIES
     include(FindXCTest)
+    include_directories(${XCTest_INCLUDE_DIRS})
 
     find_library( WEBKIT WebKit )
     message( STATUS "WebKit found at ${WEBKIT}")

--- a/test/vega_renderer/base_fixture.mm
+++ b/test/vega_renderer/base_fixture.mm
@@ -10,7 +10,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <core/util/test_macros.hpp>
 
-#import <vega_renderer/VegaRenderer.h>
+#import <visualization/vega_renderer/VegaRenderer.h>
 #import "vega_webkit_renderer.hpp"
 
 using namespace vega_renderer::test_utils;

--- a/test/vega_renderer/examples/turicreate/simple_themed_bar_chart.vl.json
+++ b/test/vega_renderer/examples/turicreate/simple_themed_bar_chart.vl.json
@@ -1,0 +1,182 @@
+{
+    "mark": "bar",
+    "encoding": {
+      "x": {
+        "field": "a",
+        "type": "ordinal"
+      },
+      "y": {
+        "field": "b",
+        "type": "quantitative"
+      },
+      "color": {
+        "condition": {
+          "value": "#A7A7AD",
+          "test": "datum.a === null"
+        }
+      }
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "data": {
+      "values": [
+        {
+          "a": "A",
+          "b": 20
+        },
+        {
+          "a": "B",
+          "b": 34
+        },
+        {
+          "a": "C",
+          "b": 55
+        },
+        {
+          "a": "D",
+          "b": 19
+        },
+        {
+          "a": "E",
+          "b": 40
+        },
+        {
+          "a": "F",
+          "b": 34
+        },
+        {
+          "a": "G",
+          "b": 91
+        },
+        {
+          "a": "H",
+          "b": 78
+        },
+        {
+          "a": "I",
+          "b": 25
+        },
+        {
+          "a": null,
+          "b": 60
+        }
+      ]
+    },
+    "config": {
+      "legend": {
+        "symbolBaseFillColor": "#fff",
+        "offset": 24
+      },
+      "range": {
+        "ramp": {
+          "scheme": "viridis",
+          "extent": [
+            0,
+            1
+          ]
+        },
+        "turi16": [
+          "#308BEF",
+          "#AFD3FD",
+          "#4DC960",
+          "#AEE395",
+          "#FF9500",
+          "#FBD397",
+          "#EF5C53",
+          "#FF9DA8",
+          "#A34FCD",
+          "#E9AEFF",
+          "#00A39B",
+          "#42D3C6",
+          "#98685E",
+          "#CCB1A0",
+          "#AC9A06",
+          "#EEDB41"
+        ],
+        "heatmap": {
+          "scheme": "viridis",
+          "extent": [
+            0,
+            1
+          ]
+        },
+        "category": [
+          "#308BEF",
+          "#4DC960",
+          "#FF9500",
+          "#EF5C53",
+          "#A34FCD",
+          "#00A39B",
+          "#98685E",
+          "#EEDB41"
+        ],
+        "ordinal": {
+          "scheme": "viridis",
+          "extent": [
+            0,
+            1
+          ]
+        }
+      },
+      "circle": {
+        "size": 50
+      },
+      "title": {
+        "color": "#fff",
+        "fontSize": 14,
+        "offset": 16
+      },
+      "point": {
+        "size": 50
+      },
+      "text": {
+        "fill": "#fff"
+      },
+      "mark": {
+        "color": "#308BEF"
+      },
+      "square": {
+        "size": 50
+      },
+      "view": {
+        "stroke": "#484856"
+      },
+      "scale": {
+        "rangeStep": 20,
+        "bandPaddingInner": 0.20000000000000001
+      },
+      "axis": {
+        "tickColor": "#484856",
+        "labelSeparation": 4,
+        "domain": false,
+        "gridColor": "#484856",
+        "titlePadding": 8
+      },
+      "background": "#23232B",
+      "area": {
+        "opacity": 0.40000000000000002
+      },
+      "style": {
+        "lineMarker": {
+          "fill": "white",
+          "stroke": "#308BEF"
+        },
+        "crosshair": {
+          "strokeDash": [
+            2,
+            2
+          ],
+          "stroke": "#666"
+        },
+        "guide-title": {
+          "fill": "#fff",
+          "fontSize": 12,
+          "fontWeight": 600
+        },
+        "guide-label": {
+          "fill": "#fff",
+          "fontSize": 11
+        }
+      }
+    }
+  }
+  

--- a/test/vega_renderer/turicreate_example_tests.cxx
+++ b/test/vega_renderer/turicreate_example_tests.cxx
@@ -16,6 +16,7 @@
 #include "examples/turicreate/clang_format_boxes_and_whiskers.vg.h"
 #include "examples/turicreate/clang_format_histogram.vg.h"
 #include "examples/turicreate/mushroom_categorical_histogram.vg.h"
+#include "examples/turicreate/simple_themed_bar_chart.vl.h"
 
 using namespace vega_renderer::test_utils;
 
@@ -73,6 +74,12 @@ BOOST_AUTO_TEST_CASE(testCategoricalHistogram) {
   this->run_test_spec(examples_turicreate_mushroom_categorical_histogram_vg_json,
                       examples_turicreate_mushroom_categorical_histogram_vg_json_len,
                       "mushroom_categorical_histogram");
+}
+
+BOOST_AUTO_TEST_CASE(testSimpleThemedBarChart) {
+  this->run_test_spec(examples_turicreate_simple_themed_bar_chart_vl_json,
+                      examples_turicreate_simple_themed_bar_chart_vl_json_len,
+                      "simple_themed_barchart");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/vega_renderer/turicreate_example_tests.cxx
+++ b/test/vega_renderer/turicreate_example_tests.cxx
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalHistogram) {
 BOOST_AUTO_TEST_CASE(testSimpleThemedBarChart) {
   this->run_test_spec(examples_turicreate_simple_themed_bar_chart_vl_json,
                       examples_turicreate_simple_themed_bar_chart_vl_json_len,
-                      "simple_themed_barchart");
+                      "simple_themed_bar_chart");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Implements the missing `fillRect(x, y, w, h)` method in `JSCanvas`. Also, fix a few import paths.