### PR TITLE
Add memory budget to tf_compute_context

### DIFF
--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -125,7 +125,8 @@ tf_compute_context::tf_compute_context() = default;
 tf_compute_context::~tf_compute_context() = default;
 
 size_t tf_compute_context::memory_budget() const {
-  return 0;
+  // TODO: Return 4GB for now. Do something that makes more sense later.
+  return 4294967296;
 }
 
 std::vector<std::string> tf_compute_context::gpu_names() const {

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -125,7 +125,8 @@ tf_compute_context::tf_compute_context() = default;
 tf_compute_context::~tf_compute_context() = default;
 
 size_t tf_compute_context::memory_budget() const {
-  // TODO: Return 4GB for now. Do something that makes more sense later.
+  // TODO: Returns 4GB as that makes sure default batch size is used. 
+  // Do something that makes more sense like MPS later.
   return 4294967296;
 }
 

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -127,7 +127,7 @@ tf_compute_context::~tf_compute_context() = default;
 size_t tf_compute_context::memory_budget() const {
   // TODO: Returns 4GB as that makes sure default batch size is used. 
   // Do something that makes more sense like MPS later.
-  return 4294967296;
+  return 4294967296lu;
 }
 
 std::vector<std::string> tf_compute_context::gpu_names() const {


### PR DESCRIPTION
I am returning 4GB as the memory as C++ side makes batch_size 32 then (which is what we want as MXNet uses always and we want to make TF comparable to MXNet as of now)