### PR TITLE
Make VegaRenderer more debuggable

### DIFF
--- a/src/visualization/vega_renderer/CMakeLists.txt
+++ b/src/visualization/vega_renderer/CMakeLists.txt
@@ -12,7 +12,10 @@ if(APPLE AND NOT TC_BUILD_IOS)
 
    set( VEGA_RENDERER_SOURCES
       JSCanvas.m
+      JSConsole.m
       JSDocument.m
+      LogProxy.m
+      LogProxyHandler.m
       VegaHTMLElement.m
       VegaRenderer.m
       colors.m

--- a/src/visualization/vega_renderer/JSCanvas.h
+++ b/src/visualization/vega_renderer/JSCanvas.h
@@ -66,7 +66,7 @@ JSExportAs(addColorStop,
 @protocol VegaCGContextInterface <JSExport>
 
 // properties
-@property id fillStyle;
+@property JSValue * fillStyle;
 @property double globalAlpha;
 @property NSString * lineCap;
 @property NSString * lineJoin;
@@ -79,7 +79,7 @@ JSExportAs(addColorStop,
 @property double lineDashOffset;
 
 // utilities
-- (VegaCGTextMetrics *)measureText:(NSString *)text;
+- (JSValue *)measureText:(NSString *)text;
 
 // save/restore context state
 - (void)save;
@@ -112,7 +112,7 @@ JSExportAs(clearRect,
 - (void)clip;
 - (void)closePath;
 JSExportAs(createLinearGradient,
-           - (VegaCGLinearGradient *)createLinearGradientWithX0:(double)x0
+           - (JSValue *)createLinearGradientWithX0:(double)x0
            y0:(double)y0
            x1:(double)x1
            y1:(double)y1

--- a/src/visualization/vega_renderer/JSConsole.h
+++ b/src/visualization/vega_renderer/JSConsole.h
@@ -1,0 +1,12 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#import <JavaScriptCore/JavaScriptCore.h>
+
+@interface JSConsole : NSObject
+
++ (void)attachToJavaScriptContext:(JSContext *)context;
+
+@end

--- a/src/visualization/vega_renderer/JSConsole.m
+++ b/src/visualization/vega_renderer/JSConsole.m
@@ -1,0 +1,36 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#import "JSConsole.h"
+
+@implementation JSConsole
+
++ (void)attachToJavaScriptContext:(JSContext *)context {
+    [context evaluateScript:@"var console = {};"];
+
+    context[@"console"][@"log"] = ^() {
+        NSArray *message = [JSContext currentArguments];
+        NSLog(@"JS console log: %@", message);
+    };
+    context[@"console"][@"warn"] = ^() {
+        NSArray *message = [JSContext currentArguments];
+        NSLog(@"JS console warning: %@", message);
+    };
+    context[@"console"][@"error"] = ^() {
+        NSArray *message = [JSContext currentArguments];
+        NSLog(@"JS console error: %@", message);
+    };
+
+    // set up error handling
+    context.exceptionHandler = ^(JSContext *context, JSValue *exception) {
+        NSLog(@"Unhandled exception: %@", [exception toString]);
+        NSLog(@"In context: %@", [context debugDescription]);
+        NSLog(@"Line %@, column %@", [exception objectForKeyedSubscript:@"line"], [exception objectForKeyedSubscript:@"column"]);
+        NSLog(@"Stacktrace: %@", [exception objectForKeyedSubscript:@"stack"]);
+        assert(false);
+    };
+}
+
+@end

--- a/src/visualization/vega_renderer/LogProxy.h
+++ b/src/visualization/vega_renderer/LogProxy.h
@@ -1,0 +1,54 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#import <JavaScriptCore/JavaScriptCore.h>
+#include <os/log.h>
+
+#import "LogProxyHandler.h"
+
+@interface LogProxy : NSObject
+
+/*
+ * Logs all property accesses using os_log_info, and will log missing
+ * properties with os_log_error, using subsystem "com.apple.turi" and component
+ * "vega_renderer".
+ */
++ (JSValue *)wrap:(JSValue *)instance;
+
+/*
+ * Logs all property accesses using os_log_info, and will log missing
+ * properties with os_log_error, using subsystem "com.apple.turi" and component
+ * "vega_renderer".
+ */
++ (JSValue *)wrapObject:(NSObject *)object;
+
+/*
+ * Takes a handler to wrap the instance with; all property accesses will go
+ * through this handler, and the handler should return the property value.
+ */
++ (JSValue *)wrap:(JSValue *)instance
+      withHandler:(id<LogProxyHandling>)handler;
+
+/*
+ * Takes a LogProxy, or any other object type.
+ * If object is a LogProxy wrapper, returns the wrapped object.
+ * Otherwise, returns the object passed in.
+ */
++ (id)tryUnwrap:(id)object;
+
+/*
+ * Takes a LogProxy wrapped object.
+ * If object is a LogProxy wrapper, returns the wrapped object.
+ * Otherwise, returns nil.
+ */
++ (JSValue *)unwrap:(JSValue *)object;
+
+/*
+ * A preconfigured log object for use with os_log methods.
+ */
++ (os_log_t)logger;
+
+@end

--- a/src/visualization/vega_renderer/LogProxy.m
+++ b/src/visualization/vega_renderer/LogProxy.m
@@ -1,0 +1,67 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#import "LogProxy.h"
+#import "LogProxyHandler.h"
+
+@implementation LogProxy
+
++ (os_log_t)logger {
+    static os_log_t log;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      log = os_log_create("com.apple.turi", "vega_renderer");
+    });
+    return log;
+}
+
++ (JSValue *)wrap:(JSValue *)instance {
+  return [LogProxy wrap:instance withHandler:[[LogProxyHandler alloc] init]];
+}
+
++ (JSValue *)wrapObject:(NSObject *)object {
+  // Assumes we have a current JSC context
+  return [LogProxy wrap:[JSValue valueWithObject:object inContext:[JSContext currentContext]]];
+}
+
++ (JSValue *)wrap:(JSValue *)instance
+   withHandler:(id<LogProxyHandling>)handler {
+  instance.context[@"__tmp_instance"] = instance;
+  instance.context[@"__tmp_handler"] = handler;
+  instance.context[@"__tmp_proxy"] = [instance.context evaluateScript:@"new Proxy(__tmp_instance, __tmp_handler);"];
+  [instance.context evaluateScript:@""
+	    "Object.defineProperty(__tmp_proxy, '__LogProxy_wrapped', {"
+	    "  enumerable: true,"
+      "  value: __tmp_instance,"
+      "});"];
+  return instance.context[@"__tmp_proxy"];
+}
+
++ (id)tryUnwrap:(id)object {
+  if ([object isKindOfClass:[JSValue class]]) {
+    if ([object hasProperty:@"__LogProxy_wrapped"]) {
+      return object[@"__LogProxy_wrapped"];
+    }
+  }
+
+  // It doesn't appear to be a Proxy object, or at least not
+  // one wrapped by LogProxy.
+  return object;
+}
+
++ (JSValue *)unwrap:(JSValue *)instance {
+  assert([instance isKindOfClass:[JSValue class]]);
+
+  if ([instance hasProperty:@"__LogProxy_wrapped"]) {
+    return instance[@"__LogProxy_wrapped"];
+  }
+
+  // It doesn't appear to be a Proxy object, or at least not
+  // one wrapped by LogProxy.
+  assert(false);
+  return nil;
+}
+
+@end

--- a/src/visualization/vega_renderer/LogProxyHandler.h
+++ b/src/visualization/vega_renderer/LogProxyHandler.h
@@ -1,0 +1,25 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#import <JavaScriptCore/JavaScriptCore.h>
+
+@protocol LogProxyHandling<JSExport>
+
+JSExportAs(get,
+    - (JSValue *)getPropertyOnObject:(JSValue *)object
+                               named:(NSString *)property
+    );
+
+JSExportAs(set,
+    - (BOOL)setPropertyOnObject:(JSValue *)object
+                          named:(NSString *)property
+                        toValue:(JSValue *)value
+    );
+
+@end
+
+@interface LogProxyHandler : NSObject<LogProxyHandling>
+@end

--- a/src/visualization/vega_renderer/LogProxyHandler.m
+++ b/src/visualization/vega_renderer/LogProxyHandler.m
@@ -1,0 +1,70 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#import "LogProxy.h"
+#import "LogProxyHandler.h"
+
+#include <os/log.h>
+
+@implementation LogProxyHandler
+
+- (JSValue *)getPropertyOnObject:(JSValue *)instance
+                            named:(NSString *)key {
+    os_log_info(LogProxy.logger, "Getting property \"%s\" on LogProxy wrapped object %s", key.UTF8String, instance.debugDescription.UTF8String);
+
+    // First off, if the JS interface for this type has this property, return it
+    JSValue *ret = instance[key];
+    if (ret != nil && !ret.isUndefined) {
+      JSContext *context = instance.context;
+      context[@"__tmp_propertyAccess"] = ret;
+      if ([[context evaluateScript:@"typeof __tmp_propertyAccess"].toString isEqualToString:@"function"]) {
+        // it's a method, bind it to the original target or else we'll get
+        // "self type check failed for Objective-C instance method"
+        ret = [ret invokeMethod:@"bind" withArguments:@[instance]];
+      }
+
+      // Make sure the wrapping is applied recursively on objects, but only
+      // if the caller isn't requesting the unwrapped object explicitly
+      if (ret.isObject && ![key isEqualToString:@"__LogProxy_wrapped"]) {
+        ret = [LogProxy wrap:ret];
+      }
+
+      return ret;
+    }
+
+    // Encountered a missing key here!
+#ifndef NDEBUG
+    NSLog(@"Get for missing property \"%@\" on LogProxy wrapped object %@", key, instance.debugDescription);
+#endif
+    os_log_error(LogProxy.logger, "Get for missing property \"%s\" on LogProxy wrapped object %s", key.UTF8String, instance.debugDescription.UTF8String);
+
+    // This will preserve the semantics of property access without LogProxy,
+    // which is to return undefined for a missing property.
+    return [JSValue valueWithUndefinedInContext:instance.context];
+}
+
+- (BOOL)setPropertyOnObject:(JSValue *)instance
+                        named:(NSString *)key
+                    toValue:(JSValue *)value {
+
+    os_log_info(LogProxy.logger, "Setting property \"%s\" on LogProxy wrapped object %s to value \"%s\"", key.UTF8String, instance.debugDescription.UTF8String, value.debugDescription.UTF8String);
+
+    // First off, if the JS interface for this type has this property, use it
+    if ([instance hasProperty:key]) {
+      instance[key] = value;
+      return TRUE;
+    }
+
+    // Encountered a missing key here!
+#ifndef NDEBUG
+    NSLog(@"Set for missing property \"%@\" on LogProxy wrapped object %@ to value %@", key, instance.debugDescription, value.debugDescription);
+#endif
+    os_log_error(LogProxy.logger, "Set for missing property \"%s\" on LogProxy wrapped object %s to value %s", key.UTF8String, instance.debugDescription.UTF8String, value.debugDescription.UTF8String);
+
+    return FALSE;
+}
+
+@end

--- a/src/visualization/vega_renderer/VegaRenderer.m
+++ b/src/visualization/vega_renderer/VegaRenderer.m
@@ -5,6 +5,7 @@
  */
 #import "VegaRenderer.h"
 #import "JSCanvas.h"
+#import "JSConsole.h"
 #import "JSDocument.h"
 
 #import <AppKit/AppKit.h>
@@ -72,28 +73,7 @@
     @autoreleasepool {
 
         // set up logging
-        [self.context evaluateScript:@"var console = {};"];
-        self.context[@"console"][@"log"] = ^() {
-            NSArray *message = [JSContext currentArguments];
-            NSLog(@"JS console log: %@", message);
-        };
-        self.context[@"console"][@"warn"] = ^() {
-            NSArray *message = [JSContext currentArguments];
-            NSLog(@"JS console warning: %@", message);
-        };
-        self.context[@"console"][@"error"] = ^() {
-            NSArray *message = [JSContext currentArguments];
-            NSLog(@"JS console error: %@", message);
-        };
-        
-        // set up error handling
-        self.context.exceptionHandler = ^(JSContext *context, JSValue *exception) {
-            NSLog(@"Unhandled exception: %@", [exception toString]);
-            NSLog(@"In context: %@", [context debugDescription]);
-            NSLog(@"Line %@, column %@", [exception objectForKeyedSubscript:@"line"], [exception objectForKeyedSubscript:@"column"]);
-            NSLog(@"Stacktrace: %@", [exception objectForKeyedSubscript:@"stack"]);
-            assert(false);
-        };
+        [JSConsole attachToJavaScriptContext:self.context];
 
         VegaCGCanvas* vegaCanvas = [[VegaCGCanvas alloc] initWithContext:parentContext];
         weakSelf.vegaCanvas = vegaCanvas;

--- a/test/vega_renderer/CMakeLists.txt
+++ b/test/vega_renderer/CMakeLists.txt
@@ -39,6 +39,8 @@ if(APPLE AND NOT TC_BUILD_IOS)
     make_boost_test(vega_example_tests.cxx ${source_deps} REQUIRES ${target_deps})
     make_boost_test(vega_lite_example_tests.cxx ${source_deps} REQUIRES ${target_deps})
     make_boost_test(turicreate_example_tests.cxx ${source_deps} REQUIRES ${target_deps})
+    make_boost_test(log_proxy_tests.cxx log_proxy_tests_impl.mm ${source_deps} REQUIRES ${target_deps})
+    target_compile_options(log_proxy_tests.cxxtest PUBLIC "-fobjc-arc")
 
     # loop through files in turicreate
     file(GLOB_RECURSE VEGA_JSON_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.json)

--- a/test/vega_renderer/log_proxy_tests.cxx
+++ b/test/vega_renderer/log_proxy_tests.cxx
@@ -1,0 +1,26 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE log_proxy_tests
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include "log_proxy_tests.hpp"
+
+BOOST_AUTO_TEST_SUITE(log_proxy_tests );
+
+BOOST_AUTO_TEST_CASE( test_wrap_unwrap ) {
+    LogProxyTests::test_wrap_unwrap();
+}
+
+BOOST_AUTO_TEST_CASE( test_expected_property_access ) {
+    LogProxyTests::test_expected_property_access();
+}
+
+BOOST_AUTO_TEST_CASE( test_unexpected_property_access ) {
+    LogProxyTests::test_unexpected_property_access();
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/test/vega_renderer/log_proxy_tests.hpp
+++ b/test/vega_renderer/log_proxy_tests.hpp
@@ -1,0 +1,11 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+struct LogProxyTests {
+    static void test_wrap_unwrap();
+    static void test_expected_property_access();
+    static void test_unexpected_property_access();
+};

--- a/test/vega_renderer/log_proxy_tests_impl.mm
+++ b/test/vega_renderer/log_proxy_tests_impl.mm
@@ -1,0 +1,114 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#import <JavaScriptCore/JavaScriptCore.h>
+#import <visualization/vega_renderer/LogProxy.h>
+#import <visualization/vega_renderer/JSConsole.h>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include "log_proxy_tests.hpp"
+
+@protocol TestExportInterface<JSExport>
+@property NSString * expected;
+@end
+
+@interface TestExport : NSObject<TestExportInterface>
+@property NSString * expected;
+@end
+
+@implementation TestExport
+@synthesize expected;
+
+- (instancetype)init {
+    self = [super init];
+    self.expected = @"this is expected.";
+    return self;
+}
+
+@end
+
+void LogProxyTests::test_wrap_unwrap() {
+    JSContext *context = [[JSContext alloc] init];
+    [JSConsole attachToJavaScriptContext:context];
+    TestExport *original = [[TestExport alloc] init];
+    JSValue *v = [JSValue valueWithObject:original inContext:context];
+    JSValue *wrapped = [LogProxy wrap:v];
+    TS_ASSERT_DIFFERS(wrapped, nil);
+
+    JSValue *unwrapped = [LogProxy unwrap:wrapped];
+    TS_ASSERT([v isEqualToObject:unwrapped]);
+}
+
+void LogProxyTests::test_expected_property_access() {
+    JSContext *context = [[JSContext alloc] init];
+    [JSConsole attachToJavaScriptContext:context];
+    TestExport *original = [[TestExport alloc] init];
+    JSValue *v = [JSValue valueWithObject:original inContext:context];
+    JSValue *wrapped = [LogProxy wrap:v];
+    TS_ASSERT_DIFFERS(wrapped, nil);
+
+    // Expect a defined property to give back the correct result through the wrapper
+    NSString *str = wrapped[@"expected"].toString;
+    TS_ASSERT_DIFFERS(str, nil);
+    std::string expected = "this is expected.";
+    std::string actual = str.UTF8String;
+    TS_ASSERT_EQUALS(expected, actual);
+
+    // Expect setting a defined property to retain it
+    wrapped[@"expected"] = @"this is the new value.";
+    str = wrapped[@"expected"].toString;
+    TS_ASSERT_DIFFERS(str, nil);
+    expected = "this is the new value.";
+    actual = str.UTF8String;
+    TS_ASSERT_EQUALS(expected, actual);
+}
+
+@interface UnexpectedPropertyAccessLogger : NSObject<LogProxyHandling>
+@end
+
+@implementation UnexpectedPropertyAccessLogger
+- (JSValue *)getPropertyOnObject:(JSValue *)v
+                            named:(NSString *)key {
+    TS_ASSERT(![v hasProperty:key]);
+    return [JSValue valueWithUndefinedInContext:v.context];
+}
+- (BOOL)setPropertyOnObject:(JSValue *)v
+                        named:(NSString *)key
+                    toValue:(JSValue *)value {
+    TS_ASSERT_EQUALS(key.UTF8String, "undeclared");
+    TS_ASSERT(![v hasProperty:key]);
+    return FALSE;
+}
+@end
+
+void LogProxyTests::test_unexpected_property_access() {
+    JSContext *context = [[JSContext alloc] init];
+    [JSConsole attachToJavaScriptContext:context];
+    TestExport *original = [[TestExport alloc] init];
+    JSValue *v = [JSValue valueWithObject:original inContext:context];
+
+    // Set up the wrapper to expect exactly what we are about to test
+    JSValue *wrapped = [LogProxy wrap:v withHandler:[[UnexpectedPropertyAccessLogger alloc] init]];
+    TS_ASSERT_DIFFERS(wrapped, nil);
+
+    // Expect accessing a missing property to return undefined, but it will also
+    // pass through the above wrapper and make assertions there.
+    NSString *str = wrapped[@"unexpected"].toString;
+    TS_ASSERT_DIFFERS(str, nil);
+    std::string expected = "undefined";
+    std::string actual = str.UTF8String;
+    TS_ASSERT_EQUALS(expected, actual);
+
+    // Expect setting a missing property to do nothing,
+    // and not retain the value
+    wrapped[@"undeclared"] = @"this is the new value.";
+    str = wrapped[@"undeclared"].toString;
+    TS_ASSERT_DIFFERS(str, nil);
+    expected = "undefined";
+    actual = str.UTF8String;
+    TS_ASSERT_EQUALS(expected, actual);
+}


### PR DESCRIPTION
* Adds a LogProxy object, and a default implementation of
  LogProxyHandler, to log to `os_log` methods when properties are
  accessed or assigned to on wrapped objects.

* Adds wrap/unwrap static methods to allow objects to easily be
  wrapped/unwrapped as needed.

* Unit tested for expected behavior (the LogProxy-wrapped object should not
  behave differently from the original object) and for wrapping
  functionality (wrapper methods get invoked as expected).

Potential uses:

* Set break points in the debugger on the getter/setter methods.
* Run `log stream --level info` to get a stream of the log.
* Insert a custom logger to get observability on a particular object.

Fixes #2158