### PR TITLE
Better error message on bad input to plot()

### DIFF
--- a/src/python/turicreate/visualization/show.py
+++ b/src/python/turicreate/visualization/show.py
@@ -77,6 +77,10 @@ def plot(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAULT):
 
     """
     title = _get_title(title)
+    if not(isinstance(x, tc.SArray)):
+      raise ValueError("The X axis data should be an SArray.")
+    if not(isinstance(y, tc.SArray)):
+      raise ValueError("The Y axis data should be an SArray.")
     plt_ref = tc.extensions.plot(x, y, xlabel, ylabel, title)
     return Plot(_proxy=plt_ref)
 


### PR DESCRIPTION
Without this fix, a user passing the wrong data type to `plot` would get
a cryptic error message like:

```python
----> 1 tc.show('date', 'temp')

/Users/zach/turicreate/debug/src/python/turicreate/visualization/show.py in show(x, y, xlabel, ylabel, title)
    141
    142     """
--> 143     plot(x, y, xlabel, ylabel, title).show()
    144
    145 def scatter(x, y, xlabel=LABEL_DEFAULT, ylabel=LABEL_DEFAULT, title=LABEL_DEFAULT):

/Users/zach/turicreate/debug/src/python/turicreate/visualization/show.py in plot(x, y, xlabel, ylabel, title)
     78     """
     79     title = _get_title(title)
---> 80     plt_ref = tc.extensions.plot(x, y, xlabel, ylabel, title)
     81     return Plot(_proxy=plt_ref)
     82

/Users/zach/turicreate/debug/src/python/turicreate/extensions.pyc in <lambda>(*args, **kwargs)
    168
    169 def _make_injected_function(fn, arguments):
--> 170     return lambda *args, **kwargs: _run_toolkit_function(fn, arguments, args, kwargs)
    171
    172 def _class_instance_from_name(class_name, *arg, **kwarg):

/Users/zach/turicreate/debug/src/python/turicreate/extensions.pyc in _run_toolkit_function(fnname, arguments, args, kwargs)
    157     if not ret[0]:
    158         if len(ret[1]) > 0:
--> 159             raise _ToolkitError(ret[1])
    160         else:
    161             raise _ToolkitError("Toolkit failed with unknown error")

ToolkitError: Variant type error: Expecting SArray but got a flexible_type
```

Fixes #141