### PR TITLE
Fixes API docs 

### DIFF
--- a/src/python/doc/source/conf.py
+++ b/src/python/doc/source/conf.py
@@ -63,7 +63,8 @@ for m in [
           'image_similarity',
           'topic_model',
           'triangle_counting',
-          'visualization'
+          'visualization',
+          'one_shot_object_detector'
           ]:
     module_name = 'turicreate.' + m
     sys.modules[module_name] = eval(module_name)

--- a/src/python/doc/source/turicreate.toolkits.drawing_classifier.rst
+++ b/src/python/doc/source/turicreate.toolkits.drawing_classifier.rst
@@ -9,7 +9,7 @@
 drawing classifier
 ------------------
 .. autosummary::
-  :toctree: 
+  :toctree: generated/
   :nosignatures:
 
   create
@@ -18,7 +18,7 @@ drawing classifier
 utilities
 ---------
 .. autosummary::
-  :toctree: 
+  :toctree: generated/
   :nosignatures:
 
   util.draw_strokes

--- a/src/python/doc/source/turicreate.toolkits.drawing_classifier.rst
+++ b/src/python/doc/source/turicreate.toolkits.drawing_classifier.rst
@@ -2,24 +2,23 @@
 ==========================
 
 .. automodule:: turicreate.toolkits.drawing_classifier
-    :members:
 
-.. currentmodule:: turicreate
+.. currentmodule:: turicreate.drawing_classifier
 
 
 drawing classifier
-----------------
+------------------
 .. autosummary::
-  :toctree: generated/
+  :toctree: 
   :nosignatures:
 
-  drawing_classifier.create
-  drawing_classifier.DrawingClassifier
+  create
+  DrawingClassifier
 
 utilities
 ---------
 .. autosummary::
-  :toctree: generated/
+  :toctree: 
   :nosignatures:
 
   util.draw_strokes

--- a/src/python/doc/source/turicreate.toolkits.one_shot_object_detector.rst
+++ b/src/python/doc/source/turicreate.toolkits.one_shot_object_detector.rst
@@ -1,5 +1,5 @@
 :mod:`one_shot_object_detector`
-==========================
+================================
 
 .. automodule:: turicreate.toolkits.one_shot_object_detector
 
@@ -7,7 +7,7 @@
 
 
 one shot object detector
----------------
+-------------------------
 .. autosummary::
   :toctree: generated/
   :nosignatures:

--- a/src/python/turicreate/toolkits/drawing_classifier/__init__.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/__init__.py
@@ -10,4 +10,4 @@ from .drawing_classifier import create, DrawingClassifier
 from ..image_classifier._annotate import annotate, recover_annotation
 from . import util
 
-__all__ = ['create', 'DrawingClassifier', 'util']
+__all__ = ['create', 'DrawingClassifier', 'util', 'annotate', 'recover_annotation']

--- a/src/python/turicreate/toolkits/drawing_classifier/__init__.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/__init__.py
@@ -10,4 +10,4 @@ from .drawing_classifier import create, DrawingClassifier
 from ..image_classifier._annotate import annotate, recover_annotation
 from . import util
 
-__all__ = ['create', 'DrawingClassifier', 'util', 'annotate', 'recover_annotation']
+__all__ = ['create', 'DrawingClassifier', 'util']

--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -134,9 +134,7 @@ def create(input_dataset, target, feature=None, validation_set='auto',
 
         # Make predictions on the training set and as column to the SFrame
         >>> data['predictions'] = model.predict(data)
-
     """
-
     import mxnet as _mx
     from mxnet import autograd as _autograd
     from ._model_architecture import Model as _Model
@@ -551,7 +549,6 @@ class DrawingClassifier(_CustomModel):
         The "probabilities" column contains the probabilities for each class
         that the model predicted for the data provided to the function.
         """
-
         from .._mxnet import _mxnet_utils
         import mxnet as _mx
         from ._sframe_loader import SFrameClassifierIter as _SFrameClassifierIter

--- a/src/python/turicreate/toolkits/one_shot_object_detector/__init__.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/__init__.py
@@ -8,4 +8,4 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 from .one_shot_object_detector import create, OneShotObjectDetector
 
-__all__ = ['create', 'OneShotObjectDetector']
+__all__ = ['create', 'OneShotObjectDetector', 'util']

--- a/src/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
@@ -77,7 +77,13 @@ def create(data,
         }
     return OneShotObjectDetector(state)
 
-class OneShotObjectDetector(_CustomModel):
+class OneShotObjectDetector(_CustomModel): 
+    """
+    An trained model that is ready to use for classification, exported to
+    Core ML, or for feature extraction.
+
+    This model should not be constructed directly.
+    """
     _PYTHON_ONE_SHOT_OBJECT_DETECTOR_VERSION = 1
 
     def __init__(self, state):

--- a/userguide/drawing_classifier/data-preparation.md
+++ b/userguide/drawing_classifier/data-preparation.md
@@ -83,8 +83,9 @@ def build_bitmap_sframe():
 
     sf = tc.SFrame({"drawing": bitmaps_list, "label": labels_list})
     sf.save(os.path.join(sframes_dir, "bitmap_square_triangle.sframe"))
+    return sf 
 
-build_bitmap_sframe()
+sf = build_bitmap_sframe()
 ```
 
 After building the two SFrames, your directory structure should look like the
@@ -177,8 +178,9 @@ def build_strokes_sframe():
         labels_list.extend([class_name] * num_examples_per_class)
     sf = tc.SFrame({"drawing": drawings_list, "label": labels_list})
     sf.save(os.path.join(sframes_dir, "stroke_square_triangle.sframe"))
+    return sf 
 
-build_strokes_sframe()
+sf = build_strokes_sframe()
 ```
 
 When stroke-based drawing data is given as input to the Drawing Classifier 
@@ -190,7 +192,7 @@ more information about the preprocessing done under the hood.
 To visualize what your stroke-based drawings look like when rendered as a 
 bitmap, you can run the following utility function:
 ```python
-sf = build_stroke_sframe()
+sf = build_strokes_sframe()
 sf["rendered"] = tc.drawing_classifier.util.draw_strokes(sf["drawing"])
 sf.explore()
 ```


### PR DESCRIPTION
fixes #2112 

This has some fixes for drawing classifier user guide that I found yesterday. 

I have locally built the API docs for one-shot object detector and drawing classifier. There is still one warning which I cannot get rid of. We should verify this works during 5.7 release.