### PR TITLE
Eliminate delay on opening TC Vis app

### DIFF
--- a/src/python/turicreate/toolkits/image_classifier/_evaluation.py
+++ b/src/python/turicreate/toolkits/image_classifier/_evaluation.py
@@ -9,7 +9,7 @@ Class definition and utilities for the evaluation of the image classification mo
 from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
-from ...visualization import _get_client_app_path, _focus_client_app
+from ...visualization import _get_client_app_path
 import turicreate as _tc
 
 import subprocess as __subprocess
@@ -189,8 +189,6 @@ def _process_value(value, extended_sframe, proc, evaluation):
 def _start_process(process_input, extended_sframe, evaluation):
   proc = __subprocess.Popen(_get_client_app_path(), stdout=__subprocess.PIPE, stdin=__subprocess.PIPE)
   proc.stdin.write(process_input.encode('utf-8'))
-
-  _focus_client_app()
 
   #https://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate
 

--- a/src/python/turicreate/visualization/__init__.py
+++ b/src/python/turicreate/visualization/__init__.py
@@ -42,4 +42,4 @@ from .show import box_plot
 from .show import columnwise_summary
 from .show import histogram
 from .show import item_frequency
-from ._plot import Plot, set_target, _get_client_app_path, _focus_client_app, LABEL_DEFAULT
+from ._plot import Plot, set_target, _get_client_app_path, LABEL_DEFAULT

--- a/src/python/turicreate/visualization/_plot.py
+++ b/src/python/turicreate/visualization/_plot.py
@@ -29,14 +29,6 @@ def _get_client_app_path():
     if _sys.platform == 'linux2' or _sys.platform == 'linux':
         return _os.path.join(tcviz_dir, 'Turi Create Visualization', 'visualization_client')
 
-def _focus_client_app():
-    scpt = '''
-            delay .5
-            tell application \"Turi Create Visualization\" to activate
-            '''
-    focus = _Popen(['osascript', '-'], stdout=_PIPE, stdin=_PIPE)
-    focus.communicate(scpt.encode('utf-8'))
-
 def _run_cmdline(command):
     # runs a shell command
     p = _Popen(args=command, stdout=_PIPE, stderr=_PIPE, shell=True)

--- a/src/visualization/client/Turi Create Visualization/src/AppDelegate.swift
+++ b/src/visualization/client/Turi Create Visualization/src/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         newWindow = NSWindow(contentRect: contentFrame, styleMask: [.resizable, .titled, .closable, .miniaturizable], backing: .buffered, defer: false)
         newWindow?.center()
         newWindow?.minSize = NSMakeSize(600, 400)
+        newWindow?.title = "Turi Create Visualization"
 
         controller = ViewController()
         let content = newWindow!.contentView! as NSView

--- a/src/visualization/client/Turi Create Visualization/src/main.swift
+++ b/src/visualization/client/Turi Create Visualization/src/main.swift
@@ -6,5 +6,9 @@
 import Cocoa
 
 let delegate = AppDelegate()
+NSApplication.shared.setActivationPolicy(.regular)
 NSApplication.shared.delegate = delegate
+DispatchQueue.main.async {
+    NSApplication.shared.activate(ignoringOtherApps: true)
+}
 NSApplication.shared.run()

--- a/src/visualization/server/process_wrapper.cpp
+++ b/src/visualization/server/process_wrapper.cpp
@@ -76,21 +76,6 @@ process_wrapper::process_wrapper(const std::string& path_to_client) : m_alive(tr
       m_cond.wait(guard);
     }
   });
-
-  // workaround to pop-under GUI app window from popen:
-  // https://stackoverflow.com/a/13553471
-
-  #ifdef __APPLE__
-  ::turi::process osascript;
-  osascript.popen("/usr/bin/osascript",
-      std::vector<std::string>({
-        "-e",
-        "delay .5",
-        "-e",
-        "tell application \"Turi Create Visualization\" to activate"
-      }),
-      0, false);
-  #endif
 }
 
 process_wrapper::~process_wrapper() {


### PR DESCRIPTION
Removes the osascript call to bring the app to front, along with the
delay (which was there to ensure the process had started by the time it
gets called). Now, the app code itself brings the window to
the front on launch.

Fixes #1834