### PR TITLE
Sanity check max_iterations in Style Transfer

### DIFF
--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -109,6 +109,10 @@ class StyleTransferTest(unittest.TestCase):
         with self.assertRaises(_ToolkitError):
             tc.style_transfer.create(self.style_sf[:1], self.content_sf[:1], max_iterations=-1)
 
+    def test_create_with_incorrect_max_iterations_format_float(self):
+        with self.assertRaises(_ToolkitError):
+            tc.style_transfer.create(self.style_sf[:1], self.content_sf[:1], max_iterations=1.25)
+
     def _get_invalid_style_cases(self):
         style_cases = []
         # when style is an empty list

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -79,27 +79,35 @@ class StyleTransferTest(unittest.TestCase):
                                               self.content_sf,
                                               style_feature=self.style_feature,
                                               content_feature=self.content_feature,
-                                              max_iterations=0,
+                                              max_iterations=1,
                                               model=self.pre_trained_model)
 
 
     @pytest.mark.xfail(raises=_ToolkitError)
     def test_create_with_missing_style_feature(self):
         tc.style_transfer.create(self.style_sf, self.content_sf, style_feature='wrong_feature',
-                                 max_iterations=0)
+                                 max_iterations=1)
 
     @pytest.mark.xfail(raises=_ToolkitError)
     def test_create_with_missing_content_feature(self):
         tc.style_transfer.create(self.style_sf, self.content_sf, content_feature='wrong_feature',
-                                 max_iterations=0)
+                                 max_iterations=1)
 
     @pytest.mark.xfail(raises=_ToolkitError)
     def test_create_with_empty_style_dataset(self):
-        tc.style_transfer.create(self.style_sf[:0], self.content_sf, max_iterations=0)
+        tc.style_transfer.create(self.style_sf[:0], self.content_sf, max_iterations=1)
 
     @pytest.mark.xfail(raises=_ToolkitError)
     def test_create_with_empty_content_dataset(self):
-        tc.style_transfer.create(self.style_sf, self.content_sf[:0], max_iterations=0)
+        tc.style_transfer.create(self.style_sf, self.content_sf[:0], max_iterations=1)
+
+    def test_create_with_incorrect_max_iterations_format_string(self):
+        with self.assertRaises(_ToolkitError):
+            tc.style_transfer.create(self.style_sf[:1], self.content_sf[:1], max_iterations='dummy_string')
+    
+    def test_create_with_incorrect_max_iterations_format_negative(self):
+        with self.assertRaises(_ToolkitError):
+            tc.style_transfer.create(self.style_sf[:1], self.content_sf[:1], max_iterations=-1)
 
     def _get_invalid_style_cases(self):
         style_cases = []

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -104,7 +104,7 @@ class StyleTransferTest(unittest.TestCase):
     def test_create_with_incorrect_max_iterations_format_string(self):
         with self.assertRaises(_ToolkitError):
             tc.style_transfer.create(self.style_sf[:1], self.content_sf[:1], max_iterations='dummy_string')
-    
+
     def test_create_with_incorrect_max_iterations_format_negative(self):
         with self.assertRaises(_ToolkitError):
             tc.style_transfer.create(self.style_sf[:1], self.content_sf[:1], max_iterations=-1)

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -110,6 +110,8 @@ def create(style_dataset, content_dataset, style_feature=None,
         raise _ToolkitError("content_dataset SFrame cannot be empty")
     if(batch_size < 1):
         raise _ToolkitError("'batch_size' must be greater than or equal to 1")
+    if max_iterations is not None and (type(max_iterations)==str or max_iterations<0):
+        raise _ToolkitError("'max_iterations' must be an integer greater than or equal to 0")
 
     from ._sframe_loader import SFrameSTIter as _SFrameSTIter
     import mxnet as _mx
@@ -176,7 +178,7 @@ def create(style_dataset, content_dataset, style_feature=None,
     input_shape = params['input_shape']
 
     iterations = 0
-    if max_iterations is None:
+    if max_iterations is None or max_iterations==0:
         max_iterations = len(style_dataset) * 10000
         if verbose:
             print('Setting max_iterations to be {}'.format(max_iterations))

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -110,7 +110,7 @@ def create(style_dataset, content_dataset, style_feature=None,
         raise _ToolkitError("content_dataset SFrame cannot be empty")
     if(batch_size < 1):
         raise _ToolkitError("'batch_size' must be greater than or equal to 1")
-    if max_iterations is not None and (type(max_iterations)==str or max_iterations<0):
+    if max_iterations is not None and (type(max_iterations)==str or type(max_iterations)==float or max_iterations<0):
         raise _ToolkitError("'max_iterations' must be an integer greater than or equal to 0")
 
     from ._sframe_loader import SFrameSTIter as _SFrameSTIter

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -110,7 +110,7 @@ def create(style_dataset, content_dataset, style_feature=None,
         raise _ToolkitError("content_dataset SFrame cannot be empty")
     if(batch_size < 1):
         raise _ToolkitError("'batch_size' must be greater than or equal to 1")
-    if max_iterations is not None and (type(max_iterations)==str or type(max_iterations)==float or max_iterations<0):
+    if max_iterations is not None and (not isinstance(max_iterations, int) or max_iterations < 0):
         raise _ToolkitError("'max_iterations' must be an integer greater than or equal to 0")
 
     from ._sframe_loader import SFrameSTIter as _SFrameSTIter


### PR DESCRIPTION
Closes #2013 

Added check for `max_iterations` in Style Transfer `create()` to ensure in integer >=0. Checking for incorrect formats: strings, floats and negative integers. Added tests.

For consistency in toolkits, input of `max_iterations=0` matches use in OD and defaults to same behavior as `max_iterations=None` i.e. automatically determine based on amount of data. (Tests where max_iterations=0 was previously set have been modified to max_iterations=1)