### PR TITLE
Change VegaRenderer to expose canvas through DOM API

### DIFF
--- a/src/visualization/vega_renderer/CMakeLists.txt
+++ b/src/visualization/vega_renderer/CMakeLists.txt
@@ -12,6 +12,7 @@ if(APPLE AND NOT TC_BUILD_IOS)
 
    set( VEGA_RENDERER_SOURCES
       JSCanvas.m
+      JSDocument.m
       VegaRenderer.m
       colors.m
    )

--- a/src/visualization/vega_renderer/JSCanvas.h
+++ b/src/visualization/vega_renderer/JSCanvas.h
@@ -17,6 +17,8 @@
 #ifndef Canvas_h
 #define Canvas_h
 
+#import "VegaHTMLElement.h"
+
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 #import <JavaScriptCore/JavaScriptCore.h>
@@ -170,29 +172,22 @@ JSExportAs(translate,
 @property CGLayerRef layer;
 @property double width;
 @property double height;
-- (instancetype)initWithWidth:(double)width
-                       height:(double)height
-                      context:(CGContextRef)parentContext;
+- (instancetype)initWithContext:(CGContextRef)parentContext;
 - (void)dealloc;
 - (NSDictionary<NSAttributedStringKey, id> *)textAttributes;
 + (CGAffineTransform)flipYAxisWithHeight:(double)height;
 + (CGColorRef)newColorFromString:(NSString *)string;
 @end
 
-@protocol VegaCGCanvasInterface <JSExport>
+@protocol VegaCGCanvasInterface <JSExport, VegaHTMLElement>
 - (VegaCGContext *)getContext:(NSString *)type;
 @property double width;
 @property double height;
 @end
 
 @interface VegaCGCanvas : NSObject<VegaCGCanvasInterface>
-
 @property VegaCGContext *context;
-
-- (instancetype)initWithWidth:(double)width
-                       height:(double)height
-                      context:(CGContextRef)parentContext;
-
+- (instancetype)initWithContext:(CGContextRef)parentContext;
 @end
 
 

--- a/src/visualization/vega_renderer/JSCanvas.m
+++ b/src/visualization/vega_renderer/JSCanvas.m
@@ -623,14 +623,6 @@
 }
 
 - (void)fill {
-    NSArray *args = [JSContext currentArguments];
-    (void)args;
-    assert(args != nil);
-    if(args.count > 0) {
-        // Vega occasionally makes calls to fill with four arguments when zero are expected.
-        // Might have intended to call fillRect instead.
-        NSLog(@"warning: 'fill' called with %lu arguments when none were expected", args.count);
-    }
     CGPathRef currentPath = CGContextCopyPath(self.context);
     if ([_fillStyle isKindOfClass:VegaCGLinearGradient.class]) {
         VegaCGLinearGradient *gradient = _fillStyle;

--- a/src/visualization/vega_renderer/JSCanvas.m
+++ b/src/visualization/vega_renderer/JSCanvas.m
@@ -109,18 +109,21 @@
 }
 
 - (void)resizeWithWidth:(double)width height:(double)height {
-    if (width > 0 && height > 0) {
+    // This is a hack to ensure that neither width or height is ever zero as this causes
+    // CGLayerCreateWithContext(...) to crash. This can occur when width and height are
+    // set one at a time in subsequent calls. A more faithful rendering context implementation
+    // would wait until both are set before creating the layer.
+    width = MAX(1, width);
+    height = MAX(1, height);
 
-        // Because we are about to create a new layer, set up other relevant
-        // instance properties so they are in the right state.
-        _currentTransform = CGAffineTransformIdentity;
-        assert(self != nil);
-        CGLayerRef layer = CGLayerCreateWithContext(_parentContext, CGSizeMake(width, height), nil);
-        self.layer = layer;
-        CGLayerRelease(layer);
-        CGContextConcatCTM(self.context, [self.class flipYAxisWithHeight:height]);
-
-    }
+    // Because we are about to create a new layer, set up other relevant
+    // instance properties so they are in the right state.
+    _currentTransform = CGAffineTransformIdentity;
+    assert(self != nil);
+    CGLayerRef layer = CGLayerCreateWithContext(_parentContext, CGSizeMake(width, height), nil);
+    self.layer = layer;
+    CGLayerRelease(layer);
+    CGContextConcatCTM(self.context, [self.class flipYAxisWithHeight:height]);
 }
 
 - (double)width {
@@ -139,14 +142,10 @@
     [self resizeWithWidth:self.width height:height];
 }
 
-- (instancetype)initWithWidth:(double)width
-                       height:(double)height
-                      context:(CGContextRef)parentContext {
+- (instancetype)initWithContext:(CGContextRef)parentContext {
     self = [super init];
     _layer = nil;
     _parentContext = parentContext;
-    [self resizeWithWidth:width height:height];
-    assert(CFGetRetainCount(_layer) == 1);
     return self;
 }
 
@@ -627,7 +626,11 @@
     NSArray *args = [JSContext currentArguments];
     (void)args;
     assert(args != nil);
-    assert(args.count == 0);
+    if(args.count > 0) {
+        // Vega occasionally makes calls to fill with four arguments when zero are expected.
+        // Might have intended to call fillRect instead.
+        NSLog(@"warning: 'fill' called with %lu arguments when none were expected", args.count);
+    }
     CGPathRef currentPath = CGContextCopyPath(self.context);
     if ([_fillStyle isKindOfClass:VegaCGLinearGradient.class]) {
         VegaCGLinearGradient *gradient = _fillStyle;
@@ -651,11 +654,9 @@
 
 @implementation VegaCGCanvas
 
-- (instancetype)initWithWidth:(double)width
-                       height:(double)height
-                      context:(CGContextRef)parentContext {
+- (instancetype)initWithContext:(CGContextRef)parentContext {
     self = [super init];
-    self.context = [[VegaCGContext alloc] initWithWidth:width height:height context:parentContext];
+    self.context = [[VegaCGContext alloc] initWithContext:parentContext];
     return self;
 }
 

--- a/src/visualization/vega_renderer/JSDocument.h
+++ b/src/visualization/vega_renderer/JSDocument.h
@@ -1,0 +1,18 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#import "VegaHTMLElement.h"
+#import "JSCanvas.h"
+
+@protocol VegaJSDocumentInterface<JSExport>
+JSExportAs(createElement,
+           -(NSObject<VegaHTMLElement>*)createElementWithString:(NSString*)element
+           );
+@end
+
+@interface VegaJSDocument : NSObject<VegaJSDocumentInterface>
+-(instancetype)initWithCanvas:(VegaCGCanvas*)vegaCanvas;
+@property VegaCGCanvas* canvas;
+@end

--- a/src/visualization/vega_renderer/JSDocument.m
+++ b/src/visualization/vega_renderer/JSDocument.m
@@ -7,7 +7,7 @@
 
 @implementation VegaJSDocument;
 - (instancetype)initWithCanvas:(VegaCGCanvas*)canvas {
-    self = [super init]
+    self = [super init];
     _canvas = canvas;
     return self;
 }

--- a/src/visualization/vega_renderer/JSDocument.m
+++ b/src/visualization/vega_renderer/JSDocument.m
@@ -1,0 +1,23 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#import "JSDocument.h"
+
+@implementation VegaJSDocument;
+- (instancetype)initWithCanvas:(VegaCGCanvas*)canvas {
+    self = [super init]
+    _canvas = canvas;
+    return self;
+}
+
+- (NSObject<VegaHTMLElement>*)createElementWithString:(NSString*)element {
+    if([element isEqualToString:@"canvas"]){
+        return _canvas;
+    } else {
+        NSLog(@"warning: creating elements of type '%@' is not supported", element);
+    }
+    return nil;
+}
+@end

--- a/src/visualization/vega_renderer/JSDocument.m
+++ b/src/visualization/vega_renderer/JSDocument.m
@@ -16,7 +16,8 @@
     if([element isEqualToString:@"canvas"]){
         return _canvas;
     } else {
-        NSLog(@"warning: creating elements of type '%@' is not supported", element);
+        NSLog(@"creating elements of type '%@' is not supported", element);
+        assert(false);
     }
     return nil;
 }

--- a/src/visualization/vega_renderer/VegaHTMLElement.h
+++ b/src/visualization/vega_renderer/VegaHTMLElement.h
@@ -1,0 +1,7 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+@protocol VegaHTMLElement
+@end

--- a/src/visualization/vega_renderer/VegaRenderer.m
+++ b/src/visualization/vega_renderer/VegaRenderer.m
@@ -5,6 +5,7 @@
  */
 #import "VegaRenderer.h"
 #import "JSCanvas.h"
+#import "JSDocument.h"
 
 #import <AppKit/AppKit.h>
 #import <JavaScriptCore/JavaScriptCore.h>
@@ -73,33 +74,20 @@
             NSLog(@"JS console error: %@", message);
             assert(false);
         };
-
+        
         // set up error handling
         self.context.exceptionHandler = ^(JSContext *context, JSValue *exception) {
             NSLog(@"Unhandled exception: %@", [exception toString]);
             NSLog(@"In context: %@", [context debugDescription]);
+            NSLog(@"Stacktrace: %@", [exception objectForKeyedSubscript:@"stack"]);
             assert(false);
         };
 
-        JSValue *require = [JSValue valueWithObject:^(NSString *module) {
-            if ([module isEqualToString:@"canvas"]) {
-                JSValue *canvas2 = [JSValue valueWithObject:^(double width, double height) {
-                    weakSelf.vegaCanvas = [[VegaCGCanvas alloc] initWithWidth:width height:height context:parentContext];
-                    return weakSelf.vegaCanvas;
-                } inContext:weakSelf.context];
-                canvas2[@"Image"] = [JSValue valueWithObject:^() {
-                    assert([[JSContext currentArguments] count] == 0);
-                    return [[VegaCGImage alloc] init];
-                } inContext:weakSelf.context];
-                return canvas2;
-            }
+        VegaCGCanvas* vegaCanvas = [[VegaCGCanvas alloc] initWithContext:parentContext];
+        weakSelf.vegaCanvas = vegaCanvas;
 
-            // fall through if we don't know what module it is
-            NSLog(@"Called require with unknown module %@", module);
-            return [JSValue valueWithNullInContext:weakSelf.context];
-        } inContext:self.context];
-
-        [self.context setObject:require forKeyedSubscript:@"require"];
+        VegaJSDocument* document = [[VegaJSDocument alloc] initWithCanvas:vegaCanvas];
+        self.context[@"document"] = document;
 
         [self.context evaluateScript:[VegaRenderer vegaJS]];
         [self.context evaluateScript:[VegaRenderer vegaliteJS]];


### PR DESCRIPTION
Expose canvas to Vega through the DOM API by partially partially implementing the `document` object.