### PR TITLE
Resolves #2276: Remove Obsolete Python Methods

### DIFF
--- a/src/python/turicreate/toolkits/_feature_engineering/_feature_engineering.py
+++ b/src/python/turicreate/toolkits/_feature_engineering/_feature_engineering.py
@@ -210,10 +210,6 @@ class TransformerBase(object):
         self.fit(data)
         return self.transform(data)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        return {'transform': {}}
-
     def _get_instance_and_data(self):
         raise NotImplementedError
 
@@ -370,10 +366,6 @@ class Transformer(TransformerBase):
         contain elements that are written using Python + Turi objects.
         """
         return False
-
-    @classmethod
-    def _get_queryable_methods(cls):
-        return {'transform': {'data': 'sframe'}}
 
 class _SampleTransformer(Transformer):
 

--- a/src/python/turicreate/toolkits/_supervised_learning.py
+++ b/src/python/turicreate/toolkits/_supervised_learning.py
@@ -185,12 +185,6 @@ class SupervisedLearningModel(Model):
         """
         return self.__proxy__.get_value(field)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        return {'predict': {}}
-
 
 class Classifier(SupervisedLearningModel):
     """
@@ -243,14 +237,6 @@ class Classifier(SupervisedLearningModel):
 
         _raise_error_if_not_sframe(dataset, "dataset")
         return self.__proxy__.classify(dataset, missing_value_action)
-
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        return {'predict': {},
-                'predict_topk': {},
-                'classify': {}}
 
 
 def print_validation_track_notification():

--- a/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
@@ -412,13 +412,6 @@ class BoostedTreesClassifier(_Classifier, _TreeModelMixin):
         return super(BoostedTreesClassifier, self).classify(dataset,
                                                             missing_value_action=missing_value_action)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        methods = _Classifier._get_queryable_methods()
-        methods['extract_features'] = {'dataset': 'sframe'}
-        return methods
 
     def export_coreml(self, filename):
         """

--- a/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
@@ -402,13 +402,6 @@ class DecisionTreeClassifier(_Classifier, _TreeModelMixin):
         return super(DecisionTreeClassifier, self).classify(dataset,
                                                             missing_value_action=missing_value_action)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        methods = _Classifier._get_queryable_methods()
-        methods['extract_features'] = {'dataset': 'sframe'}
-        return methods
 
     def export_coreml(self, filename):
         """

--- a/src/python/turicreate/toolkits/classifier/nearest_neighbor_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/nearest_neighbor_classifier.py
@@ -845,13 +845,3 @@ class NearestNeighborClassifier(_CustomModel):
                       _evaluation.roc_curve(targets=dataset[target],
                                                predictions=ystar_prob)
         return results
-
-    @classmethod
-    def _get_queryable_methods(cls):
-        """
-        Return a list of method names that are queryable through Predictive
-        Service.
-        """
-        return {'predict':{'dataset':'sframe'},
-                'predict_topk':{'dataset':'sframe'},
-                'classify':{'dataset':'sframe'}}

--- a/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
@@ -405,13 +405,6 @@ class RandomForestClassifier(_Classifier, _TreeModelMixin):
         return super(RandomForestClassifier, self).classify(dataset,
                                                             missing_value_action=missing_value_action)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        methods = _Classifier._get_queryable_methods()
-        methods['extract_features'] = {'dataset': 'sframe'}
-        return methods
 
     def export_coreml(self, filename):
         """

--- a/src/python/turicreate/toolkits/classifier/svm_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/svm_classifier.py
@@ -637,10 +637,3 @@ class SVMClassifier(_Classifier):
                                missing_value_action=missing_value_action,
                                metric=metric,
                                with_predictions=with_predictions)
-
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        return {'predict':{},
-                'classify':{}}

--- a/src/python/turicreate/toolkits/nearest_neighbors/_nearest_neighbors.py
+++ b/src/python/turicreate/toolkits/nearest_neighbors/_nearest_neighbors.py
@@ -1059,9 +1059,3 @@ class NearestNeighborsModel(_Model):
                          dst_field='reference_label')
             return sg
 
-
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        return {'query':{'dataset':'sframe'}}

--- a/src/python/turicreate/toolkits/recommender/util.py
+++ b/src/python/turicreate/toolkits/recommender/util.py
@@ -520,25 +520,6 @@ class _Recommender(_Model):
         return None
 
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        return {'predict': {
-                    'dataset': 'sframe',
-                    'new_observation_data': 'sframe',
-                    'new_user_data': 'sframe',
-                    'new_item_data': 'sframe'
-                },
-                'recommend': {
-                    'users': ['sframe', 'sarray'],
-                    'items': ['sframe', 'sarray'],
-                    'new_observation_data': 'sframe',
-                    'new_user_data': 'sframe',
-                    'new_item_data': 'sframe',
-                    'exclude': 'sframe'}
-                }
-
 
     def _list_fields(self):
         """

--- a/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
+++ b/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
@@ -270,13 +270,6 @@ class BoostedTreesRegression(_SupervisedLearningModel, _TreeModelMixin):
         return super(BoostedTreesRegression, self).predict(dataset, output_type='margin',
                                                            missing_value_action=missing_value_action)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        methods = _SupervisedLearningModel._get_queryable_methods()
-        methods['extract_features'] = {'dataset': 'sframe'}
-        return methods
 
 
 def create(dataset, target,

--- a/src/python/turicreate/toolkits/regression/decision_tree_regression.py
+++ b/src/python/turicreate/toolkits/regression/decision_tree_regression.py
@@ -298,14 +298,6 @@ class DecisionTreeRegression(_SupervisedLearningModel, _TreeModelMixin):
         return super(DecisionTreeRegression, self).predict(dataset, output_type='margin',
                                                            missing_value_action=missing_value_action)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        methods = _SupervisedLearningModel._get_queryable_methods()
-        methods['extract_features'] = {'dataset': 'sframe'}
-        return methods
-
 
 def create(dataset, target,
            features=None,

--- a/src/python/turicreate/toolkits/regression/random_forest_regression.py
+++ b/src/python/turicreate/toolkits/regression/random_forest_regression.py
@@ -271,13 +271,6 @@ class RandomForestRegression(_SupervisedLearningModel, _TreeModelMixin):
                                                            output_type='margin',
                                                            missing_value_action=missing_value_action)
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        methods = _SupervisedLearningModel._get_queryable_methods()
-        methods['extract_features'] = {'dataset': 'sframe'}
-        return methods
 
     def export_coreml(self, filename):
         """

--- a/src/python/turicreate/toolkits/topic_model/topic_model.py
+++ b/src/python/turicreate/toolkits/topic_model/topic_model.py
@@ -730,12 +730,6 @@ class TopicModel(_Model):
                                        topics['vocabulary'])
         return ret
 
-    @classmethod
-    def _get_queryable_methods(cls):
-        '''Returns a list of method names that are queryable through Predictive
-        Service'''
-        return {'predict':{'dataset':'sarray'}}
-
 
 def perplexity(test_data, predictions, topics, vocabulary):
     """


### PR DESCRIPTION
This PR resolves [#2276](https://github.com/apple/turicreate/issues/2276)
Cleanup obsolete python methods

