### PR TITLE
skip missing values when dropping words

### DIFF
--- a/src/python/turicreate/test/test_text_analytics.py
+++ b/src/python/turicreate/test/test_text_analytics.py
@@ -149,6 +149,11 @@ class FeatureEngineeringTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             tc.text_analytics.drop_words(sa)
 
+        sa = tc.SArray(["str", None])
+        # no throw, just give warning and skip
+        # avoid segfault
+        stop_words = tc.text_analytics.stop_words()
+        tc.text_analytics.drop_words(sa, stop_words=stop_words)
 
         ## Other languages
         expected = ["this is someurl http someurl this is someurl http someurl",

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -168,7 +168,7 @@ class TextClassifierCreateTests(unittest.TestCase):
         sf = tc.SFrame({'a': a, 'b': b})
         with self.assertRaises(ToolkitError):
             tc.text_classifier.create(sf, target='a', features=['b'], word_count_threshold=1)
-        # feature contains none, #2402
+        # feature contains none, Github #2402
         sf = tc.SFrame({'b': a, 'a': b})
         with self.assertRaises(ToolkitError):
             tc.text_classifier.create(sf, target='b', features=['a'], word_count_threshold=1)

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -36,9 +36,9 @@ class TextClassifierTest(unittest.TestCase):
         self.target = 'score'
         self.method = 'bow-logistic'
         self.model = tc.text_classifier.create(self.docs,
-                                                   target=self.target,
-                                                   features=self.features,
-                                                   method='auto')
+                                               target=self.target,
+                                               features=self.features,
+                                               method='auto')
 
         self.num_examples = 4
 
@@ -159,6 +159,20 @@ class TextClassifierCreateTests(unittest.TestCase):
         data_str['rating'] = data_str['rating'].astype(str)
         model = tc.text_classifier.create(data_str, target='rating')
         self.assertTrue(isinstance(model, tc.text_classifier.TextClassifier))
+
+    def test_invalid_data_set(self):
+        # infer dtype str
+        a = tc.SArray(['str', None])
+        b = tc.SArray(['str', 'str'])
+        # target contains none
+        sf = tc.SFrame({'a': a, 'b': b})
+        with self.assertRaises(ToolkitError):
+            tc.text_classifier.create(sf, target='a', features=['b'], word_count_threshold=1)
+        # feature contains none, #2402
+        sf = tc.SFrame({'b': a, 'a': b})
+        with self.assertRaises(ToolkitError):
+            tc.text_classifier.create(sf, target='b', features=['a'], word_count_threshold=1)
+
 
     def test_validation_set(self):
         train = self.data

--- a/src/python/turicreate/toolkits/text_analytics/_util.py
+++ b/src/python/turicreate/toolkits/text_analytics/_util.py
@@ -400,11 +400,11 @@ def drop_words(text, threshold=2, to_lower=True, delimiters=DEFAULT_DELIMITERS,
     ## Compute word counts
     sf = _turicreate.SFrame({'docs': text})
     fe = _feature_engineering.RareWordTrimmer(features='docs',
-                                                 threshold=threshold,
-                                                 to_lower=to_lower,
-                                                 delimiters=delimiters,
-                                                 stopwords=stop_words,
-                                                 output_column_prefix=None)
+                                              threshold=threshold,
+                                              to_lower=to_lower,
+                                              delimiters=delimiters,
+                                              stopwords=stop_words,
+                                              output_column_prefix=None)
     tokens = fe.fit_transform(sf)
 
     return tokens['docs']

--- a/src/toolkits/feature_engineering/word_trimmer.cpp
+++ b/src/toolkits/feature_engineering/word_trimmer.cpp
@@ -201,9 +201,7 @@ void word_trimmer_topk_index_mapping(const gl_sarray& src,
         }
 
         case flex_type_enum::UNDEFINED:
-          logstream(LOG_WARNING)
-              << "Skip undefined value. Please consider calling "
-              << "'dropna' on feature columns" << std::endl;
+          /* just skip */
           break;
 
         // Should not be here.

--- a/src/toolkits/feature_engineering/word_trimmer.cpp
+++ b/src/toolkits/feature_engineering/word_trimmer.cpp
@@ -202,8 +202,8 @@ void word_trimmer_topk_index_mapping(const gl_sarray& src,
 
         case flex_type_enum::UNDEFINED:
           logstream(LOG_WARNING)
-              << "Skip undefined value. please consider calling "
-              << "dropna on feature columns" << std::endl;
+              << "Skip undefined value. Please consider calling "
+              << "'dropna' on feature columns" << std::endl;
           break;
 
         // Should not be here.

--- a/src/toolkits/feature_engineering/word_trimmer.cpp
+++ b/src/toolkits/feature_engineering/word_trimmer.cpp
@@ -243,7 +243,7 @@ flexible_type word_trimmer_apply(const flexible_type& input,
                || run_mode == flex_type_enum::UNDEFINED
                || run_mode == flex_type_enum::DICT);
 
-  // do nothing; gigo
+  // do nothing; return input value
   if (run_mode == flex_type_enum::UNDEFINED) return input;
 
   const transform_utils::string_filter_list& string_filters = transform_utils::ptb_filters;

--- a/src/toolkits/feature_engineering/word_trimmer.cpp
+++ b/src/toolkits/feature_engineering/word_trimmer.cpp
@@ -202,8 +202,8 @@ void word_trimmer_topk_index_mapping(const gl_sarray& src,
 
         case flex_type_enum::UNDEFINED:
           logstream(LOG_WARNING)
-              << "Skip undefined value in 'word_trimmer_topk_index_mapping'; "
-              << " please consider dropna on feature columns" << std::endl;
+              << "Skip undefined value. please consider calling "
+              << "dropna on feature columns" << std::endl;
           break;
 
         // Should not be here.


### PR DESCRIPTION
otherwise it will cause segfault. #2402 

Current, behavior will be during the model training session, it will throw ToolkitError to remind user using dropna to clean up data.