### PR TITLE
Fix for dylib compilation issue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,7 +382,7 @@ endif()
 # seems different clang distributions have quite different warning arguments
 check_cxx_compiler_flag("-Wno-unknown-warning-option" __no_unknown_warning_option)
 if(${__no_unknown_warning_option})
-  add_compile_options(-Wno-unknown-warning-option)
+  set(CPP11_FLAGS "${CPP11_FLAGS} -Wno-unknown-warning-option")
 endif()
  
 if (${TC_STACK_DISPLAY})


### PR DESCRIPTION
It seems the dylib building process does not actually pick up flags set by add_compile_definitions; they should set the variables we track for these things instead. 