### PR TITLE
Style Transfer user guide update

### DIFF
--- a/userguide/style_transfer/README.md
+++ b/userguide/style_transfer/README.md
@@ -66,7 +66,7 @@ training process, can result in better models.
 #### Model Creation
 
 Model creation may take time. If you do not have access to a GPU, it can
-take up to a day to train a good model. The number of training
+take up to a day or more to train a good model for one style image. The number of training
 iterations is determined automatically. You may lower this value to make
 model creation faster, as the cost of obtaining a potentially worse
 model. See [how it works](how-it-works.md) for more details on how this

--- a/userguide/style_transfer/how-it-works.md
+++ b/userguide/style_transfer/how-it-works.md
@@ -26,7 +26,6 @@ There are three aspects about this technique that are worth noting:
 During training, we employ [Transfer
 Learning](../image_classifier/how-it-works.md#transfer-learning). The 
 model uses the visual semantics of an already trained VGG-16 network to
-understand and mimic stylistic elements. It also updates only a small set of
-the parameters of the stylization network; the rest of the parameters were
+understand and mimic stylistic elements. If the `finetune_all_params` parameter is set to `False` only a small set of parameters of the stylization network are updated - the rest of the parameters were
 already trained and remain unchanged. This allows you to achieve great results
-with little data and shorter training time.
+with little data and shorter training time. If  `finetune_all_params` is set to `True`, the entire model is updated in training. For more information on advanced options in training, refer to the [Advanced Usage](../advanced-usage.md) section.


### PR DESCRIPTION
Closes #1953 

Added: heads up for CPU train time, caveat for use of `finetune_all_params` and link to Advanced Usage.

