### PR TITLE
Style transfer Data Iterator

### DIFF
--- a/src/toolkits/CMakeLists.txt
+++ b/src/toolkits/CMakeLists.txt
@@ -17,6 +17,7 @@ prototype
 recsys
 sgd
 sparse_similarity
+style_transfer
 supervised_learning
 text
 util)

--- a/src/toolkits/style_transfer/CMakeLists.txt
+++ b/src/toolkits/style_transfer/CMakeLists.txt
@@ -2,7 +2,7 @@ project(unity_toolkits)
 
 make_library(unity_style_transfer OBJECT
 SOURCES
-    style_transfer.cpp
+    style_transfer_data_iterator.cpp
 REQUIRES
     unity_core
     unity_ml_model

--- a/src/toolkits/style_transfer/CMakeLists.txt
+++ b/src/toolkits/style_transfer/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(unity_toolkits)
+
+make_library(unity_style_transfer OBJECT
+SOURCES
+    style_transfer.cpp
+REQUIRES
+    unity_core
+    unity_ml_model
+)

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
@@ -5,19 +5,17 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "style_transfer_data_iterator.hpp"
+#include <toolkits/style_transfer/style_transfer_data_iterator.hpp>
 
 #include <core/data/image/io.hpp>
+#include <core/data/sframe/gl_sframe.hpp>
+#include <ml/neural_net/image_augmentation.hpp>
 #include <model_server/lib/image_util.hpp>
-
-#include <iostream>
 
 namespace turi {
 namespace style_transfer {
 
-using neural_net::image_annotation;
-using neural_net::labeled_image;
-using neural_net::shared_float_array;
+namespace {
 
 flex_image get_image(const flexible_type& image_feature) {
   if (image_feature.get_type() == flex_type_enum::STRING) {
@@ -27,19 +25,13 @@ flex_image get_image(const flexible_type& image_feature) {
   }
 }
 
-std::vector<flexible_type> get_style(const data_iterator::parameters& params) {
+gl_sarray get_style(const data_iterator::parameters& params) {
   gl_sarray style_images = params.style;
 
   if (style_images.dtype() == flex_type_enum::IMAGE)
     style_images = style_images.apply(image_util::encode_image, flex_type_enum::IMAGE);
 
-  std::vector<flexible_type> style_batch;
-  style_batch.reserve(style_images.size());
-
-  for (const auto& i : style_images.range_iterator())
-    style_batch.emplace_back(i);
-
-  return style_batch;
+  return style_images;
 }
 
 gl_sarray get_content(const data_iterator::parameters& params) {
@@ -51,17 +43,19 @@ gl_sarray get_content(const data_iterator::parameters& params) {
   return content_images;
 }
 
+}
+
 style_transfer_data_iterator::style_transfer_data_iterator(
     const data_iterator::parameters& params)
-    : m_style_vector(get_style(params)),
-      m_content(get_content(params)),
+    : m_style_images(get_style(params)),
+      m_content_images(get_content(params)),
       m_repeat(params.repeat),
       m_shuffle(params.shuffle),
-      m_content_range_iterator(m_content.range_iterator()),
+      m_content_range_iterator(m_content_images.range_iterator()),
       m_content_next_row(m_content_range_iterator.begin()),
       m_random_engine(params.random_seed) {}
 
-std::vector<st_image> style_transfer_data_iterator::next_batch(
+std::vector<st_example> style_transfer_data_iterator::next_batch(
     size_t batch_size) {
 
   std::vector<std::tuple<flexible_type, flexible_type, flexible_type>>
@@ -71,15 +65,15 @@ std::vector<st_image> style_transfer_data_iterator::next_batch(
   while (raw_batch.size() < batch_size && m_content_next_row != m_content_range_iterator.end()) {
     const turi::flexible_type& content_image = *m_content_next_row;
 
-    std::uniform_int_distribution<size_t> dist(0, m_style_vector.size() - 1);
+    std::uniform_int_distribution<size_t> dist(0, m_style_images.size() - 1);
     size_t random_style_index = dist(m_random_engine);
-    const flexible_type& style_image = m_style_vector.at(random_style_index);
+    const flexible_type& style_image = m_style_images[random_style_index];
 
     raw_batch.emplace_back(content_image, style_image, random_style_index);
 
     if (++m_content_next_row == m_content_range_iterator.end() && m_repeat) {
       if (m_shuffle) {
-        gl_sarray indices = gl_sarray::from_sequence(0, m_content.size());
+        gl_sarray indices = gl_sarray::from_sequence(0, m_content_images.size());
         std::uniform_int_distribution<uint64_t> dist(0);
         uint64_t random_mask = dist(m_random_engine);
         auto randomize_indices = [random_mask](const flexible_type& x) {
@@ -87,26 +81,26 @@ std::vector<st_image> style_transfer_data_iterator::next_batch(
           return flexible_type(hash64(masked_index));
         };
 
-        gl_sframe temp_content({{"content", m_content}});
+        gl_sframe temp_content({{"content", m_content_images}});
         temp_content.add_column(
             indices.apply(randomize_indices, flex_type_enum::INTEGER, false),
             "_random_order");
 
         temp_content = temp_content.sort("_random_order");
-        m_content = temp_content["content"];
+        m_content_images = temp_content["content"];
       }
     }
   }
 
-  std::vector<st_image> result(raw_batch.size());
+  std::vector<st_example> result(raw_batch.size());
 
   for (size_t i = 0; i < raw_batch.size(); ++i) {
     flexible_type content_image, style_image, style_index;
     std::tie(content_image, style_image, style_index) = raw_batch[i];
 
-    result[i].style = get_image(style_image);
-    result[i].content = get_image(content_image);
-    result[i].index = style_index.get<flex_int>();
+    result[i].style_image = get_image(style_image);
+    result[i].content_image = get_image(content_image);
+    result[i].style_index = style_index.get<flex_int>();
   }
 
   return result;

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
@@ -1,0 +1,123 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include "style_transfer_data_iterator.hpp"
+
+#include <core/data/image/io.hpp>
+#include <model_server/lib/image_util.hpp>
+
+namespace turi {
+namespace style_transfer {
+
+using neural_net::image_annotation;
+using neural_net::labeled_image;
+using neural_net::shared_float_array;
+
+flex_image get_image(const flexible_type& image_feature) {
+  if (image_feature.get_type() == flex_type_enum::STRING) {
+    return read_image(image_feature, /* format_hint */ "");
+  } else {
+    return image_feature;
+  }
+}
+
+std::vector<flexible_type> get_style(const data_iterator::parameters& params) {
+  gl_sarray style_images = params.style[params.style_column_name];
+
+  if (style_images.dtype() == flex_type_enum::IMAGE) {
+    style_images =
+        style_images.apply(image_util::encode_image, flex_type_enum::IMAGE);
+  }
+
+  gl_sframe result({{params.style_column_name, style_images}});
+
+  std::vector<flexible_type> style_batch;
+  style_batch.reserve(result.size());
+
+  for (const auto& i : result.range_iterator()) {
+    const flexible_type& style_image = i[0];
+    style_batch.emplace_back(style_image);
+  }
+
+  return style_batch;
+}
+
+gl_sframe get_content(const data_iterator::parameters& params) {
+  gl_sarray content_images = params.style[params.content_column_name];
+
+  if (content_images.dtype() == flex_type_enum::IMAGE) {
+    content_images =
+        content_images.apply(image_util::encode_image, flex_type_enum::IMAGE);
+  }
+
+  gl_sframe result({{params.content_column_name, content_images}});
+
+  return result;
+}
+
+style_transfer_data_iterator::style_transfer_data_iterator(
+    const parameters& params)
+    : m_style_vector(get_style(params)),
+      m_content(get_content(params)),
+      m_style_column_name(params.style_column_name),
+      m_content_column_name(params.content_column_name),
+      m_repeat(params.repeat),
+      m_shuffle(params.shuffle),
+      m_content_range_iterator(m_content.range_iterator()),
+      m_content_next_row(m_content_range_iterator.begin()),
+      m_random_engine(params.random_seed) {}
+
+std::vector<st_image> style_transfer_data_iterator::next_batch(
+    size_t batch_size) {
+  std::vector<std::tuple<flexible_type, flexible_type, flexible_type>>
+      raw_batch;
+  raw_batch.reserve(batch_size);
+
+  while (raw_batch.size() < batch_size &&
+         m_content_next_row != m_content_range_iterator.end()) {
+    const sframe_rows::row& content_row = *m_content_next_row;
+
+    std::uniform_int_distribution<size_t> dist(0, m_style_vector.size() - 1);
+    size_t random_style_index = dist(m_random_engine);
+    const flexible_type& style_image = m_style_vector.at(random_style_index);
+
+    raw_batch.emplace_back(content_row[0], style_image, random_style_index);
+
+    if (++m_content_next_row == m_content_range_iterator.end() && m_repeat) {
+      if (m_shuffle) {
+        gl_sarray indices = gl_sarray::from_sequence(0, m_content.size());
+        std::uniform_int_distribution<uint64_t> dist(0);
+        uint64_t random_mask = dist(m_random_engine);
+        auto randomize_indices = [random_mask](const flexible_type& x) {
+          uint64_t masked_index = random_mask ^ x.to<uint64_t>();
+          return flexible_type(hash64(masked_index));
+        };
+        m_content.add_column(
+            indices.apply(randomize_indices, flex_type_enum::INTEGER, false),
+            "_random_order");
+        m_content = m_content.sort("_random_order");
+        m_content.remove_column("_random_order");
+      }
+    }
+  }
+
+  std::vector<st_image> result(raw_batch.size());
+
+  for (size_t i = 0; i < raw_batch.size(); ++i) {
+    flexible_type content_image, style_image, style_index;
+    std::tie(content_image, style_image, style_index) = raw_batch[i];
+
+    result[i].style = get_image(style_image);
+    result[i].content = get_image(content_image);
+    result[i].index = style_index.get<flex_int>();
+  }
+
+  return result;
+}
+
+}  // namespace style_transfer
+}  // namespace turi

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
@@ -25,30 +25,18 @@ flex_image get_image(const flexible_type& image_feature) {
   }
 }
 
-gl_sarray get_style(const data_iterator::parameters& params) {
-  gl_sarray style_images = params.style;
-
-  if (style_images.dtype() == flex_type_enum::IMAGE)
-    style_images = style_images.apply(image_util::encode_image, flex_type_enum::IMAGE);
-
-  return style_images;
-}
-
-gl_sarray get_content(const data_iterator::parameters& params) {
-  gl_sarray content_images = params.content;
-
-  if (content_images.dtype() == flex_type_enum::IMAGE)
-    content_images = content_images.apply(image_util::encode_image, flex_type_enum::IMAGE);
-
-  return content_images;
+gl_sarray ensure_encoded(const gl_sarray& sa) {
+  if (sa.dtype() == flex_type_enum::IMAGE)
+    return sa.apply(image_util::encode_image, flex_type_enum::IMAGE);
+  return sa;
 }
 
 }
 
 style_transfer_data_iterator::style_transfer_data_iterator(
     const data_iterator::parameters& params)
-    : m_style_images(get_style(params)),
-      m_content_images(get_content(params)),
+    : m_style_images(ensure_encoded(params.style)),
+      m_content_images(ensure_encoded(params.content)),
       m_repeat(params.repeat),
       m_shuffle(params.shuffle),
       m_content_range_iterator(m_content_images.range_iterator()),

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.hpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.hpp
@@ -1,0 +1,96 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef __TOOLKITS_STYLE_TRANSFER_H_
+#define __TOOLKITS_STYLE_TRANSFER_H_
+
+#include <functional>
+#include <map>
+#include <memory>
+
+#include <core/data/sframe/gl_sframe.hpp>
+#include <core/logging/table_printer/table_printer.hpp>
+#include <ml/neural_net/compute_context.hpp>
+#include <ml/neural_net/model_backend.hpp>
+#include <ml/neural_net/model_spec.hpp>
+#include <model_server/lib/extensions/ml_model.hpp>
+#include <toolkits/coreml_export/mlmodel_wrapper.hpp>
+
+namespace turi {
+namespace style_transfer {
+
+struct st_image {
+  image_type style;
+  image_type content;
+  size_t index;
+};
+
+class data_iterator {
+ public:
+  struct parameters {
+    /** The Style SFrame to traverse */
+    gl_sframe style;
+
+    /** The Content SFrame to traverse */
+    gl_sframe content;
+
+    /**
+     * The name of the column containing the style images.
+     */
+    std::string style_column_name;
+
+    /**
+     * The name of the column containing the content images.
+     */
+    std::string content_column_name;
+
+    /**
+     * Whether to traverse the data more than once.
+     */
+    bool repeat = true;
+
+    /** Whether to shuffle the data on subsequent traversals. */
+    bool shuffle = true;
+
+    /** Determines results of shuffle operations if enabled. */
+    int random_seed = 0;
+  };
+
+  virtual ~data_iterator() = default;
+
+  virtual std::vector<st_image> next_batch(size_t batch_size) = 0;
+};
+
+class style_transfer_data_iterator : public data_iterator {
+  style_transfer_data_iterator(const parameters& params);
+
+  style_transfer_data_iterator(const style_transfer_data_iterator&) = delete;
+  style_transfer_data_iterator& operator=(const style_transfer_data_iterator&) =
+      delete;
+
+  std::vector<st_image> next_batch(size_t batch_size) override;
+
+ private:
+  std::vector<flexible_type> m_style_vector;
+  gl_sframe m_content;
+
+  std::string m_style_column_name;
+  std::string m_content_column_name;
+
+  const bool m_repeat;
+  const bool m_shuffle;
+
+  gl_sframe_range m_content_range_iterator;
+  gl_sframe_range::iterator m_content_next_row;
+
+  std::default_random_engine m_random_engine;
+};
+
+}  // namespace style_transfer
+}  // namespace turi
+
+#endif  // __TOOLKITS_STYLE_TRANSFER_H_

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.hpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.hpp
@@ -8,25 +8,17 @@
 #ifndef __TOOLKITS_STYLE_TRANSFER_DATA_ITERATOR_H_
 #define __TOOLKITS_STYLE_TRANSFER_DATA_ITERATOR_H_
 
-#include <functional>
-#include <map>
-#include <memory>
+#include <random>
 
-#include <core/data/sframe/gl_sframe.hpp>
-#include <core/logging/table_printer/table_printer.hpp>
-#include <ml/neural_net/compute_context.hpp>
-#include <ml/neural_net/model_backend.hpp>
-#include <ml/neural_net/model_spec.hpp>
-#include <model_server/lib/extensions/ml_model.hpp>
-#include <toolkits/coreml_export/mlmodel_wrapper.hpp>
+#include <core/data/sframe/gl_sarray.hpp>
 
 namespace turi {
 namespace style_transfer {
 
-struct st_image {
-  image_type style;
-  image_type content;
-  size_t index;
+struct st_example {
+  image_type content_image;
+  image_type style_image;
+  size_t style_index;
 };
 
 class data_iterator {
@@ -52,7 +44,7 @@ class data_iterator {
 
   virtual ~data_iterator() = default;
 
-  virtual std::vector<st_image> next_batch(size_t batch_size) = 0;
+  virtual std::vector<st_example> next_batch(size_t batch_size) = 0;
 };
 
 class style_transfer_data_iterator : public data_iterator {
@@ -63,11 +55,11 @@ class style_transfer_data_iterator : public data_iterator {
   style_transfer_data_iterator& operator=(const style_transfer_data_iterator&) =
       delete;
 
-  std::vector<st_image> next_batch(size_t batch_size) override;
+  std::vector<st_example> next_batch(size_t batch_size) override;
 
  private:
-  std::vector<flexible_type> m_style_vector;
-  gl_sarray m_content;
+  gl_sarray m_style_images;
+  gl_sarray m_content_images;
 
   const bool m_repeat;
   const bool m_shuffle;

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.hpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.hpp
@@ -5,8 +5,8 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef __TOOLKITS_STYLE_TRANSFER_H_
-#define __TOOLKITS_STYLE_TRANSFER_H_
+#ifndef __TOOLKITS_STYLE_TRANSFER_DATA_ITERATOR_H_
+#define __TOOLKITS_STYLE_TRANSFER_DATA_ITERATOR_H_
 
 #include <functional>
 #include <map>
@@ -32,21 +32,11 @@ struct st_image {
 class data_iterator {
  public:
   struct parameters {
-    /** The Style SFrame to traverse */
-    gl_sframe style;
+    /** The Style SArray to traverse */
+    gl_sarray style;
 
-    /** The Content SFrame to traverse */
-    gl_sframe content;
-
-    /**
-     * The name of the column containing the style images.
-     */
-    std::string style_column_name;
-
-    /**
-     * The name of the column containing the content images.
-     */
-    std::string content_column_name;
+    /** The Content SArray to traverse */
+    gl_sarray content;
 
     /**
      * Whether to traverse the data more than once.
@@ -66,7 +56,8 @@ class data_iterator {
 };
 
 class style_transfer_data_iterator : public data_iterator {
-  style_transfer_data_iterator(const parameters& params);
+ public:
+  style_transfer_data_iterator(const data_iterator::parameters& params);
 
   style_transfer_data_iterator(const style_transfer_data_iterator&) = delete;
   style_transfer_data_iterator& operator=(const style_transfer_data_iterator&) =
@@ -76,16 +67,13 @@ class style_transfer_data_iterator : public data_iterator {
 
  private:
   std::vector<flexible_type> m_style_vector;
-  gl_sframe m_content;
-
-  std::string m_style_column_name;
-  std::string m_content_column_name;
+  gl_sarray m_content;
 
   const bool m_repeat;
   const bool m_shuffle;
 
-  gl_sframe_range m_content_range_iterator;
-  gl_sframe_range::iterator m_content_next_row;
+  gl_sarray_range m_content_range_iterator;
+  gl_sarray_range::iterator m_content_next_row;
 
   std::default_random_engine m_random_engine;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(TuriTest)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
 enable_testing()
 
 subdirs(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(TuriTest)
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
 enable_testing()
 
 subdirs(

--- a/test/toolkits/CMakeLists.txt
+++ b/test/toolkits/CMakeLists.txt
@@ -1,2 +1,2 @@
-
+subdirs(style_transfer)
 

--- a/test/toolkits/style_transfer/CMakeLists.txt
+++ b/test/toolkits/style_transfer/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(neural_net_test)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
 make_library(style_transfer_toolkit_test_utils
   SOURCES
     utils.cpp

--- a/test/toolkits/style_transfer/CMakeLists.txt
+++ b/test/toolkits/style_transfer/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(neural_net_test)
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
 make_library(style_transfer_toolkit_test_utils
   SOURCES
     utils.cpp

--- a/test/toolkits/style_transfer/CMakeLists.txt
+++ b/test/toolkits/style_transfer/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(neural_net_test)
+
+make_library(style_transfer_toolkit_test_utils
+  SOURCES
+    utils.cpp
+  REQUIRES
+    unity_shared_for_testing
+)
+
+make_boost_test(test_style_transfer_data_iterator.cxx
+  REQUIRES
+    style_transfer_toolkit_test_utils
+)

--- a/test/toolkits/style_transfer/CMakeLists.txt
+++ b/test/toolkits/style_transfer/CMakeLists.txt
@@ -4,6 +4,7 @@ make_library(style_transfer_toolkit_test_utils
   SOURCES
     utils.cpp
   REQUIRES
+  	unity_style_transfer
     unity_shared_for_testing
 )
 

--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -8,11 +8,12 @@
 #define BOOST_TEST_MODULE
 
 #include <string>
-#include <toolkits/style_transfer/utils.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include <core/util/test_macros.hpp>
 #include <toolkits/style_transfer/style_transfer_data_iterator.hpp>
+
+#include "utils.hpp"
 
 using namespace turi::style_transfer;
 

--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -12,4 +12,33 @@
 
 #include <toolkits/style_transfer/style_transfer_data_iterator.hpp>
 
-BOOST_AUTO_TEST_CASE(test_initialization) {}
+#include <string>
+
+#include <iostream>
+
+#include "utils.hpp"
+
+using namespace style_transfer_testing;
+using namespace turi::style_transfer;
+
+BOOST_AUTO_TEST_CASE(test_initialization) {
+  const size_t test_batch_size = 6;
+  const size_t expected_batch_array[] = { 6, 6, 6, 6, 6, 6, 6, 6, 2 };
+
+  size_t expected_batch_size = sizeof(expected_batch_array)/sizeof(expected_batch_array[0]);
+
+  turi::gl_sarray style_sarray = style_transfer_testing::random_image_sarray(8);
+  turi::gl_sarray content_sarray = style_transfer_testing::random_image_sarray(50);
+  
+  data_iterator::parameters params;
+
+  params.style = style_sarray;
+  params.content = content_sarray;
+
+  style_transfer_data_iterator iter(params);
+
+  for (size_t x = 0; x < expected_batch_size; x++) {
+    std::vector<st_image> test_batch = iter.next_batch(test_batch_size);
+    TS_ASSERT(test_batch.size() == expected_batch_array[x]);
+  }
+}

--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -8,7 +8,7 @@
 #define BOOST_TEST_MODULE
 
 #include <string>
-#include <utils.hpp>
+#include <toolkits/style_transfer/utils.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include <core/util/test_macros.hpp>

--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -7,26 +7,23 @@
 
 #define BOOST_TEST_MODULE
 
+#include <string>
+#include <utils.hpp>
+
 #include <boost/test/unit_test.hpp>
 #include <core/util/test_macros.hpp>
-
 #include <toolkits/style_transfer/style_transfer_data_iterator.hpp>
 
-#include <string>
-
-#include "utils.hpp"
-
-using namespace style_transfer_testing;
 using namespace turi::style_transfer;
 
 BOOST_AUTO_TEST_CASE(test_initialization) {
   const size_t test_batch_size = 6;
   const size_t expected_batch_array[] = { 6, 6, 6, 6, 6, 6, 6, 6, 2 };
 
-  size_t expected_batch_size = sizeof(expected_batch_array)/sizeof(expected_batch_array[0]);
+  size_t expected_batch_size = sizeof(expected_batch_array)/sizeof(size_t);
 
-  turi::gl_sarray style_sarray = style_transfer_testing::random_image_sarray(8);
-  turi::gl_sarray content_sarray = style_transfer_testing::random_image_sarray(50);
+  turi::gl_sarray style_sarray = random_image_sarray(8);
+  turi::gl_sarray content_sarray = random_image_sarray(50);
   
   data_iterator::parameters params;
 
@@ -38,5 +35,18 @@ BOOST_AUTO_TEST_CASE(test_initialization) {
   for (size_t x = 0; x < expected_batch_size; x++) {
     std::vector<st_example> test_batch = iter.next_batch(test_batch_size);
     TS_ASSERT(test_batch.size() == expected_batch_array[x]);
+    for (size_t y = 0; y < test_batch.size(); y++) {
+      size_t offset = x * test_batch_size + y;
+
+      size_t style_index = test_batch[y].style_index;
+      turi::image_type content_image = test_batch[y].content_image;
+      turi::image_type style_image = test_batch[y].style_image;
+
+      turi::image_type expected_content_image = content_sarray[offset].get<turi::flex_image>();
+      turi::image_type expected_style_image = style_sarray[style_index].get<turi::flex_image>();
+
+      TS_ASSERT(expected_content_image == content_image);
+      TS_ASSERT(expected_style_image == style_image);
+    }
   }
 }

--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -1,0 +1,15 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+
+#include <toolkits/style_transfer/style_transfer_data_iterator.hpp>
+
+BOOST_AUTO_TEST_CASE(test_initialization) {}

--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include <iostream>
-
 #include "utils.hpp"
 
 using namespace style_transfer_testing;
@@ -38,7 +36,7 @@ BOOST_AUTO_TEST_CASE(test_initialization) {
   style_transfer_data_iterator iter(params);
 
   for (size_t x = 0; x < expected_batch_size; x++) {
-    std::vector<st_image> test_batch = iter.next_batch(test_batch_size);
+    std::vector<st_example> test_batch = iter.next_batch(test_batch_size);
     TS_ASSERT(test_batch.size() == expected_batch_array[x]);
   }
 }

--- a/test/toolkits/style_transfer/utils.cpp
+++ b/test/toolkits/style_transfer/utils.cpp
@@ -5,7 +5,7 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include <toolkits/style_transfer/utils.hpp>
+#include "utils.hpp"
 
 #include <model_server/lib/image_util.hpp>
 

--- a/test/toolkits/style_transfer/utils.cpp
+++ b/test/toolkits/style_transfer/utils.cpp
@@ -5,9 +5,12 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "utils.hpp"
+#include <utils.hpp>
 
-namespace style_transfer_testing {
+#include <model_server/lib/image_util.hpp>
+
+namespace turi {
+namespace style_transfer {
 
 std::string generate_data(size_t data_size) {
   std::string data_array;
@@ -42,7 +45,7 @@ turi::gl_sarray random_image_sarray(size_t length) {
   turi::gl_sarray sa;
   sa.construct_from_vector(image_column_data, turi::flex_type_enum::IMAGE);
 
-  return sa;
+  return sa.apply(turi::image_util::encode_image, turi::flex_type_enum::IMAGE);;
 }
 
 turi::gl_sframe random_sframe(size_t length, std::string image_column_name) {
@@ -53,4 +56,5 @@ turi::gl_sframe random_sframe(size_t length, std::string image_column_name) {
   return image_sf;
 }
 
-} // namespace style_transfer_testing
+} // namespace style_transfer
+} // namespace turi

--- a/test/toolkits/style_transfer/utils.cpp
+++ b/test/toolkits/style_transfer/utils.cpp
@@ -5,7 +5,7 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include <utils.hpp>
+#include <toolkits/style_transfer/utils.hpp>
 
 #include <model_server/lib/image_util.hpp>
 

--- a/test/toolkits/style_transfer/utils.cpp
+++ b/test/toolkits/style_transfer/utils.cpp
@@ -1,0 +1,56 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include "utils.hpp"
+
+namespace style_transfer_testing {
+
+std::string generate_data(size_t data_size) {
+  std::string data_array;
+  data_array.reserve(data_size);
+  for (size_t x = 0; x < data_size; x++)
+    data_array[x] = static_cast<char>((uint8_t)(rand() % 256));
+
+  return data_array;
+}
+
+turi::flex_image random_image() {
+  size_t height = ((size_t)(rand() % 10) + 15);
+  size_t width = ((size_t)(rand() % 10) + 15);
+  size_t channels = 3;
+
+  size_t data_size = height * width * channels;
+
+  size_t image_type_version = IMAGE_TYPE_CURRENT_VERSION;
+  size_t format = 2;
+
+  std::string img_data = generate_data(data_size);
+
+  return turi::image_type(img_data.c_str(), height, width, channels, data_size,
+                          image_type_version, format);
+}
+
+turi::gl_sarray random_image_sarray(size_t length) {
+  std::vector<turi::flexible_type> image_column_data;
+  for (size_t x = 0; x < length; x++)
+    image_column_data.push_back(random_image());
+
+  turi::gl_sarray sa;
+  sa.construct_from_vector(image_column_data, turi::flex_type_enum::IMAGE);
+
+  return sa;
+}
+
+turi::gl_sframe random_sframe(size_t length, std::string image_column_name) {
+  turi::gl_sarray image_sa = random_image_sarray(length);
+  turi::gl_sframe image_sf;
+  image_sf.add_column(image_sa, image_column_name);
+
+  return image_sf;
+}
+
+} // namespace style_transfer_testing

--- a/test/toolkits/style_transfer/utils.hpp
+++ b/test/toolkits/style_transfer/utils.hpp
@@ -1,0 +1,29 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef __TC_TEST_TOOLKITS_STYLE_TRANSFER_UTILS
+#define __TC_TEST_TOOLKITS_STYLE_TRANSFER_UTILS
+
+#include <core/data/flexible_type/flexible_type.hpp>
+#include <core/data/image/image_type.hpp>
+#include <core/data/sframe/gl_sarray.hpp>
+#include <core/data/sframe/gl_sframe.hpp>
+#include <core/storage/sframe_data/testing_utils.hpp>
+#include <core/util/testing_utils.hpp>
+
+#include <string>
+
+namespace style_transfer_testing {
+
+std::string generate_data(size_t data_size);
+turi::flex_image random_image();
+turi::gl_sarray random_image_sarray(size_t length);
+turi::gl_sframe random_sframe(size_t length, std::string image_column_name);
+
+} // namespace style_transfer_testing
+
+#endif // __TC_TEST_TOOLKITS_STYLE_TRANSFER_UTILS

--- a/test/toolkits/style_transfer/utils.hpp
+++ b/test/toolkits/style_transfer/utils.hpp
@@ -17,13 +17,16 @@
 
 #include <string>
 
-namespace style_transfer_testing {
+
+namespace turi {
+namespace style_transfer {
 
 std::string generate_data(size_t data_size);
 turi::flex_image random_image();
 turi::gl_sarray random_image_sarray(size_t length);
 turi::gl_sframe random_sframe(size_t length, std::string image_column_name);
 
-} // namespace style_transfer_testing
+} // namespace style_transfer
+} // namespace turi
 
 #endif // __TC_TEST_TOOLKITS_STYLE_TRANSFER_UTILS


### PR DESCRIPTION
## Overview

Setup the class for the Style Transfer Data Iterator. It takes in data iterator params. and the relevant method on this iterator is `next_batch`. `next_batch` returns a batch containing a tie of `content_image`, `style_image`, and `style_index`.