### PR TITLE
[WIP] log_and_throw should throw std::runtime_error instead

### DIFF
--- a/src/core/logging/logger.hpp
+++ b/src/core/logging/logger.hpp
@@ -328,7 +328,7 @@
   do {                                                              \
     auto throw_error = [&]() GL_COLD_NOINLINE_ERROR {  \
       logstream(LOG_ERROR) << (message) << std::endl;               \
-      throw(std::string(message));                                  \
+      throw(std::runtime_error(message));                                  \
     };                                                              \
     throw_error();                                                  \
   } while(0)


### PR DESCRIPTION
As we discussed in #2145 , @znation suggested I splitting the PR into 2. 

change `log_and_throw` behavior from throwing `std::string` type exception to `std::runtime_error`;

One reason is that throw by string is flexible because one can throw by `const char *` or `std::string`, which makes it hard to remember which to catch.

The other reason is that it's hard for an exception handler to exhaust exception handling situations before it gives up and uses `catch(...)` for the last hope.

cited my comment from #2145 

Change the default `log_and_throw` behavior. Previous behavior is to `throw(std::string(message))`, which is really hard to catch since it's not an `std::exception` type and you need to specify error handling logic like `catch(const string& ex)`. That's why there're lots of `catch(...)` around the codebase, which is a bad practice since you miss the chance to interpret the exception message or propagate the original exception message. After we set `runtime_error` as default exception, we can use `catch (const std::exception& ex)` to avoid `catch(...)`.

Meanwhile, we also need to restrict the exception categories.  Unlimited different types of exceptions will make you lazy and tempt you to use `catch (const std::exception& ex)` as a brutal solution. Even though it can help, but we should have provided error handling for certain recoverable exceptions. 

Therefore, I think we need to use only few common exception types like `runtime`, `io` and `engine_optimizer` specific exception. Those types of exceptions should be the only types of exceptions we expect. In this way, we can expect a fairly hierarchical  error-handling or logging to react to specific errors.
```cpp
try {
} catch (const std::runtime_error & ex) {
} catch (const std::turi::fileio::io_error& ex) {
} catch (const std::exception& ex) {
} catch (...) {
// unknown which should not happen
}
```