### PR TITLE
init/export model spec for DC

### DIFF
--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -186,9 +186,9 @@ void wrap_network_params(const std::string& name,
   params_out->emplace(name + "_beta", std::move(beta));
 
 
-  // The CoreML Spec uses the batchNorm layer to do instanceNormalization. This 
+  // The CoreML Spec uses the batchNorm layer to do instanceNormalization. This
   // can cause issues in CoreML imports because those layers in particular don't
-  // contain moving mean and moving variance values since the batch is 
+  // contain moving mean and moving variance values since the batch is
   // technically irrelevant in InstanceNorm. This check is in place to catch
   // these instances.
 
@@ -722,6 +722,16 @@ void model_spec::add_softmax(const std::string& name,
   layer->add_output(name);
 
   layer->mutable_softmax();
+}
+
+void model_spec::add_flatten(const std::string& name,
+                             const std::string& input) {
+  NeuralNetworkLayer* layer = impl_->add_layers();
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  layer->mutable_flatten();
 }
 
 void model_spec::add_addition(const std::string& name,

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -149,11 +149,16 @@ public:
 
   /**
    * Appends a pooling layer.
+   * By default, it's a max pooling layer. And it can only be max pooling
+   * TODO: be able to set other pooling types
+   *
+   * \param use_poolexcludepadding padded values are excluded from the
+   * count (denominator) when computing average pooling.
    */
   void add_pooling(const std::string& name, const std::string& input,
                    size_t kernel_height, size_t kernel_width, size_t stride_h,
                    size_t stride_w, padding_type padding,
-                   bool use_poolexcludepadding);
+                   bool use_poolexcludepadding = false);
 
   /**
    * Appends a convolution layer.
@@ -233,6 +238,18 @@ public:
    * \param input The name of the layer's input
    */
   void add_softmax(const std::string& name, const std::string& input);
+
+  /**
+   * Appends a layer that performs flatten normalization (along channel axis).
+   *
+   * currently only supports channel first flattening, which means if the input order is
+   * ``[C, H, W]``, then output array will be ``[C * H * W, 1, 1]``, still `C-major`
+   * orderring. No underlying array storage will be changed.
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   */
+  void add_flatten(const std::string& name, const std::string& input);
 
   /**
    * Appends a layer that performs elementwise addition.

--- a/src/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/toolkits/activity_classification/activity_classifier.hpp
@@ -21,7 +21,6 @@ namespace activity_classification {
 class EXPORT activity_classifier: public ml_model_base {
 
  public:
-  
   static std::tuple<gl_sframe, gl_sframe> random_split_by_session(
       gl_sframe data, std::string session_id_column_name, float fraction,
       size_t seed);

--- a/src/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -40,6 +40,11 @@ std::shared_ptr<coreml::MLModelWrapper> export_activity_classifier_model(
     const flex_list& features, size_t lstm_hidden_layer_size,
     const flex_list& class_labels, const flex_string& target);
 
+/** Wraps a trained drawing classifier model_spec as a complete MLModel. */
+std::shared_ptr<coreml::MLModelWrapper> export_drawing_classifier_model(
+    const neural_net::model_spec& nn_spec, const flex_list& features,
+    const flex_list& class_labels, const flex_string& target);
+
 }  // namespace turi
 
 #endif  // UNITY_TOOLKITS_COREML_EXPORT_NEURAL_NETS_MODELS_EXPORTER_HPP_

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -34,7 +34,7 @@ using neural_net::weight_initializer;
 using neural_net::zero_weight_initializer;
 
 using padding_type = model_spec::padding_type;
-// anoymous helper sections
+// anonymous helper sections
 
 }  // namespace
 

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -130,8 +130,8 @@ std::unique_ptr<model_spec> drawing_classifier::init_model() const {
   output_name = prefix + "_dense1_fwd";
 
   result->add_inner_product(
-      /* name                */ "dense_1",
-      /* input               */ "dense_0",
+      /* name                */ output_name,
+      /* input               */ input_name,
       /* num_output_channels */ 128,
       /* num_input_channels  */ num_classes,
       /* weight_init_fn      */ initializer);

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -34,7 +34,7 @@ using neural_net::weight_initializer;
 using neural_net::zero_weight_initializer;
 
 using padding_type = model_spec::padding_type;
-// annoymous helper sections
+// anoymous helper sections
 
 }  // namespace
 
@@ -114,6 +114,7 @@ std::unique_ptr<model_spec> drawing_classifier::init_model() const {
 
   input_name = std::move(output_name);
   output_name = prefix + "_flatten0_fwd";
+
   result->add_flatten(output_name, input_name);
 
   input_name = std::move(output_name);
@@ -122,8 +123,8 @@ std::unique_ptr<model_spec> drawing_classifier::init_model() const {
   result->add_inner_product(
       /* name                */ output_name,
       /* input               */ input_name,
-      /* num_output_channels */ 64 * 3 * 3,
-      /* num_input_channels  */ 128,
+      /* num_output_channels */ 128,
+      /* num_input_channels  */ 64 * 3 * 3,
       /* weight_init_fn      */ initializer);
 
   input_name = std::move(output_name);
@@ -132,11 +133,12 @@ std::unique_ptr<model_spec> drawing_classifier::init_model() const {
   result->add_inner_product(
       /* name                */ output_name,
       /* input               */ input_name,
-      /* num_output_channels */ 128,
-      /* num_input_channels  */ num_classes,
+      /* num_output_channels */ num_classes,
+      /* num_input_channels  */ 128,
       /* weight_init_fn      */ initializer);
 
   input_name = std::move(output_name);
+
   result->add_softmax(target + "Probability", input_name);
 
   return result;

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -198,6 +198,12 @@ variant_map_type drawing_classifier::evaluate(gl_sframe data,
 std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(
     std::string filename) {
   /* Add code for export_to_coreml */
+  if (!nn_spec_) {
+    // use empty nn spec if not initalized;
+    // avoid test bad memory access
+    nn_spec_ = std::unique_ptr<model_spec>(new model_spec);
+  }
+
   std::shared_ptr<MLModelWrapper> model_wrapper =
       export_drawing_classifier_model(
           *nn_spec_, read_state<flex_list>("features"),

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -196,12 +196,16 @@ variant_map_type drawing_classifier::evaluate(gl_sframe data,
 
 
 std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(
-    std::string filename) {
+    std::string filename, bool use_default_spec) {
   /* Add code for export_to_coreml */
   if (!nn_spec_) {
     // use empty nn spec if not initalized;
     // avoid test bad memory access
-    nn_spec_ = std::unique_ptr<model_spec>(new model_spec);
+    if (use_default_spec) {
+      nn_spec_ = std::unique_ptr<model_spec>(new model_spec);
+    } else {
+      log_and_throw("model is not initialized; please call train before export_coreml");
+    }
   }
 
   std::shared_ptr<MLModelWrapper> model_wrapper =

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -4,14 +4,20 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include <toolkits/drawing_classifier/drawing_classifier.hpp>
 
 #include <iostream>
+#include <random>
+#include <memory>
+#include <sstream>
 
+#include <ml/neural_net/compute_context.hpp>
+#include <ml/neural_net/model_backend.hpp>
+#include <ml/neural_net/model_spec.hpp>
 #include <core/logging/assertions.hpp>
 #include <core/logging/logger.hpp>
 #include <model_server/lib/variant_deep_serialize.hpp>
 #include <toolkits/evaluation/metrics.hpp>
+#include <toolkits/drawing_classifier/drawing_classifier.hpp>
 
 
 namespace turi {
@@ -24,19 +30,122 @@ using neural_net::float_array_map;
 using neural_net::model_backend;
 using neural_net::model_spec;
 using neural_net::shared_float_array;
+using neural_net::weight_initializer;
+using neural_net::zero_weight_initializer;
+
+using padding_type = model_spec::padding_type;
+// annoymous helper sections
 
 }  // namespace
 
 std::unique_ptr<model_spec> drawing_classifier::init_model() const {
   std::unique_ptr<model_spec> result(new model_spec);
+
+  // state is updated through init_train
+  flex_string target = read_state<flex_string>("target");
+  size_t num_classes = read_state<flex_int>("num_classes");
+
+  // feature columns names
+  const flex_list &features_list = read_state<flex_list>("features");
+
+  result->add_channel_concat(
+      "features",
+      std::vector<std::string>(features_list.begin(), features_list.end()));
+
+  weight_initializer initializer = zero_weight_initializer();
+
+  std::string prefix{"drawing"};
+  std::string input_name{"features"};
+  std::string output_name;
+
+  {
+    size_t channels_filter = 16;
+    size_t channels_kernel = 1;
+    std::stringstream ss;
+
+    for (size_t ii = 0; ii < 3; ii++) {
+      if (ii) {
+        input_name = std::move(output_name);
+      }
+
+      ss.str("");
+      ss << prefix << "_conv" << ii << "_fwd";
+      output_name = ss.str();
+
+      result->add_convolution(
+          /* name                */ output_name,
+          /* input               */ input_name,
+          /* num_output_channels */ channels_filter,
+          /* num_kernel_channels */ channels_kernel,
+          /* kernel_height       */ 3,
+          /* kernel_width        */ 3,
+          /* stride_height       */ 1,
+          /* stride_width        */ 1,
+          /* padding             */ padding_type::SAME,
+          /* weight_init_fn      */ initializer,
+          /* bias_init_fn        */ zero_weight_initializer());
+
+      channels_kernel = channels_filter;
+      channels_filter *= 2;
+
+      input_name = std::move(output_name);
+      ss.str("");
+      ss << prefix << "_relu" << ii << "_fwd";
+      output_name = ss.str();
+
+      result->add_relu(output_name, input_name);
+
+      input_name = std::move(output_name);
+      ss.str("");
+      ss << prefix << "_pool" << ii << "_fwd";
+      output_name = ss.str();
+      result->add_pooling(
+        /* name                 */ output_name,
+        /* input                */ input_name,
+        /* kernel_height        */ 2,
+        /* kernel_width         */ 2,
+        /* stride_height        */ 2,
+        /* stride_width         */ 2,
+        /* padding              */ padding_type::VALID,
+        /* avg excluded padding */ false);
+
+    }
+  }
+
+  input_name = std::move(output_name);
+  output_name = prefix + "_flatten0_fwd";
+  result->add_flatten(output_name, input_name);
+
+  input_name = std::move(output_name);
+  output_name = prefix + "_dense0_fwd";
+
+  result->add_inner_product(
+      /* name                */ output_name,
+      /* input               */ input_name,
+      /* num_output_channels */ 64 * 3 * 3,
+      /* num_input_channels  */ 128,
+      /* weight_init_fn      */ initializer);
+
+  input_name = std::move(output_name);
+  output_name = prefix + "_dense1_fwd";
+
+  result->add_inner_product(
+      /* name                */ "dense_1",
+      /* input               */ "dense_0",
+      /* num_output_channels */ 128,
+      /* num_input_channels  */ num_classes,
+      /* weight_init_fn      */ initializer);
+
+  input_name = std::move(output_name);
+  result->add_softmax(target + "Probability", input_name);
+
   return result;
 }
 
-void drawing_classifier::train(gl_sframe data,
-    std::string target_column_name,
-    std::string feature_column_name,
-    variant_type validation_data,
-    std::map<std::string, flexible_type> opts) {
+void drawing_classifier::train(gl_sframe data, std::string target_column_name,
+                               std::string feature_column_name,
+                               variant_type validation_data,
+                               std::map<std::string, flexible_type> opts) {
   nn_spec_ = init_model();
   /* TODO: Add code to train! */
 }
@@ -46,20 +155,20 @@ gl_sarray drawing_classifier::predict(gl_sframe data, std::string output_type) {
   return gl_sarray();
 }
 
-gl_sframe drawing_classifier::predict_topk(gl_sframe data, 
-  std::string output_type, size_t k) {
+gl_sframe drawing_classifier::predict_topk(gl_sframe data,
+                                           std::string output_type, size_t k) {
   /* TODO: Add code to predict_topk! */
   return gl_sframe();
 }
 
-variant_map_type drawing_classifier::evaluate(gl_sframe data, std::string metric) {
+variant_map_type drawing_classifier::evaluate(gl_sframe data,
+                                              std::string metric) {
   // Perform prediction.
   gl_sarray predictions = predict(data, "probability_vector");
 
   /* TODO: This is just for the skeleton. Rewrite. */
-  return evaluation::compute_classifier_metrics(
-      data, "label", metric, predictions,
-      {{"classes", 2}});
+  return evaluation::compute_classifier_metrics(data, "label", metric,
+                                                predictions, {{"classes", 2}});
 }
 
 std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(

--- a/src/toolkits/drawing_classifier/drawing_classifier.hpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.hpp
@@ -14,6 +14,7 @@
 #include <model_server/lib/extensions/ml_model.hpp>
 #include <model_server/lib/variant.hpp>
 #include <toolkits/coreml_export/mlmodel_wrapper.hpp>
+#include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 
 namespace turi {
 namespace drawing_classifier {

--- a/src/toolkits/drawing_classifier/drawing_classifier.hpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.hpp
@@ -21,15 +21,15 @@ namespace drawing_classifier {
 
 class EXPORT drawing_classifier : public ml_model_base {
  public:
-  // ml_model_base interface
+  /* ml_model_base interface */
 
   /* Commented out for the purpose of a skeleton. */
-  // void init_options(const std::map<std::string, flexible_type>& opts)
-  // override; size_t get_version() const override; void save_impl(oarchive&
-  // oarc) const override; void load_version(iarchive& iarc, size_t version)
-  // override;
+  // void init_options(const std::map<std::string, flexible_type>& opts) override;
+  // size_t get_version() const override;
+  // void save_impl(oarchive& oarc) const override;
+  // void load_version(iarchive& iarc, size_t version) override;
 
-  // Interface exposed via Unity server
+  /* Interface exposed via Unity server */
 
   void train(gl_sframe data, std::string target_column_name,
              std::string feature_column_name, variant_type validation_data,
@@ -117,7 +117,7 @@ class EXPORT drawing_classifier : public ml_model_base {
       "    If dataset is an SFrame, it must have a column with the same name\n"
       "    as the feature column during training. Additional columns are\n"
       "    ignored.\n"
-      "    If the data is a single drawing, it can be either of type "
+      "    If the data is a single drawing, it can be either of type\n"
       "    tc.Image, in which case it is a bitmap-based drawing input,\n"
       "    or of type list, in which case it is a stroke-based drawing input.\n"
       "output_type : {\"class\", \"probability_vector\"}, optional\n"

--- a/src/toolkits/drawing_classifier/drawing_classifier.hpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.hpp
@@ -42,7 +42,7 @@ class EXPORT drawing_classifier : public ml_model_base {
   variant_map_type evaluate(gl_sframe data, std::string metric);
 
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename);
+      std::string filename, bool use_default_spec = false);
 
   BEGIN_CLASS_MEMBER_REGISTRATION("drawing_classifier")
 

--- a/src/toolkits/drawing_classifier/drawing_classifier.hpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.hpp
@@ -11,8 +11,8 @@
 #include <ml/neural_net/compute_context.hpp>
 #include <ml/neural_net/model_backend.hpp>
 #include <ml/neural_net/model_spec.hpp>
-#include <model_server/lib/variant.hpp>
 #include <model_server/lib/extensions/ml_model.hpp>
+#include <model_server/lib/variant.hpp>
 #include <toolkits/coreml_export/mlmodel_wrapper.hpp>
 
 namespace turi {

--- a/src/toolkits/drawing_classifier/drawing_classifier.hpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.hpp
@@ -6,42 +6,43 @@
 #ifndef TURI_DRAWING_CLASSIFIER_H_
 #define TURI_DRAWING_CLASSIFIER_H_
 
-#include <core/logging/table_printer/table_printer.hpp>
-#include <model_server/lib/extensions/ml_model.hpp>
-#include <model_server/lib/variant.hpp>
 #include <core/data/sframe/gl_sframe.hpp>
-#include <toolkits/coreml_export/mlmodel_wrapper.hpp>
+#include <core/logging/table_printer/table_printer.hpp>
 #include <ml/neural_net/compute_context.hpp>
 #include <ml/neural_net/model_backend.hpp>
 #include <ml/neural_net/model_spec.hpp>
+#include <model_server/lib/variant.hpp>
+#include <model_server/lib/extensions/ml_model.hpp>
+#include <toolkits/coreml_export/mlmodel_wrapper.hpp>
 
 namespace turi {
 namespace drawing_classifier {
 
-class EXPORT drawing_classifier: public ml_model_base {
-
+class EXPORT drawing_classifier : public ml_model_base {
  public:
-  
   // ml_model_base interface
 
   /* Commented out for the purpose of a skeleton. */
-  // void init_options(const std::map<std::string, flexible_type>& opts) override;
-  // size_t get_version() const override;
-  // void save_impl(oarchive& oarc) const override;
-  // void load_version(iarchive& iarc, size_t version) override;
+  // void init_options(const std::map<std::string, flexible_type>& opts)
+  // override; size_t get_version() const override; void save_impl(oarchive&
+  // oarc) const override; void load_version(iarchive& iarc, size_t version)
+  // override;
 
   // Interface exposed via Unity server
 
-  void train(gl_sframe data,
-             std::string target_column_name, std::string feature_column_name,
-             variant_type validation_data,
+  void train(gl_sframe data, std::string target_column_name,
+             std::string feature_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
+
   gl_sarray predict(gl_sframe data, std::string output_type);
+
   gl_sframe predict_topk(gl_sframe data, std::string output_type, size_t k);
+
   variant_map_type evaluate(gl_sframe data, std::string metric);
+
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename);
-  
+
   BEGIN_CLASS_MEMBER_REGISTRATION("drawing_classifier")
 
   IMPORT_BASE_CLASS_REGISTRATION(ml_model_base);
@@ -49,10 +50,12 @@ class EXPORT drawing_classifier: public ml_model_base {
   REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::train, "data",
                                  "target_column_name", "feature_column_name",
                                  "validation_data", "options");
+
   register_defaults("train",
                     {{"validation_data", to_variant(std::string("auto"))},
                      {"options",
                       to_variant(std::map<std::string, flexible_type>())}});
+
   REGISTER_CLASS_MEMBER_DOCSTRING(
       drawing_classifier::train,
       "----------\n"
@@ -102,7 +105,9 @@ class EXPORT drawing_classifier: public ml_model_base {
 
   REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::predict, "data",
                                  "output_type");
+
   register_defaults("predict", {{"output_type", std::string("class")}});
+
   REGISTER_CLASS_MEMBER_DOCSTRING(
       drawing_classifier::predict,
       "----------\n"
@@ -111,8 +116,8 @@ class EXPORT drawing_classifier: public ml_model_base {
       "    If dataset is an SFrame, it must have a column with the same name\n"
       "    as the feature column during training. Additional columns are\n"
       "    ignored.\n"
-      "    If the data is a single drawing, it can be either of type tc.Image,\n"
-      "    in which case it is a bitmap-based drawing input,\n"
+      "    If the data is a single drawing, it can be either of type "
+      "    tc.Image, in which case it is a bitmap-based drawing input,\n"
       "    or of type list, in which case it is a stroke-based drawing input.\n"
       "output_type : {\"class\", \"probability_vector\"}, optional\n"
       "    Form of each prediction which is one of:\n"
@@ -121,12 +126,14 @@ class EXPORT drawing_classifier: public ml_model_base {
       "      alphanumerically by name of the class in the training set) is in\n"
       "      position 0 of the vector, the second in position 1 and so on.\n"
       "    - \"class\": Class prediction. This returns the class with maximum\n"
-      "      probability.\n"
-  );
+      "      probability.\n");
 
-  REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::predict_topk,
-                                 "data", "output_type", "k");
-  register_defaults("predict_topk", {{"output_type", std::string("probability")}});
+  REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::predict_topk, "data",
+                                 "output_type", "k");
+
+  register_defaults("predict_topk",
+                    {{"output_type", std::string("probability")}});
+
   REGISTER_CLASS_MEMBER_DOCSTRING(
       drawing_classifier::predict_topk,
       "----------\n"
@@ -145,14 +152,16 @@ class EXPORT drawing_classifier: public ml_model_base {
 
   REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::evaluate, "data",
                                  "metric");
+
   register_defaults("evaluate", {{"metric", std::string("auto")}});
+
   REGISTER_CLASS_MEMBER_DOCSTRING(
       drawing_classifier::evaluate,
       "----------\n"
       "data : SFrame\n"
       "    Dataset of new observations. Must include columns with the same\n"
-      "    names as the features used for model training, but does not require\n"
-      "    a target column. Additional columns are ignored.\n"
+      "    names as the features used for model training, but does not\n"
+      "    require a target column. Additional columns are ignored.\n"
       "metric : str, optional\n"
       "    Name of the evaluation metric.  Possible values are:\n"
       "    - 'auto'             : Returns all available metrics\n"
@@ -164,29 +173,30 @@ class EXPORT drawing_classifier: public ml_model_base {
       "    - 'log_loss'         : Log loss\n"
       "    - 'confusion_matrix' : An SFrame with counts of possible\n"
       "                           prediction/true label combinations.\n"
-      "    - 'roc_curve'        : An SFrame containing information needed for an\n"
-      "                           ROC curve\n"
-  );
+      "    - 'roc_curve'        : An SFrame containing information needed for\n"
+      "                           an ROC curve\n");
   REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::export_to_coreml,
                                  "filename");
 
   END_CLASS_MEMBER_REGISTRATION
 
  protected:
-
   // Returns the initial neural network to train
   virtual std::unique_ptr<neural_net::model_spec> init_model() const;
 
+  template <typename T>
+  T read_state(const std::string& key) const {
+    return variant_get_value<T>(get_state().at(key));
+  }
 
  private:
   // Primary representation for the trained model.
   std::unique_ptr<neural_net::model_spec> nn_spec_;
   std::unique_ptr<neural_net::model_backend> training_model_;
   std::unique_ptr<neural_net::compute_context> training_compute_context_;
-
 };
 
 }  // namespace drawing_classifier
 }  // namespace turi
 
-#endif //TURI_DRAWING_CLASSIFIER_H_
+#endif  // TURI_DRAWING_CLASSIFIER_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ project(TuriTest)
 enable_testing()
 
 subdirs(
-  # annotation
+        annotation
         toolkits
         ml_data
         optimization

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,7 @@ subdirs(
         table_printer
         network
         process
-        # vega_renderer
+        vega_renderer
         neural_net
         benchmark
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ project(TuriTest)
 enable_testing()
 
 subdirs(
-        annotation
+  # annotation
         toolkits
         ml_data
         optimization
@@ -29,7 +29,7 @@ subdirs(
         table_printer
         network
         process
-        vega_renderer
+        # vega_renderer
         neural_net
         benchmark
 )

--- a/test/unity/toolkits/drawing_classifier/CMakeLists.txt
+++ b/test/unity/toolkits/drawing_classifier/CMakeLists.txt
@@ -1,4 +1,7 @@
 project(unity_test_toolkits)
 
-        make_boost_test(
-            test_dc_data_iterator.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(
+  test_dc_data_iterator.cxx REQUIRES unity_shared_for_testing)
+
+make_boost_test(
+  test_dc_serialization.cxx REQUIRES unity_shared_for_testing)

--- a/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
@@ -1,0 +1,140 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_od_serialization
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include <cstdio>
+#include <ml/neural_net/model_spec.hpp>
+#include <toolkits/coreml_export/mlmodel_include.hpp>
+#include <toolkits/drawing_classifier/drawing_classifier.hpp>
+
+namespace turi {
+namespace drawing_classifer {
+namespace {
+
+class drawing_classifier_mock : public turi::drawing_classifier::drawing_classifier {
+ public:
+  std::unique_ptr<neural_net::model_spec> my_init_model() {
+    return init_model();
+  }
+};
+
+BOOST_AUTO_TEST_CASE(test_dc_init_model) {
+  // states
+  constexpr unsigned int num_classes = 10;
+  const std::string target = "target";
+  const std::vector<std::string> features = {"0", "1"};
+
+  // init_model
+  drawing_classifier_mock dc;
+  dc.add_or_update_state(
+      {{"target", target},
+       {"num_classes", num_classes},
+       {"features", flex_list(features.begin(), features.end())}});
+
+  auto nn_spec = dc.my_init_model();
+
+  const CoreML::Specification::NeuralNetwork& nn = nn_spec->get_coreml_spec();
+  /*
+   * 1 input,
+   * 3 (conv layers, relu, maxpool), 1 flatten, 2 dense, 1 softmax
+   * in total: 14 layers
+   */
+  TS_ASSERT_EQUALS(nn.layers_size(), 14);
+
+
+  /* layer 0: concat layer */
+  {
+    auto concat_layer = nn.layers(0);
+    TS_ASSERT(concat_layer.has_concat());
+    TS_ASSERT(concat_layer.output_size() == 1);
+    TS_ASSERT_EQUALS(concat_layer.output(0), "features");
+    TS_ASSERT_EQUALS(concat_layer.name(), "features");
+    for (int ii = 0; ii < concat_layer.input_size(); ii++) {
+      TS_ASSERT_EQUALS(concat_layer.input(ii), features.at(ii));
+    }
+  }
+
+  {
+    const std::map<int, int> layer_num_to_channels = {
+        {0, 16}, {1, 32}, {2, 64}};
+    for (auto& x : layer_num_to_channels) {
+      int layer_index = x.first * 3 + 1;
+      const auto& convlayer = nn.layers(layer_index);
+      TS_ASSERT(convlayer.has_convolution());
+      TS_ASSERT_EQUALS(convlayer.name(),
+                       "drawing_conv" + std::to_string(x.first) + "_fwd");
+      TS_ASSERT_EQUALS(convlayer.convolution().outputchannels(), x.second);
+      TS_ASSERT_EQUALS(convlayer.convolution().kernelchannels(),
+                       x.first == 0 ? 1 : x.second / 2);
+      TS_ASSERT_EQUALS(convlayer.convolution().stride(0), 1);
+      TS_ASSERT_EQUALS(convlayer.convolution().stride(1), 1);
+      TS_ASSERT_EQUALS(convlayer.convolution().kernelsize(0), 3);
+      TS_ASSERT_EQUALS(convlayer.convolution().kernelsize(1), 3);
+      TS_ASSERT(convlayer.convolution().has_same());
+
+      const auto& relu_layer = nn.layers(layer_index + 1);
+      TS_ASSERT_EQUALS(relu_layer.name(),
+                       "drawing_relu" + std::to_string(x.first) + "_fwd");
+      TS_ASSERT(relu_layer.has_activation());
+      TS_ASSERT(relu_layer.activation().has_relu());
+
+      const auto& pool_layer = nn.layers(layer_index + 2);
+      TS_ASSERT(pool_layer.has_pooling());
+      TS_ASSERT_EQUALS(pool_layer.name(),
+                       "drawing_pool" + std::to_string(x.first) + "_fwd");
+      TS_ASSERT_EQUALS(pool_layer.pooling().kernelsize(0), 2);
+      TS_ASSERT_EQUALS(pool_layer.pooling().kernelsize(1), 2);
+      TS_ASSERT_EQUALS(pool_layer.pooling().stride(0), 2);
+      TS_ASSERT_EQUALS(pool_layer.pooling().stride(1), 2);
+      TS_ASSERT(pool_layer.pooling().has_valid());
+    }
+  }
+
+  unsigned layer_index = 10;
+  {
+    const auto& flatten_layer = nn.layers(layer_index);
+    TS_ASSERT(flatten_layer.has_flatten());
+    TS_ASSERT_EQUALS(flatten_layer.name(), "drawing_flatten0_fwd");
+  }
+
+  layer_index++;
+  {
+    const auto& dense_layer = nn.layers(layer_index);
+    TS_ASSERT(dense_layer.has_innerproduct());
+    TS_ASSERT_EQUALS(dense_layer.name(), "drawing_dense0_fwd");
+    TS_ASSERT_EQUALS(dense_layer.innerproduct().inputchannels(), 64 * 3 * 3);
+    TS_ASSERT_EQUALS(dense_layer.innerproduct().outputchannels(), 128);
+  }
+
+  layer_index++;
+  {
+    const auto& dense_layer = nn.layers(layer_index);
+    TS_ASSERT_EQUALS(dense_layer.name(), "drawing_dense1_fwd");
+    TS_ASSERT(dense_layer.has_innerproduct());
+    TS_ASSERT_EQUALS(dense_layer.innerproduct().inputchannels(), 128);
+    TS_ASSERT_EQUALS(dense_layer.innerproduct().outputchannels(), num_classes);
+  }
+
+  layer_index++;
+  TS_ASSERT(layer_index == 13);
+  {
+    const auto& softmax_layer = nn.layers(layer_index);
+    TS_ASSERT(softmax_layer.has_softmax());
+    TS_ASSERT_EQUALS(softmax_layer.output(0), target + "Probability");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_save_load) {
+// TODO
+}
+
+}  // anonymous namespace
+}  // namespace drawing_classifier
+}  // namespace turi

--- a/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(test_export_coreml) {
        {"warm_start", false},
        {"features", flex_list(features.begin(), features.end())}});
 
-  auto ml_model_wrapper = dc.export_to_coreml("");
+  auto ml_model_wrapper = dc.export_to_coreml("", /* debug no throw */ true);
   // TS_ASSERT(ml_model_wrapper != nullptr);
 
   const auto& my_model_spec = ml_model_wrapper->coreml_model()->getProto();

--- a/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
@@ -18,7 +18,8 @@ namespace turi {
 namespace drawing_classifer {
 namespace {
 
-class drawing_classifier_mock : public turi::drawing_classifier::drawing_classifier {
+class drawing_classifier_mock
+    : public turi::drawing_classifier::drawing_classifier {
  public:
   std::unique_ptr<neural_net::model_spec> my_init_model() {
     return init_model();
@@ -47,7 +48,6 @@ BOOST_AUTO_TEST_CASE(test_dc_init_model) {
    * in total: 14 layers
    */
   TS_ASSERT_EQUALS(nn.layers_size(), 14);
-
 
   /* layer 0: concat layer */
   {
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(test_export_coreml) {
        {"features", flex_list(features.begin(), features.end())}});
 
   auto ml_model_wrapper = dc.export_to_coreml("", /* debug no throw */ true);
-  // TS_ASSERT(ml_model_wrapper != nullptr);
+  TS_ASSERT(ml_model_wrapper != nullptr);
 
   const auto& my_model_spec = ml_model_wrapper->coreml_model()->getProto();
   TS_ASSERT_EQUALS(my_model_spec.specificationversion(), 1);
@@ -170,13 +170,14 @@ BOOST_AUTO_TEST_CASE(test_export_coreml) {
   TS_ASSERT_EQUALS(my_model_desc.output(1).name(), target);
 
   TS_ASSERT_EQUALS(my_model_desc.predictedfeaturename(), target);
-  TS_ASSERT_EQUALS(my_model_desc.predictedprobabilitiesname(), target + "Probability");
+  TS_ASSERT_EQUALS(my_model_desc.predictedprobabilitiesname(),
+                   target + "Probability");
 }
 
 BOOST_AUTO_TEST_CASE(test_save_load) {
-// TODO
+  // TODO
 }
 
 }  // anonymous namespace
-}  // namespace drawing_classifier
+}  // namespace drawing_classifer
 }  // namespace turi


### PR DESCRIPTION
model spec follows CoreML neural network spec format which describes ANN architecture to be used.

__MySuggestion__
You can skip reviewing `drawing_classifier.hpp` since it only has minor code style change, which is irrelevant to this topic.

__MyPlan__
- [X] `init_model`
- [x] `export_coreml`
- [x] basic unittest for `init_model`
- [x] basic unittest for `export_coreml`
 
__MySummary__
* [Y] adding unittest[Y/N]?
* [N] breaking current unittest[Y/N]?