### PR TITLE
Cleaned up compilation of python flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_PREFIX_PATH ${CMAKE_SOURCE_DIR}/deps/local)
 set(ENV{PATH} "${CMAKE_SOURCE_DIR}/deps/local/bin:${CMAKE_SOURCE_DIR}/deps/env/bin:$ENV{PATH}")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-if(${TC_BUILD_PYTHON})
+if(TC_BUILD_PYTHON)
   message("Building python libraries.")
 
   if(NOT EXISTS ${CMAKE_SOURCE_DIR}/deps/env/)

--- a/configure
+++ b/configure
@@ -203,7 +203,7 @@ if [[ $with_python == 1 ]]; then
   install_python_toolchain
   CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_BUILD_PYTHON=1"
 else
-  CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_BUILD_PYTHON=0"
+  CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS"
 fi
 
 if [[ $with_extra_opt_flags == 1 ]]; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ toolkits
 visualization)
 
 
-if(${TC_BUILD_PYTHON})
+if(TC_BUILD_PYTHON)
   subdirs(python)
 
   include_directories(${PYTHON_INCLUDE_DIRS})

--- a/src/ml/neural_net/CMakeLists.txt
+++ b/src/ml/neural_net/CMakeLists.txt
@@ -73,6 +73,8 @@ make_library(unity_neural_net OBJECT
     ${additional_unity_neural_net_requirements}
 )
 
+if(TC_BUILD_PYTHON)
+
 make_library(tctensorflow SHARED
   SOURCES
   tf_compute_context.cpp
@@ -85,3 +87,5 @@ set_target_properties(tctensorflow
     SUFFIX ".so"
     LIBRARY_OUTPUT_DIRECTORY ${TF_BUILD_DIR}
 )
+
+endif()


### PR DESCRIPTION
Currently, compilation with --no-python is broken in master, as some modules that depend on python are compiled even when that flag is specified.  This fixes that.  