### PR TITLE
Fixed namespace conflicts Obj-C

### DIFF
--- a/src/ml/neural_net/mps_layer_helper.h
+++ b/src/ml/neural_net/mps_layer_helper.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TCMPSInstanceNormDataLoader;
 
 @interface MPSCNNFullyConnectedNode (TCMPSLayerHelper)
-@property (nonatomic, strong) TCMPSConvolutionWeights *tcWeightsData API_AVAILABLE(macosx(10.14));
+@property (nonatomic, strong) TCMPSConvolutionWeights *tc_weightsData API_AVAILABLE(macosx(10.14));
 + (TCMPSConvolutionWeights *) createFullyConnected:(MPSNNImageNode *)inputNode
                               inputFeatureChannels:(NSUInteger)inputFeatureChannels
                              outputFeatureChannels:(NSUInteger)outputFeatureChannels
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MPSCNNConvolutionNode (TCMPSLayerHelper)
-@property (nonatomic, strong) TCMPSConvolutionWeights *tcWeightsData API_AVAILABLE(macosx(10.14));
+@property (nonatomic, strong) TCMPSConvolutionWeights *tc_weightsData API_AVAILABLE(macosx(10.14));
 + (MPSCNNConvolutionNode *) createConvolutional:(MPSNNImageNode *)inputNode
                                     kernelWidth:(NSUInteger)kernelWidth
                                    kernelHeight:(NSUInteger)kernelHeight
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MPSCNNInstanceNormalizationNode (TCMPSLayerHelper)
-@property (nonatomic, strong) TCMPSInstanceNormDataLoader *tcWeightsData API_AVAILABLE(macosx(10.14));
+@property (nonatomic, strong) TCMPSInstanceNormDataLoader *tc_weightsData API_AVAILABLE(macosx(10.14));
 + (MPSCNNInstanceNormalizationNode *) createInstanceNormalization:(MPSNNImageNode *)inputNode
                                                          channels:(NSUInteger)channels
                                                            styles:(NSUInteger)styles

--- a/src/ml/neural_net/mps_layer_helper.h
+++ b/src/ml/neural_net/mps_layer_helper.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TCMPSInstanceNormDataLoader;
 
 @interface MPSCNNFullyConnectedNode (TCMPSLayerHelper)
-@property (nonatomic, strong) TCMPSConvolutionWeights *weights API_AVAILABLE(macosx(10.14));
+@property (nonatomic, strong) TCMPSConvolutionWeights *tcWeightsData API_AVAILABLE(macosx(10.14));
 + (TCMPSConvolutionWeights *) createFullyConnected:(MPSNNImageNode *)inputNode
                               inputFeatureChannels:(NSUInteger)inputFeatureChannels
                              outputFeatureChannels:(NSUInteger)outputFeatureChannels
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MPSCNNConvolutionNode (TCMPSLayerHelper)
-@property (nonatomic, strong) TCMPSConvolutionWeights *weights API_AVAILABLE(macosx(10.14));
+@property (nonatomic, strong) TCMPSConvolutionWeights *tcWeightsData API_AVAILABLE(macosx(10.14));
 + (MPSCNNConvolutionNode *) createConvolutional:(MPSNNImageNode *)inputNode
                                     kernelWidth:(NSUInteger)kernelWidth
                                    kernelHeight:(NSUInteger)kernelHeight
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MPSCNNInstanceNormalizationNode (TCMPSLayerHelper)
-@property (nonatomic, strong) TCMPSInstanceNormDataLoader *weights API_AVAILABLE(macosx(10.14));
+@property (nonatomic, strong) TCMPSInstanceNormDataLoader *tcWeightsData API_AVAILABLE(macosx(10.14));
 + (MPSCNNInstanceNormalizationNode *) createInstanceNormalization:(MPSNNImageNode *)inputNode
                                                          channels:(NSUInteger)channels
                                                            styles:(NSUInteger)styles

--- a/src/ml/neural_net/mps_layer_helper.mm
+++ b/src/ml/neural_net/mps_layer_helper.mm
@@ -14,13 +14,13 @@
 static char kWeightsKey;
 
 @implementation MPSCNNFullyConnectedNode (TCMPSLayerHelper)
-@dynamic tcWeightsData;
+@dynamic tc_weightsData;
 
-- (void)setTcWeightsData:(TCMPSConvolutionWeights *)tcWeightsData {
-  objc_setAssociatedObject(self, &kWeightsKey, tcWeightsData, OBJC_ASSOCIATION_RETAIN);
+- (void)setTc_weightsData:(TCMPSConvolutionWeights *)tc_weightsData {
+  objc_setAssociatedObject(self, &kWeightsKey, tc_weightsData, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (NSString *)tcWeightsData {
+- (NSString *)tc_weightsData {
   return objc_getAssociatedObject(self, &kWeightsKey);
 }
 
@@ -59,20 +59,20 @@ static char kWeightsKey;
     [MPSCNNFullyConnectedNode nodeWithSource:inputNode
                                      weights:fullyConnectedDataLoad];
 
-  fullyConnectedNode.tcWeightsData = fullyConnectedDataLoad;
+  fullyConnectedNode.tc_weightsData = fullyConnectedDataLoad;
   
   return fullyConnectedNode;
 }
 @end
 
 @implementation MPSCNNConvolutionNode (TCMPSLayerHelper)
-@dynamic tcWeightsData;
+@dynamic tc_weightsData;
 
-- (void)setTcWeightsData:(TCMPSConvolutionWeights *)tcWeightsData {
-  objc_setAssociatedObject(self, &kWeightsKey, tcWeightsData, OBJC_ASSOCIATION_RETAIN);
+- (void)setTc_weightsData:(TCMPSConvolutionWeights *)tc_weightsData {
+  objc_setAssociatedObject(self, &kWeightsKey, tc_weightsData, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (NSString *)tcWeightsData {
+- (NSString *)tc_weightsData {
   return objc_getAssociatedObject(self, &kWeightsKey);
 }
 
@@ -123,20 +123,20 @@ static char kWeightsKey;
 
   convNode.paddingPolicy = padding;
 
-  convNode.tcWeightsData = convDataLoad;
+  convNode.tc_weightsData = convDataLoad;
   
   return convNode;
 }
 @end
 
 @implementation MPSCNNInstanceNormalizationNode (TCMPSLayerHelper)
-@dynamic tcWeightsData;
+@dynamic tc_weightsData;
 
-- (void)setTcWeightsData:(TCMPSInstanceNormDataLoader *)tcWeightsData {
-  objc_setAssociatedObject(self, &kWeightsKey, tcWeightsData, OBJC_ASSOCIATION_RETAIN);
+- (void)setTc_weightsData:(TCMPSInstanceNormDataLoader *)tc_weightsData {
+  objc_setAssociatedObject(self, &kWeightsKey, tc_weightsData, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (NSString *)tcWeightsData {
+- (NSString *)tc_weightsData {
   return objc_getAssociatedObject(self, &kWeightsKey);
 }
 
@@ -160,7 +160,7 @@ static char kWeightsKey;
   MPSCNNInstanceNormalizationNode *instNormNode =  [MPSCNNInstanceNormalizationNode nodeWithSource:inputNode
                                                                                         dataSource:instNormDataLoad];
 
-  instNormNode.tcWeightsData = instNormDataLoad;
+  instNormNode.tc_weightsData = instNormDataLoad;
 
   return instNormNode;
 }

--- a/src/ml/neural_net/mps_layer_helper.mm
+++ b/src/ml/neural_net/mps_layer_helper.mm
@@ -14,13 +14,13 @@
 static char kWeightsKey;
 
 @implementation MPSCNNFullyConnectedNode (TCMPSLayerHelper)
-@dynamic weights;
+@dynamic tcWeightsData;
 
-- (void)setWeights:(TCMPSConvolutionWeights *)weights {
-  objc_setAssociatedObject(self, &kWeightsKey, weights, OBJC_ASSOCIATION_RETAIN);
+- (void)setTcWeightsData:(TCMPSConvolutionWeights *)tcWeightsData {
+  objc_setAssociatedObject(self, &kWeightsKey, tcWeightsData, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (NSString *)weights {
+- (NSString *)tcWeightsData {
   return objc_getAssociatedObject(self, &kWeightsKey);
 }
 
@@ -59,20 +59,20 @@ static char kWeightsKey;
     [MPSCNNFullyConnectedNode nodeWithSource:inputNode
                                      weights:fullyConnectedDataLoad];
 
-  fullyConnectedNode.weights = fullyConnectedDataLoad;
+  fullyConnectedNode.tcWeightsData = fullyConnectedDataLoad;
   
   return fullyConnectedNode;
 }
 @end
 
 @implementation MPSCNNConvolutionNode (TCMPSLayerHelper)
-@dynamic weights;
+@dynamic tcWeightsData;
 
-- (void)setWeights:(TCMPSConvolutionWeights *)weights {
-  objc_setAssociatedObject(self, &kWeightsKey, weights, OBJC_ASSOCIATION_RETAIN);
+- (void)setTcWeightsData:(TCMPSConvolutionWeights *)tcWeightsData {
+  objc_setAssociatedObject(self, &kWeightsKey, tcWeightsData, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (NSString *)weights {
+- (NSString *)tcWeightsData {
   return objc_getAssociatedObject(self, &kWeightsKey);
 }
 
@@ -123,20 +123,20 @@ static char kWeightsKey;
 
   convNode.paddingPolicy = padding;
 
-  convNode.weights = convDataLoad;
+  convNode.tcWeightsData = convDataLoad;
   
   return convNode;
 }
 @end
 
 @implementation MPSCNNInstanceNormalizationNode (TCMPSLayerHelper)
-@dynamic weights;
+@dynamic tcWeightsData;
 
-- (void)setWeights:(TCMPSInstanceNormDataLoader *)weights {
-  objc_setAssociatedObject(self, &kWeightsKey, weights, OBJC_ASSOCIATION_RETAIN);
+- (void)setTcWeightsData:(TCMPSInstanceNormDataLoader *)tcWeightsData {
+  objc_setAssociatedObject(self, &kWeightsKey, tcWeightsData, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (NSString *)weights {
+- (NSString *)tcWeightsData {
   return objc_getAssociatedObject(self, &kWeightsKey);
 }
 
@@ -160,7 +160,7 @@ static char kWeightsKey;
   MPSCNNInstanceNormalizationNode *instNormNode =  [MPSCNNInstanceNormalizationNode nodeWithSource:inputNode
                                                                                         dataSource:instNormDataLoad];
 
-  instNormNode.weights = instNormDataLoad;
+  instNormNode.tcWeightsData = instNormDataLoad;
 
   return instNormNode;
 }

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.mm
@@ -77,27 +77,27 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv weights] setLearningRate:lr];
-  [[_instNorm weights] setLearningRate:lr];
+  [[_conv tcWeightsData] setLearningRate:lr];
+  [[_instNorm tcWeightsData] setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
   NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];
 
-  NSUInteger convWeightSize = (NSUInteger)([[_conv weights] weightSize] * sizeof(float));
+  NSUInteger convWeightSize = (NSUInteger)([[_conv tcWeightsData] weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
-  memcpy(convDataWeight.mutableBytes, [[_conv weights] weights], convWeightSize);
+  memcpy(convDataWeight.mutableBytes, [[_conv tcWeightsData] weights], convWeightSize);
 
   NSString* convWeight = [NSString stringWithFormat:@"%@%@", prefix, @"conv_weights"];
 
   weights[convWeight] = convDataWeight;
 
-  NSUInteger instNormSize = (NSUInteger)([[_instNorm weights] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNormSize = (NSUInteger)([[_instNorm tcWeightsData] numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
   NSMutableData* instNormDataBeta = [NSMutableData dataWithLength:instNormSize];
 
-  memcpy(instNormDataGamma.mutableBytes, [[_instNorm weights] gamma], instNormSize);
-  memcpy(instNormDataBeta.mutableBytes, [[_instNorm weights] beta], instNormSize);
+  memcpy(instNormDataGamma.mutableBytes, [[_instNorm tcWeightsData] gamma], instNormSize);
+  memcpy(instNormDataBeta.mutableBytes, [[_instNorm tcWeightsData] beta], instNormSize);
 
   NSString* instNormGamma = [NSString stringWithFormat:@"%@%@", prefix, @"inst_gamma"];
   NSString* instNormBeta = [NSString stringWithFormat:@"%@%@", prefix, @"inst_beta"];

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.mm
@@ -77,27 +77,27 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv tcWeightsData] setLearningRate:lr];
-  [[_instNorm tcWeightsData] setLearningRate:lr];
+  [_conv.tc_weightsData setLearningRate:lr];
+  [_instNorm.tc_weightsData setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
   NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];
 
-  NSUInteger convWeightSize = (NSUInteger)([[_conv tcWeightsData] weightSize] * sizeof(float));
+  NSUInteger convWeightSize = (NSUInteger)([_conv.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
-  memcpy(convDataWeight.mutableBytes, [[_conv tcWeightsData] weights], convWeightSize);
+  memcpy(convDataWeight.mutableBytes, [_conv.tc_weightsData weights], convWeightSize);
 
   NSString* convWeight = [NSString stringWithFormat:@"%@%@", prefix, @"conv_weights"];
 
   weights[convWeight] = convDataWeight;
 
-  NSUInteger instNormSize = (NSUInteger)([[_instNorm tcWeightsData] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNormSize = (NSUInteger)([_instNorm.tc_weightsData numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
   NSMutableData* instNormDataBeta = [NSMutableData dataWithLength:instNormSize];
 
-  memcpy(instNormDataGamma.mutableBytes, [[_instNorm tcWeightsData] gamma], instNormSize);
-  memcpy(instNormDataBeta.mutableBytes, [[_instNorm tcWeightsData] beta], instNormSize);
+  memcpy(instNormDataGamma.mutableBytes, [_instNorm.tc_weightsData gamma], instNormSize);
+  memcpy(instNormDataBeta.mutableBytes, [_instNorm.tc_weightsData beta], instNormSize);
 
   NSString* instNormGamma = [NSString stringWithFormat:@"%@%@", prefix, @"inst_gamma"];
   NSString* instNormBeta = [NSString stringWithFormat:@"%@%@", prefix, @"inst_beta"];

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_encoding_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_encoding_node.mm
@@ -71,27 +71,27 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv tcWeightsData] setLearningRate:lr];
-  [[_instNorm tcWeightsData] setLearningRate:lr];
+  [_conv.tc_weightsData setLearningRate:lr];
+  [_instNorm.tc_weightsData setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
   NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];
 
-  NSUInteger convWeightSize = (NSUInteger)([[_conv tcWeightsData] weightSize] * sizeof(float));
+  NSUInteger convWeightSize = (NSUInteger)([_conv.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
-  memcpy(convDataWeight.mutableBytes, [[_conv tcWeightsData] weights], convWeightSize);
+  memcpy(convDataWeight.mutableBytes, [_conv.tc_weightsData weights], convWeightSize);
 
   NSString* convWeight = [NSString stringWithFormat:@"%@%@", prefix, @"conv_weights"];
 
   weights[convWeight] = convDataWeight;
 
-  NSUInteger instNormSize = (NSUInteger)([[_instNorm tcWeightsData] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNormSize = (NSUInteger)([_instNorm.tc_weightsData numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
   NSMutableData* instNormDataBeta = [NSMutableData dataWithLength:instNormSize];
 
-  memcpy(instNormDataGamma.mutableBytes, [[_instNorm tcWeightsData] gamma], instNormSize);
-  memcpy(instNormDataBeta.mutableBytes, [[_instNorm tcWeightsData] beta], instNormSize);
+  memcpy(instNormDataGamma.mutableBytes, [_instNorm.tc_weightsData gamma], instNormSize);
+  memcpy(instNormDataBeta.mutableBytes, [_instNorm.tc_weightsData beta], instNormSize);
 
   NSString* instNormGamma = [NSString stringWithFormat:@"%@%@", prefix, @"inst_gamma"];
   NSString* instNormBeta = [NSString stringWithFormat:@"%@%@", prefix, @"inst_beta"];

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_encoding_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_encoding_node.mm
@@ -71,27 +71,27 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv weights] setLearningRate:lr];
-  [[_instNorm weights] setLearningRate:lr];
+  [[_conv tcWeightsData] setLearningRate:lr];
+  [[_instNorm tcWeightsData] setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
   NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];
 
-  NSUInteger convWeightSize = (NSUInteger)([[_conv weights] weightSize] * sizeof(float));
+  NSUInteger convWeightSize = (NSUInteger)([[_conv tcWeightsData] weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
-  memcpy(convDataWeight.mutableBytes, [[_conv weights] weights], convWeightSize);
+  memcpy(convDataWeight.mutableBytes, [[_conv tcWeightsData] weights], convWeightSize);
 
   NSString* convWeight = [NSString stringWithFormat:@"%@%@", prefix, @"conv_weights"];
 
   weights[convWeight] = convDataWeight;
 
-  NSUInteger instNormSize = (NSUInteger)([[_instNorm weights] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNormSize = (NSUInteger)([[_instNorm tcWeightsData] numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
   NSMutableData* instNormDataBeta = [NSMutableData dataWithLength:instNormSize];
 
-  memcpy(instNormDataGamma.mutableBytes, [[_instNorm weights] gamma], instNormSize);
-  memcpy(instNormDataBeta.mutableBytes, [[_instNorm weights] beta], instNormSize);
+  memcpy(instNormDataGamma.mutableBytes, [[_instNorm tcWeightsData] gamma], instNormSize);
+  memcpy(instNormDataBeta.mutableBytes, [[_instNorm tcWeightsData] beta], instNormSize);
 
   NSString* instNormGamma = [NSString stringWithFormat:@"%@%@", prefix, @"inst_gamma"];
   NSString* instNormBeta = [NSString stringWithFormat:@"%@%@", prefix, @"inst_beta"];

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.mm
@@ -107,39 +107,39 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv1 weights] setLearningRate:lr];
-  [[_instNorm1 weights] setLearningRate:lr];
-  [[_conv2 weights] setLearningRate:lr];
-  [[_instNorm2 weights] setLearningRate:lr];
+  [[_conv1 tcWeightsData] setLearningRate:lr];
+  [[_instNorm1 tcWeightsData] setLearningRate:lr];
+  [[_conv2 tcWeightsData] setLearningRate:lr];
+  [[_instNorm2 tcWeightsData] setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
   NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];;
 
   NSString* conv1Keys = [NSString stringWithFormat:@"%@%@", prefix, @"conv_1_weights"];
-  NSUInteger conv1WeightSize = (NSUInteger)([[_conv1 weights] weightSize] * sizeof(float));
+  NSUInteger conv1WeightSize = (NSUInteger)([[_conv1 tcWeightsData] weightSize] * sizeof(float));
   NSMutableData* conv1DataWeight = [NSMutableData dataWithLength:conv1WeightSize];
-  memcpy(conv1DataWeight.mutableBytes, [[_conv1 weights] weights], conv1WeightSize);
+  memcpy(conv1DataWeight.mutableBytes, [[_conv1 tcWeightsData] weights], conv1WeightSize);
 
   weights[conv1Keys] = conv1DataWeight;
 
   NSString* conv2Keys = [NSString stringWithFormat:@"%@%@", prefix, @"conv_2_weights"];
-  NSUInteger conv2WeightSize = (NSUInteger)([[_conv2 weights] weightSize] * sizeof(float));
+  NSUInteger conv2WeightSize = (NSUInteger)([[_conv2 tcWeightsData] weightSize] * sizeof(float));
   NSMutableData* conv2DataWeight = [NSMutableData dataWithLength:conv2WeightSize];
-  memcpy(conv2DataWeight.mutableBytes, [[_conv2 weights] weights], conv2WeightSize);
+  memcpy(conv2DataWeight.mutableBytes, [[_conv2 tcWeightsData] weights], conv2WeightSize);
 
   weights[conv2Keys] = conv2DataWeight;
 
   NSString* instNorm1GammaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_1_gamma"];
   NSString* instNorm1BetaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_1_beta"];
 
-  NSUInteger instNorm1Size = (NSUInteger)([[_instNorm1 weights] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNorm1Size = (NSUInteger)([[_instNorm1 tcWeightsData] numberOfFeatureChannels] * sizeof(float));
   
   NSMutableData* instNorm1DataGamma = [NSMutableData dataWithLength:instNorm1Size];
   NSMutableData* instNorm1DataBeta = [NSMutableData dataWithLength:instNorm1Size];
   
-  memcpy(instNorm1DataGamma.mutableBytes, [[_instNorm1 weights] gamma], instNorm1Size);
-  memcpy(instNorm1DataBeta.mutableBytes, [[_instNorm1 weights] beta], instNorm1Size);
+  memcpy(instNorm1DataGamma.mutableBytes, [[_instNorm1 tcWeightsData] gamma], instNorm1Size);
+  memcpy(instNorm1DataBeta.mutableBytes, [[_instNorm1 tcWeightsData] beta], instNorm1Size);
 
   weights[instNorm1GammaKeys] = instNorm1DataGamma;
   weights[instNorm1BetaKeys] = instNorm1DataBeta;
@@ -147,13 +147,13 @@
   NSString* instNorm2GammaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_2_gamma"];
   NSString* instNorm2BetaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_2_beta"];
 
-  NSUInteger instNorm2Size = (NSUInteger)([[_instNorm2 weights] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNorm2Size = (NSUInteger)([[_instNorm2 tcWeightsData] numberOfFeatureChannels] * sizeof(float));
 
   NSMutableData* instNorm2DataGamma = [NSMutableData dataWithLength:instNorm2Size];
   NSMutableData* instNorm2DataBeta = [NSMutableData dataWithLength:instNorm2Size];
 
-  memcpy(instNorm2DataGamma.mutableBytes, [[_instNorm2 weights] gamma], instNorm2Size);
-  memcpy(instNorm2DataBeta.mutableBytes, [[_instNorm2 weights] beta], instNorm2Size);
+  memcpy(instNorm2DataGamma.mutableBytes, [[_instNorm2 tcWeightsData] gamma], instNorm2Size);
+  memcpy(instNorm2DataBeta.mutableBytes, [[_instNorm2 tcWeightsData] beta], instNorm2Size);
 
   weights[instNorm2GammaKeys] = instNorm2DataGamma;
   weights[instNorm2BetaKeys] = instNorm2DataBeta;

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.mm
@@ -107,39 +107,39 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv1 tcWeightsData] setLearningRate:lr];
-  [[_instNorm1 tcWeightsData] setLearningRate:lr];
-  [[_conv2 tcWeightsData] setLearningRate:lr];
-  [[_instNorm2 tcWeightsData] setLearningRate:lr];
+  [_conv1.tc_weightsData setLearningRate:lr];
+  [_instNorm1.tc_weightsData setLearningRate:lr];
+  [_conv2.tc_weightsData setLearningRate:lr];
+  [_instNorm2.tc_weightsData setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
   NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];;
 
   NSString* conv1Keys = [NSString stringWithFormat:@"%@%@", prefix, @"conv_1_weights"];
-  NSUInteger conv1WeightSize = (NSUInteger)([[_conv1 tcWeightsData] weightSize] * sizeof(float));
+  NSUInteger conv1WeightSize = (NSUInteger)([_conv1.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* conv1DataWeight = [NSMutableData dataWithLength:conv1WeightSize];
-  memcpy(conv1DataWeight.mutableBytes, [[_conv1 tcWeightsData] weights], conv1WeightSize);
+  memcpy(conv1DataWeight.mutableBytes, [_conv1.tc_weightsData weights], conv1WeightSize);
 
   weights[conv1Keys] = conv1DataWeight;
 
   NSString* conv2Keys = [NSString stringWithFormat:@"%@%@", prefix, @"conv_2_weights"];
-  NSUInteger conv2WeightSize = (NSUInteger)([[_conv2 tcWeightsData] weightSize] * sizeof(float));
+  NSUInteger conv2WeightSize = (NSUInteger)([_conv2.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* conv2DataWeight = [NSMutableData dataWithLength:conv2WeightSize];
-  memcpy(conv2DataWeight.mutableBytes, [[_conv2 tcWeightsData] weights], conv2WeightSize);
+  memcpy(conv2DataWeight.mutableBytes, [_conv2.tc_weightsData weights], conv2WeightSize);
 
   weights[conv2Keys] = conv2DataWeight;
 
   NSString* instNorm1GammaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_1_gamma"];
   NSString* instNorm1BetaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_1_beta"];
 
-  NSUInteger instNorm1Size = (NSUInteger)([[_instNorm1 tcWeightsData] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNorm1Size = (NSUInteger)([_instNorm1.tc_weightsData numberOfFeatureChannels] * sizeof(float));
   
   NSMutableData* instNorm1DataGamma = [NSMutableData dataWithLength:instNorm1Size];
   NSMutableData* instNorm1DataBeta = [NSMutableData dataWithLength:instNorm1Size];
   
-  memcpy(instNorm1DataGamma.mutableBytes, [[_instNorm1 tcWeightsData] gamma], instNorm1Size);
-  memcpy(instNorm1DataBeta.mutableBytes, [[_instNorm1 tcWeightsData] beta], instNorm1Size);
+  memcpy(instNorm1DataGamma.mutableBytes, [_instNorm1.tc_weightsData gamma], instNorm1Size);
+  memcpy(instNorm1DataBeta.mutableBytes, [_instNorm1.tc_weightsData beta], instNorm1Size);
 
   weights[instNorm1GammaKeys] = instNorm1DataGamma;
   weights[instNorm1BetaKeys] = instNorm1DataBeta;
@@ -147,13 +147,13 @@
   NSString* instNorm2GammaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_2_gamma"];
   NSString* instNorm2BetaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_2_beta"];
 
-  NSUInteger instNorm2Size = (NSUInteger)([[_instNorm2 tcWeightsData] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNorm2Size = (NSUInteger)([_instNorm2.tc_weightsData numberOfFeatureChannels] * sizeof(float));
 
   NSMutableData* instNorm2DataGamma = [NSMutableData dataWithLength:instNorm2Size];
   NSMutableData* instNorm2DataBeta = [NSMutableData dataWithLength:instNorm2Size];
 
-  memcpy(instNorm2DataGamma.mutableBytes, [[_instNorm2 tcWeightsData] gamma], instNorm2Size);
-  memcpy(instNorm2DataBeta.mutableBytes, [[_instNorm2 tcWeightsData] beta], instNorm2Size);
+  memcpy(instNorm2DataGamma.mutableBytes, [_instNorm2.tc_weightsData gamma], instNorm2Size);
+  memcpy(instNorm2DataBeta.mutableBytes, [_instNorm2.tc_weightsData beta], instNorm2Size);
 
   weights[instNorm2GammaKeys] = instNorm2DataGamma;
   weights[instNorm2BetaKeys] = instNorm2DataBeta;

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_transformer_network.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_transformer_network.mm
@@ -179,8 +179,8 @@
   [_residual5 setLearningRate:lr];
   [_decoding1 setLearningRate:lr];
   [_decoding2 setLearningRate:lr];
-  [[_conv weights] setLearningRate:lr];
-  [[_instNorm weights] setLearningRate:lr];
+  [[_conv tcWeightsData] setLearningRate:lr];
+  [[_instNorm tcWeightsData] setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *) exportWeights:(NSString *)prefix {
@@ -226,21 +226,22 @@
   NSDictionary<NSString *, NSData *> * decode2Weights = [_decoding2 exportWeights:decode2Prefix];
   [weights addEntriesFromDictionary: decode2Weights];
 
-  NSUInteger convWeightSize = (NSUInteger)([[_conv weights] weightSize] * sizeof(float));
+  NSUInteger convWeightSize = (NSUInteger)([[_conv tcWeightsData] weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
-  memcpy(convDataWeight.mutableBytes, [[_conv weights] weights], convWeightSize);
+  
+  memcpy(convDataWeight.mutableBytes, [[_conv tcWeightsData] weights], convWeightSize);
   NSString* conv5Weight = [NSString stringWithFormat:@"%@%@", prefix, @"conv5_weight"];
 
   weights[conv5Weight] = convDataWeight;
 
   NSString* instNorm5Gamma = [NSString stringWithFormat:@"%@%@", prefix, @"instancenorm5_gamma"];
   NSString* instNorm5Beta = [NSString stringWithFormat:@"%@%@", prefix, @"instancenorm5_beta"];
-  NSUInteger instNormSize = (NSUInteger)([[_instNorm weights] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNormSize = (NSUInteger)([[_instNorm tcWeightsData] numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
   NSMutableData* instNormDataBeta = [NSMutableData dataWithLength:instNormSize];
 
-  memcpy(instNormDataGamma.mutableBytes, [[_instNorm weights] gamma], instNormSize);
-  memcpy(instNormDataBeta.mutableBytes, [[_instNorm weights] beta], instNormSize);
+  memcpy(instNormDataGamma.mutableBytes, [[_instNorm tcWeightsData] gamma], instNormSize);
+  memcpy(instNormDataBeta.mutableBytes, [[_instNorm tcWeightsData] beta], instNormSize);
 
   weights[instNorm5Gamma] = instNormDataGamma;
   weights[instNorm5Beta] = instNormDataBeta;

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_transformer_network.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_transformer_network.mm
@@ -179,8 +179,8 @@
   [_residual5 setLearningRate:lr];
   [_decoding1 setLearningRate:lr];
   [_decoding2 setLearningRate:lr];
-  [[_conv tcWeightsData] setLearningRate:lr];
-  [[_instNorm tcWeightsData] setLearningRate:lr];
+  [_conv.tc_weightsData setLearningRate:lr];
+  [_instNorm.tc_weightsData setLearningRate:lr];
 }
 
 - (NSDictionary<NSString *, NSData *> *) exportWeights:(NSString *)prefix {
@@ -226,22 +226,22 @@
   NSDictionary<NSString *, NSData *> * decode2Weights = [_decoding2 exportWeights:decode2Prefix];
   [weights addEntriesFromDictionary: decode2Weights];
 
-  NSUInteger convWeightSize = (NSUInteger)([[_conv tcWeightsData] weightSize] * sizeof(float));
+  NSUInteger convWeightSize = (NSUInteger)([_conv.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
   
-  memcpy(convDataWeight.mutableBytes, [[_conv tcWeightsData] weights], convWeightSize);
+  memcpy(convDataWeight.mutableBytes, [_conv.tc_weightsData weights], convWeightSize);
   NSString* conv5Weight = [NSString stringWithFormat:@"%@%@", prefix, @"conv5_weight"];
 
   weights[conv5Weight] = convDataWeight;
 
   NSString* instNorm5Gamma = [NSString stringWithFormat:@"%@%@", prefix, @"instancenorm5_gamma"];
   NSString* instNorm5Beta = [NSString stringWithFormat:@"%@%@", prefix, @"instancenorm5_beta"];
-  NSUInteger instNormSize = (NSUInteger)([[_instNorm tcWeightsData] numberOfFeatureChannels] * sizeof(float));
+  NSUInteger instNormSize = (NSUInteger)([_instNorm.tc_weightsData numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
   NSMutableData* instNormDataBeta = [NSMutableData dataWithLength:instNormSize];
 
-  memcpy(instNormDataGamma.mutableBytes, [[_instNorm tcWeightsData] gamma], instNormSize);
-  memcpy(instNormDataBeta.mutableBytes, [[_instNorm tcWeightsData] beta], instNormSize);
+  memcpy(instNormDataGamma.mutableBytes, [_instNorm.tc_weightsData gamma], instNormSize);
+  memcpy(instNormDataBeta.mutableBytes, [_instNorm.tc_weightsData beta], instNormSize);
 
   weights[instNorm5Gamma] = instNormDataGamma;
   weights[instNorm5Beta] = instNormDataBeta;

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_1_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_1_node.mm
@@ -86,8 +86,8 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv1 weights] setLearningRate:lr];
-  [[_conv2 weights] setLearningRate:lr];
+  [[_conv1 tcWeightsData] setLearningRate:lr];
+  [[_conv2 tcWeightsData] setLearningRate:lr];
 }
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_1_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_1_node.mm
@@ -86,8 +86,8 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv1 tcWeightsData] setLearningRate:lr];
-  [[_conv2 tcWeightsData] setLearningRate:lr];
+  [_conv1.tc_weightsData setLearningRate:lr];
+  [_conv2.tc_weightsData setLearningRate:lr];
 }
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_2_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_2_node.mm
@@ -106,9 +106,9 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv1 weights] setLearningRate:lr];
-  [[_conv2 weights] setLearningRate:lr];
-  [[_conv3 weights] setLearningRate:lr];
+  [[_conv1 tcWeightsData] setLearningRate:lr];
+  [[_conv2 tcWeightsData] setLearningRate:lr];
+  [[_conv3 tcWeightsData] setLearningRate:lr];
 }
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_2_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_vgg_16_block_2_node.mm
@@ -106,9 +106,9 @@
 }
 
 - (void) setLearningRate:(float)lr {
-  [[_conv1 tcWeightsData] setLearningRate:lr];
-  [[_conv2 tcWeightsData] setLearningRate:lr];
-  [[_conv3 tcWeightsData] setLearningRate:lr];
+  [_conv1.tc_weightsData setLearningRate:lr];
+  [_conv2.tc_weightsData setLearningRate:lr];
+  [_conv3.tc_weightsData setLearningRate:lr];
 }
 
 @end


### PR DESCRIPTION
- weights key conflicts with property already existent on `MPSCNNConvolutionNode`