### PR TITLE
AC on MPS: when performing inference with training network, mark the loss gradient as unused

### DIFF
--- a/src/ml/neural_net/mps_cnnmodule.mm
+++ b/src/ml/neural_net/mps_cnnmodule.mm
@@ -168,6 +168,12 @@ float_array_map mps_cnn_module::perform_batch(const float_array_map &inputs,
 
       // Schedule the actual weight update.
       network_->GpuUpdate(commandBuffer);
+
+    } else {
+
+      // If we don't pass the loss gradient to a backward pass, decrement the
+      // read count to allow MPS to deallocate it.
+      MPSImageBatchIncrementReadCount(topGrad, -1);
     }
   }
 


### PR DESCRIPTION
By decrementing the read count manually, MPS can clean up the batch of temporary images. Otherwise, the toolkit crashes with MPS API validation enabled, when we try to deallocate the unused images