### PR TITLE
Rename ST to MPS_ST for contexts

### DIFF
--- a/src/ml/neural_net/mps_graph_trainer.mm
+++ b/src/ml/neural_net/mps_graph_trainer.mm
@@ -21,7 +21,7 @@ using turi::neural_net::mps_graph_cnn_module;
 using turi::neural_net::shared_float_array;
 
 #ifdef HAS_MACOS_10_15
-using turi::style_transfer::style_transfer;
+using turi::style_transfer::mps_style_transfer;
 #endif
 
 int TCMPSHasHighPowerMetalDevice(bool *has_device) {
@@ -67,7 +67,7 @@ EXPORT int TCMPSTrainStyleTransferGraph(MPSHandle handle, int index, TCMPSFloatA
                                         TCMPSFloatArrayRef labels, TCMPSFloatArrayRef *loss_out) {
   API_BEGIN();
 #ifdef HAS_MACOS_10_15
-  style_transfer *obj = reinterpret_cast<style_transfer *>(handle);
+  mps_style_transfer *obj = reinterpret_cast<mps_style_transfer *>(handle);
   float_array *inputs_ptr = reinterpret_cast<float_array *>(inputs);
   float_array *labels_ptr = reinterpret_cast<float_array *>(labels);
 
@@ -140,7 +140,7 @@ int TCMPSCreateGraphModule(MPSHandle *handle, int network_id, int n, int c_in, i
     *handle = (void *)mps;
   } else {
 #ifdef HAS_MACOS_10_15
-    style_transfer *mps = new style_transfer(config, weights);
+    mps_style_transfer *mps = new mps_style_transfer(config, weights);
 
     *handle = (void *)mps;
 #else

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_backend.hpp
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_backend.hpp
@@ -5,8 +5,8 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef TURI_STYLE_TRANSFER_STYLE_TRANSFER_H_
-#define TURI_STYLE_TRANSFER_STYLE_TRANSFER_H_
+#ifndef TURI_STYLE_TRANSFER_MPS_STYLE_TRANSFER_BACKEND_H_
+#define TURI_STYLE_TRANSFER_MPS_STYLE_TRANSFER_BACKEND_H_
 
 #include <functional>
 #include <map>
@@ -20,12 +20,12 @@
 namespace turi {
 namespace style_transfer {
 
-class EXPORT style_transfer : public turi::neural_net::model_backend {
+class EXPORT mps_style_transfer : public turi::neural_net::model_backend {
 public:
-  style_transfer(const turi::neural_net::float_array_map &config,
+  mps_style_transfer(const turi::neural_net::float_array_map &config,
                  const turi::neural_net::float_array_map &weights);
   
-  ~style_transfer();
+  ~mps_style_transfer();
 
   turi::neural_net::float_array_map export_weights() const override;
   turi::neural_net::float_array_map predict(const turi::neural_net::float_array_map& inputs) const override;

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_backend.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_backend.mm
@@ -68,12 +68,12 @@ using namespace turi::neural_net;
 namespace turi {
 namespace style_transfer {
 
-struct style_transfer::impl {
+struct mps_style_transfer::impl {
   API_AVAILABLE(macos(10.15)) TCMPSStyleTransfer *model = nil;
 };
 
-style_transfer::style_transfer(const float_array_map &config,
-                               const float_array_map &weights) : m_impl(new style_transfer::impl()) {
+mps_style_transfer::mps_style_transfer(const float_array_map &config,
+                               const float_array_map &weights) : m_impl(new mps_style_transfer::impl()) {
   @autoreleasepool {
     if (@available(macOS 10.15, *)) {
       id <MTLDevice> dev = [[TCMPSDeviceManager sharedInstance] preferredDevice];
@@ -96,9 +96,9 @@ style_transfer::style_transfer(const float_array_map &config,
   }
 }
 
-style_transfer::~style_transfer() = default;
+mps_style_transfer::~mps_style_transfer() = default;
 
-float_array_map style_transfer::export_weights() const {
+float_array_map mps_style_transfer::export_weights() const {
   if (@available(macOS 10.15, *)) {
     NSDictionary<NSString *, NSData *> *dictWeights
         = [m_impl->model exportWeights];
@@ -113,7 +113,7 @@ float_array_map style_transfer::export_weights() const {
   }
 }
 
-float_array_map style_transfer::predict(const float_array_map& inputs) const {
+float_array_map mps_style_transfer::predict(const float_array_map& inputs) const {
   if (@available(macOS 10.15, *)) {
     NSDictionary<NSString *, NSData *> *dictInputs
         = [TCMPSStyleTransferHelpers toNSDictionary: inputs];
@@ -131,7 +131,7 @@ float_array_map style_transfer::predict(const float_array_map& inputs) const {
   }
 }
 
-void style_transfer::set_learning_rate(float lr) {
+void mps_style_transfer::set_learning_rate(float lr) {
   if (@available(macOS 10.15, *)) {
     [m_impl->model setLearningRate:lr];
   } else {
@@ -140,7 +140,7 @@ void style_transfer::set_learning_rate(float lr) {
   }
 }
 
-float_array_map style_transfer::train(const float_array_map& inputs) {
+float_array_map mps_style_transfer::train(const float_array_map& inputs) {
   if (@available(macOS 10.15, *)) {
     NSDictionary<NSString *, NSData *> *dictInputs
         = [TCMPSStyleTransferHelpers toNSDictionary: inputs];


### PR DESCRIPTION
Renamed the `style_transfer` class to the `mps_style_transfer` class.