### PR TITLE
Fixed offset for the initialization of the instance norm data loader

### DIFF
--- a/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
+++ b/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
@@ -95,15 +95,19 @@ API_AVAILABLE(macos(10.14))
                                                    dataType:(MPSDataTypeFloat32)];
 
     _style_props = [[NSMutableArray alloc] init];
-    
+
     for (NSUInteger index = 0; index < styles; index ++) {
       TCMPSInstanceNormDataLoaderProps *style_property = [[TCMPSInstanceNormDataLoaderProps alloc] init];
 
-      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:_gamma_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float))
+      size_t gammaBufferOffset = _gamma_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float));
+
+      size_t betaBufferOffset = _beta_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float))
+
+      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:gammaBufferOffset
                                                    length:sizeof(float) * _numberOfFeatureChannels
                                                   options:MTLResourceStorageModeManaged];
 
-      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:_beta_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float))
+      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:betaBufferOffset
                                                   length:sizeof(float) * _numberOfFeatureChannels
                                                  options:MTLResourceStorageModeManaged];
 

--- a/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
+++ b/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
@@ -99,15 +99,13 @@ API_AVAILABLE(macos(10.14))
     for (NSUInteger index = 0; index < styles; index ++) {
       TCMPSInstanceNormDataLoaderProps *style_property = [[TCMPSInstanceNormDataLoaderProps alloc] init];
 
-      size_t gammaBufferOffset = _gamma_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float));
+      size_t offset = index * _numberOfFeatureChannels * sizeof(float);
 
-      size_t betaBufferOffset = _beta_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float))
-
-      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:gammaBufferOffset
+      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:(char *) _gamma_weights.bytes + offset
                                                    length:sizeof(float) * _numberOfFeatureChannels
                                                   options:MTLResourceStorageModeManaged];
 
-      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:betaBufferOffset
+      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:(char *) _beta_weights.bytes + offset
                                                   length:sizeof(float) * _numberOfFeatureChannels
                                                  options:MTLResourceStorageModeManaged];
 

--- a/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
+++ b/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
@@ -95,15 +95,15 @@ API_AVAILABLE(macos(10.14))
                                                    dataType:(MPSDataTypeFloat32)];
 
     _style_props = [[NSMutableArray alloc] init];
-
+    
     for (NSUInteger index = 0; index < styles; index ++) {
       TCMPSInstanceNormDataLoaderProps *style_property = [[TCMPSInstanceNormDataLoaderProps alloc] init];
 
-      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:_gamma_weights.mutableBytes
+      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:_gamma_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float))
                                                    length:sizeof(float) * _numberOfFeatureChannels
                                                   options:MTLResourceStorageModeManaged];
 
-      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:_beta_weights.mutableBytes
+      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:_beta_weights.bytes + (index * _numberOfFeatureChannels * sizeof(float))
                                                   length:sizeof(float) * _numberOfFeatureChannels
                                                  options:MTLResourceStorageModeManaged];
 


### PR DESCRIPTION
Missed an offset in the Instance norm data loader on initialization of weights.