### PR TITLE
Implement equality operator for image_type

### DIFF
--- a/src/core/data/flexible_type/flexible_type_detail.hpp
+++ b/src/core/data/flexible_type/flexible_type_detail.hpp
@@ -197,6 +197,7 @@ struct equality_operator {
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_int t, const flex_int u) const { return t == u; }
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_float t, const flex_float u) const { return t == u; }
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_string& t, const flex_string& u) const { return t == u; }
+  inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_image& t, const flex_image& u) const { return t == u; }
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_vec& t, const flex_vec& u) const {
     if (t.size() != u.size()) return false;
     for (size_t i = 0;i < t.size(); ++i) if (t[i] != u[i]) return false;
@@ -245,6 +246,7 @@ struct approx_equality_operator {
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_int t, const flex_float u) const { return t == u; }
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_float t, const flex_int u) const { return t == u; }
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_string& t, const flex_string& u) const { return t == u; }
+  inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_image& t, const flex_image& u) const { return t == u; }
   inline FLEX_ALWAYS_INLINE_FLATTEN bool operator()(const flex_vec& t, const flex_vec& u) const {
     if (t.size() != u.size()) return false;
     for (size_t i = 0;i < t.size(); ++i) if (t[i] != u[i]) return false;

--- a/src/core/data/image/image_type.cpp
+++ b/src/core/data/image/image_type.cpp
@@ -5,6 +5,7 @@
  */
 #include <core/data/image/image_type.hpp>
 #include <boost/gil/gil_all.hpp>
+#include <algorithm>
 
 namespace turi{
 
@@ -86,7 +87,9 @@ bool image_type::operator==(const image_type& other) const {
       m_image_data_size == other.m_image_data_size &&
       m_version == other.m_version &&
       m_format == other.m_format &&
-      strcmp(m_image_data.get(), other.m_image_data.get()) == 0;
+      std::equal(m_image_data.get(),
+                 m_image_data.get() + m_image_data_size,
+                 other.m_image_data.get());
 }
 
 }

--- a/src/core/data/image/image_type.cpp
+++ b/src/core/data/image/image_type.cpp
@@ -75,4 +75,18 @@ const unsigned char* image_type::get_image_data() const {
   }
 }
 
+// The equality behavior is currently mirrored from python implementation 
+// where every property is compared directly, but we might want to later
+// support comparing two images with different lossless types.
+bool image_type::operator==(const image_type& other) const {
+  return
+      m_height == other.m_height &&
+      m_width == other.m_width &&
+      m_channels == other.m_channels && 
+      m_image_data_size == other.m_image_data_size &&
+      m_version == other.m_version &&
+      m_format == other.m_format &&
+      strcmp(m_image_data.get(), other.m_image_data.get()) == 0;
+}
+
 }

--- a/src/core/data/image/image_type.hpp
+++ b/src/core/data/image/image_type.hpp
@@ -7,7 +7,6 @@
 #define TURI_IMAGE_IMAGE_TYPE_HPP
 
 #include <string>
-#include <string.h>
 #include <core/storage/serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/gil/typedefs.hpp>

--- a/src/core/data/image/image_type.hpp
+++ b/src/core/data/image/image_type.hpp
@@ -7,6 +7,7 @@
 #define TURI_IMAGE_IMAGE_TYPE_HPP
 
 #include <string>
+#include <string.h>
 #include <core/storage/serialization/serialization_includes.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/gil/typedefs.hpp>
@@ -66,6 +67,8 @@ public:
   void load(iarchive& iarc);
   /// Returns a char* pointer to the raw image data
   const unsigned char* get_image_data() const;
+  /// Equality comparator, two images are equal when every property is identical
+  bool operator==(const image_type& other) const;
 };
 
 

--- a/src/python/turicreate/test/test_sarray.py
+++ b/src/python/turicreate/test/test_sarray.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import as _
 from ..data_structures.sarray import SArray
 from ..data_structures.sframe import SFrame
 from ..data_structures.sarray import load_sarray
-from ..toolkits.image_analysis import image_analysis
+from ..toolkits.image_analysis.image_analysis import load_images
 from .._cython.cy_flexible_type import GMT
 from . import util
 
@@ -1213,8 +1213,8 @@ class SArrayTest(unittest.TestCase):
         current_file_dir = os.path.dirname(os.path.realpath(__file__))
         image_url_1 = current_file_dir + '/images/sample.png'
         image_url_2 = current_file_dir + '/images/sample.jpg'
-        i = image_analysis.load_images(image_url_1)['image']
-        j = image_analysis.load_images(image_url_2)['image']
+        i = load_images(image_url_1)['image']
+        j = load_images(image_url_2)['image']
 
         self.__test_equal(i == i, [x == y for (x,y) in zip(i, i)], int)
         self.__test_equal(j == j, [x == y for (x,y) in zip(j, j)], int)

--- a/src/python/turicreate/test/test_sarray.py
+++ b/src/python/turicreate/test/test_sarray.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import as _
 from ..data_structures.sarray import SArray
 from ..data_structures.sframe import SFrame
 from ..data_structures.sarray import load_sarray
+from ..toolkits.image_analysis import image_analysis
 from .._cython.cy_flexible_type import GMT
 from . import util
 
@@ -1207,6 +1208,17 @@ class SArrayTest(unittest.TestCase):
         self.assertEqual(len((t + t2).dropna()), 7)
         self.assertEqual(len((t - t2).dropna()), 7)
         self.assertEqual(len((t * t2).dropna()), 7)
+
+    def test_sarray_image_equality(self):
+        current_file_dir = os.path.dirname(os.path.realpath(__file__))
+        image_url_1 = current_file_dir + '/images/sample.png'
+        image_url_2 = current_file_dir + '/images/sample.jpg'
+        i = image_analysis.load_images(image_url_1)['image']
+        j = image_analysis.load_images(image_url_2)['image']
+
+        self.__test_equal(i == i, [x == y for (x,y) in zip(i, i)], int)
+        self.__test_equal(j == j, [x == y for (x,y) in zip(j, j)], int)
+        self.__test_equal(i == j, [x == y for (x,y) in zip(i, j)], int)
 
     def test_dropna(self):
         no_nas = ['strings', 'yeah', 'nan', 'NaN', 'NA', 'None']


### PR DESCRIPTION
- fix #2042 to allow comparing SArray with Image type
- Currently, implementation of the equality operator mirrors the python implementation where two images are equal *only* when every property (`m_height`, `m_width`, ..., `m_image_data`) are identical, but we might want to allow comparing two identical images with different lossless types (png vs. RAW) by decoding to RAW type