### PR TITLE
Fixed comparison function in Object Detector C++

### DIFF
--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -386,7 +386,7 @@ void object_detector::import_from_custom_model(variant_map_type model_data,
     }
   }
 
-  auto cmp = [](flex_dict::value_type& a, flex_dict::value_type& b) {
+  auto cmp = [](const flex_dict::value_type& a, const flex_dict::value_type& b) {
     return (a.first < b.first);
   };
 


### PR DESCRIPTION
Fixes #2436 

Added a const qualifier in the comparison function to pass Linux builds.

Waiting for internal builds to pass.