### PR TITLE
Control OD/AC (C-API) weight initialization and random sampling with seeds

### DIFF
--- a/src/ml/neural_net/TCMPSImageAugmenting.h
+++ b/src/ml/neural_net/TCMPSImageAugmenting.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** Facilitates the injection of Turi (C++) random number generators. */
+/** Facilitates the injection of C++ random number generators. */
 typedef CGFloat (^TCMPSUniformRandomNumberGenerator)(CGFloat lowerBound,
                                                      CGFloat upperBound);
 
@@ -54,7 +54,8 @@ API_AVAILABLE(macos(10.13))
 API_AVAILABLE(macos(10.13))
 @protocol TCMPSImageAugmenting <NSObject>
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 
 @end
 
@@ -66,7 +67,8 @@ API_AVAILABLE(macos(10.13))
 
 - (instancetype)initWithSize:(CGSize)size;
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 
 @end
 
@@ -76,9 +78,8 @@ API_AVAILABLE(macos(10.13))
 
 @property(nonatomic) CGFloat skipProbability;
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng;
-
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 
 @end
 
@@ -97,10 +98,8 @@ API_AVAILABLE(macos(10.13))
 @property(nonatomic) NSUInteger maxAttempts;
 @property(nonatomic) CGFloat minEjectCoverage;
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng;
-
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
-
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 @end
 
 /** Augmenter that possibly applies random padding. */
@@ -116,9 +115,8 @@ API_AVAILABLE(macos(10.13))
 @property(nonatomic) CGFloat maxAreaFraction;
 @property(nonatomic) NSUInteger maxAttempts;
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng;
-
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 
 @end
 
@@ -132,9 +130,8 @@ API_AVAILABLE(macos(10.13))
 @property(nonatomic) CGFloat maxContrastProportion;
 @property(nonatomic) CGFloat maxSaturationProportion;
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng;
-
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 
 @end
 
@@ -145,9 +142,8 @@ API_AVAILABLE(macos(10.13))
 // Multiplied by pi to obtain maximum angular change in radians.
 @property(nonatomic) CGFloat maxHueAdjust;
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng;
-
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source;
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform;
 
 @end
 

--- a/src/ml/neural_net/TCMPSImageAugmenting.m
+++ b/src/ml/neural_net/TCMPSImageAugmenting.m
@@ -36,8 +36,9 @@
   return self;
 }
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source {
-
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform
+{
   TCMPSLabeledImage *result = [TCMPSLabeledImage new];
 
   // Determine the affine transform to apply.
@@ -77,27 +78,21 @@
 
 @end
 
-@interface TCMPSHorizontalFlipAugmenter ()
-
-@property(nonatomic) TCMPSUniformRandomNumberGenerator random;
-
-@end
-
 @implementation TCMPSHorizontalFlipAugmenter
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng {
-
+- (instancetype)init
+{
   self = [super init];
   if (self) {
-    _random = rng;
     _skipProbability = 0.5f;
   }
   return self;
 }
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source {
-
-  if (self.random(0.f, 1.f) < self.skipProbability) {
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform
+{
+  if (uniform(0.f, 1.f) < self.skipProbability) {
     return source;
   }
 
@@ -126,19 +121,12 @@
 
 @end
 
-@interface TCMPSRandomCropAugmenter ()
-
-@property(nonatomic) TCMPSUniformRandomNumberGenerator random;
-
-@end
-
 @implementation TCMPSRandomCropAugmenter
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng {
-
+- (instancetype)init
+{
   self = [super init];
   if (self) {
-    _random = rng;
     _skipProbability = 0.1f;
     _minAspectRatio = 0.8f;
     _maxAspectRatio = 1.25f;
@@ -151,9 +139,10 @@
   return self;
 }
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source {
-
-  if (self.random(0.f, 1.f) < self.skipProbability) {
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform
+{
+  if (uniform(0.f, 1.f) < self.skipProbability) {
     return source;
   }
 
@@ -165,7 +154,7 @@
   for (NSUInteger i = 0; i < self.maxAttempts; ++i) {
 
     // Randomly sample an aspect ratio.
-    CGFloat aspectRatio = self.random(self.minAspectRatio, self.maxAspectRatio);
+    CGFloat aspectRatio = uniform(self.minAspectRatio, self.maxAspectRatio);
 
     // Next we'll sample a height (which combined with the now known aspect
     // ratio, determines the size and area). But first we must compute the range
@@ -203,12 +192,12 @@
     }
 
     CGRect cropRect;
-    cropRect.size.height = self.random(minHeight, maxHeight);
+    cropRect.size.height = uniform(minHeight, maxHeight);
     cropRect.size.width = cropRect.size.height * aspectRatio;
 
     // Sample a position for the crop, constrained to lie within the image.
-    cropRect.origin.x = self.random(0.f, imageWidth - cropRect.size.width);
-    cropRect.origin.y = self.random(0.f, imageHeight - cropRect.size.height);
+    cropRect.origin.x = uniform(0.f, imageWidth - cropRect.size.width);
+    cropRect.origin.y = uniform(0.f, imageHeight - cropRect.size.height);
 
     // Compensate for the image bound's origin.
     cropRect.origin.x += source.bounds.origin.x;
@@ -277,19 +266,12 @@
 
 @end
 
-@interface TCMPSRandomPadAugmenter ()
-
-@property(nonatomic) TCMPSUniformRandomNumberGenerator random;
-
-@end
-
 @implementation TCMPSRandomPadAugmenter
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng {
-
+- (instancetype)init
+{
   self = [super init];
   if (self) {
-    _random = rng;
     _skipProbability = 0.1f;
     _minAspectRatio = 0.8f;
     _maxAspectRatio = 1.25f;
@@ -300,9 +282,10 @@
   return self;
 }
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source {
-
-  if (self.random(0.f, 1.f) < self.skipProbability) {
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform
+{
+  if (uniform(0.f, 1.f) < self.skipProbability) {
     return source;
   }
 
@@ -318,7 +301,7 @@
   while (minHeight >= maxHeight && numAttempts++ < self.maxAttempts) {
 
     // Randomly sample an aspect ratio.
-    aspectRatio = self.random(self.minAspectRatio, self.maxAspectRatio);
+    aspectRatio = uniform(self.minAspectRatio, self.maxAspectRatio);
 
     // The padded height must be at least as large as the original height.
     // h' >= h
@@ -351,12 +334,12 @@
 
   // Sample a final size, given the sampled aspect ratio and range of heights.
   CGSize paddedSize;
-  paddedSize.height = self.random(minHeight, maxHeight);
+  paddedSize.height = uniform(minHeight, maxHeight);
   paddedSize.width = paddedSize.height * aspectRatio;
 
   // Sample the offset of the source image inside the padded image.
-  CGFloat xOffset = self.random(0.f, paddedSize.width - imageWidth);
-  CGFloat yOffset = self.random(0.f, paddedSize.height - imageHeight);
+  CGFloat xOffset = uniform(0.f, paddedSize.width - imageWidth);
+  CGFloat yOffset = uniform(0.f, paddedSize.height - imageHeight);
 
   // Pad the image by compositing the source image over a gray background and
   // cropping to the desired bounds.
@@ -383,18 +366,12 @@
 
 @end
 
-@interface TCMPSColorControlAugmenter ()
-
-@property(nonatomic) TCMPSUniformRandomNumberGenerator random;
-
-@end
-
 @implementation TCMPSColorControlAugmenter
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng {
+- (instancetype)init
+{
   self = [super init];
   if (self) {
-    _random = rng;
     _maxBrightnessDelta = 0.05f;
     _maxContrastProportion = 0.05f;
     _maxSaturationProportion = 0.05f;
@@ -402,27 +379,28 @@
   return self;
 }
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source {
-
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform
+{
   // Sample a random adjustment to brightness.
   CGFloat brightnessDelta = 0.0f;
   if (self.maxBrightnessDelta > 0.f) {
-    brightnessDelta += self.random(-self.maxBrightnessDelta,
-                                   self.maxBrightnessDelta);
+    brightnessDelta += uniform(-self.maxBrightnessDelta,
+                               self.maxBrightnessDelta);
   }
 
   // Sample a random adjustment to contrast.
   CGFloat contrastProportion = 1.0f;
   if (self.maxContrastProportion > 0.f) {
-    contrastProportion += self.random(-self.maxContrastProportion,
-                                      self.maxContrastProportion);
+    contrastProportion += uniform(-self.maxContrastProportion,
+                                  self.maxContrastProportion);
   }
 
   // Sample a random adjustment to saturation.
   CGFloat saturationProportion = 1.0f;
   if (self.maxSaturationProportion > 0.f) {
-    saturationProportion += self.random(-self.maxSaturationProportion,
-                                        self.maxSaturationProportion);
+    saturationProportion += uniform(-self.maxSaturationProportion,
+                                    self.maxSaturationProportion);
   }
 
   TCMPSLabeledImage *result = [TCMPSLabeledImage new];
@@ -445,29 +423,24 @@
 
 @end
 
-@interface TCMPSHueAdjustAugmenter ()
-
-@property(nonatomic) TCMPSUniformRandomNumberGenerator random;
-
-@end
-
 @implementation TCMPSHueAdjustAugmenter
 
-- (instancetype)initWithRNG:(TCMPSUniformRandomNumberGenerator)rng {
+- (instancetype)init
+{
   self = [super init];
   if (self) {
-    _random = rng;
     _maxHueAdjust = 0.05f;
   }
   return self;
 }
 
-- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source {
-
+- (TCMPSLabeledImage *)imageAugmentedFromImage:(TCMPSLabeledImage *)source
+                                     generator:(TCMPSUniformRandomNumberGenerator)uniform
+{
   // Sample a random rotation around the color wheel.
   CGFloat hueAdjust = 0.0f;
   if (self.maxHueAdjust > 0.f) {
-    hueAdjust += M_PI * self.random(-self.maxHueAdjust, self.maxHueAdjust);
+    hueAdjust += M_PI * uniform(-self.maxHueAdjust, self.maxHueAdjust);
   }
 
   TCMPSLabeledImage *result = [TCMPSLabeledImage new];

--- a/src/ml/neural_net/image_augmentation.hpp
+++ b/src/ml/neural_net/image_augmentation.hpp
@@ -173,6 +173,9 @@ public:
     /** The H dimension of the resulting float array. */
     size_t output_height = 0;
 
+    /** Seed for all pseudo-random number generation used by augmentation. */
+    int random_seed = 0;
+
     /** The probability of applying (attempting) a random crop. */
     float crop_prob = 0.f;
     crop_options crop_opts;

--- a/src/ml/neural_net/mps_image_augmentation.hpp
+++ b/src/ml/neural_net/mps_image_augmentation.hpp
@@ -22,20 +22,27 @@ namespace neural_net {
 class API_AVAILABLE(macos(10.13)) mps_image_augmenter: public image_augmenter {
 public:
 
-  // Uses turi::random::fast_uniform for a random number generator if one is not
-  // provided.
-  explicit mps_image_augmenter(
+  explicit mps_image_augmenter(const options& opts);
+
+  // Variant constructor allowing injection of the random number generator,
+  // largely for testing.
+  mps_image_augmenter(
       const options& opts,
-      std::function<float(float lower_bound, float upper_bound)> rng = nullptr);
+      std::function<float(float lower_bound, float upper_bound)> rng);
 
   const options& get_options() const override { return opts_; }
 
   result prepare_images(std::vector<labeled_image> source_batch) override;
 
 private:
+
+  mps_image_augmenter(const options& opts,
+                      NSArray<TCMPSUniformRandomNumberGenerator> *rng_batch);
+
   options opts_;
-  CIContext *context_ = nullptr;
-  NSArray<id <TCMPSImageAugmenting>> *augmentations_ = nullptr;
+  CIContext *context_ = nil;
+  NSArray<id <TCMPSImageAugmenting>> *augmentations_ = nil;
+  NSArray<TCMPSUniformRandomNumberGenerator> *rng_batch_ = nil;
 };
 
 }  // neural_net

--- a/src/ml/neural_net/weight_init.cpp
+++ b/src/ml/neural_net/weight_init.cpp
@@ -15,10 +15,10 @@ namespace {
 
 std::uniform_real_distribution<float> uniform_distribution_for_xavier(
     size_t fan_in, size_t fan_out)
-  {
-  float magnitude = std::sqrt(3.f / (0.5f * fan_in 0.5f * fan_out));
+{
+  float magnitude = std::sqrt(3.f / (0.5f * fan_in + 0.5f * fan_out));
   return std::uniform_real_distribution<float>(-magnitude, magnitude);
-  }
+}
 
 }  // namespace
 

--- a/src/ml/neural_net/weight_init.hpp
+++ b/src/ml/neural_net/weight_init.hpp
@@ -8,6 +8,7 @@
 #define UNITY_TOOLKITS_NEURAL_NET_WEIGHT_INIT_HPP_
 
 #include <functional>
+#include <random>
 
 namespace turi {
 namespace neural_net {
@@ -29,18 +30,22 @@ public:
    *
    * \param fan_in The number of inputs that affect each output from the layer
    * \param fan_out The number of outputs affected by each input to the layer
+   * \param random_engine The random number generator to use, which must remain
+   *     valid for the lifetime of this instance.
    */
-  xavier_weight_initializer(size_t fan_in, size_t fan_out);
+  xavier_weight_initializer(size_t fan_in, size_t fan_out,
+                            std::mt19937* random_engine);
 
   /**
    * Initializes each value in uniformly at random in the range [-c,c], where
    * c = sqrt(3 / (0.5 * fan_in + 0.5 * fan_out).
    */
-  void operator()(float* first_weight, float* last_weight) const;
+  void operator()(float* first_weight, float* last_weight);
 
 private:
 
-  float magnitude_;
+  std::uniform_real_distribution<float> dist_;
+  std::mt19937& random_engine_;
 };
 
 struct zero_weight_initializer {
@@ -53,7 +58,7 @@ struct zero_weight_initializer {
 struct lstm_weight_initializers {
 
   static lstm_weight_initializers create_with_xavier_method(
-      size_t input_size, size_t state_size);
+      size_t input_size, size_t state_size, std::mt19937* random_engine);
 
   // Initializers for matrices applied to sequence input
   weight_initializer input_gate_weight_fn;

--- a/src/toolkits/activity_classification/ac_data_iterator.cpp
+++ b/src/toolkits/activity_classification/ac_data_iterator.cpp
@@ -517,7 +517,9 @@ simple_data_iterator::simple_data_iterator(const parameters &params)
       end_of_rows_(range_iterator_.end()),
       sample_in_row_(0),
       is_train_(params.is_train),
-      use_data_augmentation_(params.use_data_augmentation) {}
+      use_data_augmentation_(params.use_data_augmentation),
+      random_engine_(params.random_seed)
+{}
 
 const flex_list& simple_data_iterator::feature_names() const {
   return data_.feature_names;
@@ -587,7 +589,9 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
     if (sample_in_row_ == 0 &&
         static_cast<size_t>(chunk_length) > num_samples_per_prediction_ &&
         is_train_ && use_data_augmentation_) {
-      sample_in_row_ = std::rand() % (num_samples_per_prediction_ - 1);
+      std::uniform_int_distribution<size_t> dist(
+          0, num_samples_per_prediction_ - 1);
+      sample_in_row_ = dist(random_engine_);
     }
 
     // Stores the start of next instance

--- a/src/toolkits/activity_classification/ac_data_iterator.hpp
+++ b/src/toolkits/activity_classification/ac_data_iterator.hpp
@@ -7,6 +7,7 @@
 #ifndef TURI_ACTIVITY_CLASSIFICATION_AC_DATA_ITERATOR_HPP_
 #define TURI_ACTIVITY_CLASSIFICATION_AC_DATA_ITERATOR_HPP_
 
+#include <random>
 #include <string>
 #include <vector>
 
@@ -66,6 +67,9 @@ public:
 
     /** Augments training data when set to true*/
     bool use_data_augmentation = false;
+
+    /** Determines results of data augmentation if enabled. */
+    int random_seed = 0;
   };
 
   /** Defines the output of a data_iterator. */
@@ -195,6 +199,7 @@ private:
   size_t sample_in_row_ = 0;
   bool is_train_ = false;
   bool use_data_augmentation_ = false;
+  std::default_random_engine random_engine_;
 };
 
 /**

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -168,9 +168,22 @@ void activity_classifier::init_options(
       "offset."
       " If set to True, the trained model uses augmented data.",
       false);
+  options.create_integer_option(
+      "random_seed",
+      "Seed for random weight initialization and sampling during training",
+      FLEX_UNDEFINED,
+      std::numeric_limits<int>::min(),
+      std::numeric_limits<int>::max());
 
   // Validate user-provided options.
   options.set_options(opts);
+
+  // Choose a random seed if not set.
+  if (options.value("random_seed") == FLEX_UNDEFINED) {
+    std::random_device random_device;
+    int random_seed = static_cast<int>(random_device());
+    options.set_option("random_seed", random_seed);
+  }
 
   // Write model fields.
   add_or_update_state(flexmap_to_varmap(options.current_option_values()));
@@ -295,18 +308,14 @@ void activity_classifier::init_table_printer(bool has_validation) {
 }
 
 void activity_classifier::train(
-    gl_sframe data, const std::string& target_column_name,
-    const std::string& session_id_column_name, variant_type validation_data,
-    const std::map<std::string, flexible_type>& opts) {
-  gl_sframe train_data;
-  gl_sframe val_data;
-  std::tie(train_data, val_data) =
-      init_data(data, validation_data, session_id_column_name);
-
+    gl_sframe data, std::string target_column_name,
+    std::string session_id_column_name, variant_type validation_data,
+    std::map<std::string, flexible_type> opts)
+{
   // Instantiate the training dependencies: data iterator, compute context,
   // backend NN model.
-  init_train(std::move(train_data), target_column_name, session_id_column_name,
-             std::move(val_data), opts);
+  init_train(data, target_column_name, session_id_column_name, validation_data,
+             opts);
 
   // Perform all the iterations at once.
   flex_int max_iterations = read_state<flex_int>("max_iterations");
@@ -327,9 +336,9 @@ void activity_classifier::train(
 
   // Update the state with recall, precision and confusion matrix for training
   // data
-  gl_sarray train_predictions = predict(train_data, "probability_vector");
+  gl_sarray train_predictions = predict(training_data_, "probability_vector");
   variant_map_type train_metric = evaluation::compute_classifier_metrics(
-      train_data, target_column_name, "report", train_predictions,
+      training_data_, target_column_name, "report", train_predictions,
       {{"classes", read_state<flex_list>("classes")}});
 
   for (auto &p : train_metric) {
@@ -338,10 +347,10 @@ void activity_classifier::train(
 
   // Update the state with recall, precision and confusion matrix for validation
   // data
-  if (!val_data.empty()) {
-    gl_sarray val_predictions = predict(val_data, "probability_vector");
+  if (!validation_data_.empty()) {
+    gl_sarray val_predictions = predict(validation_data_, "probability_vector");
     variant_map_type val_metric = evaluation::compute_classifier_metrics(
-        val_data, target_column_name, "report", val_predictions,
+        validation_data_, target_column_name, "report", val_predictions,
         {{"classes", read_state<flex_list>("classes")}});
 
     for (auto &p : val_metric) {
@@ -600,13 +609,14 @@ std::unique_ptr<data_iterator> activity_classifier::create_iterator(
   if (requires_labels) {
     data_params.target_column_name = read_state<flex_string>("target");
   }
-  data_params.use_data_augmentation = use_data_augmentation;
   data_params.session_id_column_name = read_state<flex_string>("session_id");
   flex_list features = read_state<flex_list>("features");
   data_params.feature_column_names =
       std::vector<std::string>(features.begin(), features.end());
   data_params.prediction_window = read_state<flex_int>("prediction_window");
   data_params.predictions_in_chunk = NUM_PREDICTIONS_PER_CHUNK;
+  data_params.use_data_augmentation = use_data_augmentation;
+  data_params.random_seed = read_state<int>("random_seed");
   return std::unique_ptr<data_iterator>(new simple_data_iterator(data_params));
 }
 
@@ -626,6 +636,10 @@ std::unique_ptr<model_spec> activity_classifier::init_model() const
   size_t prediction_window = read_state<flex_int>("prediction_window");
   const flex_list &features_list = read_state<flex_list>("features");
 
+  // Initialize a random number generator for weight initialization.
+  std::seed_seq seed_seq = { read_state<int>("random_seed") };
+  std::mt19937 random_engine(seed_seq);
+
   result->add_channel_concat(
       "features",
       std::vector<std::string>(features_list.begin(), features_list.end()));
@@ -643,7 +657,8 @@ std::unique_ptr<model_spec> activity_classifier::init_model() const
       /* padding */ padding_type::VALID,
       /* weight_init_fn */
       xavier_weight_initializer(num_features * prediction_window,
-                                NUM_CONV_FILTERS * prediction_window),
+                                NUM_CONV_FILTERS * prediction_window,
+                                &random_engine),
       /* bias_init_fn */ zero_weight_initializer());
   result->add_relu("relu1", "conv");
 
@@ -660,7 +675,7 @@ std::unique_ptr<model_spec> activity_classifier::init_model() const
       /* output_vector_size */  LSTM_HIDDEN_SIZE,
       /* cell_clip_threshold */ LSTM_CELL_CLIP_THRESHOLD,
       /* initializers */  lstm_weight_initializers::create_with_xavier_method(
-          NUM_CONV_FILTERS, LSTM_HIDDEN_SIZE));
+          NUM_CONV_FILTERS, LSTM_HIDDEN_SIZE, &random_engine));
   result->add_channel_concat("stateOut",{"hiddenOut","cellOut"});
   result->add_inner_product(
       /* name */ "dense0",
@@ -668,7 +683,8 @@ std::unique_ptr<model_spec> activity_classifier::init_model() const
       /* num_output_channels */ FULLY_CONNECTED_HIDDEN_SIZE,
       /* num_input_channels */ LSTM_HIDDEN_SIZE,
       /* weight_init_fn */
-      xavier_weight_initializer(LSTM_HIDDEN_SIZE, FULLY_CONNECTED_HIDDEN_SIZE),
+      xavier_weight_initializer(LSTM_HIDDEN_SIZE, FULLY_CONNECTED_HIDDEN_SIZE,
+                                &random_engine),
       /* bias_init_fn */ zero_weight_initializer());
   result->add_batchnorm("bn", "dense0", FULLY_CONNECTED_HIDDEN_SIZE, 0.001f);
   result->add_relu("relu6", "bn");
@@ -678,7 +694,7 @@ std::unique_ptr<model_spec> activity_classifier::init_model() const
       /* num_output_channels */ num_classes,
       /* num_input_channels */  FULLY_CONNECTED_HIDDEN_SIZE,
       /* weight_init_fn */      xavier_weight_initializer(
-          FULLY_CONNECTED_HIDDEN_SIZE, num_classes),
+          FULLY_CONNECTED_HIDDEN_SIZE, num_classes, &random_engine),
       /* bias_init_fn */        zero_weight_initializer());
   result->add_softmax(target + "Probability", "dense1");
 
@@ -701,16 +717,18 @@ activity_classifier::init_data(gl_sframe data, variant_type validation_data,
   }
   else if ((variant_is<flex_string>(validation_data)) && (variant_get_value<flex_string>(validation_data)=="auto")) {
     gl_sarray unique_session = data[session_id_column_name].unique();
+    size_t seed = read_state<size_t>("random_seed");
     if (unique_session.size() >= 200000) {
       // TODO: Expose seed parameter publicly.
       float p = 10000.0 / unique_session.size();
       std::tie(train_data, val_data) =
-          random_split_by_session(data, session_id_column_name, p, 1);
+          random_split_by_session(data, session_id_column_name, p, seed);
     } else if (unique_session.size() >= 200) {
-      std::tie(train_data, val_data) = random_split_by_session(data, session_id_column_name, 0.95, 1);
+      std::tie(train_data, val_data) =
+          random_split_by_session(data, session_id_column_name, 0.95, seed);
     } else if (unique_session.size() >= 50) {
       std::tie(train_data, val_data) =
-          random_split_by_session(data, session_id_column_name, 0.90, 1);
+          random_split_by_session(data, session_id_column_name, 0.90, seed);
     } else {
       train_data = data;
       std::cout << "The dataset has less than the minimum of 50 sessions required for train-validation split. "
@@ -724,12 +742,9 @@ activity_classifier::init_data(gl_sframe data, variant_type validation_data,
 
 void activity_classifier::init_train(
     gl_sframe data, std::string target_column_name,
-    std::string session_id_column_name, gl_sframe validation_data,
-    std::map<std::string, flexible_type> opts) {
-  // Begin printing progress.
-  // TODO: Make progress printing optional.
-  init_table_printer(!validation_data.empty());
-
+    std::string session_id_column_name, variant_type validation_data,
+    std::map<std::string, flexible_type> opts)
+{
   // Extract feature names from options.
   std::vector<std::string> feature_column_names;
   auto features_it = opts.find("features");
@@ -741,7 +756,24 @@ void activity_classifier::init_train(
     // Don't pass "features" to init_options, which doesn't recognize it.
     opts.erase(features_it);
   }
+
+  // Read user-specified options.
   init_options(opts);
+
+  // Choose a random seed if not set.
+  if (read_state<flexible_type>("random_seed") == FLEX_UNDEFINED) {
+    std::random_device random_device;
+    int random_seed = static_cast<int>(random_device());
+    add_or_update_state({{"random_seed", random_seed}});
+  }
+
+  // Perform validation split if necessary.
+  std::tie(training_data_, validation_data_) =
+      init_data(data, validation_data, session_id_column_name);
+
+  // Begin printing progress.
+  // TODO: Make progress printing optional.
+  init_table_printer(!validation_data_.empty());
 
   add_or_update_state({{"session_id", session_id_column_name},
                        {"target", target_column_name},
@@ -751,15 +783,15 @@ void activity_classifier::init_train(
   // Bind the data to a data iterator.
   bool use_data_augmentation = read_state<bool>("use_data_augmentation");
   training_data_iterator_ =
-      create_iterator(data, /* requires_labels */ true, /* is_train */ true,
-                      use_data_augmentation);
+      create_iterator(training_data_, /* requires_labels */ true,
+                      /* is_train */ true, use_data_augmentation);
 
   add_or_update_state({{"classes", training_data_iterator_->class_labels()}});
 
   // Bind the validation data to a data iterator.
-  if (!validation_data.empty()) {
+  if (!validation_data_.empty()) {
     validation_data_iterator_ = create_iterator(
-        validation_data, /* requires_labels */ true, /* is_train */ false,
+        validation_data_, /* requires_labels */ true, /* is_train */ false,
         /* use_data_augmentation */ false);
   } else {
     validation_data_iterator_ = nullptr;

--- a/src/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/toolkits/activity_classification/activity_classifier.hpp
@@ -35,10 +35,9 @@ class EXPORT activity_classifier: public ml_model_base {
 
   // Interface exposed via Unity server
 
-  void train(gl_sframe data, const std::string& target_column_name,
-             const std::string& session_id_column_name,
-             variant_type validation_data,
-             const std::map<std::string, flexible_type>& opts);
+  void train(gl_sframe data, std::string target_column_name,
+             std::string session_id_column_name, variant_type validation_data,
+             std::map<std::string, flexible_type> opts);
   gl_sarray predict(gl_sframe data, std::string output_type);
   gl_sframe predict_per_window(gl_sframe data, std::string output_type);
   variant_map_type evaluate(gl_sframe data, std::string metric);
@@ -198,7 +197,7 @@ class EXPORT activity_classifier: public ml_model_base {
   // TODO: Expose via forthcoming C-API checkpointing mechanism?
   virtual void init_train(gl_sframe data, std::string target_column_name,
                           std::string session_id_column_name,
-                          gl_sframe validation_data,
+                          variant_type validation_data,
                           std::map<std::string, flexible_type> opts);
   virtual void perform_training_iteration();
 
@@ -228,6 +227,8 @@ class EXPORT activity_classifier: public ml_model_base {
 
   // Primary dependencies for training. These should be nonnull while training
   // is in progress.
+  gl_sframe training_data_;  // TODO: Avoid storing gl_sframe AND data_iterator.
+  gl_sframe validation_data_;
   std::unique_ptr<data_iterator> training_data_iterator_;
   std::unique_ptr<data_iterator> validation_data_iterator_;
   std::unique_ptr<neural_net::compute_context> training_compute_context_;

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -127,6 +127,7 @@ class EXPORT object_detector: public ml_model_base {
 
   virtual void init_train(gl_sframe data, std::string annotations_column_name,
                           std::string image_column_name,
+                          variant_type validation_data,
                           std::map<std::string, flexible_type> opts);
   virtual void perform_training_iteration();
 
@@ -150,6 +151,9 @@ class EXPORT object_detector: public ml_model_base {
   flex_int get_max_iterations() const;
   flex_int get_training_iterations() const;
 
+  // Sets certain user options heuristically (from the data).
+  void infer_derived_options();
+
   // Waits until the number of pending patches is at most `max_pending`.
   void wait_for_training_batches(size_t max_pending = 0);
 
@@ -161,6 +165,8 @@ class EXPORT object_detector: public ml_model_base {
 
   // Primary dependencies for training. These should be nonnull while training
   // is in progress.
+  gl_sframe training_data_;  // TODO: Avoid storing gl_sframe AND data_iterator.
+  gl_sframe validation_data_;
   std::unique_ptr<neural_net::compute_context> training_compute_context_;
   std::unique_ptr<data_iterator> training_data_iterator_;
   std::unique_ptr<neural_net::image_augmenter> training_data_augmenter_;

--- a/src/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/toolkits/object_detection/od_data_iterator.hpp
@@ -7,6 +7,7 @@
 #ifndef TURI_OBJECT_DETECTION_OD_DATA_ITERATOR_HPP_
 #define TURI_OBJECT_DETECTION_OD_DATA_ITERATOR_HPP_
 
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -77,6 +78,9 @@ public:
 
     /** Whether to shuffle the data on subsequent traversals. */
     bool shuffle = true;
+
+    /** Determines results of shuffle operations if enabled. */
+    int random_seed = 0;
   };
 
   virtual ~data_iterator() = default;
@@ -155,6 +159,7 @@ private:
 
   gl_sframe_range range_iterator_;
   gl_sframe_range::iterator next_row_;
+  std::default_random_engine random_engine_;
 };
 
 }  // object_detection

--- a/src/toolkits/supervised_learning/automatic_model_creation.hpp
+++ b/src/toolkits/supervised_learning/automatic_model_creation.hpp
@@ -26,7 +26,12 @@ std::shared_ptr<supervised_learning_model_base> create_automatic_regression_mode
     const std::map<std::string, flexible_type>& options);
 
 std::pair<gl_sframe, gl_sframe> create_validation_data(
+    gl_sframe data, const variant_type& validation_data, int random_seed);
+
+std::pair<gl_sframe, gl_sframe> create_validation_data(
     gl_sframe data, const variant_type& validation_data);
-}}
+
+}  // namespace supervised
+}  // namespace turi
 
 #endif


### PR DESCRIPTION
Adds to the `options` argument for OD and AC (C-API) a new supported key, `"random_seed"`. This seed is used to control all randomness in the toolkit code. If left unset, one is chosen randomly using `std::random_device`.

This should allow us to experiment and test in a more reproducible way, and we can expose this parameter in Python when we adopt the C-API versions there!