### PR TITLE
TCMPS Style Transfer Fixes

### DIFF
--- a/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
+++ b/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
@@ -177,11 +177,11 @@ API_AVAILABLE(macos(10.14))
 
 - (float *) beta {
   NSUInteger previousStyle = _styleIndex;
-  _betaPlaceHolder = [NSMutableData data];
+  _betaPlaceHolder.length = 0;
   for (NSUInteger index = 0; index < _styles; index++) {
     _styleIndex = index;
     [self checkpointWithCommandQueue:_cq];
-    float* betaWeights = (float *) [[[_style_props objectAtIndex: _styleIndex] betaBuffer] contents];
+    float* betaWeights = (float *) [_style_props[_styleIndex].betaBuffer contents];
     [_betaPlaceHolder appendBytes:betaWeights length:sizeof(float)*_numberOfFeatureChannels];
   }
   _styleIndex = previousStyle;
@@ -196,12 +196,12 @@ API_AVAILABLE(macos(10.14))
 
 // TODO: refactor for multiple indicies
 - (float *) gamma {
-  _gammaPlaceHolder = [NSMutableData data];
   NSUInteger previousStyle = _styleIndex;
+  _gammaPlaceHolder.length = 0;
   for (NSUInteger index = 0; index < _styles; index++) { 
     _styleIndex = index; 
     [self checkpointWithCommandQueue:_cq];
-    float* gammaWeights = (float *) [[[_style_props objectAtIndex: _styleIndex] gammaBuffer] contents];
+    float* gammaWeights = (float *) [_style_props[_styleIndex].gammaBuffer contents];
     [_gammaPlaceHolder appendBytes:gammaWeights length:sizeof(float)*_numberOfFeatureChannels];
   }
   _styleIndex = previousStyle;

--- a/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
+++ b/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
@@ -104,12 +104,12 @@ API_AVAILABLE(macos(10.14))
       size_t offset = index * _numberOfFeatureChannels * sizeof(float);
 
       style_property.gammaBuffer = [dev newBufferWithBytes:(char *) _gamma_weights.bytes + offset
-                                                    length:sizeof(float) * _numberOfFeatureChannels
-                                                   options:MTLResourceStorageModeManaged];
-
-      style_property.betaBuffer = [dev newBufferWithBytes:(char *) _beta_weights.bytes + offset
                                                    length:sizeof(float) * _numberOfFeatureChannels
                                                   options:MTLResourceStorageModeManaged];
+
+      style_property.betaBuffer = [dev newBufferWithBytes:(char *) _beta_weights.bytes + offset
+                                                  length:sizeof(float) * _numberOfFeatureChannels
+                                                 options:MTLResourceStorageModeManaged];
 
       style_property.gammaMomentumBuffer = [dev newBufferWithBytes:zeros_ptr
                                                             length:sizeof(float) * _numberOfFeatureChannels
@@ -196,8 +196,8 @@ API_AVAILABLE(macos(10.14))
 
 // TODO: refactor for multiple indicies
 - (float *) gamma {
-  NSUInteger previousStyle = _styleIndex;
   _gammaPlaceHolder = [NSMutableData data];
+  NSUInteger previousStyle = _styleIndex;
   for (NSUInteger index = 0; index < _styles; index++) { 
     _styleIndex = index; 
     [self checkpointWithCommandQueue:_cq];
@@ -243,7 +243,7 @@ API_AVAILABLE(macos(10.14))
 
   }
 
-    return [[_style_props objectAtIndex: _styleIndex] state];
+  return [[_style_props objectAtIndex: _styleIndex] state];
 }
 
 - (void)checkpointWithCommandQueue:(nonnull id<MTLCommandQueue>)commandQueue {

--- a/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
+++ b/src/ml/neural_net/mps_layer_instance_norm_data_loader.mm
@@ -22,6 +22,8 @@ API_AVAILABLE(macos(10.14))
   @property (nonatomic) id<MTLBuffer> gammaVelocityBuffer;
   @property (nonatomic) id<MTLBuffer> betaMomentumBuffer;
   @property (nonatomic) id<MTLBuffer> betaVelocityBuffer;
+  @property (nonatomic) id<MTLBuffer> gammaBuffer;
+  @property (nonatomic) id<MTLBuffer> betaBuffer;
 
   @property (nonatomic) MPSCNNNormalizationGammaAndBetaState *state;
 @end
@@ -101,13 +103,13 @@ API_AVAILABLE(macos(10.14))
 
       size_t offset = index * _numberOfFeatureChannels * sizeof(float);
 
-      id<MTLBuffer> gammaBuffer = [dev newBufferWithBytes:(char *) _gamma_weights.bytes + offset
+      style_property.gammaBuffer = [dev newBufferWithBytes:(char *) _gamma_weights.bytes + offset
+                                                    length:sizeof(float) * _numberOfFeatureChannels
+                                                   options:MTLResourceStorageModeManaged];
+
+      style_property.betaBuffer = [dev newBufferWithBytes:(char *) _beta_weights.bytes + offset
                                                    length:sizeof(float) * _numberOfFeatureChannels
                                                   options:MTLResourceStorageModeManaged];
-
-      id<MTLBuffer> betaBuffer = [dev newBufferWithBytes:(char *) _beta_weights.bytes + offset
-                                                  length:sizeof(float) * _numberOfFeatureChannels
-                                                 options:MTLResourceStorageModeManaged];
 
       style_property.gammaMomentumBuffer = [dev newBufferWithBytes:zeros_ptr
                                                             length:sizeof(float) * _numberOfFeatureChannels
@@ -133,7 +135,7 @@ API_AVAILABLE(macos(10.14))
                                                              length:sizeof(float) * _numberOfFeatureChannels
                                                             options:MTLResourceStorageModeManaged];
 
-      style_property.gammaVector = [[MPSVector alloc] initWithBuffer:gammaBuffer
+      style_property.gammaVector = [[MPSVector alloc] initWithBuffer:style_property.gammaBuffer
                                                           descriptor:_vDesc];
 
       style_property.gammaMomentumVector = [[MPSVector alloc] initWithBuffer:style_property.gammaMomentumBuffer
@@ -142,7 +144,7 @@ API_AVAILABLE(macos(10.14))
       style_property.gammaVelocityVector = [[MPSVector alloc] initWithBuffer:style_property.gammaVelocityBuffer
                                                                   descriptor:_vDesc];
 
-      style_property.betaVector = [[MPSVector alloc] initWithBuffer:betaBuffer
+      style_property.betaVector = [[MPSVector alloc] initWithBuffer:style_property.betaBuffer
                                                          descriptor:_vDesc];
 
       style_property.betaMomentumVector = [[MPSVector alloc] initWithBuffer:style_property.betaMomentumBuffer
@@ -151,8 +153,8 @@ API_AVAILABLE(macos(10.14))
       style_property.betaVelocityVector = [[MPSVector alloc] initWithBuffer:style_property.betaVelocityBuffer
                                                                  descriptor:_vDesc];
 
-      style_property.state = [[MPSCNNNormalizationGammaAndBetaState alloc] initWithGamma:gammaBuffer
-                                                                                    beta:betaBuffer];
+      style_property.state = [[MPSCNNNormalizationGammaAndBetaState alloc] initWithGamma:style_property.gammaBuffer
+                                                                                    beta:style_property.betaBuffer];
 
       [_style_props addObject:style_property];
     }
@@ -175,10 +177,11 @@ API_AVAILABLE(macos(10.14))
 
 - (float *) beta {
   NSUInteger previousStyle = _styleIndex;
+  _betaPlaceHolder = [NSMutableData data];
   for (NSUInteger index = 0; index < _styles; index++) {
     _styleIndex = index;
     [self checkpointWithCommandQueue:_cq];
-    float* betaWeights = (float *) [[[[_style_props objectAtIndex: _styleIndex] betaVector] data] contents];
+    float* betaWeights = (float *) [[[_style_props objectAtIndex: _styleIndex] betaBuffer] contents];
     [_betaPlaceHolder appendBytes:betaWeights length:sizeof(float)*_numberOfFeatureChannels];
   }
   _styleIndex = previousStyle;
@@ -194,10 +197,11 @@ API_AVAILABLE(macos(10.14))
 // TODO: refactor for multiple indicies
 - (float *) gamma {
   NSUInteger previousStyle = _styleIndex;
+  _gammaPlaceHolder = [NSMutableData data];
   for (NSUInteger index = 0; index < _styles; index++) { 
     _styleIndex = index; 
     [self checkpointWithCommandQueue:_cq];
-    float* gammaWeights = (float *) [[[[_style_props objectAtIndex: _styleIndex] gammaVector] data] contents];
+    float* gammaWeights = (float *) [[[_style_props objectAtIndex: _styleIndex] gammaBuffer] contents];
     [_gammaPlaceHolder appendBytes:gammaWeights length:sizeof(float)*_numberOfFeatureChannels];
   }
   _styleIndex = previousStyle;

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.h
@@ -35,6 +35,7 @@ API_AVAILABLE(macos(10.15))
 - (NSDictionary<NSString *, NSData *> *) predict:(NSDictionary<NSString *, NSData *> *)inputs;
 - (void) setLearningRate:(float)lr;
 - (NSDictionary<NSString *, NSData *> *) train:(NSDictionary<NSString *, NSData *> *)inputs;
+- (void) checkpoint;
 
 @end
 

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -252,6 +252,7 @@
 }
 
 - (NSDictionary<NSString *, NSData *> *) exportWeights {
+  [self checkpoint];
   return [_model exportWeights:@"transformer_"];
 }
 
@@ -435,6 +436,14 @@
   lossDict[@"loss"] = [NSData dataWithData:lossData];
 
   return [lossDict copy];
+}
+
+- (void) checkpoint {
+  _inferenceGraph = [MPSNNGraph graphWithDevice:_dev
+                                    resultImage:_model.forwardPass
+                            resultImageIsNeeded:YES];
+  
+  _inferenceGraph.format = MPSImageFeatureChannelFormatFloat32;
 }
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -235,7 +235,10 @@
                                              nodeHandler: nil];
 
     _trainingGraph = [MPSNNGraph graphWithDevice:_dev
-                                    resultImages:@[lastNodes[0].resultImage, lastNodes[1].resultImage]
+                                    resultImages:@[lastNodes[0].resultImage,
+                                                   lastNodes[1].resultImage,
+                                                   lastNodes[2].resultImage,
+                                                   lastNodes[3].resultImage]
                                 resultsAreNeeded:&resultsAreNeeded[0]];
 
     _inferenceGraph = [MPSNNGraph graphWithDevice:_dev

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -438,6 +438,10 @@
   return [lossDict copy];
 }
 
+/**
+* HACK: this somehow checkpoints the model for weight exports and updating the
+*       data loaders. Following up internally for a proper fix to this issue.
+**/
 - (void) checkpoint {
   _inferenceGraph = [MPSNNGraph graphWithDevice:_dev
                                     resultImage:_model.forwardPass

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -409,6 +409,18 @@ def create(style_dataset, content_dataset, style_feature=None,
 
         mps_mxnet_key_map = _MpsStyleGraphAPI.mps_mxnet_weight_dict()
 
+        # LOGIC
+        #
+        # The two layers we are concerned about are very different. The instance
+        # norm layer weights should have a dimensionality two. Wheras the 
+        # Convolutional Weights have a dimensionality of four. The Convolutional
+        # weights are in a different format in MxNet then they are in MPS. Since
+        # the arrays come back flattened in the MPS a reshape has to occur. But
+        # this reshape happens before the transpose therefore the shape itself
+        # has to be transposed. For the InstanceNorm Layer, however, the weights
+        # are passed back to MxNet in the correct format so just a simple
+        # reshape suffices.
+        #
         for key in mps_weights:
             if "transformer" in key:
                 weight = transformer.collect_params()[mps_mxnet_key_map[key]].data()

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -410,9 +410,9 @@ def create(style_dataset, content_dataset, style_feature=None,
         mps_mxnet_key_map = _MpsStyleGraphAPI.mps_mxnet_weight_dict()
 
         for key in mps_weights:
-            if "transformer" in key and "inst" in key:
+            if "transformer" in key:
                 weight = transformer.collect_params()[mps_mxnet_key_map[key]].data()
-                if inst in key:
+                if "inst" in key:
                     mxnet_weight = _mx.nd.array(_mps_to_mxnet(mps_weights[key].reshape((weight.shape))))
                 elif "conv" in key:
                     mxnet_weight = _mx.nd.array(_mps_to_mxnet(mps_weights[key].reshape((weight.shape[0], weight.shape[2], weight.shape[3], weight.shape[1]))))


### PR DESCRIPTION
Added necessary changes to make TCMPS Style Transfer converge.
- Changed weight export from Instance Norm Data Loader
- Added `resultImages` to training graph definition
- Change the the weight reshape in Python