### PR TITLE
Adding argument check for output_frequency

### DIFF
--- a/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -493,6 +493,8 @@ class ActivityClassifier_beta(_Model):
             |      ...      |    ...     | ... |
             +---------------+------------+-----+
         """
+        _tkutl._check_categorical_option_type(
+            'output_frequency', output_frequency, ['per_window', 'per_row'])
         if output_frequency == 'per_row':
             return self.__proxy__.predict(dataset, output_type)
         elif output_frequency == 'per_window':


### PR DESCRIPTION
In C++ implementation, doing prediction with either 'per_row' and 'per_window' is using two different functions and thus, the check needs to be in the python layer. 
