### PR TITLE
Support enough of the DOM so that Vega attempts to register event listeners

### DIFF
--- a/src/visualization/vega_renderer/CMakeLists.txt
+++ b/src/visualization/vega_renderer/CMakeLists.txt
@@ -13,6 +13,7 @@ if(APPLE AND NOT TC_BUILD_IOS)
    set( VEGA_RENDERER_SOURCES
       JSCanvas.m
       JSDocument.m
+      VegaHTMLElement.m
       VegaRenderer.m
       colors.m
    )

--- a/src/visualization/vega_renderer/JSCanvas.h
+++ b/src/visualization/vega_renderer/JSCanvas.h
@@ -181,13 +181,13 @@ JSExportAs(translate,
 + (CGColorRef)newColorFromString:(NSString *)string;
 @end
 
-@protocol VegaCGCanvasInterface <JSExport, VegaHTMLElement>
+@protocol VegaCGCanvasInterface <JSExport>
 - (VegaCGContext *)getContext:(NSString *)type;
 @property double width;
 @property double height;
 @end
 
-@interface VegaCGCanvas : NSObject<VegaCGCanvasInterface>
+@interface VegaCGCanvas : VegaHTMLElement<VegaCGCanvasInterface>
 @property VegaCGContext *context;
 - (instancetype)initWithContext:(CGContextRef)parentContext;
 @end

--- a/src/visualization/vega_renderer/JSCanvas.m
+++ b/src/visualization/vega_renderer/JSCanvas.m
@@ -695,7 +695,9 @@
 
 - (instancetype)initWithContext:(CGContextRef)parentContext {
     self = [super initWithTagName:@"canvas"];
-    self.context = [[VegaCGContext alloc] initWithContext:parentContext];
+    if(self) {
+        self.context = [[VegaCGContext alloc] initWithContext:parentContext];
+    }
     return self;
 }
 

--- a/src/visualization/vega_renderer/JSCanvas.m
+++ b/src/visualization/vega_renderer/JSCanvas.m
@@ -694,13 +694,12 @@
 @implementation VegaCGCanvas
 
 - (instancetype)initWithContext:(CGContextRef)parentContext {
-    self = [super init];
+    self = [super initWithTagName:@"canvas"];
     self.context = [[VegaCGContext alloc] initWithContext:parentContext];
     return self;
 }
 
 - (VegaCGContext *)getContext:(NSString *)type {
-    (void)type;
     assert([type isEqualToString:@"2d"]); // no other types handled
     return self.context;
 }

--- a/src/visualization/vega_renderer/JSDocument.h
+++ b/src/visualization/vega_renderer/JSDocument.h
@@ -7,12 +7,18 @@
 #import "JSCanvas.h"
 
 @protocol VegaJSDocumentInterface<JSExport>
+
+@property VegaHTMLElement* body;
+
 JSExportAs(createElement,
-           -(NSObject<VegaHTMLElement>*)createElementWithString:(NSString*)element
+           -(VegaHTMLElement*)createElementWithString:(NSString*)element
            );
+
 @end
 
 @interface VegaJSDocument : NSObject<VegaJSDocumentInterface>
+
 -(instancetype)initWithCanvas:(VegaCGCanvas*)vegaCanvas;
 @property VegaCGCanvas* canvas;
+
 @end

--- a/src/visualization/vega_renderer/JSDocument.m
+++ b/src/visualization/vega_renderer/JSDocument.m
@@ -11,8 +11,10 @@
 
 - (instancetype)initWithCanvas:(VegaCGCanvas*)canvas {
     self = [super init];
-    self.body = [[VegaHTMLElement alloc] init];
-    _canvas = canvas;
+    if(self) {
+        self.body = [[VegaHTMLElement alloc] init];
+        _canvas = canvas;
+    }
     return self;
 };
 

--- a/src/visualization/vega_renderer/JSDocument.m
+++ b/src/visualization/vega_renderer/JSDocument.m
@@ -5,20 +5,28 @@
  */
 #import "JSDocument.h"
 
-@implementation VegaJSDocument;
+@implementation VegaJSDocument 
+
+@synthesize body;
+
 - (instancetype)initWithCanvas:(VegaCGCanvas*)canvas {
     self = [super init];
+    self.body = [[VegaHTMLElement alloc] init];
     _canvas = canvas;
     return self;
-}
+};
 
-- (NSObject<VegaHTMLElement>*)createElementWithString:(NSString*)element {
+- (VegaHTMLElement*)createElementWithString:(NSString*)element {
+
     if([element isEqualToString:@"canvas"]){
         return _canvas;
+    } else if([element isEqualToString:@"div"]) {
+        return [[VegaHTMLElement alloc] initWithTagName:@"div"];
     } else {
         NSLog(@"creating elements of type '%@' is not supported", element);
         assert(false);
     }
     return nil;
 }
+
 @end

--- a/src/visualization/vega_renderer/VegaHTMLElement.h
+++ b/src/visualization/vega_renderer/VegaHTMLElement.h
@@ -3,5 +3,43 @@
  * Use of this source code is governed by a BSD-3-clause license that can
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
-@protocol VegaHTMLElement
+#import <JavaScriptCore/JavaScriptCore.h>
+
+@class VegaCGCanvas;
+
+@protocol VegaCSSStyleDeclarationInterface<JSExport>
+
+@property NSString* cursor;
+
+@end
+
+@interface VegaCSSStyleDeclaration : NSObject<VegaCSSStyleDeclarationInterface>
+@end
+
+@protocol VegaHTMLElementInterface<JSExport>
+
+@property VegaCSSStyleDeclaration* style;
+@property NSMutableArray<NSObject<VegaHTMLElementInterface>*>* childNodes;
+@property NSString* tagName;
+
+- (instancetype) initWithTagName:(NSString*)tagName;
+
+JSExportAs(removeChild,
+           - (NSObject<VegaHTMLElementInterface>*)removeWithChild:(NSObject<VegaHTMLElementInterface>*)child
+           );
+JSExportAs(appendChild,
+            - (NSObject<VegaHTMLElementInterface>*)appendWithChild:(NSObject<VegaHTMLElementInterface>*)child
+           );
+JSExportAs(setAttribute, 
+           - (void)setAttributeWithName:(NSString*)name 
+           value:(NSString*)value
+           );
+JSExportAs(addEventListener,
+            - (void)addEventListenerWithType:(NSString*)type
+            listener:(JSValue*)listener
+           );
+
+@end
+
+@interface VegaHTMLElement : NSObject<VegaHTMLElementInterface>
 @end

--- a/src/visualization/vega_renderer/VegaHTMLElement.m
+++ b/src/visualization/vega_renderer/VegaHTMLElement.m
@@ -8,7 +8,9 @@
 
 - (instancetype) init {
     self = [super init];
-    self.cursor = [[NSString alloc] init];
+    if(self) {
+        self.cursor = [[NSString alloc] init];
+    }
     return self;
 }
 
@@ -22,14 +24,18 @@
 
 - (instancetype)init {
     self = [super init];
-    self.style = [[VegaCSSStyleDeclaration alloc] init];
-    self.childNodes = [[NSMutableArray alloc] init];
+    if(self) {
+        self.style = [[VegaCSSStyleDeclaration alloc] init];
+        self.childNodes = [[NSMutableArray alloc] init];
+    }
     return self;
 }
 
 - (instancetype)initWithTagName:(NSString*)tag {
     self = [self init];
-    self.tagName = tag;
+    if(self) {
+        self.tagName = tag;
+    }
     return self; 
 }
 

--- a/src/visualization/vega_renderer/VegaHTMLElement.m
+++ b/src/visualization/vega_renderer/VegaHTMLElement.m
@@ -1,0 +1,60 @@
+#import "VegaHTMLElement.h"
+#import "JSCanvas.h"
+
+@implementation VegaCSSStyleDeclaration
+
+// TODO: modifications to the cursor attribute should actually be applied
+@synthesize cursor;
+
+- (instancetype) init {
+    self = [super init];
+    self.cursor = [[NSString alloc] init];
+    return self;
+}
+
+@end
+
+@implementation VegaHTMLElement
+
+@synthesize style;
+@synthesize childNodes;
+@synthesize tagName;
+
+- (instancetype)init {
+    self = [super init];
+    self.style = [[VegaCSSStyleDeclaration alloc] init];
+    self.childNodes = [[NSMutableArray alloc] init];
+    return self;
+}
+
+- (instancetype)initWithTagName:(NSString*)tag {
+    self = [self init];
+    self.tagName = tag;
+    return self; 
+}
+
+- (NSObject<VegaHTMLElementInterface>*)removeWithChild:(NSObject<VegaHTMLElementInterface>*)child {
+    // TODO: removeChild should technically return the object it removed, however, since the
+    // return value is never used in Vega we can afford to always return nil.
+   [self.childNodes removeObject:child];
+   return nil;
+}
+
+- (NSObject<VegaHTMLElementInterface>*)appendWithChild:(NSObject<VegaHTMLElementInterface>*)child {
+    // TODO: appendChild should technically remove the child node from its current parent (if one exists)
+    // since we currently don't keep track of parent nodes this can't be implemented.
+    [self.childNodes addObject:child];
+    return child;
+}
+
+- (void)setAttributeWithName:(NSString*)name value:(NSString*)value {
+    // TODO: we currently just log these calls. Not sure if we need to do anything.
+    NSLog(@"call made to setAttribute(%@, %@)", name, value);
+}
+
+- (void)addEventListenerWithType:(NSString*)type listener:(JSValue*)listener {
+    // TODO: store these listeners and trigger them when appropriate
+    // NSLog(@"call made to addEventListener(%@, ...)", type);
+}
+
+@end

--- a/src/visualization/vega_renderer/VegaRenderer.m
+++ b/src/visualization/vega_renderer/VegaRenderer.m
@@ -100,6 +100,9 @@
 
         VegaJSDocument* document = [[VegaJSDocument alloc] initWithCanvas:vegaCanvas];
         self.context[@"document"] = document;
+        
+        // set up an element to contain Vega's canvas, referenced in vg2canvasJS
+        self.context[@"container"] = [[VegaHTMLElement alloc] initWithTagName:@"div"];
 
         // set up Image type
         self.context[@"Image"] = [JSValue valueWithObject:^() {
@@ -185,7 +188,7 @@
     "    logLevel: vega.Warn,"
     "    renderer: 'canvas'"
     "  })"
-    "  .initialize()"
+    "  .initialize(container)"
     "  .runAsync()"
     "  .then(view => {"
     "    view.toCanvas().then(canvas => {"


### PR DESCRIPTION
In this PR we implement enough of the DOM API so that Vega will now attempt to add event listeners for interactivity. Our current Obj-C implementation of `addEventListener` is a no-op and will need to be expanded in a later PR; it is however being called by Vega which is promising.

The relevant changes include:
1. Expanding the `VegaHTMLElementInterface` so that it now supports calls to methods such as `addChild`, `removeChild`, `addEventListener`, etc.
2. Implementing versions of these methods in `VegaHTMLElement`.
3. Instantiating a container element which Vega will place our canvas in `VegaRenderer` and referencing this element during Vega initialization.
4. Adding the `body` property to `document`.