### PR TITLE
[C++ OD] Add import function for Python saved model. Fix import function for C++ saved model.

### DIFF
--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -25,7 +25,10 @@ using CoreML::Specification::ConvolutionLayerParams;
 using CoreML::Specification::InnerProductLayerParams;
 using CoreML::Specification::Model;
 using CoreML::Specification::NeuralNetwork;
+using CoreML::Specification::NeuralNetworkImageScaler;
 using CoreML::Specification::NeuralNetworkLayer;
+using CoreML::Specification::NeuralNetworkPreprocessing;
+using CoreML::Specification::PoolingLayerParams;
 using CoreML::Specification::SamePadding;
 using CoreML::Specification::UniDirectionalLSTMLayerParams;
 using CoreML::Specification::WeightParams;
@@ -551,6 +554,35 @@ void model_spec::add_sigmoid(const std::string& name,
   layer->mutable_activation()->mutable_sigmoid();
 }
 
+void model_spec::add_pooling(const std::string& name, const std::string& input,
+                             size_t kernel_height, size_t kernel_width,
+                             size_t stride_h, size_t stride_w,
+                             padding_type padding,
+                             bool use_poolexcludepadding) {
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  PoolingLayerParams* params = layer->mutable_pooling();
+  params->add_kernelsize(kernel_height);
+  params->add_kernelsize(kernel_width);
+  params->add_stride(stride_h);
+  params->add_stride(stride_w);
+  switch (padding) {
+    case padding_type::VALID:
+      params->mutable_valid()->mutable_paddingamounts()->add_borderamounts();
+      params->mutable_valid()->mutable_paddingamounts()->add_borderamounts();
+      break;
+    case padding_type::SAME:
+      params->mutable_same();
+      break;
+  }
+  if (use_poolexcludepadding) {
+    params->set_avgpoolexcludepadding(true);
+  }
+}
+
 void model_spec::add_convolution(
     const std::string& name, const std::string& input,
     size_t num_output_channels, size_t num_kernel_channels,
@@ -849,6 +881,14 @@ void model_spec::add_lstm(
                      output_vector_size, initializers.block_input_bias_fn);
   init_weight_params(lstm_weights->mutable_outputgatebiasvector(),
                      output_vector_size, initializers.output_gate_bias_fn);
+}
+
+void model_spec::add_preprocessing(const std::string& feature_name,
+                                   const float image_scale) {
+  NeuralNetworkPreprocessing* layer = impl_->add_preprocessing();
+  layer->set_featurename(feature_name);
+  NeuralNetworkImageScaler* image_scaler = layer->mutable_scaler();
+  image_scaler->set_channelscale(image_scale);
 }
 
 }  // neural_net

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -148,7 +148,7 @@ public:
   void add_sigmoid(const std::string& name, const std::string& input);
 
   /**
-   * Appends a pooliong layer.
+   * Appends a pooling layer.
    */
   void add_pooling(const std::string& name, const std::string& input,
                    size_t kernel_height, size_t kernel_width, size_t stride_h,
@@ -333,8 +333,8 @@ public:
   // this could be shared in some form with coremltools.
 
   /**
-   * Appends an preprocessing layer
-   * Now only support image scaleing preprocessing though.
+   * Appends a preprocessing layer
+   * Now only support image scaling preprocessing though.
    */
   void add_preprocessing(const std::string& feature_name,
                          const float image_scale);

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -148,6 +148,14 @@ public:
   void add_sigmoid(const std::string& name, const std::string& input);
 
   /**
+   * Appends a pooliong layer.
+   */
+  void add_pooling(const std::string& name, const std::string& input,
+                   size_t kernel_height, size_t kernel_width, size_t stride_h,
+                   size_t stride_w, padding_type padding,
+                   bool use_poolexcludepadding);
+
+  /**
    * Appends a convolution layer.
    *
    * \param name The name of the layer and its output
@@ -324,8 +332,14 @@ public:
   // needed. If/when we support the full range of NeuralNetworkLayer values,
   // this could be shared in some form with coremltools.
 
-private:
+  /**
+   * Appends an preprocessing layer
+   * Now only support image scaleing preprocessing though.
+   */
+  void add_preprocessing(const std::string& feature_name,
+                         const float image_scale);
 
+ private:
   std::unique_ptr<CoreML::Specification::NeuralNetwork> impl_;
 };
 

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -506,8 +506,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         'training_epochs': training_iterations * batch_size // num_images,
         'training_iterations': training_iterations,
         'max_iterations': max_iterations,
-        'training_loss': progress['smoothed_loss'],
-        'use_tensorflow': params['use_tensorflow']
+        'training_loss': progress['smoothed_loss']
     }
     return ObjectDetector(state)
 

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -506,7 +506,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         'training_epochs': training_iterations * batch_size // num_images,
         'training_iterations': training_iterations,
         'max_iterations': max_iterations,
-        'training_loss': progress['smoothed_loss']
+        'training_loss': progress['smoothed_loss'],
     }
     return ObjectDetector(state)
 

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -507,6 +507,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         'training_iterations': training_iterations,
         'max_iterations': max_iterations,
         'training_loss': progress['smoothed_loss'],
+        'use_tensorflow': params['use_tensorflow']
     }
     return ObjectDetector(state)
 

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -353,7 +353,7 @@ void object_detector::load_version(iarchive& iarc, size_t version) {
 void object_detector::import_from_custom_model(variant_map_type model_data,
                                                size_t version) {
   auto model_iter = model_data.find("_model");
-  if (model_iter == model_data.end()){
+  if (model_iter == model_data.end()) {
     log_and_throw("The loaded turicreate model must contain '_model'!\n");
   }
   const flex_dict& model = variant_get_value<flex_dict>(model_iter->second);
@@ -363,7 +363,8 @@ void object_detector::import_from_custom_model(variant_map_type model_data,
     height = 13;
     width = 13;
   } else {
-    std::vector<size_t> shape = variant_get_value<std::vector<size_t>>(shape_iter->second);
+    std::vector<size_t> shape =
+        variant_get_value<std::vector<size_t>>(shape_iter->second);
     height = shape[0];
     width = shape[1];
   }

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -897,6 +897,10 @@ std::unique_ptr<data_iterator> object_detector::create_iterator(
 
 std::unique_ptr<compute_context> object_detector::create_compute_context() const
 {
+  //add this line to prevent evaluation for python model from crash
+  if (state.find("use_tensorflow") == state.end()){
+    return compute_context::create();
+  }
   bool use_tensorflow = read_state<bool>("use_tensorflow");
   if (use_tensorflow) {
     return compute_context::create_tf();

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -279,10 +279,6 @@ void object_detector::init_options(
       /* default_value     */ "center",
       /* allowed_values    */ {flexible_type("center"), flexible_type("top_left"), flexible_type("bottom_left")},
       /* allowed_overwrite */ false);
-  options.create_boolean_option(
-      /* name             */ "use_tensorflow",
-      /* description      */
-      "If set to True, model training will be done using TensorFlow.", false);
 
   // Validate user-provided options.
   options.set_options(opts);
@@ -902,16 +898,7 @@ std::unique_ptr<data_iterator> object_detector::create_iterator(
 
 std::unique_ptr<compute_context> object_detector::create_compute_context() const
 {
-  //add this line to prevent evaluation for python model from crash
-  if (state.find("use_tensorflow") == state.end()){
-    return compute_context::create();
-  }
-  bool use_tensorflow = read_state<bool>("use_tensorflow");
-  if (use_tensorflow) {
-    return compute_context::create_tf();
-  } else {
-    return compute_context::create();
-  }
+  return compute_context::create();
 }
 
 void object_detector::init_train(

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -352,17 +352,21 @@ void object_detector::load_version(iarchive& iarc, size_t version) {
 
 void object_detector::import_from_custom_model(variant_map_type model_data,
                                                size_t version) {
-  auto it = model_data.find("_model");
-  const flex_dict& model = variant_get_value<flex_dict>(it->second);
-  auto it2 = model_data.find("_grid_shape");
-  if (it2 == model_data.end()) {
-    log_and_throw("The provided model must contain field '_grid_shape'!");
+  auto model_iter = model_data.find("_model");
+  if (model_iter == model_data.end()){
+    log_and_throw("The loaded turicreate model must contain '_model'!\n");
   }
-  std::vector<size_t> shape =
-      variant_get_value<std::vector<size_t>>(it2->second);
-  size_t height = shape[0];
-  size_t width = shape[1];
-  model_data.erase(it2);
+  const flex_dict& model = variant_get_value<flex_dict>(model_iter->second);
+  auto shape_iter = model_data.find("_grid_shape");
+  size_t height, width;
+  if (shape_iter == model_data.end()) {
+    height = 13;
+    width = 13;
+  } else {
+    std::vector<size_t> shape = variant_get_value<std::vector<size_t>>(shape_iter->second);
+    height = shape[0];
+    width = shape[1];
+  }
   model_data.emplace("grid_height", height);
   model_data.emplace("grid_width", width);
 
@@ -413,7 +417,7 @@ void object_detector::import_from_custom_model(variant_map_type model_data,
                     variant_get_value<size_t>(state.at("num_classes")),
                     anchor_boxes());
   nn_spec_->update_params(nn_params);
-  model_data.erase(it);
+  model_data.erase(model_iter);
   return;
 }
 

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -355,7 +355,7 @@ void object_detector::import_from_custom_model(variant_map_type model_data,
   auto it = model_data.find("_model");
   const flex_dict& model = variant_get_value<flex_dict>(it->second);
   auto it2 = model_data.find("_grid_shape");
-  if (it2 == model_data.end()){
+  if (it2 == model_data.end()) {
     log_and_throw("The provided model must contain field '_grid_shape'!");
   }
   std::vector<size_t> shape =

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -356,7 +356,8 @@ void object_detector::import_from_custom_model(variant_map_type model_data,
   flex_dict model = variant_get_value<flex_dict>(it->second);
   model_data.erase(it);
   auto it2 = model_data.find("_grid_shape");
-  std::vector<size_t> shape = variant_get_value<std::vector<size_t>>(it2->second);
+  std::vector<size_t> shape =
+      variant_get_value<std::vector<size_t>>(it2->second);
   size_t height = shape[0];
   size_t width = shape[1];
   model_data.erase(it2);
@@ -465,6 +466,7 @@ void object_detector::train(gl_sframe data,
 
 variant_map_type object_detector::evaluate(
     gl_sframe data, std::string metric) {
+
   std::vector<std::string> metrics;
   static constexpr char AP[] = "average_precision";
   static constexpr char MAP[] = "mean_average_precision";
@@ -552,10 +554,12 @@ void object_detector::perform_predict(gl_sframe data,
   size_t grid_width = read_state<size_t>("grid_width");
   float iou_threshold =
       read_state<flex_float>("non_maximum_suppression_threshold");
+
   // Bind the data to a data iterator.
   std::unique_ptr<data_iterator> data_iter = create_iterator(
       data, std::vector<std::string>(class_labels.begin(), class_labels.end()),
       /* repeat */ false);
+
   // Instantiate the compute context.
   std::unique_ptr<compute_context> ctx = create_compute_context();
   if (ctx == nullptr) {
@@ -581,6 +585,7 @@ void object_detector::perform_predict(gl_sframe data,
       shared_float_array::wrap(get_max_iterations());
   pred_config["num_classes"] =
       shared_float_array::wrap(get_num_classes());
+
   std::unique_ptr<model_backend> model = ctx->create_object_detector(
       /* n       */ read_state<int>("batch_size"),
       /* c_in    */ NUM_INPUT_CHANNELS,
@@ -591,6 +596,7 @@ void object_detector::perform_predict(gl_sframe data,
       /* w_out   */ grid_width,
       /* config  */ pred_config,
       /* weights */ get_model_params());
+    
   // To support double buffering, use a queue of pending inference results.
   std::queue<image_augmenter::result> pending_batches;
 

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -43,6 +43,7 @@ class EXPORT object_detector: public ml_model_base {
   gl_sarray predict(gl_sframe data);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename, std::map<std::string, flexible_type> opts);
+  void import_from_custom_model(variant_map_type model_data, size_t version);
 
   // Register with Unity server
 
@@ -99,6 +100,9 @@ class EXPORT object_detector: public ml_model_base {
       "    the confidence_threshold are eliminiated. If no value is specified,\n"
       "    a default value of 0.25 is used.\n"
   );
+
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::import_from_custom_model,
+                                 "model_data", "version");
 
   // TODO: Remainder of interface: predict, etc.
 


### PR DESCRIPTION
In this PR I did several things:
1. Import for C++ saved model:
    Mainly in od_serialization.cpp::init_darknet_yolo(),
    I add max pooling layer, preprocessing layer, and change the input of the network,
    in order to make the nn_spec exactly the same as which we get when we train a model in c++.
    So in model_spec.cpp, I added pooling layer and preprocessing layer in order to use them. 
2. Import for Python saved model:
    Mainly in object_detector.cpp:import_from_custom(),
    It basically move the weight from saved Python model to c++.
3. Add "use_tensorflow" flag for Python model:
    Since currently when we evaluate a c++model, the code request a "use_tensorflow" flag,
    which wasn't presented in python model when it is trained with _advance_param =  
    {'use_tensorflow':false}. I simply add it to the model state.
    But for sure this flag should be removed in the future.

close #2399 