### PR TITLE
Fix built error or OD's import_from_custom() function

### DIFF
--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -386,7 +386,7 @@ void object_detector::import_from_custom_model(variant_map_type model_data,
     }
   }
 
-  auto cmp = [](flex_dict::value_type& a, flex_dict::value_type& b) {
+  auto cmp = [](const flex_dict::value_type& a, const flex_dict::value_type& b) {
     return (a.first < b.first);
   };
 


### PR DESCRIPTION
Linux system seems to throw compile error for lambda function for sorting without const.