### PR TITLE
Export weights in pybind11 expects Contiguous Array

### DIFF
--- a/src/python/turicreate/toolkits/object_detector/_tf_model_architecture.py
+++ b/src/python/turicreate/toolkits/object_detector/_tf_model_architecture.py
@@ -431,6 +431,8 @@ class ODTensorFlowModel(object):
                 # [output_channels, input_channels, filter_height, filter_width]
                 tf_export_params.update(
                     {var.name.replace(":0", ""): val.transpose(3,2,0,1)})
+        for layer_name in tf_export_params.keys():
+            tf_export_params[layer_name] = _np.ascontiguousarray(tf_export_params[layer_name])
 
         return tf_export_params
 


### PR DESCRIPTION
The array passed from numpy in Python is being transposed to be converted in the correct CoreML format. But the numpy transpose just changes the strides, doesn't touch the actual array. This is then mapped to our `shared_float_array`(strides unaware) in pybind11. This will basically mix the trained weights because our shared_float_array reads the buffer without knowing the change made to the strides even though the shape being sent is correct.