### PR TITLE
Adds error logging for pybind11

### DIFF
--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -55,7 +55,7 @@ void call_pybind_function(const CallFunc& func) {
   } catch (const pybind11::error_already_set& e) {
     log_and_throw(std::string("An error occurred: ") + e.what());
   } catch (...) {
-    log_and_throw("Unknown Error occurred");
+    log_and_throw("Unknown error occurred");
   }
 
 }

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -52,10 +52,12 @@ void call_pybind_function(const CallFunc& func) {
 
   try {
     func();
+  } catch (const pybind11::error_already_set& e) {
+    log_and_throw(std::string("An error occurred: ") + e.what());
   } catch (...) {
-    // TODO: Do better error logging
-    log_and_throw("An error occurred!");
+    log_and_throw("Unknown Error occurred");
   }
+
 }
 
 


### PR DESCRIPTION
Would print out the errors from Python side correctly. Won't show vague errors like #2373 anymore.