### PR TITLE
JSCanvas now falls back to system font when the requested font is unavailable

### DIFF
--- a/src/visualization/vega_renderer/JSCanvas.h
+++ b/src/visualization/vega_renderer/JSCanvas.h
@@ -29,6 +29,8 @@
 @property NSString *fontWeight;
 @property NSString *fontVariant;
 @property NSString *lineHeight;
+
+- (instancetype)initWithString:(NSString*)font;
 @end
 
 @protocol VegaCGGradientInterface<JSExport>

--- a/test/vega_renderer/examples/turicreate/simple_themed_bar_chart.vl.json
+++ b/test/vega_renderer/examples/turicreate/simple_themed_bar_chart.vl.json
@@ -169,6 +169,7 @@
         },
         "guide-title": {
           "fill": "#fff",
+          "font": "not-a-font",
           "fontSize": 12,
           "fontWeight": 600
         },


### PR DESCRIPTION
Fixes bug where calling `setFont` with an unavailable font would cause an exception.