### PR TITLE
Random x-y translation to object in the superimposed image

### DIFF
--- a/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.cpp
+++ b/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.cpp
@@ -83,20 +83,20 @@ void ParameterSampler::compute_coordinates_from_warped_corners() {
 
 void ParameterSampler::perform_x_y_translation(size_t background_width,
     size_t background_height, std::mt19937 *engine_pointer) {
-  int x_margin = static_cast<int>(bounding_box_width_/2);
-  int y_margin = static_cast<int>(bounding_box_height_/2);
+  size_t x_margin = static_cast<size_t>(bounding_box_width_/2);
+  size_t y_margin = static_cast<size_t>(bounding_box_height_/2);
   if (background_width < x_margin || background_height < y_margin) {
     dx_ = 0;
     dy_ = 0;
   } else {
-    std::uniform_int_distribution<int> final_center_x_distribution(
+    std::uniform_int_distribution<size_t> final_center_x_distribution(
       x_margin, background_width - x_margin);
-    std::uniform_int_distribution<int> final_center_y_distribution(
+    std::uniform_int_distribution<size_t> final_center_y_distribution(
       y_margin, background_height - y_margin);
-    int new_center_x = final_center_x_distribution(*engine_pointer);
-    int new_center_y = final_center_y_distribution(*engine_pointer);
-    dx_ = new_center_x - static_cast<int>(center_x_);
-    dy_ = new_center_y - static_cast<int>(center_y_);
+    size_t new_center_x = final_center_x_distribution(*engine_pointer);
+    size_t new_center_y = final_center_y_distribution(*engine_pointer);
+    dx_ = new_center_x - static_cast<size_t>(center_x_);
+    dy_ = new_center_y - static_cast<size_t>(center_y_);
   }
   
   boost::gil::matrix3x2<double> affine = boost::gil::matrix3x2<double>::get_translate(

--- a/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.cpp
+++ b/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.cpp
@@ -85,14 +85,19 @@ void ParameterSampler::perform_x_y_translation(size_t background_width,
     size_t background_height, std::mt19937 *engine_pointer) {
   int x_margin = static_cast<int>(bounding_box_width_/2);
   int y_margin = static_cast<int>(bounding_box_height_/2);
-  std::uniform_int_distribution<int> final_center_x_distribution(
-    x_margin, background_width - x_margin);
-  std::uniform_int_distribution<int> final_center_y_distribution(
-    y_margin, background_height - y_margin);
-  int new_center_x = final_center_x_distribution(*engine_pointer);
-  int new_center_y = final_center_y_distribution(*engine_pointer);
-  dx_ = new_center_x - static_cast<int>(center_x_);
-  dy_ = new_center_y - static_cast<int>(center_y_);
+  if (background_width < x_margin || background_height < y_margin) {
+    dx_ = 0;
+    dy_ = 0;
+  } else {
+    std::uniform_int_distribution<int> final_center_x_distribution(
+      x_margin, background_width - x_margin);
+    std::uniform_int_distribution<int> final_center_y_distribution(
+      y_margin, background_height - y_margin);
+    int new_center_x = final_center_x_distribution(*engine_pointer);
+    int new_center_y = final_center_y_distribution(*engine_pointer);
+    dx_ = new_center_x - static_cast<int>(center_x_);
+    dy_ = new_center_y - static_cast<int>(center_y_);
+  }
   
   boost::gil::matrix3x2<double> affine = boost::gil::matrix3x2<double>::get_translate(
     boost::gil::point2<double>(dx_, dy_));

--- a/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.hpp
+++ b/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.hpp
@@ -17,6 +17,8 @@
 #include <random>
 #include <vector>
 
+#include <core/data/flexible_type/flexible_type.hpp>
+
 namespace turi {
 namespace one_shot_object_detection {
 
@@ -26,7 +28,7 @@ namespace one_shot_object_detection {
  */
 class ParameterSampler {
  public:
-  ParameterSampler(size_t starter_width, size_t starter_height, size_t dx, size_t dy);
+  ParameterSampler(size_t starter_width, size_t starter_height);
 
   /* Getters for all the parameters:
    * theta: rotation around the x axis.
@@ -34,22 +36,16 @@ class ParameterSampler {
    * gamma: rotation around the z axis.
    * dz: distance of the object from the camera.
    * focal: focal length of the camera used.
+   * coordinates: coordinates in the annotation.
    * transform: The transformation matrix built from the above parameters.
-   * warped_corners: The four corners of the object in the warped image.
    */
   double get_theta();
   double get_phi();
   double get_gamma();
   size_t get_dz();
   double get_focal();
+  flex_dict get_coordinates();
   Eigen::Matrix<float, 3, 3> get_transform();
-  std::vector<Eigen::Vector3f> get_warped_corners();
-
-  /* Setter for warped_corners, built after applying the transformation
-   * matrix on the corners of the starter image.
-   * Order of warped_corners is top_left, top_right, bottom_left, bottom_right
-   */
-  void set_warped_corners(const std::vector<Eigen::Vector3f> &warped_corners);
 
   /* Function to sample all the parameters needed to build a transform, and
    * then also build the transform.
@@ -69,12 +65,28 @@ class ParameterSampler {
   double theta_;
   double phi_;
   double gamma_;
-  size_t dx_;
-  size_t dy_;
+  size_t dx_ = 0;
+  size_t dy_ = 0;
   size_t dz_;
   double focal_;
+  float center_x_;
+  float center_y_;
+  float bounding_box_width_;
+  float bounding_box_height_;
   Eigen::Matrix<float, 3, 3> transform_;
   std::vector<Eigen::Vector3f> warped_corners_;
+
+  /* Getters for some private parameters:
+   * warped_corners: The four corners of the object in the warped image.
+   */
+  std::vector<Eigen::Vector3f> get_warped_corners();
+  
+  /* Setter for warped_corners, built after applying the transformation
+   * matrix on the corners of the starter image.
+   * Order of warped_corners is top_left, top_right, bottom_left, bottom_right
+   */
+  void set_warped_corners(const std::vector<Eigen::Vector3f> &warped_corners);
+  void set_annotation_without_planar_translation();
 };
 
 }  // namespace one_shot_object_detection

--- a/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.hpp
+++ b/src/toolkits/object_detection/one_shot_object_detection/util/parameter_sampler.hpp
@@ -34,18 +34,27 @@ class ParameterSampler {
    * theta: rotation around the x axis.
    * phi: rotation around the y axis.
    * gamma: rotation around the z axis.
+   * dx: translation along x axis.
+   * dy: translation along y axis.
    * dz: distance of the object from the camera.
    * focal: focal length of the camera used.
    * coordinates: coordinates in the annotation.
-   * transform: The transformation matrix built from the above parameters.
+   * perspective_transform: The perspective transformation matrix built from the
+   *                        above parameters.
+   * affine_transform: The affine transformation matrix built from the
+   *                   dx and dy translations.
+   * warped_corners: The four corners of the object in the warped image.
    */
   double get_theta();
   double get_phi();
   double get_gamma();
+  int get_dx();
+  int get_dy();
   size_t get_dz();
   double get_focal();
   flex_dict get_coordinates();
-  Eigen::Matrix<float, 3, 3> get_transform();
+  Eigen::Matrix<float, 3, 3> get_perspective_transform();
+  Eigen::Matrix<float, 3, 3> get_affine_transform();
 
   /* Function to sample all the parameters needed to build a transform, and
    * then also build the transform.
@@ -65,15 +74,17 @@ class ParameterSampler {
   double theta_;
   double phi_;
   double gamma_;
-  size_t dx_ = 0;
-  size_t dy_ = 0;
+  int dx_ = 0;
+  int dy_ = 0;
   size_t dz_;
   double focal_;
   float center_x_;
   float center_y_;
   float bounding_box_width_;
   float bounding_box_height_;
-  Eigen::Matrix<float, 3, 3> transform_;
+
+  Eigen::Matrix<float, 3, 3> affine_transform_;
+  Eigen::Matrix<float, 3, 3> perspective_transform_;
   std::vector<Eigen::Vector3f> warped_corners_;
 
   /* Getters for some private parameters:
@@ -81,12 +92,9 @@ class ParameterSampler {
    */
   std::vector<Eigen::Vector3f> get_warped_corners();
   
-  /* Setter for warped_corners, built after applying the transformation
-   * matrix on the corners of the starter image.
-   * Order of warped_corners is top_left, top_right, bottom_left, bottom_right
-   */
-  void set_warped_corners(const std::vector<Eigen::Vector3f> &warped_corners);
-  void set_annotation_without_planar_translation();
+  void compute_coordinates_from_warped_corners();
+  void perform_x_y_translation(size_t background_width, size_t background_height, std::mt19937 *engine_pointer);
+  void perform_perspective_transform();
 };
 
 }  // namespace one_shot_object_detection


### PR DESCRIPTION
Currently, objects in the superimposed image always have the same center coordinate. This hasn't adversely affected mAP performance so far because the object ends up with different relative positions in the augmented image (because of varying sizes of the backgrounds). This PR seeks to add a random amount of x-y translation to the object in the superimposed image in order to prevent the object being lodged at the same place while also making an effort to keep the object inside the background image as much as possible. Performance testing in progress.