### PR TITLE
1977 annotation skip invalid images

### DIFF
--- a/src/visualization/annotation/annotation_base.cpp
+++ b/src/visualization/annotation/annotation_base.cpp
@@ -63,7 +63,7 @@ AnnotationBase::returnAnnotations(bool drop_null) {
   std::shared_ptr<unity_sframe> copy_data;
   {
     // append undefined values
-    if (m_data_na || !m_data_na->size()) {
+    if (m_data_na && m_data_na->size()) {
       auto cast_type = m_data->select_column(m_annotation_column)->dtype();
       auto na_type = m_data_na->select_column(m_annotation_column)->dtype();
       if (cast_type != na_type) {

--- a/src/visualization/annotation/annotation_base.cpp
+++ b/src/visualization/annotation/annotation_base.cpp
@@ -22,7 +22,7 @@ AnnotationBase::AnnotationBase(const std::shared_ptr<unity_sframe> &data,
   /* Copy as so not to mutate the sframe passed into the function */
   m_data = std::static_pointer_cast<unity_sframe>(
       m_data->copy_range(0, 1, m_data->size()));
-  this->_addIndexColumn();
+  _addIndexColumn();
 }
 
 void AnnotationBase::annotate(const std::string &path_to_client) {
@@ -58,11 +58,32 @@ void AnnotationBase::_sendProgress(double value) {
 
 std::shared_ptr<unity_sframe>
 AnnotationBase::returnAnnotations(bool drop_null) {
-  this->cast_annotations();
+  cast_annotations();
 
-  std::shared_ptr<unity_sframe> copy_data =
-      std::static_pointer_cast<unity_sframe>(
+  std::shared_ptr<unity_sframe> copy_data;
+  {
+    // append undefined values
+    if (m_data_na || !m_data_na->size()) {
+      auto cast_type = m_data->select_column(m_annotation_column)->dtype();
+      auto na_type = m_data_na->select_column(m_annotation_column)->dtype();
+      if (cast_type != na_type) {
+        auto data_sarray = std::static_pointer_cast<unity_sarray>(
+            m_data_na->select_column(m_annotation_column));
+        auto integer_annotations =
+            data_sarray->astype(cast_type, true);
+        m_data_na->remove_column(m_data_na->column_index(m_annotation_column));
+        m_data_na->add_column(integer_annotations, m_annotation_column);
+      }
+      copy_data =
+          std::static_pointer_cast<unity_sframe>(m_data->append(m_data_na));
+    } else {
+      copy_data = std::static_pointer_cast<unity_sframe>(
           m_data->copy_range(0, 1, m_data->size()));
+    }
+  }
+  // temporary solution
+  copy_data = std::static_pointer_cast<unity_sframe>(
+      copy_data->sort({"__idx"}, {true}));
 
   size_t id_column = copy_data->column_index("__idx");
   copy_data->remove_column(id_column);
@@ -73,18 +94,19 @@ AnnotationBase::returnAnnotations(bool drop_null) {
   if (!drop_null) {
     annotation_global->annotation_sframe = copy_data;
     return copy_data;
-  }
+    }
 
-  std::vector<std::string> annotation_column_name = {m_annotation_column};
-  std::list<std::shared_ptr<unity_sframe_base>> dropped_missing =
-      copy_data->drop_missing_values(annotation_column_name, false, false, false);
+    std::vector<std::string> annotation_column_name = {m_annotation_column};
+    std::list<std::shared_ptr<unity_sframe_base>> dropped_missing =
+        copy_data->drop_missing_values(annotation_column_name, false, false,
+                                       false);
 
-  std::shared_ptr<unity_sframe> final_sf =
-      std::static_pointer_cast<unity_sframe>(dropped_missing.front());
+    std::shared_ptr<unity_sframe> final_sf =
+        std::static_pointer_cast<unity_sframe>(dropped_missing.front());
 
-  annotation_global->annotation_sframe = final_sf;
+    annotation_global->annotation_sframe = final_sf;
 
-  return final_sf;
+    return final_sf;
 }
 
 std::shared_ptr<annotation_global> AnnotationBase::get_annotation_registry() {
@@ -95,20 +117,18 @@ std::shared_ptr<annotation_global> AnnotationBase::get_annotation_registry() {
 
 size_t AnnotationBase::size() { return m_data->size(); }
 
+/* must be called after _addIndexColumn */
+void AnnotationBase::splitUndefined(const std::string& column_names, bool how, bool recursive) {
+  DASSERT_TRUE(m_data->contains_column("__idx"));
+  const auto &image_column_name = m_data_columns.at(0);
+  auto split_data_set =
+      m_data->drop_missing_values({image_column_name}, how, true, recursive);
+  m_data = std::static_pointer_cast<unity_sframe>(split_data_set.front());
+  m_data_na = std::static_pointer_cast<unity_sframe>(split_data_set.back());
+}
+
 void AnnotationBase::_addIndexColumn() {
-  std::vector<flexible_type> indicies;
-
-  for (size_t x = 0; x < m_data->size(); x++) {
-    indicies.push_back(x);
-  }
-
-  std::shared_ptr<unity_sarray> empty_annotation_sarray =
-      std::make_shared<unity_sarray>();
-
-  empty_annotation_sarray->construct_from_vector(indicies,
-                                                 flex_type_enum::INTEGER);
-
-  m_data->add_column(empty_annotation_sarray, "__idx");
+  m_data->add_column(unity_sarray::create_sequential_sarray(m_data->size(), 0, false), "__idx");
 }
 
 void AnnotationBase::_reshapeIndicies(size_t &start, size_t &end) {

--- a/src/visualization/annotation/annotation_base.cpp
+++ b/src/visualization/annotation/annotation_base.cpp
@@ -74,16 +74,14 @@ AnnotationBase::returnAnnotations(bool drop_null) {
         m_data_na->remove_column(m_data_na->column_index(m_annotation_column));
         m_data_na->add_column(integer_annotations, m_annotation_column);
       }
-      copy_data =
-          std::static_pointer_cast<unity_sframe>(m_data->append(m_data_na));
+      // temporary solution using sort to reconstruct
+      copy_data = std::static_pointer_cast<unity_sframe>(
+          m_data->append(m_data_na)->sort({"__idx"}, {true}));
     } else {
       copy_data = std::static_pointer_cast<unity_sframe>(
           m_data->copy_range(0, 1, m_data->size()));
     }
   }
-  // temporary solution
-  copy_data = std::static_pointer_cast<unity_sframe>(
-      copy_data->sort({"__idx"}, {true}));
 
   size_t id_column = copy_data->column_index("__idx");
   copy_data->remove_column(id_column);
@@ -118,7 +116,7 @@ std::shared_ptr<annotation_global> AnnotationBase::get_annotation_registry() {
 size_t AnnotationBase::size() { return m_data->size(); }
 
 /* must be called after _addIndexColumn */
-void AnnotationBase::splitUndefined(const std::string& column_names, bool how, bool recursive) {
+void AnnotationBase::_splitUndefined(const std::string& column_names, bool how, bool recursive) {
   DASSERT_TRUE(m_data->contains_column("__idx"));
   const auto &image_column_name = m_data_columns.at(0);
   auto split_data_set =

--- a/src/visualization/annotation/annotation_base.hpp
+++ b/src/visualization/annotation/annotation_base.hpp
@@ -90,6 +90,9 @@ public:
 
   virtual void checkDataSet() = 0;
 
+  /* must be called after construction */
+  virtual void splitUndefined(const std::string& column_names, bool how, bool recursive);
+
   BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
 
   IMPORT_BASE_CLASS_REGISTRATION(ml_model_base);
@@ -112,6 +115,7 @@ public:
 
 protected:
   std::shared_ptr<unity_sframe> m_data;
+  std::shared_ptr<unity_sframe> m_data_na;
   const std::vector<std::string> m_data_columns;
   std::string m_annotation_column;
   std::shared_ptr<visualization::process_wrapper> m_aw;

--- a/src/visualization/annotation/annotation_base.hpp
+++ b/src/visualization/annotation/annotation_base.hpp
@@ -90,9 +90,6 @@ public:
 
   virtual void checkDataSet() = 0;
 
-  /* must be called after construction */
-  virtual void splitUndefined(const std::string& column_names, bool how, bool recursive);
-
   BEGIN_BASE_CLASS_MEMBER_REGISTRATION()
 
   IMPORT_BASE_CLASS_REGISTRATION(ml_model_base);
@@ -132,6 +129,11 @@ protected:
   template <typename T, typename = typename std::enable_if<std::is_base_of<
                             ::google::protobuf::MessageLite, T>::value>::type>
   std::string _serialize_proto(T message);
+
+  /*
+   * split data set into 2 parts: non-missing values and missing values
+   * */
+  void _splitUndefined(const std::string& column_names, bool how, bool recursive);
 
 private:
   std::string __parse_proto_and_respond(std::string &input);

--- a/src/visualization/annotation/image_classification.cpp
+++ b/src/visualization/annotation/image_classification.cpp
@@ -30,9 +30,9 @@ ImageClassification::ImageClassification(
     : AnnotationBase(data, data_columns, annotation_column) {
   addAnnotationColumn();
   checkDataSet();
-  // tempaory workaround for avoiding resizing undefined images, check issue #1977
-  splitUndefined(data_columns.at(0), false, false);
-  // must be called after splitUndefined
+  // temporay workaround for avoiding resizing undefined images, check issue #1977
+  _splitUndefined(data_columns.at(0), false, false);
+  // must be called after _splitUndefined
   _createFeaturesExtractor();
 }
 

--- a/src/visualization/annotation/image_classification.cpp
+++ b/src/visualization/annotation/image_classification.cpp
@@ -520,7 +520,7 @@ void ImageClassification::_createFeaturesExtractor() {
 #ifdef __APPLE__
   if (m_data->size() == 0) {
     std::stringstream ss;
-    ss << "Exepect positive number of images. Found 0 valid images and "
+    ss << "Expect positive number of images. Found 0 valid images and "
        << m_data_na->size() << " missing images." << std::endl;
     std_log_and_throw(std::runtime_error, ss.str());
   }

--- a/src/visualization/annotation/image_classification.cpp
+++ b/src/visualization/annotation/image_classification.cpp
@@ -30,9 +30,10 @@ ImageClassification::ImageClassification(
     : AnnotationBase(data, data_columns, annotation_column) {
   addAnnotationColumn();
   checkDataSet();
-  _createFeaturesExtractor();
   // tempaory workaround for avoiding resizing undefined images, check issue #1977
   splitUndefined(data_columns.at(0), false, false);
+  // must be called after splitUndefined
+  _createFeaturesExtractor();
 }
 
 annotate_spec::Data ImageClassification::getItems(size_t start, size_t end) {
@@ -514,7 +515,16 @@ void ImageClassification::checkDataSet() {
 }
 
 void ImageClassification::_createFeaturesExtractor() {
+  // gurantee splitUndefined is called first
+  DASSERT_TRUE(m_data_na != nullptr);
 #ifdef __APPLE__
+  if (m_data->size() == 0) {
+    std::stringstream ss;
+    ss << "Exepect positive number of images. Found 0 valid images and "
+       << m_data_na->size() << " missing images." << std::endl;
+    std_log_and_throw(std::runtime_error, ss.str());
+  }
+
   m_extractor = create_feature_extractor();
   auto data_sarray = std::static_pointer_cast<unity_sarray>(m_data->select_column(m_data_columns.at(0)));
   m_image_feature_extraction_sarray = gl_sarray(data_sarray);

--- a/src/visualization/annotation/image_classification.cpp
+++ b/src/visualization/annotation/image_classification.cpp
@@ -28,9 +28,11 @@ ImageClassification::ImageClassification(
     const std::vector<std::string> &data_columns,
     const std::string &annotation_column)
     : AnnotationBase(data, data_columns, annotation_column) {
-  this->addAnnotationColumn();
-  this->checkDataSet();
-  this->_createFeaturesExtractor();
+  addAnnotationColumn();
+  checkDataSet();
+  _createFeaturesExtractor();
+  // tempaory workaround for avoiding resizing undefined images, check issue #1977
+  splitUndefined(data_columns.at(0), false, false);
 }
 
 annotate_spec::Data ImageClassification::getItems(size_t start, size_t end) {

--- a/test/annotation/image_classifier_tests.cxx
+++ b/test/annotation/image_classifier_tests.cxx
@@ -346,7 +346,7 @@ public:
 
     TS_ASSERT(annotation_testing::check_equality(annotation_sf, returned_sf));
 
-    
+
     turi::annotate::ImageClassification back_up_annotation;
 
     std::shared_ptr<turi::annotate::annotation_global>

--- a/userguide/image_classifier/advanced-usage.md
+++ b/userguide/image_classifier/advanced-usage.md
@@ -6,7 +6,7 @@ classifier toolkit that let you do more.
 
 #### Annotating Data
 
-If you only have images without corresponding labels, you can 
+If you only have images without corresponding labels, you can
 use the annotation utility built into the image_classifier. An example
 of its usage is shown below:
 
@@ -20,7 +20,12 @@ annotated_data = tc.image_classifier.annotate(data)
 
 ```
 
-If you forget to assign the output of your annotation to a variable, 
+This utility will **only collect valid images**. All undefined values
+won't be shown in the window but it will be still included in result
+set with default annotation value (undefined value, which denotes missing
+annotation). Exception will be thrown if no valid image is found.
+
+If you forget to assign the output of your annotation to a variable,
 we've included a method to help you recover those annotations. The code
 for that is shown below:
 

--- a/userguide/image_classifier/advanced-usage.md
+++ b/userguide/image_classifier/advanced-usage.md
@@ -20,9 +20,8 @@ annotated_data = tc.image_classifier.annotate(data)
 
 ```
 
-This utility will **only collect valid images**. All undefined values
-won't be shown in the window but it will be still included in result
-set with default annotation value (undefined value, which denotes missing
+This utility will only present rows from the SFrame that have non-missing values.
+All missing values won't be shown in the GUI but they will be still included in the result set with default annotation value (undefined value, which denotes missing
 annotation). Exception will be thrown if no valid image is found.
 
 If you forget to assign the output of your annotation to a variable,


### PR DESCRIPTION
It depends on #2227, which will make `unity_sframe::append` work as the same as what frontend part does.

The new behavior will:
1. prohibit undefined images from being shown in the annotation GUI window.
2. will throw if no valid images there to be ready to render in GUI.
3. will return result-set including all rows having missing values in their `image` column, with the corresponding annotation column value being set as None (undefined).
```
In [6]: images = tc.SFrame("my_image/")
In [6]: images = tc.SFrame("my_image/")

In [7]: images
Out[7]:
Columns:
        path    str
        image   Image

Rows: 2

Data:
+-------------------------------+------------------------+
|              path             |         image          |
+-------------------------------+------------------------+
| /Users/guihaoliang/Work/te... | Height: 412 Width: 430 |
|              None             |          None          |
+-------------------------------+------------------------+
[2 rows x 2 columns]

In [8]: tc.image_classifier.annotate(images)
Out[8]:
Columns:
        path    str
        image   Image
        annotations     str

Rows: 2

Data:
+-------------------------------+------------------------+-------------+
|              path             |         image          | annotations |
+-------------------------------+------------------------+-------------+
| /Users/guihaoliang/Work/te... | Height: 412 Width: 430 |     Cat     |
|              None             |          None          |     None    |
+-------------------------------+------------------------+-------------+
[2 rows x 3 columns]

In [9]: tc.image_classifier.annotate(images[1:2])
---------------------------------------------------------------------------
ToolkitError                              Traceback (most recent call last)
<ipython-input-11-05069e9b96e8> in <module>
----> 1 tc.image_classifier.annotate(images[1:2])

~/Work/guicreate-1/debug/src/python/turicreate/toolkits/image_classifier/_annotate.py in annotate(data, image_column, annotation_column)
    111                             data,
    112                             [image_column],
--> 113                             annotation_column
    114                         )
    115     if __platform == "linux" or __platform == "linux2":

~/Work/guicreate-1/debug/src/python/turicreate/extensions.py in <lambda>(*args, **kwargs)
    168
    169 def _make_injected_function(fn, arguments):
--> 170     return lambda *args, **kwargs: _run_toolkit_function(fn, arguments, args, kwargs)
    171
    172 def _class_instance_from_name(class_name, *arg, **kwarg):

~/Work/guicreate-1/debug/src/python/turicreate/extensions.py in _run_toolkit_function(fnname, arguments, args, kwargs)
    157     if not ret[0]:
    158         if len(ret[1]) > 0:
--> 159             raise _ToolkitError(ret[1])
    160         else:
    161             raise _ToolkitError("Toolkit failed with unknown error")

ToolkitError: Expect positive number of images. Found 0 valid images and 1 missing images.
```