### PR TITLE
Adding support for annotations coordinate transform in OD

### DIFF
--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -224,19 +224,19 @@ void object_detector::init_options(
       1,
       std::numeric_limits<int>::max());
   options.create_integer_option(
-      /* name          */ "grid_height",
-      /* description   */
+      /* name             */ "grid_height",
+      /* description      */
       "Height of the grid of features computed for each image",
-      /* default_value */ 13,
-      /* lower_bound   */ 1,
-      /* upper_bound   */ std::numeric_limits<int>::max());
+      /* default_value    */ 13,
+      /* lower_bound      */ 1,
+      /* upper_bound      */ std::numeric_limits<int>::max());
   options.create_integer_option(
-      /* name          */ "grid_width",
-      /* description   */
+      /* name             */ "grid_width",
+      /* description      */
       "Width of the grid of features computed for each image",
-      /* default_value */ 13,
-      /* lower_bound   */ 1,
-      /* upper_bound   */ std::numeric_limits<int>::max());
+      /* default_value    */ 13,
+      /* lower_bound      */ 1,
+      /* upper_bound      */ std::numeric_limits<int>::max());
   options.create_integer_option(
       "random_seed",
       "Seed for random weight initialization and sampling during training",
@@ -244,26 +244,26 @@ void object_detector::init_options(
       std::numeric_limits<int>::min(),
       std::numeric_limits<int>::max());
   options.create_categorical_option(
-      /* name          */"annotation_scale",
-      /* description   */
+      /* name              */"annotation_scale",
+      /* description       */
       "Defines annotations scale: pixel or normalized",
-      /* default_value */ "pixel",
-      /* allowed_values*/ {flexible_type("pixel"), flexible_type("normalized")},
-      /*allowed_overwrite*/ false);
+      /* default_value     */ "pixel",
+      /* allowed_values    */ {flexible_type("pixel"), flexible_type("normalized")},
+      /* allowed_overwrite */ false);
   options.create_categorical_option(
-      /* name          */"image_origin",
-      /* description   */
+      /* name              */"image_origin",
+      /* description       */
       "Defines image origin: top_left or bottom_left",
-      /* default_value */ "top_left",
-      /* allowed_values*/ {flexible_type("top_left"), flexible_type("bottom_left")},
-      /*allowed_overwrite*/ false);
+      /* default_value     */ "top_left",
+      /* allowed_values    */ {flexible_type("top_left"), flexible_type("bottom_left")},
+      /* allowed_overwrite */ false);
   options.create_categorical_option(
-      /* name          */"annotation_position",
-      /* description   */
+      /* name              */"annotation_position",
+      /* description       */
       "Defines annotations position: center, top_left or bottom_left",
-      /* default_value */ "center",
-      /* allowed_values*/ {flexible_type("center"), flexible_type("top_left"), flexible_type("bottom_left")},
-      /*allowed_overwrite*/ false);
+      /* default_value     */ "center",
+      /* allowed_values    */ {flexible_type("center"), flexible_type("top_left"), flexible_type("bottom_left")},
+      /* allowed_overwrite */ false);
  
   // Validate user-provided options.
   options.set_options(opts);

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -251,7 +251,7 @@ void object_detector::init_options(
       /* allowed_values    */ {flexible_type("pixel"), flexible_type("normalized")},
       /* allowed_overwrite */ false);
   options.create_categorical_option(
-      /* name              */ "image_origin",
+      /* name              */ "annotation_origin",
       /* description       */
       "Defines image origin: top_left or bottom_left",
       /* default_value     */ "top_left",
@@ -264,7 +264,7 @@ void object_detector::init_options(
       /* default_value     */ "center",
       /* allowed_values    */ {flexible_type("center"), flexible_type("top_left"), flexible_type("bottom_left")},
       /* allowed_overwrite */ false);
- 
+
   // Validate user-provided options.
   options.set_options(opts);
 
@@ -715,23 +715,23 @@ std::unique_ptr<data_iterator> object_detector::create_iterator(
   iterator_params.class_labels = std::move(class_labels);
   iterator_params.repeat = repeat;
 
-  std::string image_origin = read_state<flex_string>("image_origin");
+  std::string annotation_origin = read_state<flex_string>("annotation_origin");
   std::string annotation_scale = read_state<flex_string>("annotation_scale");
   std::string annotation_position = read_state<flex_string>("annotation_position");
 
   // Setting input for Image Origin
-  if (image_origin == "top_left") {
-      iterator_params.image_origin = data_iterator::image_origin_enum::TOP_LEFT;
+  if (annotation_origin == "top_left") {
+      iterator_params.annotation_origin = data_iterator::annotation_origin_enum::TOP_LEFT;
   }
-  if (image_origin == "bottom_left") {
-      iterator_params.image_origin = data_iterator::image_origin_enum::BOTTOM_LEFT;
+  else if (annotation_origin == "bottom_left") {
+      iterator_params.annotation_origin = data_iterator::annotation_origin_enum::BOTTOM_LEFT;
   }
 
   // Setting input for Annotation Scale
   if (annotation_scale == "pixel") {
       iterator_params.annotation_scale = data_iterator::annotation_scale_enum::PIXEL;
   }
-  if (annotation_scale == "normalized") {
+  else if (annotation_scale == "normalized") {
       iterator_params.annotation_scale = data_iterator::annotation_scale_enum::NORMALIZED;
   }
 
@@ -739,10 +739,10 @@ std::unique_ptr<data_iterator> object_detector::create_iterator(
   if (annotation_position == "center") {
       iterator_params.annotation_position = data_iterator::annotation_position_enum::CENTER;
   }
-  if (annotation_position == "top_left") {
+  else if (annotation_position == "top_left") {
       iterator_params.annotation_position = data_iterator::annotation_position_enum::TOP_LEFT;
   }
-  if (annotation_position == "bottom_left") {
+  else if (annotation_position == "bottom_left") {
       iterator_params.annotation_position = data_iterator::annotation_position_enum::BOTTOM_LEFT;
   }
 

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -244,21 +244,21 @@ void object_detector::init_options(
       std::numeric_limits<int>::min(),
       std::numeric_limits<int>::max());
   options.create_categorical_option(
-      /* name              */"annotation_scale",
+      /* name              */ "annotation_scale",
       /* description       */
       "Defines annotations scale: pixel or normalized",
       /* default_value     */ "pixel",
       /* allowed_values    */ {flexible_type("pixel"), flexible_type("normalized")},
       /* allowed_overwrite */ false);
   options.create_categorical_option(
-      /* name              */"image_origin",
+      /* name              */ "image_origin",
       /* description       */
       "Defines image origin: top_left or bottom_left",
       /* default_value     */ "top_left",
       /* allowed_values    */ {flexible_type("top_left"), flexible_type("bottom_left")},
       /* allowed_overwrite */ false);
   options.create_categorical_option(
-      /* name              */"annotation_position",
+      /* name              */ "annotation_position",
       /* description       */
       "Defines annotations position: center, top_left or bottom_left",
       /* default_value     */ "center",

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -110,7 +110,7 @@ class EXPORT object_detector: public ml_model_base {
 
   // Factory for data_iterator
   virtual std::unique_ptr<data_iterator> create_iterator(
-      gl_sframe data, std::vector<std::string> class_labels, bool repeat) const;
+      data_iterator::parameters iterator_params) const;
 
   // Factory for compute_context
   virtual

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -111,6 +111,9 @@ class EXPORT object_detector: public ml_model_base {
   // Factory for data_iterator
   virtual std::unique_ptr<data_iterator> create_iterator(
       data_iterator::parameters iterator_params) const;
+  
+  std::unique_ptr<data_iterator> create_iterator(gl_sframe data, 
+      std::vector<std::string> class_labels, bool repeat) const;
 
   // Factory for compute_context
   virtual

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -111,8 +111,8 @@ class EXPORT object_detector: public ml_model_base {
   // Factory for data_iterator
   virtual std::unique_ptr<data_iterator> create_iterator(
       data_iterator::parameters iterator_params) const;
-  
-  std::unique_ptr<data_iterator> create_iterator(gl_sframe data, 
+
+  std::unique_ptr<data_iterator> create_iterator(gl_sframe data,
       std::vector<std::string> class_labels, bool repeat) const;
 
   // Factory for compute_context

--- a/src/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/toolkits/object_detection/od_data_iterator.hpp
@@ -25,6 +25,23 @@ namespace object_detection {
  */
 class data_iterator {
 public:
+  
+  enum class image_origin_enum {
+    TOP_LEFT,
+    BOTTOM_LEFT
+  };
+
+  enum class annotation_scale_enum {
+    PIXEL,
+    NORMALIZED
+  };
+
+  enum class annotation_origin_enum {
+    CENTER,
+    TOP_LEFT,
+    BOTTOM_LEFT
+  };
+  
 
   /**
    * Defines the inputs to a data_iterator factory function.
@@ -70,6 +87,10 @@ public:
      * \TODO: This should be a flex_list to accomodate integer labels!
      */
     std::vector<std::string> class_labels;
+
+    image_origin_enum image_origin = image_origin_enum::TOP_LEFT;
+    annotation_scale_enum annotation_scale = annotation_scale_enum::PIXEL;
+    annotation_origin_enum annotation_origin = annotation_origin_enum::CENTER;
 
     /**
      * Whether to traverse the data more than once.
@@ -152,8 +173,15 @@ private:
   const size_t annotations_index_;
   const ssize_t predictions_index_;
   const size_t image_index_;
+
+  const image_origin_enum image_origin_;
+  const annotation_scale_enum annotation_scale_;
+  const annotation_origin_enum annotation_origin_;
+
   const bool repeat_;
   const bool shuffle_;
+
+  
 
   const annotation_properties annotation_properties_;
 

--- a/src/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/toolkits/object_detection/od_data_iterator.hpp
@@ -45,7 +45,6 @@ public:
     BOTTOM_LEFT
   };
 
-
   /**
    * Defines the inputs to a data_iterator factory function.
    */
@@ -183,8 +182,6 @@ private:
 
   const bool repeat_;
   const bool shuffle_;
-
-
 
   const annotation_properties annotation_properties_;
 

--- a/src/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/toolkits/object_detection/od_data_iterator.hpp
@@ -25,9 +25,9 @@ namespace object_detection {
  */
 class data_iterator {
 public:
-  
+
   /* Enumerate possible values for image origin */
-  enum class image_origin_enum {
+  enum class annotation_origin_enum {
     TOP_LEFT,
     BOTTOM_LEFT
   };
@@ -44,7 +44,7 @@ public:
     TOP_LEFT,
     BOTTOM_LEFT
   };
-  
+
 
   /**
    * Defines the inputs to a data_iterator factory function.
@@ -91,7 +91,7 @@ public:
      */
     std::vector<std::string> class_labels;
 
-    image_origin_enum image_origin = image_origin_enum::TOP_LEFT;
+    annotation_origin_enum annotation_origin = annotation_origin_enum::TOP_LEFT;
     annotation_scale_enum annotation_scale = annotation_scale_enum::PIXEL;
     annotation_position_enum annotation_position = annotation_position_enum::CENTER;
 
@@ -177,14 +177,14 @@ private:
   const ssize_t predictions_index_;
   const size_t image_index_;
 
-  image_origin_enum image_origin_;
+  annotation_origin_enum annotation_origin_;
   annotation_scale_enum annotation_scale_;
   annotation_position_enum annotation_position_;
 
   const bool repeat_;
   const bool shuffle_;
 
-  
+
 
   const annotation_properties annotation_properties_;
 

--- a/src/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/toolkits/object_detection/od_data_iterator.hpp
@@ -26,17 +26,20 @@ namespace object_detection {
 class data_iterator {
 public:
   
+  /* Enumerate possible values for image origin */
   enum class image_origin_enum {
     TOP_LEFT,
     BOTTOM_LEFT
   };
 
+  /* Enumerate possible values for the annotation scale */
   enum class annotation_scale_enum {
     PIXEL,
     NORMALIZED
   };
 
-  enum class annotation_origin_enum {
+  /* Enumerate possible values for the annotation position */
+  enum class annotation_position_enum {
     CENTER,
     TOP_LEFT,
     BOTTOM_LEFT
@@ -90,7 +93,7 @@ public:
 
     image_origin_enum image_origin = image_origin_enum::TOP_LEFT;
     annotation_scale_enum annotation_scale = annotation_scale_enum::PIXEL;
-    annotation_origin_enum annotation_origin = annotation_origin_enum::CENTER;
+    annotation_position_enum annotation_position = annotation_position_enum::CENTER;
 
     /**
      * Whether to traverse the data more than once.
@@ -174,9 +177,9 @@ private:
   const ssize_t predictions_index_;
   const size_t image_index_;
 
-  const image_origin_enum image_origin_;
-  const annotation_scale_enum annotation_scale_;
-  const annotation_origin_enum annotation_origin_;
+  image_origin_enum image_origin_;
+  annotation_scale_enum annotation_scale_;
+  annotation_position_enum annotation_position_;
 
   const bool repeat_;
   const bool shuffle_;

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -212,7 +212,7 @@ class test_object_detector: public object_detector {
 public:
   using create_iterator_call =
       std::function<std::unique_ptr<data_iterator>(
-          gl_sframe data, std::vector<std::string> class_labels, bool repeat)>;
+          data_iterator::parameters iterator_params)>;
 
   using create_compute_context_call =
       std::function<std::unique_ptr<compute_context>()>;
@@ -228,16 +228,15 @@ public:
     TS_ASSERT(create_compute_context_calls_.empty());
     TS_ASSERT(init_model_calls_.empty());
   }
-
+  
   std::unique_ptr<data_iterator> create_iterator(
-      gl_sframe data, std::vector<std::string> class_labels,
-      bool repeat) const override {
+      data_iterator::parameters iterator_params) const override {
 
     TS_ASSERT(!create_iterator_calls_.empty());
     create_iterator_call expected_call =
         std::move(create_iterator_calls_.front());
     create_iterator_calls_.pop_front();
-    return expected_call(data, std::move(class_labels), repeat);
+    return expected_call(iterator_params);
   }
 
   std::unique_ptr<compute_context> create_compute_context() const override {
@@ -397,7 +396,7 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
-
+  /*
   auto create_iterator_impl = [&](gl_sframe data,
                                   std::vector<std::string> class_labels,
                                   bool repeat) {
@@ -407,6 +406,16 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
     return std::move(mock_iterator);
   };
+  */
+  // check if input to the function is fed correctly?? look at other fiunctions ***
+  auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
+
+    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
+    TS_ASSERT(iterator_params.repeat);
+
+    return std::move(mock_iterator);
+  };
+
   model.create_iterator_calls_.push_back(create_iterator_impl);
 
   auto create_augmenter_impl = [&](const image_augmenter::options& opts) {
@@ -631,14 +640,11 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
 
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
-
-  auto create_iterator_impl = [&](gl_sframe data,
-                                  std::vector<std::string> class_labels,
-                                  bool repeat) {
+  auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
     // The train data is smaller than the original dataset
-    TS_ASSERT(test_num_examples > data.size());
-    TS_ASSERT(class_labels.empty());  // Should infer class labels from data.
-    TS_ASSERT(repeat);
+    TS_ASSERT(test_num_examples > iterator_params.data.size());
+    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
+    TS_ASSERT(iterator_params.repeat);
 
     return std::move(mock_iterator);
   };
@@ -718,6 +724,9 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   // object_detector uses the number of rows to compute num_examples, which is
   // used as a normalizer.
   gl_sframe data({{"ignored", gl_sarray::from_sequence(0, test_num_examples)}});
+
+  data_iterator::parameters iterator_params;
+  iterator_params.data = std::move(data);
 
   // Now, actually invoke object_detector::train. This will trigger all the
   // assertions registered above.

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -212,7 +212,7 @@ class test_object_detector: public object_detector {
 public:
   using create_iterator_call =
       std::function<std::unique_ptr<data_iterator>(
-          data_iterator::parameters iterator_params)>;
+        data_iterator::parameters iterator_params)>; 
 
   using create_compute_context_call =
       std::function<std::unique_ptr<compute_context>()>;
@@ -236,7 +236,7 @@ public:
     create_iterator_call expected_call =
         std::move(create_iterator_calls_.front());
     create_iterator_calls_.pop_front();
-    return expected_call(iterator_params);
+    return expected_call(iterator_params); 
   }
 
   std::unique_ptr<compute_context> create_compute_context() const override {
@@ -396,22 +396,10 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
-  /*
-  auto create_iterator_impl = [&](gl_sframe data,
-                                  std::vector<std::string> class_labels,
-                                  bool repeat) {
-
-    TS_ASSERT(class_labels.empty());  // Should infer class labels from data.
-    TS_ASSERT(repeat);
-
-    return std::move(mock_iterator);
-  };
-  */
-  // check if input to the function is fed correctly?? look at other fiunctions ***
   auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
 
-    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
-    TS_ASSERT(iterator_params.repeat);
+    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data. 
+    TS_ASSERT(iterator_params.repeat); 
 
     return std::move(mock_iterator);
   };
@@ -640,11 +628,11 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
 
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
-  auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
-    // The train data is smaller than the original dataset
+  auto create_iterator_impl = [&](data_iterator::parameters iterator_params) { 
+
     TS_ASSERT(test_num_examples > iterator_params.data.size());
-    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
-    TS_ASSERT(iterator_params.repeat);
+    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data. 
+    TS_ASSERT(iterator_params.repeat); 
 
     return std::move(mock_iterator);
   };
@@ -725,8 +713,8 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   // used as a normalizer.
   gl_sframe data({{"ignored", gl_sarray::from_sequence(0, test_num_examples)}});
 
-  data_iterator::parameters iterator_params;
-  iterator_params.data = std::move(data);
+  data_iterator::parameters iterator_params; 
+  iterator_params.data = std::move(data);  
 
   // Now, actually invoke object_detector::train. This will trigger all the
   // assertions registered above.

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -212,7 +212,7 @@ class test_object_detector: public object_detector {
 public:
   using create_iterator_call =
       std::function<std::unique_ptr<data_iterator>(
-        data_iterator::parameters iterator_params)>; 
+        data_iterator::parameters iterator_params)>;
 
   using create_compute_context_call =
       std::function<std::unique_ptr<compute_context>()>;
@@ -228,7 +228,7 @@ public:
     TS_ASSERT(create_compute_context_calls_.empty());
     TS_ASSERT(init_model_calls_.empty());
   }
-  
+
   std::unique_ptr<data_iterator> create_iterator(
       data_iterator::parameters iterator_params) const override {
 
@@ -236,7 +236,7 @@ public:
     create_iterator_call expected_call =
         std::move(create_iterator_calls_.front());
     create_iterator_calls_.pop_front();
-    return expected_call(iterator_params); 
+    return expected_call(iterator_params);
   }
 
   std::unique_ptr<compute_context> create_compute_context() const override {
@@ -398,8 +398,8 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
   // ownership of the mocks created above.
   auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
 
-    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data. 
-    TS_ASSERT(iterator_params.repeat); 
+    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
+    TS_ASSERT(iterator_params.repeat);
 
     return std::move(mock_iterator);
   };
@@ -628,11 +628,11 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
 
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
-  auto create_iterator_impl = [&](data_iterator::parameters iterator_params) { 
+  auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
     // The train data is smaller than the original dataset
     TS_ASSERT(test_num_examples > iterator_params.data.size());
-    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data. 
-    TS_ASSERT(iterator_params.repeat); 
+    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
+    TS_ASSERT(iterator_params.repeat);
 
     return std::move(mock_iterator);
   };
@@ -712,9 +712,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   // object_detector uses the number of rows to compute num_examples, which is
   // used as a normalizer.
   gl_sframe data({{"ignored", gl_sarray::from_sequence(0, test_num_examples)}});
-
-  data_iterator::parameters iterator_params; 
-  iterator_params.data = std::move(data);  
 
   // Now, actually invoke object_detector::train. This will trigger all the
   // assertions registered above.

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -629,7 +629,7 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
   auto create_iterator_impl = [&](data_iterator::parameters iterator_params) { 
-
+    // The train data is smaller than the original dataset
     TS_ASSERT(test_num_examples > iterator_params.data.size());
     TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data. 
     TS_ASSERT(iterator_params.repeat); 

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
 
   };
 
-  // Case 1: Input: ('top_left', 'pixel', 'center') → ('top_left', 'normalized', 'top_left')
+  // Case 1 | Input: ('top_left', 'pixel', 'center') → Output: ('top_left', 'normalized', 'top_left')
   const labeled_image& case1_example = create_data_opts("top_left", "pixel", "center", 28, 18, 16, 16);
   TS_ASSERT_EQUALS(case1_example.annotations[0].bounding_box,
                       image_box(static_cast<float>(20) / IMAGE_WIDTH,
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
                                  16.f / IMAGE_HEIGHT
                                  ));
 
-  // Case 2: ('bottom_left', 'pixel', 'bottom_left') → ('top_left', 'normalized', 'top_left')
+  // Case 2 | Input: ('bottom_left', 'pixel', 'bottom_left') → Output: ('top_left', 'normalized', 'top_left')
   const labeled_image& case2_example = create_data_opts("bottom_left", "pixel", "bottom_left", 20, 38, 16, 16);
   TS_ASSERT_EQUALS(case2_example.annotations[0].bounding_box,
                       image_box(static_cast<float>(20) / IMAGE_WIDTH,
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
                                  16.f / IMAGE_HEIGHT
                                  ));
 
-  // Case 3: ('bottom_left', 'normalized', 'bottom_left') → ('top_left', 'normalized', 'top_left')
+  // Case 3 | Input: ('bottom_left', 'normalized', 'bottom_left') → Output: ('top_left', 'normalized', 'top_left')
   const labeled_image& case3_example = create_data_opts("bottom_left", "normalized", "bottom_left", 20./IMAGE_WIDTH, 38./IMAGE_HEIGHT, 16./IMAGE_WIDTH, 16./IMAGE_HEIGHT);
   TS_ASSERT_EQUALS(case3_example.annotations[0].bounding_box,
                       image_box(static_cast<float>(20) / IMAGE_WIDTH,
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
                                  16.f / IMAGE_HEIGHT
                                  ));
 
-  // Case 4: ('top_left', 'pixel', 'top_left') → ('top_left', 'normalized', 'top_left')
+  // Case 4 | Input: ('top_left', 'pixel', 'top_left') → Output: ('top_left', 'normalized', 'top_left')
   const labeled_image& case4_example = create_data_opts("top_left", "pixel", "top_left", 20, 10, 16, 16);
   TS_ASSERT_EQUALS(case4_example.annotations[0].bounding_box,
                       image_box(static_cast<float>(20) / IMAGE_WIDTH,

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
       TS_ASSERT_EQUALS(example.image.m_height, IMAGE_HEIGHT);
       TS_ASSERT_EQUALS(example.image.m_width, IMAGE_WIDTH);
       TS_ASSERT_EQUALS(example.image.m_channels, 3);
-      
+
       // The first byte of the first pixel should contain the row index.
       flex_image image = image_util::decode_image(example.image);
       TS_ASSERT_EQUALS(static_cast<size_t>(image.get_image_data()[0]),
@@ -122,10 +122,10 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems) {
 
-  auto create_data_opts = [](const std::string image_origin,
+  auto create_data_opts = [](const std::string annotation_origin,
                          const std::string annotation_scale,
                          const std::string annotation_position,
-                         float x, float y, float w, float h) {  
+                         float x, float y, float w, float h) {
 
     data_iterator::parameters result;
 
@@ -142,13 +142,13 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
                            static_cast<int>(Format::RAW_ARRAY));
 
     // Setting input for Image Origin
-    if (image_origin == "top_left") {
-        result.image_origin = data_iterator::image_origin_enum::TOP_LEFT;
+    if (annotation_origin == "top_left") {
+        result.annotation_origin = data_iterator::annotation_origin_enum::TOP_LEFT;
     }
-    if (image_origin == "bottom_left") {
-        result.image_origin = data_iterator::image_origin_enum::BOTTOM_LEFT;
+    if (annotation_origin == "bottom_left") {
+        result.annotation_origin = data_iterator::annotation_origin_enum::BOTTOM_LEFT;
     }
-    
+
     // Setting input for Annotation Scale
     if (annotation_scale == "pixel") {
         result.annotation_scale = data_iterator::annotation_scale_enum::PIXEL;
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
     if (annotation_scale == "normalized") {
         result.annotation_scale = data_iterator::annotation_scale_enum::NORMALIZED;
     }
-    
+
     // Setting input for Annotation Position
     if (annotation_position == "center") {
         result.annotation_position = data_iterator::annotation_position_enum::CENTER;
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
     if (annotation_position == "bottom_left") {
         result.annotation_position = data_iterator::annotation_position_enum::BOTTOM_LEFT;
     }
-    
+
     // Each image has one annotation, with the label "foo" and a bounding box
     // with height and width 16. As the row index increases, the box moves to
     // the right until eventually resetting to the left and moving down.
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems
                                       {"width", w},
                                       {"height", h}      })},
         }));
-     
+
     result.annotations_column_name = "test_annotations";
     result.image_column_name = "test_image";
     result.data =  gl_sframe({

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -75,10 +75,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 
   data_iterator::parameters params = create_data(NUM_ROWS);
 
-  params.image_origin = data_iterator::image_origin_enum::TOP_LEFT;
-  params.annotation_scale = data_iterator::annotation_scale_enum::PIXEL;
-  params.annotation_origin = data_iterator::annotation_origin_enum::CENTER;
-
   std::vector<std::string> class_labels = { "foo" };
 
   simple_data_iterator data_source(params);
@@ -121,16 +117,14 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
   batch = data_source.next_batch(BATCH_SIZE);
   TS_ASSERT_EQUALS(batch.size(), BATCH_SIZE);
   assert_batch(batch, 0);
+
 }
 
-//=============================================================================
-
-BOOST_AUTO_TEST_CASE(test_simple_data_iterator_coordinates) {
-
+BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_different_coordinate_systems) {
 
   auto create_data_opts = [](const std::string image_origin,
                          const std::string annotation_scale,
-                         const std::string annotation_origin,
+                         const std::string annotation_position,
                          float x, float y, float w, float h) {  
 
     data_iterator::parameters result;
@@ -147,48 +141,33 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_coordinates) {
                            IMAGE_TYPE_CURRENT_VERSION,
                            static_cast<int>(Format::RAW_ARRAY));
 
-     
-
+    // Setting input for Image Origin
     if (image_origin == "top_left") {
-        std::cout << "image : top_left" <<std::endl;
         result.image_origin = data_iterator::image_origin_enum::TOP_LEFT;
     }
-    else if (image_origin == "bottom_left") {
-        std::cout << "image : bottom_left" <<std::endl;
+    if (image_origin == "bottom_left") {
         result.image_origin = data_iterator::image_origin_enum::BOTTOM_LEFT;
     }
-    else {
-        // Add error logging
-    } 
-
+    
+    // Setting input for Annotation Scale
     if (annotation_scale == "pixel") {
-        std::cout << "annon scale: pixel" <<std::endl;
         result.annotation_scale = data_iterator::annotation_scale_enum::PIXEL;
     }
-    else if (annotation_scale == "normalized") {
-        std::cout << "annon scale: norm" <<std::endl;
+    if (annotation_scale == "normalized") {
         result.annotation_scale = data_iterator::annotation_scale_enum::NORMALIZED;
     }
-    else {
-        // Add error logging
+    
+    // Setting input for Annotation Position
+    if (annotation_position == "center") {
+        result.annotation_position = data_iterator::annotation_position_enum::CENTER;
+    }
+    if (annotation_position == "top_left") {
+        result.annotation_position = data_iterator::annotation_position_enum::TOP_LEFT;
+    }
+    if (annotation_position == "bottom_left") {
+        result.annotation_position = data_iterator::annotation_position_enum::BOTTOM_LEFT;
     }
     
-    if (annotation_origin == "center") {
-        std::cout << "annon origin: center" <<std::endl;
-        result.annotation_origin = data_iterator::annotation_origin_enum::CENTER;
-    }
-    else if (annotation_origin == "top_left") {
-        std::cout << "annon origin: top_left" <<std::endl;
-        result.annotation_origin = data_iterator::annotation_origin_enum::TOP_LEFT;
-    }
-    else if (annotation_origin == "bottom_left") {
-        std::cout << "annon origin: bottom_left" <<std::endl;
-        result.annotation_origin = data_iterator::annotation_origin_enum::BOTTOM_LEFT;
-    }
-    else {
-        // Add error logging
-    }
-
     // Each image has one annotation, with the label "foo" and a bounding box
     // with height and width 16. As the row index increases, the box moves to
     // the right until eventually resetting to the left and moving down.
@@ -200,7 +179,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_coordinates) {
                                       {"width", w},
                                       {"height", h}      })},
         }));
-
      
     result.annotations_column_name = "test_annotations";
     result.image_column_name = "test_image";
@@ -228,7 +206,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_coordinates) {
                                  16.f / IMAGE_HEIGHT
                                  ));
 
-  // Case 2: ('bottom_left', 'normalized', 'bottom_left') → ('top_left', 'normalized', 'top_left')
+  // Case 2: ('bottom_left', 'pixel', 'bottom_left') → ('top_left', 'normalized', 'top_left')
   const labeled_image& case2_example = create_data_opts("bottom_left", "pixel", "bottom_left", 20, 38, 16, 16);
   TS_ASSERT_EQUALS(case2_example.annotations[0].bounding_box,
                       image_box(static_cast<float>(20) / IMAGE_WIDTH,
@@ -254,14 +232,8 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_coordinates) {
                                  16.f / IMAGE_WIDTH,
                                  16.f / IMAGE_HEIGHT
                                  ));
-  
-
 
 }
-
-
-//=============================================================================
-
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_classes) {
 

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -75,6 +75,10 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 
   data_iterator::parameters params = create_data(NUM_ROWS);
 
+  params.image_origin = data_iterator::image_origin_enum::TOP_LEFT;
+  params.annotation_scale = data_iterator::annotation_scale_enum::PIXEL;
+  params.annotation_origin = data_iterator::annotation_origin_enum::CENTER;
+
   std::vector<std::string> class_labels = { "foo" };
 
   simple_data_iterator data_source(params);
@@ -91,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
       TS_ASSERT_EQUALS(example.image.m_height, IMAGE_HEIGHT);
       TS_ASSERT_EQUALS(example.image.m_width, IMAGE_WIDTH);
       TS_ASSERT_EQUALS(example.image.m_channels, 3);
-
+      
       // The first byte of the first pixel should contain the row index.
       flex_image image = image_util::decode_image(example.image);
       TS_ASSERT_EQUALS(static_cast<size_t>(image.get_image_data()[0]),
@@ -118,6 +122,146 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
   TS_ASSERT_EQUALS(batch.size(), BATCH_SIZE);
   assert_batch(batch, 0);
 }
+
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(test_simple_data_iterator_coordinates) {
+
+
+  auto create_data_opts = [](const std::string image_origin,
+                         const std::string annotation_scale,
+                         const std::string annotation_origin,
+                         float x, float y, float w, float h) {  
+
+    data_iterator::parameters result;
+
+    flex_list images(1);
+    flex_list annotations(1);
+    std::vector<unsigned char> buffer(IMAGE_HEIGHT * IMAGE_WIDTH * 3);
+
+    // Each pixel has R, G, and B value equal to the row index (modulo 256).
+    std::fill(buffer.begin(), buffer.end(),
+              static_cast<unsigned char>(0 % 256));
+    images[0] = flex_image(reinterpret_cast<char*>(buffer.data()), IMAGE_HEIGHT,
+                           IMAGE_WIDTH, 3, buffer.size(),
+                           IMAGE_TYPE_CURRENT_VERSION,
+                           static_cast<int>(Format::RAW_ARRAY));
+
+     
+
+    if (image_origin == "top_left") {
+        std::cout << "image : top_left" <<std::endl;
+        result.image_origin = data_iterator::image_origin_enum::TOP_LEFT;
+    }
+    else if (image_origin == "bottom_left") {
+        std::cout << "image : bottom_left" <<std::endl;
+        result.image_origin = data_iterator::image_origin_enum::BOTTOM_LEFT;
+    }
+    else {
+        // Add error logging
+    } 
+
+    if (annotation_scale == "pixel") {
+        std::cout << "annon scale: pixel" <<std::endl;
+        result.annotation_scale = data_iterator::annotation_scale_enum::PIXEL;
+    }
+    else if (annotation_scale == "normalized") {
+        std::cout << "annon scale: norm" <<std::endl;
+        result.annotation_scale = data_iterator::annotation_scale_enum::NORMALIZED;
+    }
+    else {
+        // Add error logging
+    }
+    
+    if (annotation_origin == "center") {
+        std::cout << "annon origin: center" <<std::endl;
+        result.annotation_origin = data_iterator::annotation_origin_enum::CENTER;
+    }
+    else if (annotation_origin == "top_left") {
+        std::cout << "annon origin: top_left" <<std::endl;
+        result.annotation_origin = data_iterator::annotation_origin_enum::TOP_LEFT;
+    }
+    else if (annotation_origin == "bottom_left") {
+        std::cout << "annon origin: bottom_left" <<std::endl;
+        result.annotation_origin = data_iterator::annotation_origin_enum::BOTTOM_LEFT;
+    }
+    else {
+        // Add error logging
+    }
+
+    // Each image has one annotation, with the label "foo" and a bounding box
+    // with height and width 16. As the row index increases, the box moves to
+    // the right until eventually resetting to the left and moving down.
+    annotations[0] = flex_list();
+    annotations[0].push_back(flex_dict({
+          {"label", "foo"},
+          {"coordinates", flex_dict({ {"x", x},
+                                      {"y", y},
+                                      {"width", w},
+                                      {"height", h}      })},
+        }));
+
+     
+    result.annotations_column_name = "test_annotations";
+    result.image_column_name = "test_image";
+    result.data =  gl_sframe({
+        {"test_image", gl_sarray(images)},
+        {"test_annotations", gl_sarray(annotations)},
+    });
+
+    result.shuffle = false;
+
+    simple_data_iterator data_source(result);
+    std::vector<labeled_image> batch = data_source.next_batch(1);
+    const labeled_image& example = batch[0];
+
+    return example;
+
+  };
+
+  // Case 1: Input: ('top_left', 'pixel', 'center') → ('top_left', 'normalized', 'top_left')
+  const labeled_image& case1_example = create_data_opts("top_left", "pixel", "center", 28, 18, 16, 16);
+  TS_ASSERT_EQUALS(case1_example.annotations[0].bounding_box,
+                      image_box(static_cast<float>(20) / IMAGE_WIDTH,
+                                 static_cast<float>(10) / IMAGE_HEIGHT,
+                                 16.f / IMAGE_WIDTH,
+                                 16.f / IMAGE_HEIGHT
+                                 ));
+
+  // Case 2: ('bottom_left', 'normalized', 'bottom_left') → ('top_left', 'normalized', 'top_left')
+  const labeled_image& case2_example = create_data_opts("bottom_left", "pixel", "bottom_left", 20, 38, 16, 16);
+  TS_ASSERT_EQUALS(case2_example.annotations[0].bounding_box,
+                      image_box(static_cast<float>(20) / IMAGE_WIDTH,
+                                 static_cast<float>(10) / IMAGE_HEIGHT,
+                                 16.f / IMAGE_WIDTH,
+                                 16.f / IMAGE_HEIGHT
+                                 ));
+
+  // Case 3: ('bottom_left', 'normalized', 'bottom_left') → ('top_left', 'normalized', 'top_left')
+  const labeled_image& case3_example = create_data_opts("bottom_left", "normalized", "bottom_left", 20./IMAGE_WIDTH, 38./IMAGE_HEIGHT, 16./IMAGE_WIDTH, 16./IMAGE_HEIGHT);
+  TS_ASSERT_EQUALS(case3_example.annotations[0].bounding_box,
+                      image_box(static_cast<float>(20) / IMAGE_WIDTH,
+                                 static_cast<float>(10) / IMAGE_HEIGHT,
+                                 16.f / IMAGE_WIDTH,
+                                 16.f / IMAGE_HEIGHT
+                                 ));
+
+  // Case 4: ('top_left', 'pixel', 'top_left') → ('top_left', 'normalized', 'top_left')
+  const labeled_image& case4_example = create_data_opts("top_left", "pixel", "top_left", 20, 10, 16, 16);
+  TS_ASSERT_EQUALS(case4_example.annotations[0].bounding_box,
+                      image_box(static_cast<float>(20) / IMAGE_WIDTH,
+                                 static_cast<float>(10) / IMAGE_HEIGHT,
+                                 16.f / IMAGE_WIDTH,
+                                 16.f / IMAGE_HEIGHT
+                                 ));
+  
+
+
+}
+
+
+//=============================================================================
+
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_classes) {
 


### PR DESCRIPTION
TuriCore expects each OD annotation to specify a bounding box as a dictionary with four keys: x, y, width, height. Currently, the code assumes annotations to be in pixel scale, centered at origin, with top-left image origin. We want to support conversion from any given coordinate system to one which the code consumes.

Annotation options added:
* `annotation_scale` with values`pixel` or `normalized`
* `image_origin` with values `top_left` or `bottom_left`
* `annotation_position` with values `center`, `top_left` or `bottom_left`

Default values are `annotation_scale`:`pixel`, `image_origin`:`top_left` and `annotation_position`:`center`, which is the currently assumed annotations input format. 

These options can be added in the `opts` dictionary passed in OD `train()`. At the backend, `od_data_iterator` parses these options and updates the annotation values in each batch. 
