### PR TITLE
adding src location info in exception messages to accelerate debugging

### DIFF
--- a/src/core/logging/logger.hpp
+++ b/src/core/logging/logger.hpp
@@ -335,7 +335,7 @@
   do {                                                \
     auto throw_error = [&]() GL_COLD_NOINLINE_ERROR { \
       logstream(LOG_ERROR) << (message) << std::endl; \
-      throw(std::runtime_error(message);              \
+      throw(std::runtime_error(message));             \
     };                                                \
     throw_error();                                    \
   } while (0)

--- a/src/core/logging/logger.hpp
+++ b/src/core/logging/logger.hpp
@@ -265,56 +265,61 @@
 
 #else
 
-#define logger(lvl,fmt,...)                 \
-    (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__, __func__ ,__LINE__,fmt,##__VA_ARGS__))
+#define logger(lvl, fmt, ...)                                                  \
+  (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl, __FILE__, __func__, __LINE__, \
+                                            fmt, ##__VA_ARGS__))
 
+#define logbuf(lvl, buf, len)                                                  \
+  (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl, __FILE__, __func__, __LINE__, \
+                                            buf, len))
 
-#define logbuf(lvl,buf,len)                 \
-    (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__,     \
-                        __func__ ,__LINE__,buf,len))
+#define logstream(lvl)                                                      \
+  if (lvl >= global_logger().get_log_level())                               \
+  (log_stream_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl, __FILE__, __func__, \
+                                                   __LINE__))
 
-#define logstream(lvl)                      \
-    if(lvl >= global_logger().get_log_level()) (log_stream_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__, __func__ ,__LINE__) )
+#define logger_once(lvl, fmt, ...)                                 \
+  {                                                                \
+    static bool __printed__ = false;                               \
+    if (!__printed__) {                                            \
+      __printed__ = true;                                          \
+      (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(                   \
+          lvl, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)); \
+    }                                                              \
+  }
 
-#define logger_once(lvl,fmt,...)                 \
-{    \
-  static bool __printed__ = false;    \
-  if (!__printed__) {                 \
-    __printed__ = true;               \
-    (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__, __func__ ,__LINE__,fmt,##__VA_ARGS__)); \
-  }  \
-}
+#define logstream_once(lvl)                                     \
+  (*({                                                          \
+    static bool __printed__ = false;                            \
+    bool __prev_printed__ = __printed__;                        \
+    if (!__printed__) __printed__ = true;                       \
+    &(log_stream_dispatch<(lvl >= OUTPUTLEVEL)>::exec(          \
+        lvl, __FILE__, __func__, __LINE__, !__prev_printed__)); \
+  }))
 
-#define logstream_once(lvl)                      \
-(*({    \
-  static bool __printed__ = false;    \
-  bool __prev_printed__ = __printed__; \
-  if (!__printed__) __printed__ = true;  \
-  &(log_stream_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__, __func__ ,__LINE__, !__prev_printed__) ); \
-}))
+#define logger_ontick(sec, lvl, fmt, ...)                          \
+  {                                                                \
+    static float last_print = -sec - 1;                            \
+    float curtime = turi::timer::approx_time_seconds();            \
+    if (last_print + sec <= curtime) {                             \
+      last_print = curtime;                                        \
+      (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(                   \
+          lvl, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)); \
+    }                                                              \
+  }
 
-#define logger_ontick(sec,lvl,fmt,...)                 \
-{    \
-  static float last_print = -sec - 1;        \
-  float curtime = turi::timer::approx_time_seconds(); \
-  if (last_print + sec <= curtime) {                 \
-    last_print = curtime;                     \
-    (log_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__, __func__ ,__LINE__,fmt,##__VA_ARGS__)); \
-  }  \
-}
-
-#define logstream_ontick(sec,lvl)                      \
-(*({    \
-  static float last_print = -sec - 1;        \
-  float curtime = turi::timer::approx_time_seconds();        \
-  bool print_now = false;             \
-  if (last_print + sec <= curtime) {                 \
-    last_print = curtime;                 \
-    print_now = true;                \
-  }                    \
-  &(log_stream_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl,__FILE__, __func__ ,__LINE__, print_now) ); \
-}))
-
+#define logstream_ontick(sec, lvl)                                             \
+  (*({                                                                         \
+    static float last_print = -sec - 1;                                        \
+    float curtime = turi::timer::approx_time_seconds();                        \
+    bool print_now = false;                                                    \
+    if (last_print + sec <= curtime) {                                         \
+      last_print = curtime;                                                    \
+      print_now = true;                                                        \
+    }                                                                          \
+    &(log_stream_dispatch<(lvl >= OUTPUTLEVEL)>::exec(lvl, __FILE__, __func__, \
+                                                      __LINE__, print_now));   \
+  }))
 
 #define logprogress(fmt,...) logger(LOG_PROGRESS, fmt, ##__VA_ARGS__)
 #define logprogress_stream logstream(LOG_PROGRESS)
@@ -324,16 +329,15 @@
 
 #endif
 
-#define log_and_throw(message)                                            \
-  do {                                                                    \
-    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {                     \
-      std::stringstream _turi_ss;                                         \
-      _turi_ss << (message) << ",from " << __FILE__ << " at " << __LINE__ \
-               << std::endl;                                              \
-      logstream(LOG_ERROR) << _turi_ss.str();                             \
-      throw(std::runtime_error(_turi_ss.str()));                          \
-    };                                                                    \
-    throw_error();                                                        \
+#ifdef NDEBUG
+
+#define log_and_throw(message)                        \
+  do {                                                \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR { \
+      logstream(LOG_ERROR) << (message) << std::endl; \
+      throw(std::runtime_error(message);              \
+    };                                                \
+    throw_error();                                    \
   } while (0)
 
 #define std_log_and_throw(key_type, message)          \
@@ -346,42 +350,96 @@
   } while (0)
 
 #ifdef COMPILER_HAS_IOS_BASE_FAILURE_WITH_ERROR_CODE
-#define log_and_throw_io_failure(message)                             \
-  do {                                                                \
-    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {    \
-      logstream(LOG_ERROR) << (message) << std::endl;                 \
-      throw(turi::error::io_error(message, std::error_code()));      \
-    };                                                                \
-    throw_error();                                                    \
-  } while(0)
+#define log_and_throw_io_failure(message)                       \
+  do {                                                          \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {           \
+      logstream(LOG_ERROR) << (message) << std::endl;           \
+      throw(turi::error::io_error(message, std::error_code())); \
+    };                                                          \
+    throw_error();                                              \
+  } while (0)
 #else
-#define log_and_throw_io_failure(message)                             \
-  do {                                                                \
-    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {    \
-      logstream(LOG_ERROR) << (message) << std::endl;                 \
-      throw(turi::error::io_error(message));                         \
-    };                                                                \
-    throw_error();                                                    \
-  } while(0)
+#define log_and_throw_io_failure(message)             \
+  do {                                                \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR { \
+      logstream(LOG_ERROR) << (message) << std::endl; \
+      throw(turi::error::io_error(message));          \
+    };                                                \
+    throw_error();                                    \
+  } while (0)
 #endif
 
-#define log_and_throw_current_io_failure()                            \
-  do {                                                                \
-    auto error_code = errno;                                          \
-    std::string error_message = std::strerror(error_code);            \
-    errno = 0; /* clear errno */                                      \
-    log_and_throw_io_failure(error_message);                          \
-  } while(0)
+#else // debug mode
 
-#define log_func_entry()                                       \
-  do {                                                         \
-    logstream(LOG_INFO) << "Function entry" << std::endl;      \
-  } while(0)
+#define log_and_throw(message)                                          \
+  do {                                                                  \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {                   \
+      std::stringstream _turi_ss;                                       \
+      _turi_ss << (message) << ". " << __func__ << " from " << __FILE__ \
+               << " at " << __LINE__ << std::endl;                      \
+      logstream(LOG_ERROR) << message << std::endl;                     \
+      throw(std::runtime_error(_turi_ss.str()));                        \
+    };                                                                  \
+    throw_error();                                                      \
+  } while (0)
 
-#define Dlog_func_entry()                                       \
-  do {                                                         \
-    logstream(LOG_DEBUG) << "Function entry" << std::endl;      \
-  } while(0)
+#define std_log_and_throw(key_type, message)                            \
+  do {                                                                  \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {                   \
+      std::stringstream _turi_ss;                                       \
+      _turi_ss << (message) << ". " << __func__ << " from " << __FILE__ \
+               << " at " << __LINE__ << std::endl;                      \
+      logstream(LOG_ERROR) << message << std::endl;                     \
+      throw(key_type(_turi_ss.str()));                                  \
+    };                                                                  \
+    throw_error();                                                      \
+  } while (0)
+
+#ifdef COMPILER_HAS_IOS_BASE_FAILURE_WITH_ERROR_CODE
+#define log_and_throw_io_failure(message)                               \
+  do {                                                                  \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {                   \
+      std::stringstream _turi_ss;                                       \
+      _turi_ss << (message) << ". " << __func__ << " from " << __FILE__ \
+               << " at " << __LINE__ << std::endl;                      \
+      logstream(LOG_ERROR) << message << std::endl;                     \
+      throw(turi::error::io_error(__turi_ss.str(), std::error_code())); \
+    };                                                                  \
+    throw_error();                                                      \
+  } while (0)
+#else
+#define log_and_throw_io_failure(message)                               \
+  do {                                                                  \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {                   \
+      std::stringstream _turi_ss;                                       \
+      _turi_ss << (message) << ". " << __func__ << " from " << __FILE__ \
+               << " at " << __LINE__ << std::endl;                      \
+      logstream(LOG_ERROR) << message << std::endl;                     \
+      throw(turi::error::io_error(_turi_ss.str()));                     \
+    };                                                                  \
+    throw_error();                                                      \
+  } while (0)
+#endif
+
+#endif // end of NDEBUG
+
+#define log_and_throw_current_io_failure()                 \
+  do {                                                     \
+    auto error_code = errno;                               \
+    std::string error_message = std::strerror(error_code); \
+    errno = 0; /* clear errno */                           \
+    log_and_throw_io_failure(error_message);               \
+  } while (0)
+
+#define log_func_entry()                                  \
+  do {                                                    \
+    logstream(LOG_INFO) << "Function entry" << std::endl; \
+  } while (0)
+
+#define Dlog_func_entry()                                  \
+  do {                                                     \
+    logstream(LOG_DEBUG) << "Function entry" << std::endl; \
+  } while (0)
 
 namespace logger_impl {
 struct streambuff_tls_entry {

--- a/src/core/logging/logger.hpp
+++ b/src/core/logging/logger.hpp
@@ -324,14 +324,17 @@
 
 #endif
 
-#define log_and_throw(message)                                      \
-  do {                                                              \
-    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {  \
-      logstream(LOG_ERROR) << (message) << std::endl;               \
-      throw(std::string(message));                                  \
-    };                                                              \
-    throw_error();                                                  \
-  } while(0)
+#define log_and_throw(message)                                            \
+  do {                                                                    \
+    auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {                     \
+      std::stringstream _turi_ss;                                         \
+      _turi_ss << (message) << ",from " << __FILE__ << " at " << __LINE__ \
+               << std::endl;                                              \
+      logstream(LOG_ERROR) << _turi_ss.str();                             \
+      throw(std::runtime_error(_turi_ss.str()));                          \
+    };                                                                    \
+    throw_error();                                                        \
+  } while (0)
 
 #define std_log_and_throw(key_type, message)          \
   do {                                                \

--- a/src/core/logging/logger.hpp
+++ b/src/core/logging/logger.hpp
@@ -335,7 +335,7 @@
   do {                                                \
     auto throw_error = [&]() GL_COLD_NOINLINE_ERROR { \
       logstream(LOG_ERROR) << (message) << std::endl; \
-      throw(std::runtime_error(message));             \
+      throw(std::string(message));                    \
     };                                                \
     throw_error();                                    \
   } while (0)
@@ -378,7 +378,7 @@
       _turi_ss << (message) << ". " << __func__ << " from " << __FILE__ \
                << " at " << __LINE__ << std::endl;                      \
       logstream(LOG_ERROR) << message << std::endl;                     \
-      throw(std::runtime_error(_turi_ss.str()));                        \
+      throw(_turi_ss.str());                                            \
     };                                                                  \
     throw_error();                                                      \
   } while (0)

--- a/src/python/turicreate/test/test_nearest_neighbors.py
+++ b/src/python/turicreate/test/test_nearest_neighbors.py
@@ -336,17 +336,16 @@ class NearestNeighborsCreateTest(unittest.TestCase):
                                             method='brute_force',
                                             verbose=False)
             except ToolkitError as e:
-                self.assertEqual(str(e),
-                    "Cannot compute jaccard distances with column 'array_ftr'."+\
-                    " Jaccard distances currently can only be computed for"
-                    " dictionary and list features.\n")
+                self.assertTrue(str(e).startswith("Cannot compute jaccard distances with column 'array_ftr'."
+                                                  " Jaccard distances currently can only be computed for"
+                                                  " dictionary and list features.\n"))
 
             try:
                 tc.nearest_neighbors.create(self.refs, self.label, ['str_ftr'],
                                             distance=dist_name, verbose=False)
             except ToolkitError as e:
-                self.assertTrue(str(e).startswith("The only distance allowed for string " +
-                                                  "features is 'levenshtein'. Please try this distance, or use 'text_analytics.count_ngrams' " +
+                self.assertTrue(str(e).startswith("The only distance allowed for string features is 'levenshtein'. "
+                                                  "Please try this distance, or use 'text_analytics.count_ngrams' "
                                                   "to convert the strings to dictionaries, which permit more distance functions.\n"))
 
         ## Jacard distance throws TypeError on lists of non-strings

--- a/src/python/turicreate/test/test_nearest_neighbors.py
+++ b/src/python/turicreate/test/test_nearest_neighbors.py
@@ -277,8 +277,9 @@ class NearestNeighborsCreateTest(unittest.TestCase):
                 tc.nearest_neighbors.create(self.refs, self.label, ['str_ftr'],
                                             distance=dist_name)
             except ToolkitError as e:
-                self.assertEqual(str(e),
-                    "The only distance allowed for string features is 'levenshtein'. Please try this distance, or use 'text_analytics.count_ngrams' to convert the strings to dictionaries, which permit more distance functions.\n")
+                self.assertTrue(str(e).startswith("The only distance allowed for string features is 'levenshtein'. "
+                                                  "Please try this distance, or use 'text_analytics.count_ngrams' to "
+                                                  "convert the strings to dictionaries, which permit more distance functions.\n"))
 
     def test_create_sparse_distances(self):
         """
@@ -344,7 +345,9 @@ class NearestNeighborsCreateTest(unittest.TestCase):
                 tc.nearest_neighbors.create(self.refs, self.label, ['str_ftr'],
                                             distance=dist_name, verbose=False)
             except ToolkitError as e:
-                self.assertEqual(str(e), "The only distance allowed for string features is 'levenshtein'. Please try this distance, or use 'text_analytics.count_ngrams' to convert the strings to dictionaries, which permit more distance functions.\n")
+                self.assertTrue(str(e).startswith("The only distance allowed for string " +
+                                                  "features is 'levenshtein'. Please try this distance, or use 'text_analytics.count_ngrams' " +
+                                                  "to convert the strings to dictionaries, which permit more distance functions.\n"))
 
         ## Jacard distance throws TypeError on lists of non-strings
         refs = self.refs.__copy__()
@@ -402,9 +405,8 @@ class NearestNeighborsCreateTest(unittest.TestCase):
                                             distance=dist_name,
                                             method='brute_force', verbose=False)
             except ToolkitError as e:
-                self.assertEqual(str(e),
-                    "Cannot compute {} distance with column 'dict_ftr'.".format(dist_name) +\
-                    " {} distance can only computed for string features.\n".format(dist_name))
+                self.assertTrue(str(e).startswith("Cannot compute {} distance with column 'dict_ftr'.".format(dist_name) +
+                                                  " {} distance can only computed for string features.\n".format(dist_name)))
 
     def test_create_composite_distances(self):
         """


### PR DESCRIPTION
In an ideal world, the exception message should be adequate for us to locate where the exception is thrown. But many times the error reports from those exceptions are too opaque, such as "file not found".

In the current logger, `filename`, `function name` and `line number` are actually included in the logging body. Initially, I thought we don't have those in our logger. Now my work simplifies by adding those into exception message for the debug mode.

I find it's inconvenient to check the logging file all the time to find where the exception is thrown. Now if we have `filename`, `function name` and `line number` in the exception message, it's straightforward for us to look into the issue and search solutions.

Also, it's easy for users to report issues since most of them may not know where to find the log files to copy & paste error logs. Often the time, the exception message body tells you very little useful info.