### PR TITLE
Skipping two bottleneck Python unit tests for OSOD

### DIFF
--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -115,11 +115,13 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
         data = tc.one_shot_object_detector.util.preview_synthetic_training_data(
             image, 'custom_logo', backgrounds=self.backgrounds)
 
+    @unittest.skip("Skipping until https://github.com/apple/turicreate/issues/2406 gets resolved")
     def test_create_with_single_image(self):
         image = self.train[0][self.feature]
         model = tc.one_shot_object_detector.create(
             image, 'custom_logo', backgrounds=self.backgrounds)
 
+    @unittest.skip("Skipping until https://github.com/apple/turicreate/issues/2406 gets resolved")
     def test_create_with_missing_value(self):
         sf = self.train.append(tc.SFrame({self.feature: tc.SArray([None], dtype=tc.Image), self.target: [self.train[self.target][0]]}))
         with self.assertRaises(_ToolkitError):

--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -110,6 +110,7 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
         }
         self.fields_ans = self.get_ans.keys()
 
+    @unittest.skip("Skipping until https://github.com/apple/turicreate/issues/2406 gets resolved")
     def test_synthesis_with_single_image(self):
         image = self.train[0][self.feature]
         data = tc.one_shot_object_detector.util.preview_synthetic_training_data(
@@ -121,7 +122,6 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
         model = tc.one_shot_object_detector.create(
             image, 'custom_logo', backgrounds=self.backgrounds)
 
-    @unittest.skip("Skipping until https://github.com/apple/turicreate/issues/2406 gets resolved")
     def test_create_with_missing_value(self):
         sf = self.train.append(tc.SFrame({self.feature: tc.SArray([None], dtype=tc.Image), self.target: [self.train[self.target][0]]}))
         with self.assertRaises(_ToolkitError):


### PR DESCRIPTION
This is a temporary workaround for #2406 so our unit tests run faster. These tests seem to take up almost an hour and I'm not sure why... Until we figure that out, let's skip these unit tests.