### PR TITLE
Fixed incorrect call to sampler.sample in unit test.

### DIFF
--- a/test/unity/toolkits/object_detection/one_shot_object_detection/test_parameter_sampler.cxx
+++ b/test/unity/toolkits/object_detection/one_shot_object_detection/test_parameter_sampler.cxx
@@ -16,6 +16,7 @@
 
 static constexpr int kMaxDimension = 6000;
 static constexpr int kNumRows = 1000;
+static constexpr int kBaseDimensionSize = 2500;
 
 namespace turi {
 namespace one_shot_object_detection {
@@ -39,8 +40,8 @@ constuct_angle_samples_map(ParameterSampler &sampler, int seed) {
   std::vector<double> phis;
   std::vector<double> gammas;
   for (int i = 0; i < kNumRows; i++) {
-    size_t background_width = 2500 + i;
-    size_t background_height = 2500 - i;
+    size_t background_width = kBaseDimensionSize + i;
+    size_t background_height = kBaseDimensionSize - i;
     sampler.sample(background_width, background_height, seed, i);
     double theta = sampler.get_theta();
     double phi = sampler.get_phi();

--- a/test/unity/toolkits/object_detection/one_shot_object_detection/test_parameter_sampler.cxx
+++ b/test/unity/toolkits/object_detection/one_shot_object_detection/test_parameter_sampler.cxx
@@ -39,7 +39,9 @@ constuct_angle_samples_map(ParameterSampler &sampler, int seed) {
   std::vector<double> phis;
   std::vector<double> gammas;
   for (int i = 0; i < kNumRows; i++) {
-    sampler.sample(seed + i);
+    size_t background_width = 2500 + i;
+    size_t background_height = 2500 - i;
+    sampler.sample(background_width, background_height, seed, i);
     double theta = sampler.get_theta();
     double phi = sampler.get_phi();
     double gamma = sampler.get_gamma();


### PR DESCRIPTION
Tested and fixed now.

C++ test build was failing because of this. Fixed now.