### PR TITLE
Fix for broken unit test in vega renderer

### DIFF
--- a/src/visualization/vega_renderer/JSDocument.m
+++ b/src/visualization/vega_renderer/JSDocument.m
@@ -22,13 +22,9 @@
 
     if([element isEqualToString:@"canvas"]){
         return _canvas;
-    } else if([element isEqualToString:@"div"]) {
-        return [[VegaHTMLElement alloc] initWithTagName:@"div"];
     } else {
-        NSLog(@"creating elements of type '%@' is not supported", element);
-        assert(false);
+        return [[VegaHTMLElement alloc] initWithTagName:element];
     }
-    return nil;
 }
 
 @end


### PR DESCRIPTION
Allows arbitrary tag names without asserting false -- if we need to
catch an unintended tag name here, we can use LogProxy (added in #2180)
to debug it. Otherwise, the vega example tests try to create span
elements and fail due to the assertion. The tests pass as is without the
assertion.

Fixes #2186