### PR TITLE
Fixed CMakeLists typo with arguments.

### DIFF
--- a/src/ml/neural_net/CMakeLists.txt
+++ b/src/ml/neural_net/CMakeLists.txt
@@ -50,7 +50,7 @@ if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
       ${METAL}
       ${METAL_PERFORMANCE_SHADERS}
   )
-  target_compile_options(tcmps PUBLIC "-fobjc-arc -Wno-nullability-completeness -Wno-shadow-ivar")
+  target_compile_options(tcmps PRIVATE -fobjc-arc -Wno-nullability-completeness -Wno-shadow-ivar)
   set(additional_unity_neural_net_requirements tcmps)
 else()
   set(additional_unity_neural_net_requirements "")


### PR DESCRIPTION
The target flags for the Obj-C module should be separated out so they are passed
in as individual flags.  Also, since it is exposed through C headers, they
should be private to restrict them to only compilation of that module.