### PR TITLE
Changed default max_iterations for DC

### DIFF
--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -56,7 +56,7 @@ def _drop_missing_values(dataset, feature, is_train):
 
 def create(input_dataset, target, feature=None, validation_set='auto',
             warm_start='auto', batch_size=256,
-            max_iterations=100, verbose=True):
+            max_iterations=500, verbose=True):
     """
     Create a :class:`DrawingClassifier` model.
 

--- a/userguide/drawing_classifier/advanced-usage.md
+++ b/userguide/drawing_classifier/advanced-usage.md
@@ -18,7 +18,7 @@ If you specify both `max_iterations` and `num_epochs`, `max_iterations` would
 take precedence and the model would train for that number of iterations and the 
 provided value of `num_epochs` would be ignored.
 
-When training a model for a large number of classes, it may be helpful to increase `max_iterations` to allow the model more revisions of the data to learn better.
+When training a model it may be useful to look at the progress table in the output to see if the model has converged. This will help determine whether `max_iterations` needs to be increased to allow model to converge to an optimal solution.
 
 ### Warm Start
 

--- a/userguide/drawing_classifier/advanced-usage.md
+++ b/userguide/drawing_classifier/advanced-usage.md
@@ -18,6 +18,8 @@ If you specify both `max_iterations` and `num_epochs`, `max_iterations` would
 take precedence and the model would train for that number of iterations and the 
 provided value of `num_epochs` would be ignored.
 
+When training a model for a large number of classes, it may be helpful to increase `max_iterations` to allow the model more revisions of the data to learn better.
+
 ### Warm Start
 
 To boost the accuracy of the Drawing Classifier models you train, and to help


### PR DESCRIPTION
Closes #2092 

- Changed `max_iterations` from 100 to 500.
- Added caveat in user-guide for using more epochs when training model for a larger number of classes.