### PR TITLE
Enable more accurate language breakdown on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Treat these paths as external for the purposes of GitHub's Linguist
+deps/* linguist-vendored
+src/external/* linguist-vendored


### PR DESCRIPTION
The GitHub feature that computes the language breakdown supports [adding
overrides](https://github.com/github/linguist#overrides) to the
`.gitattributes` file; we can use this to explicitly ignore code from
outside this repo.