### PR TITLE
Angle distributions have a mean of zero

### DIFF
--- a/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.hpp
+++ b/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.hpp
@@ -62,9 +62,9 @@ class ParameterSampler {
   size_t max_depth_ = 13000;
   double angle_stdev_ = 20.0;
   double focal_stdev_ = 40.0;
-  std::vector<double> theta_means_ = {-180.0, 0.0, 180.0};
-  std::vector<double> phi_means_ = {-180.0, 0.0, 180.0};
-  std::vector<double> gamma_means_ = {-180.0, -90.0, 0.0, 90.0, 180.0};
+  std::vector<double> theta_means_ = {0.0};
+  std::vector<double> phi_means_ = {0.0};
+  std::vector<double> gamma_means_ = {0.0};
   std::default_random_engine theta_generator_;
   std::default_random_engine phi_generator_;
   std::default_random_engine gamma_generator_;


### PR DESCRIPTION
We want to bias all the angle distributions to zero for now so we do not create synthetic images with objects rotated that in the real world, cannot be. We can expose parameters to tune this at a later point.