### PR TITLE
Updates and optimizations to logic for dropna.

### DIFF
--- a/src/core/storage/sframe_interface/unity_sarray.hpp
+++ b/src/core/storage/sframe_interface/unity_sarray.hpp
@@ -489,6 +489,17 @@ class unity_sarray: public unity_sarray_base {
   std::shared_ptr<unity_sarray_base> drop_missing_values();
 
   /**
+   * Returns a new integer typed array indicating the presence of a missing value or float NA
+   * in the corresponding element.
+   *
+   * If recursive is true, then it also checks if a NA is present in any element of a recursive type.
+   *
+   * If missing_is_true  is true, then the array contains a 1 if the element is a
+   * missing value and a 0 if it is not; otherwise, it returns 1 on the presence of a na.
+   */
+  std::shared_ptr<unity_sarray_base> missing_mask(bool recursive = false, bool missing_is_true = true);
+
+  /**
    * Returns a new array with all UNDEFINED values replaced with the given value.
    *
    * Throws if the given value is not convertible to the SArray's type.

--- a/src/core/storage/sframe_interface/unity_sframe.hpp
+++ b/src/core/storage/sframe_interface/unity_sframe.hpp
@@ -164,6 +164,16 @@ class unity_sframe : public unity_sframe_base {
   std::vector<flex_type_enum> dtype() override;
 
   /**
+   * Returns the dtype of a particular column.
+   */
+  flex_type_enum dtype(size_t column_index);
+
+  /**
+   * Returns the dtype of a particular column.
+   */
+  flex_type_enum dtype(const std::string& column_name);
+
+  /**
    * Returns an array containing the name of each column. The length
    * of the return array is equal to num_columns(). If the sframe is empty,
    * this returns an empty array.
@@ -217,6 +227,12 @@ class unity_sframe : public unity_sframe_base {
   std::shared_ptr<unity_sarray_base> select_column(const std::string &name) override;
 
   /**
+   * Returns an SArray with the column that corresponds to index idx.  Throws an
+   * exception if the name is not in the current SFrame.
+   */
+  std::shared_ptr<unity_sarray_base> select_column(size_t idx);
+
+  /**
    * Returns a new SFrame which is filtered by a given logical column.
    * The index array must be the same length as the current array. An output
    * array is returned containing only the elements in the current where are the
@@ -229,6 +245,11 @@ class unity_sframe : public unity_sframe_base {
    * exception if ANY of the names given are not in the current SFrame.
    */
   std::shared_ptr<unity_sframe_base> select_columns(const std::vector<std::string> &names) override;
+
+  /**
+   * Returns an lazy sframe with the columns given by the indices.
+   */
+  std::shared_ptr<unity_sframe_base> select_columns(const std::vector<size_t>& indices);
 
   /**
    * Mutates the current SFrame by adding the given column.
@@ -613,14 +634,7 @@ class unity_sframe : public unity_sframe_base {
    *
    * Throw if column_names has duplication, or some column name does not exist.
    */
-  std::vector<size_t> _convert_column_names_to_indices(const std::vector<std::string> &column_names);
-
-  /**
-   * a cell is considered to be nan iff it contains nan.
-   * it will be passed to lambda, so declare it as static,
-   * otherwise this pointer needs to be captured.
-   */
-  static inline bool _contains_nan(const flexible_type& cell);
+  std::vector<size_t> _convert_column_names_to_indices(const std::vector<std::string>& column_names);
 
   /**
    * Generate a new column name

--- a/test/unity/unity_sframe.cxx
+++ b/test/unity/unity_sframe.cxx
@@ -53,8 +53,11 @@ struct unity_sframe_test {
     // check types match
     std::vector<flex_type_enum> dtypes = sframe->dtype();
     TS_ASSERT_EQUALS(dtypes[0], flex_type_enum::INTEGER);
+    TS_ASSERT_EQUALS(sframe->dtype(0), flex_type_enum::INTEGER);
     TS_ASSERT_EQUALS(dtypes[1], flex_type_enum::FLOAT);
+    TS_ASSERT_EQUALS(sframe->dtype(1), flex_type_enum::FLOAT);
     TS_ASSERT_EQUALS(dtypes[2], flex_type_enum::STRING);
+    TS_ASSERT_EQUALS(sframe->dtype(2), flex_type_enum::STRING);
 
     // check names match
     std::vector<std::string> names = sframe->column_names();


### PR DESCRIPTION
This PR updates the logic in unity_sframe and unity_sarray for dealing
with dropping missing values.

- Fixes https://github.com/apple/turicreate/issues/2170.  The root issue
  there was that the dropna function was defined as a function over all
  the rows instead of just the rows needed.  Thus the optimizer would
  not treat it correctly.

- Eliminated duplicated code between unity_sarray and unity_sframe.
  Dropna on a single column now uses unity_sarray implementation to
  provide the mask column.