### PR TITLE
Add checkpointing support for OD

### DIFF
--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -338,6 +338,10 @@ size_t object_detector::get_version() const {
 }
 
 void object_detector::save_impl(oarchive& oarc) const {
+  if (training_model_) {
+    // If checkpointing during training, first copy weights from the backend.
+    synchronize_model(nn_spec_.get());
+  }
   _save_impl(oarc, *nn_spec_, state);
 }
 
@@ -424,28 +428,21 @@ void object_detector::train(gl_sframe data,
                             variant_type validation_data,
                             std::map<std::string, flexible_type> opts)
 {
-  // Begin printing progress.
-  // TODO: Make progress printing optional.
-  training_table_printer_.reset(new table_printer(
-      {{ "Iteration", 12}, {"Loss", 12}, {"Elapsed Time", 12}}));
-
   // Instantiate the training dependencies: data iterator, image augmenter,
   // backend NN model.
-  init_train(data, annotations_column_name, image_column_name, validation_data,
-             opts);
+  init_training(data, annotations_column_name, image_column_name,
+                validation_data, opts);
 
   // Perform all the iterations at once.
   while (get_training_iterations() < get_max_iterations()) {
-    perform_training_iteration();
+    iterate_training();
   }
 
   // Wait for any outstanding batches to finish.
-  wait_for_training_batches();
+  finalize_training();
+}
 
-  // Finish printing progress.
-  training_table_printer_->print_footer();
-  training_table_printer_.reset();
-
+void object_detector::synchronize_model(model_spec* nn_spec) const {
   // Sync trained weights to our local storage of the NN weights.
   float_array_map raw_trained_weights = training_model_->export_weights();
   float_array_map trained_weights;
@@ -458,7 +455,27 @@ void object_detector::train(gl_sframe data,
     key.insert(it, modifier.begin(), modifier.end());
     trained_weights[key] = kv.second;
   }
-  nn_spec_->update_params(trained_weights);
+  nn_spec->update_params(trained_weights);
+}
+
+void object_detector::finalize_training() {
+  // Wait for any outstanding batches.
+  synchronize_training();
+
+  // Finish printing progress.
+  if (training_table_printer_) {
+    training_table_printer_->print_footer();
+    training_table_printer_.reset();
+  }
+
+  // Copy out the trained mdoel.
+  synchronize_model(nn_spec_.get());
+
+  // Tear down the training backend.
+  training_model_.reset();
+  training_data_augmenter_.reset();
+  training_data_iterator_.reset();
+  training_compute_context_.reset();
 
   // Compute training and validation metrics.
   update_model_metrics(training_data_, validation_data_);
@@ -680,8 +697,7 @@ object_detector::convert_yolo_to_annotations(
 }
 
 std::unique_ptr<model_spec> object_detector::init_model(
-    const std::string& pretrained_mlmodel_path) const {
-
+    const std::string& pretrained_mlmodel_path, size_t num_classes) const {
   // All of this presumes that the pre-trained model is the darknet model from
   // our first object detector implementation....
 
@@ -729,7 +745,6 @@ std::unique_ptr<model_spec> object_detector::init_model(
 
   // Append conv8.
   static constexpr float CONV8_MAGNITUDE = 0.00005f;
-  const size_t num_classes = training_data_iterator_->class_labels().size();
   const size_t num_predictions = 5 + num_classes;  // Per anchor box
   const size_t conv8_c_out = anchor_boxes().size() * num_predictions;
   auto conv8_weight_init_fn = [&random_engine](float* w, float* w_end) {
@@ -766,6 +781,11 @@ std::unique_ptr<model_spec> object_detector::init_model(
 
 std::shared_ptr<MLModelWrapper> object_detector::export_to_coreml(
     std::string filename, std::map<std::string, flexible_type> opts) {
+  // If called during training, synchronize the model first.
+  if (training_model_) {
+    synchronize_training();
+    synchronize_model(nn_spec_.get());
+  }
 
   // Initialize the result with the learned layers from the model_backend.
   model_spec yolo_nn_spec(nn_spec_->get_coreml_spec());
@@ -901,11 +921,11 @@ std::unique_ptr<compute_context> object_detector::create_compute_context() const
   return compute_context::create();
 }
 
-void object_detector::init_train(
-    gl_sframe data, std::string annotations_column_name,
-    std::string image_column_name, variant_type validation_data,
-    std::map<std::string, flexible_type> opts)
-{
+void object_detector::init_training(gl_sframe data,
+                                    std::string annotations_column_name,
+                                    std::string image_column_name,
+                                    variant_type validation_data,
+                                    std::map<std::string, flexible_type> opts) {
   // Extract 'mlmodel_path' from the options, to avoid storing it as a model
   // field.
   auto mlmodel_path_iter = opts.find("mlmodel_path");
@@ -925,11 +945,6 @@ void object_detector::init_train(
     add_or_update_state({{"random_seed", random_seed}});
   }
 
-  // Perform random validation split if necessary.
-  std::tie(training_data_, validation_data_) =
-      supervised::create_validation_data(data, validation_data,
-                                         read_state<int>("random_seed"));
-
   // Record the relevant column names upfront, for use in create_iterator. Also
   // values fixed by this version of the toolkit.
   add_or_update_state({
@@ -940,9 +955,20 @@ void object_detector::init_train(
         DEFAULT_NON_MAXIMUM_SUPPRESSION_THRESHOLD },
   });
 
+  // Perform random validation split if necessary.
+  std::tie(training_data_, validation_data_) =
+      supervised::create_validation_data(data, validation_data,
+                                         read_state<int>("random_seed"));
+
   // Bind the data to a data iterator.
   training_data_iterator_ = create_iterator(
       training_data_, /* expected class_labels */ {}, /* repeat */ true);
+
+  // Load the pre-trained model from the provided path. The final layers are
+  // initialized randomly using the random seed above, using the number of
+  // classes observed by the training_data_iterator_ above.
+  nn_spec_ =
+      init_model(mlmodel_path, training_data_iterator_->class_labels().size());
 
   // Instantiate the compute context.
   training_compute_context_ = create_compute_context();
@@ -953,11 +979,6 @@ void object_detector::init_train(
   // Infer values for unspecified options. Note that this depends on training
   // data statistics and the compute context, initialized above.
   infer_derived_options();
-
-  // Load the pre-trained model from the provided path. The final layers are
-  // initialized randomly using the random seed above, using the number of
-  // classes observed by the training_data_iterator_ above.
-  nn_spec_ = init_model(mlmodel_path);
 
   // Set additional model fields.
   flex_int grid_height = read_state<flex_int>("grid_height");
@@ -972,14 +993,43 @@ void object_detector::init_train(
        flex_list(input_image_shape.begin(), input_image_shape.end())},
       {"num_bounding_boxes", training_data_iterator_->num_instances()},
       {"num_classes", training_data_iterator_->class_labels().size()},
-      {"num_examples", data.size()},
+      {"num_examples", training_data_.size()},
       {"training_epochs", 0},
       {"training_iterations", 0},
   });
   // TODO: The original Python implementation also exposed "anchors",
   // "non_maximum_suppression_threshold", and "training_time".
 
+  init_training_backend();
+}
+
+void object_detector::resume_training(gl_sframe data,
+                                      variant_type validation_data) {
+  // Perform random validation split if necessary.
+  std::tie(training_data_, validation_data_) =
+      supervised::create_validation_data(data, validation_data,
+                                         read_state<int>("random_seed"));
+
+  // Bind the data to a data iterator.
+  flex_list class_labels = read_state<flex_list>("classes");
+  training_data_iterator_ = create_iterator(
+      training_data_,
+      std::vector<std::string>(class_labels.begin(), class_labels.end()),
+      /* repeat */ true);
+
+  // Instantiate the compute context.
+  training_compute_context_ = create_compute_context();
+  if (training_compute_context_ == nullptr) {
+    log_and_throw("No neural network compute context provided");
+  }
+
+  init_training_backend();
+}
+
+void object_detector::init_training_backend() {
   // Instantiate the data augmenter.
+  flex_int grid_height = read_state<flex_int>("grid_height");
+  flex_int grid_width = read_state<flex_int>("grid_width");
   training_data_augmenter_ = training_compute_context_->create_image_augmenter(
       get_augmentation_options(read_state<flex_int>("batch_size"), grid_height,
                                grid_width));
@@ -1006,13 +1056,14 @@ void object_detector::init_train(
       /* config  */ train_config,
       /* weights */ get_model_params());
 
-  // Print the header last, after any logging triggered by initialization above.
-  if (training_table_printer_) {
-    training_table_printer_->print_header();
-  }
+  // Begin printing progress, after any logging triggered above.
+  // TODO: Make progress printing optional.
+  training_table_printer_.reset(new table_printer(
+      {{"Iteration", 12}, {"Loss", 12}, {"Elapsed Time", 12}}));
+  training_table_printer_->print_header();
 }
 
-void object_detector::perform_training_iteration() {
+void object_detector::iterate_training() {
   // Training must have been initialized.
   ASSERT_TRUE(training_data_iterator_ != nullptr);
   ASSERT_TRUE(training_data_augmenter_ != nullptr);
@@ -1071,6 +1122,8 @@ void object_detector::perform_training_iteration() {
   // completion of this batch.
   pending_training_batches_.emplace(iteration_idx, std::move(loss_batch));
 }
+
+void object_detector::synchronize_training() { wait_for_training_batches(); }
 
 float_array_map object_detector::get_model_params() const {
 

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -26,6 +26,7 @@ namespace object_detection {
 
 class EXPORT object_detector: public ml_model_base {
  public:
+  object_detector() = default;
 
   // ml_model_base interface
 
@@ -44,6 +45,17 @@ class EXPORT object_detector: public ml_model_base {
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename, std::map<std::string, flexible_type> opts);
   void import_from_custom_model(variant_map_type model_data, size_t version);
+
+  // Support for iterative training.
+  virtual void init_training(gl_sframe data,
+                             std::string annotations_column_name,
+                             std::string image_column_name,
+                             variant_type validation_data,
+                             std::map<std::string, flexible_type> opts);
+  virtual void resume_training(gl_sframe data, variant_type validation_data);
+  virtual void iterate_training();
+  virtual void synchronize_training();
+  virtual void finalize_training();
 
   // Register with Unity server
 
@@ -73,6 +85,23 @@ class EXPORT object_detector: public ml_model_base {
       "    The number of training iterations. If 0, then it will be automatically\n"
       "    be determined based on the amount of data you provide.\n"
   );
+
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::init_training, "data",
+                                 "annotations_column_name", "image_column_name",
+                                 "validation_data", "options");
+  register_defaults("init_training",
+                    {{"validation_data", to_variant(gl_sframe())},
+                     {"options",
+                      to_variant(std::map<std::string, flexible_type>())}});
+
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::resume_training, "data",
+                                 "validation_data");
+  register_defaults("resume_training",
+                    {{"validation_data", to_variant(gl_sframe())}});
+
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::iterate_training);
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::synchronize_training);
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::finalize_training);
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric");
   register_defaults("evaluate",
@@ -109,6 +138,22 @@ class EXPORT object_detector: public ml_model_base {
   END_CLASS_MEMBER_REGISTRATION
 
  protected:
+  // Constructor allowing tests to set the initial state of this class and to
+  // inject dependencies.
+  object_detector(
+      const std::map<std::string, variant_type>& initial_state,
+      std::unique_ptr<neural_net::model_spec> nn_spec,
+      std::unique_ptr<neural_net::compute_context> training_compute_context,
+      std::unique_ptr<data_iterator> training_data_iterator,
+      std::unique_ptr<neural_net::image_augmenter> training_data_augmenter,
+      std::unique_ptr<neural_net::model_backend> training_model)
+      : nn_spec_(std::move(nn_spec)),
+        training_compute_context_(std::move(training_compute_context)),
+        training_data_iterator_(std::move(training_data_iterator)),
+        training_data_augmenter_(std::move(training_data_augmenter)),
+        training_model_(std::move(training_model)) {
+    add_or_update_state(initial_state);
+  }
 
   // Override points allowing subclasses to inject dependencies
 
@@ -126,21 +171,14 @@ class EXPORT object_detector: public ml_model_base {
   // Returns the initial neural network to train (represented by its CoreML
   // spec), given the path to a mlmodel file containing the pretrained weights.
   virtual std::unique_ptr<neural_net::model_spec> init_model(
-      const std::string& pretrained_mlmodel_path) const;
+      const std::string& pretrained_mlmodel_path, size_t num_classes) const;
+
+  void init_training_backend();
 
   virtual std::vector<neural_net::image_annotation> convert_yolo_to_annotations(
       const neural_net::float_array& yolo_map,
       const std::vector<std::pair<float, float>>& anchor_boxes,
       float min_confidence);
-
-  // Support for iterative training.
-  // TODO: Expose via forthcoming C-API checkpointing mechanism?
-
-  virtual void init_train(gl_sframe data, std::string annotations_column_name,
-                          std::string image_column_name,
-                          variant_type validation_data,
-                          std::map<std::string, flexible_type> opts);
-  virtual void perform_training_iteration();
 
   virtual variant_map_type perform_evaluation(gl_sframe data,
                                               std::string metric);
@@ -174,6 +212,10 @@ class EXPORT object_detector: public ml_model_base {
 
   // Waits until the number of pending patches is at most `max_pending`.
   void wait_for_training_batches(size_t max_pending = 0);
+
+  // Ensures that the local copy of the model weights are in sync with the
+  // training backend.
+  void synchronize_model(neural_net::model_spec* nn_spec) const;
 
   // Computes and records training/validation metrics.
   void update_model_metrics(gl_sframe data, gl_sframe validation_data);

--- a/test/unity/toolkits/neural_net/neural_net_mocks.hpp
+++ b/test/unity/toolkits/neural_net/neural_net_mocks.hpp
@@ -1,0 +1,161 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef TEST_UNITY_TOOLKITS_NEURAL_NET_NEURAL_NET_MOCKS_HPP_
+#define TEST_UNITY_TOOLKITS_NEURAL_NET_NEURAL_NET_MOCKS_HPP_
+
+#include <deque>
+#include <functional>
+#include <memory>
+
+#include <core/util/test_macros.hpp>
+#include <ml/neural_net/compute_context.hpp>
+#include <ml/neural_net/image_augmentation.hpp>
+#include <ml/neural_net/model_backend.hpp>
+
+namespace turi {
+namespace neural_net {
+
+using turi::neural_net::compute_context;
+using turi::neural_net::float_array;
+using turi::neural_net::float_array_map;
+using turi::neural_net::image_annotation;
+using turi::neural_net::image_augmenter;
+using turi::neural_net::labeled_image;
+using turi::neural_net::model_backend;
+using turi::neural_net::shared_float_array;
+
+// TODO: Adopt a real mocking library. Or at least factor out the shared
+// boilerplate into some utility templates or macros. Yes, if necessary, create
+// our own simplistic mocking tools.
+
+class mock_image_augmenter : public image_augmenter {
+ public:
+  using prepare_images_call =
+      std::function<result(std::vector<labeled_image> source_batch)>;
+
+  ~mock_image_augmenter() { TS_ASSERT(prepare_images_calls_.empty()); }
+
+  const options& get_options() const override { return options_; }
+
+  result prepare_images(std::vector<labeled_image> source_batch) override {
+    TS_ASSERT(!prepare_images_calls_.empty());
+    prepare_images_call expected_call =
+        std::move(prepare_images_calls_.front());
+    prepare_images_calls_.pop_front();
+    return expected_call(std::move(source_batch));
+  }
+
+  options options_;
+  std::deque<prepare_images_call> prepare_images_calls_;
+};
+
+class mock_model_backend : public model_backend {
+ public:
+  using set_learning_rate_call = std::function<void(float lr)>;
+
+  using train_call =
+      std::function<float_array_map(const float_array_map& inputs)>;
+
+  using predict_call =
+      std::function<float_array_map(const float_array_map& inputs)>;
+
+  ~mock_model_backend() {
+    TS_ASSERT(train_calls_.empty());
+    TS_ASSERT(predict_calls_.empty());
+  }
+
+  void set_learning_rate(float lr) override {
+    TS_ASSERT(!set_learning_rate_calls_.empty());
+    set_learning_rate_call expected_call =
+        std::move(set_learning_rate_calls_.front());
+    set_learning_rate_calls_.pop_front();
+    expected_call(lr);
+  }
+
+  float_array_map train(const float_array_map& inputs) override {
+    TS_ASSERT(!train_calls_.empty());
+    train_call expected_call = std::move(train_calls_.front());
+    train_calls_.pop_front();
+    return expected_call(inputs);
+  }
+
+  float_array_map predict(const float_array_map& inputs) const override {
+    TS_ASSERT(!predict_calls_.empty());
+    predict_call expected_call = std::move(predict_calls_.front());
+    predict_calls_.pop_front();
+    return expected_call(inputs);
+  }
+
+  float_array_map export_weights() const override {
+    return export_weights_retval_;
+  }
+
+  std::deque<set_learning_rate_call> set_learning_rate_calls_;
+  std::deque<train_call> train_calls_;
+  mutable std::deque<predict_call> predict_calls_;
+  float_array_map export_weights_retval_;
+};
+
+class mock_compute_context : public compute_context {
+ public:
+  using create_augmenter_call = std::function<std::unique_ptr<image_augmenter>(
+      const image_augmenter::options& opts)>;
+
+  using create_object_detector_call =
+      std::function<std::unique_ptr<model_backend>(
+          int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+          const float_array_map& config, const float_array_map& weights)>;
+
+  ~mock_compute_context() {
+    TS_ASSERT(create_augmenter_calls_.empty());
+    TS_ASSERT(create_object_detector_calls_.empty());
+  }
+
+  size_t memory_budget() const override { return 0; }
+
+  std::vector<std::string> gpu_names() const override { return {}; }
+
+  std::unique_ptr<image_augmenter> create_image_augmenter(
+      const image_augmenter::options& opts) override {
+    TS_ASSERT(!create_augmenter_calls_.empty());
+    create_augmenter_call expected_call =
+        std::move(create_augmenter_calls_.front());
+    create_augmenter_calls_.pop_front();
+    return expected_call(opts);
+  }
+
+  std::unique_ptr<model_backend> create_object_detector(
+      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+      const float_array_map& config, const float_array_map& weights) override {
+    TS_ASSERT(!create_object_detector_calls_.empty());
+    create_object_detector_call expected_call =
+        std::move(create_object_detector_calls_.front());
+    create_object_detector_calls_.pop_front();
+    return expected_call(n, c_in, h_in, w_in, c_out, h_out, w_out, config,
+                         weights);
+  }
+
+  std::unique_ptr<model_backend> create_activity_classifier(
+      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+      const float_array_map& config, const float_array_map& weights) override {
+    return nullptr;
+  }
+
+  std::unique_ptr<model_backend> create_style_transfer(
+      const float_array_map& config, const float_array_map& weights) override {
+    return nullptr;
+  }
+
+  mutable std::deque<create_augmenter_call> create_augmenter_calls_;
+  mutable std::deque<create_object_detector_call> create_object_detector_calls_;
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // TEST_UNITY_TOOLKITS_NEURAL_NET_NEURAL_NET_MOCKS_HPP_

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -16,6 +16,8 @@
 #include <boost/test/unit_test.hpp>
 #include <core/util/test_macros.hpp>
 
+#include "../neural_net/neural_net_mocks.hpp"
+
 namespace turi {
 namespace object_detection {
 namespace {
@@ -28,6 +30,9 @@ using turi::neural_net::float_array_map;
 using turi::neural_net::image_annotation;
 using turi::neural_net::image_augmenter;
 using turi::neural_net::labeled_image;
+using turi::neural_net::mock_compute_context;
+using turi::neural_net::mock_image_augmenter;
+using turi::neural_net::mock_model_backend;
 using turi::neural_net::model_backend;
 using turi::neural_net::model_spec;
 using turi::neural_net::shared_float_array;
@@ -41,8 +46,6 @@ using turi::neural_net::shared_float_array;
 // TODO: Adopt a real mocking library. Or at least factor out the shared
 // boilerplate into some utility templates or macros. Yes, if necessary, create
 // our own simplistic mocking tools.
-
-// TODO: Move these mocks somewhere shared in case other tests want to use them.
 
 class mock_data_iterator: public data_iterator {
 public:
@@ -74,145 +77,6 @@ public:
   size_t num_instances_ = 0;
 };
 
-class mock_image_augmenter: public image_augmenter {
-public:
-  using prepare_images_call =
-      std::function<result(std::vector<labeled_image> source_batch)>;
-
-  ~mock_image_augmenter() {
-    TS_ASSERT(prepare_images_calls_.empty());
-  }
-
-  const options& get_options() const override { return options_; }
-
-  result prepare_images(std::vector<labeled_image> source_batch) override {
-    TS_ASSERT(!prepare_images_calls_.empty());
-    prepare_images_call expected_call =
-        std::move(prepare_images_calls_.front());
-    prepare_images_calls_.pop_front();
-    return expected_call(std::move(source_batch));
-  }
-
-  options options_;
-  std::deque<prepare_images_call> prepare_images_calls_;
-};
-
-class mock_model_backend: public model_backend {
-public:
-
-  using set_learning_rate_call = std::function<void(float lr)>;
-
-  using train_call =
-      std::function<float_array_map(const float_array_map& inputs)>;
-
-  using predict_call =
-      std::function<float_array_map(const float_array_map& inputs)>;
-
-  ~mock_model_backend() {
-    TS_ASSERT(train_calls_.empty());
-    TS_ASSERT(predict_calls_.empty());
-  }
-
-  void set_learning_rate(float lr) override {
-    TS_ASSERT(!set_learning_rate_calls_.empty());
-    set_learning_rate_call expected_call =
-        std::move(set_learning_rate_calls_.front());
-    set_learning_rate_calls_.pop_front();
-    expected_call(lr);
-  }
-
-  float_array_map train(const float_array_map& inputs) override {
-
-    TS_ASSERT(!train_calls_.empty());
-    train_call expected_call = std::move(train_calls_.front());
-    train_calls_.pop_front();
-    return expected_call(inputs);
-  }
-
-  float_array_map predict(const float_array_map& inputs) const override {
-
-    TS_ASSERT(!predict_calls_.empty());
-    predict_call expected_call = std::move(predict_calls_.front());
-    predict_calls_.pop_front();
-    return expected_call(inputs);
-  }
-
-  float_array_map export_weights() const override {
-    return export_weights_retval_;
-  }
-
-  std::deque<set_learning_rate_call> set_learning_rate_calls_;
-  std::deque<train_call> train_calls_;
-  mutable std::deque<predict_call> predict_calls_;
-  float_array_map export_weights_retval_;
-};
-
-class mock_compute_context: public compute_context {
-public:
-
-  using create_augmenter_call = std::function<std::unique_ptr<image_augmenter>(
-      const image_augmenter::options& opts)>;
-
-  using create_object_detector_call =
-      std::function<std::unique_ptr<model_backend>(
-          int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
-          const float_array_map& config, const float_array_map& weights)>;
-
-  ~mock_compute_context() {
-    TS_ASSERT(create_augmenter_calls_.empty());
-    TS_ASSERT(create_object_detector_calls_.empty());
-  }
-
-  size_t memory_budget() const override {
-    return 0;
-  }
-
-  std::vector<std::string> gpu_names() const override {
-    return {};
-  }
-
-  std::unique_ptr<image_augmenter> create_image_augmenter(
-      const image_augmenter::options& opts) override {
-
-    TS_ASSERT(!create_augmenter_calls_.empty());
-    create_augmenter_call expected_call =
-        std::move(create_augmenter_calls_.front());
-    create_augmenter_calls_.pop_front();
-    return expected_call(opts);
-  }
-
-  std::unique_ptr<model_backend> create_object_detector(
-      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
-      const float_array_map& config,
-      const float_array_map& weights) override {
-
-    TS_ASSERT(!create_object_detector_calls_.empty());
-    create_object_detector_call expected_call =
-        std::move(create_object_detector_calls_.front());
-    create_object_detector_calls_.pop_front();
-    return expected_call(n, c_in, h_in, w_in, c_out, h_out, w_out, config,
-                         weights);
-  }
-
-  std::unique_ptr<model_backend> create_activity_classifier(
-      int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
-      const float_array_map& config,
-      const float_array_map& weights) override
-  {
-    return nullptr;
-  }
-
-  std::unique_ptr<model_backend> create_style_transfer(
-      const float_array_map& config,
-      const float_array_map& weights) override
-  {
-    return nullptr;
-  }
-
-  mutable std::deque<create_augmenter_call> create_augmenter_calls_;
-  mutable std::deque<create_object_detector_call> create_object_detector_calls_;
-};
-
 // Subclass of object_detector that mocks out the methods that inject the
 // object_detector dependencies.
 class test_object_detector: public object_detector {
@@ -225,7 +89,7 @@ public:
       std::function<std::unique_ptr<compute_context>()>;
 
   using init_model_call = std::function<std::unique_ptr<model_spec>(
-      const std::string& pretrained_mlmodel_path)>;
+      const std::string& pretrained_mlmodel_path, size_t num_classes)>;
 
   using perform_evaluation_call =
       std::function<variant_map_type(gl_sframe data, std::string metric)>;
@@ -235,6 +99,20 @@ public:
           const neural_net::float_array& yolo_map,
           const std::vector<std::pair<float, float>>& anchor_boxes,
           float min_confidence)>;
+
+  test_object_detector() = default;
+  test_object_detector(
+      const std::map<std::string, variant_type>& initial_state,
+      std::unique_ptr<model_spec> nn_spec,
+      std::unique_ptr<compute_context> training_compute_context,
+      std::unique_ptr<data_iterator> training_data_iterator,
+      std::unique_ptr<image_augmenter> training_data_augmenter,
+      std::unique_ptr<model_backend> training_model)
+      : object_detector(initial_state, std::move(nn_spec),
+                        std::move(training_compute_context),
+                        std::move(training_data_iterator),
+                        std::move(training_data_augmenter),
+                        std::move(training_model)) {}
 
   ~test_object_detector() {
     TS_ASSERT(create_iterator_calls_.empty());
@@ -262,12 +140,12 @@ public:
   }
 
   std::unique_ptr<model_spec> init_model(
-      const std::string& pretrained_mlmodel_path) const override {
-
+      const std::string& pretrained_mlmodel_path,
+      size_t num_classes) const override {
     TS_ASSERT(!init_model_calls_.empty());
     init_model_call expected_call = std::move(init_model_calls_.front());
     init_model_calls_.pop_front();
-    return expected_call(pretrained_mlmodel_path);
+    return expected_call(pretrained_mlmodel_path, num_classes);
   }
 
   variant_map_type perform_evaluation(gl_sframe data,
@@ -303,29 +181,26 @@ public:
       convert_yolo_to_annotations_calls_;
 };
 
-BOOST_AUTO_TEST_CASE(test_object_detector_train) {
-
+BOOST_AUTO_TEST_CASE(test_object_detector_iterate_training) {
   // Most of this test body will be spent setting up the mock objects that we'll
   // inject into the object_detector implementation. These mock objects will
   // make assertions about their inputs along the way and provide the outputs
-  // that we manually pre-program. At the end will be a single call to
-  // object_detector::train that will trigger all the actual testing.
-  test_object_detector model;
+  // that we manually pre-program. At the end will be the calls to
+  // object_detector::iterate_training that will trigger all the actual testing.
 
   // Allocate the mock dependencies. We'll transfer ownership when the toolkit
   // code attempts to instantiate these dependencies.
   std::unique_ptr<mock_data_iterator> mock_iterator(new mock_data_iterator);
   std::unique_ptr<mock_image_augmenter> mock_augmenter(
       new mock_image_augmenter);
-  std::unique_ptr<mock_model_backend> mock_nn_model(
-      new mock_model_backend);
+  std::unique_ptr<mock_model_backend> mock_nn_model(new mock_model_backend);
   std::unique_ptr<mock_compute_context> mock_context(new mock_compute_context);
 
   // We'll request 4 training iterations, since the learning rate schedule
   // kicks in at the 50% and 75% points.
   static constexpr size_t test_max_iterations = 4;
   static constexpr size_t test_batch_size = 2;
-  const std::vector<std::string> test_class_labels = { "label1", "label2" };
+  const std::vector<std::string> test_class_labels = {"label1", "label2"};
   static constexpr size_t test_num_instances = 123;
   static constexpr size_t test_num_examples = 100;
   static constexpr float test_loss = 5.f;
@@ -335,19 +210,16 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
   auto num_iterations_submitted = std::make_shared<size_t>(0);
   for (size_t i = 0; i < test_max_iterations; ++i) {
-
     // Program the mock_iterator to return two arbitrary images, each with one
     // unique annotation. We'll store a copy of the annotations for later
     // comparison.
     auto test_annotations =
         std::make_shared<std::vector<std::vector<image_annotation>>>();
     auto next_batch_impl = [=](size_t batch_size) {
-
       TS_ASSERT_EQUALS(batch_size, test_batch_size);
 
       std::vector<labeled_image> result(test_batch_size);
       for (size_t j = 0; j < result.size(); ++j) {
-
         // The actual contents of the image and the annotations are irrelevant
         // for the purposes of this test. But encode the batch index and row
         // index into the bounding box so that we can verify this data is passed
@@ -368,7 +240,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
     // pass through the annotations.
     auto test_image_batch = std::make_shared<shared_float_array>();
     auto prepare_images_impl = [=](std::vector<labeled_image> source_batch) {
-
       // The source batch should batch what we returned from the mock_iterator.
       TS_ASSERT_EQUALS(source_batch.size(), test_batch_size);
       for (size_t j = 0; j < source_batch.size(); ++j) {
@@ -391,7 +262,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
     // The mock_model_backend should expect calls to set_learning_rate just at
     // the 50% and 75% marks.
     if (i == test_max_iterations / 2 || i == test_max_iterations * 3 / 4) {
-
       auto set_learning_rate_impl = [=](float lr) {
         TS_ASSERT_EQUALS(*num_iterations_submitted, i);
       };
@@ -400,7 +270,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
 
     // The mock_model_backend should expect `train` calls on every iteration.
     auto train_impl = [=](const float_array_map& inputs) {
-
       // The input_batch should just be whatever the image_augmenter returned.
       shared_float_array input_batch = inputs.at("input");
       TS_ASSERT_EQUALS(input_batch.data(), test_image_batch->data());
@@ -417,14 +286,66 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
     mock_nn_model->train_calls_.push_back(train_impl);
   }
 
+  test_object_detector model(
+      {{"batch_size", test_batch_size},
+       {"grid_height", 13},
+       {"grid_width", 13},
+       {"max_iterations", 4},
+       {"num_examples", test_num_examples},
+       {"training_iterations", 0}},
+      nullptr, std::move(mock_context), std::move(mock_iterator),
+      std::move(mock_augmenter), std::move(mock_nn_model));
+
+  // Now, actually invoke object_detector::iterate_training. This will trigger
+  // all the assertions registered above.
+  for (size_t i = 0; i < test_max_iterations; ++i) {
+    model.iterate_training();
+  }
+
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"),
+                   test_max_iterations);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_epochs"),
+                   test_max_iterations * test_batch_size / test_num_examples);
+
+  // Deconstructing `model` here will assert that every expected call to a
+  // mocked-out method has been called.
+}
+
+BOOST_AUTO_TEST_CASE(test_object_detector_init_training) {
+  // Most of this test body will be spent setting up the mock objects that we'll
+  // inject into the object_detector implementation. These mock objects will
+  // make assertions about their inputs along the way and provide the outputs
+  // that we manually pre-program. At the end will be a single call to
+  // object_detector::init_training that will trigger all the actual testing.
+  test_object_detector model;
+
+  // Allocate the mock dependencies. We'll transfer ownership when the toolkit
+  // code attempts to instantiate these dependencies.
+  std::unique_ptr<mock_data_iterator> mock_iterator(new mock_data_iterator);
+  std::unique_ptr<mock_image_augmenter> mock_augmenter(
+      new mock_image_augmenter);
+  std::unique_ptr<mock_model_backend> mock_nn_model(new mock_model_backend);
+  std::unique_ptr<mock_compute_context> mock_context(new mock_compute_context);
+
+  // We'll request 4 training iterations, since the learning rate schedule
+  // kicks in at the 50% and 75% points.
+  static constexpr size_t test_max_iterations = 4;
+  static constexpr size_t test_batch_size = 2;
+  const std::vector<std::string> test_class_labels = {"label1", "label2"};
+  static constexpr size_t test_num_instances = 123;
+  static constexpr size_t test_num_examples = 100;
+
+  mock_iterator->class_labels_ = test_class_labels;
+  mock_iterator->num_instances_ = test_num_instances;
+
   const std::string test_annotations_name = "test_annotations";
   const std::string test_image_name = "test_image";
 
   // The following callbacks capture by reference so that they can transfer
   // ownership of the mocks created above.
   auto create_iterator_impl = [&](data_iterator::parameters iterator_params) {
-
-    TS_ASSERT(iterator_params.class_labels.empty());  // Should infer class labels from data.
+    TS_ASSERT(iterator_params.class_labels
+                  .empty());  // Should infer class labels from data.
     TS_ASSERT(iterator_params.repeat);
 
     return std::move(mock_iterator);
@@ -433,7 +354,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
   model.create_iterator_calls_.push_back(create_iterator_impl);
 
   auto create_augmenter_impl = [&](const image_augmenter::options& opts) {
-
     TS_ASSERT_EQUALS(opts.output_height, 416);
     TS_ASSERT_EQUALS(opts.output_width, 416);
     return std::move(mock_augmenter);
@@ -444,13 +364,15 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
   // object_detector attempts to initialize weights from that path, just return
   // some arbitrary dummy params.
   const std::string test_mlmodel_path = "/test/foo.mlmodel";
-  model.init_model_calls_.emplace_back([=](const std::string& model_path) {
+  model.init_model_calls_.emplace_back([=](const std::string& model_path,
+                                           size_t num_classes) {
     TS_ASSERT_EQUALS(model_path, test_mlmodel_path);
+    TS_ASSERT_EQUALS(num_classes, test_class_labels.size());
 
     std::unique_ptr<model_spec> nn_spec(new model_spec);
     nn_spec->add_convolution("test_layer", "test_input", 16, 16, 3, 3, 1, 1,
                              model_spec::padding_type::SAME,
-                             /* weight_init_fn */ [](float*w , float* w_end) {
+                             /* weight_init_fn */ [](float* w, float* w_end) {
                                for (int i = 0; i < w_end - w; ++i) {
                                  w[i] = static_cast<float>(i);
                                }
@@ -458,57 +380,49 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
     return nn_spec;
   });
 
-  auto create_object_detector_impl = [&](int n, int c_in, int h_in, int w_in,
-                                    int c_out, int h_out, int w_out,
-                                    const float_array_map& config,
-                                    const float_array_map& weights) {
+  auto create_object_detector_impl =
+      [&](int n, int c_in, int h_in, int w_in, int c_out, int h_out, int w_out,
+          const float_array_map& config, const float_array_map& weights) {
+        TS_ASSERT_EQUALS(n, test_batch_size);
+        TS_ASSERT_EQUALS(c_in, 3);
+        TS_ASSERT_EQUALS(h_in, 416);
+        TS_ASSERT_EQUALS(w_in, 416);
+        TS_ASSERT_EQUALS(c_out, 15 * (5 + test_class_labels.size()));
+        TS_ASSERT_EQUALS(h_out, 13);
+        TS_ASSERT_EQUALS(w_out, 13);
 
-    TS_ASSERT_EQUALS(n, test_batch_size);
-    TS_ASSERT_EQUALS(c_in, 3);
-    TS_ASSERT_EQUALS(h_in, 416);
-    TS_ASSERT_EQUALS(w_in, 416);
-    TS_ASSERT_EQUALS(c_out, 15 * (5 + test_class_labels.size()));
-    TS_ASSERT_EQUALS(h_out, 13);
-    TS_ASSERT_EQUALS(w_out, 13);
+        // weights should be what we returned from init_model, as copied by
+        // neural_net::wrap_network_params
+        TS_ASSERT_EQUALS(weights.size(), 1);
+        auto it = weights.find("test_layer_weight");
+        TS_ASSERT(it != weights.end());
+        for (size_t i = 0; i < it->second.size(); ++i) {
+          TS_ASSERT_EQUALS(it->second.data()[i], static_cast<float>(i));
+        }
 
-    // weights should be what we returned from init_model, as copied by
-    // neural_net::wrap_network_params
-    TS_ASSERT_EQUALS(weights.size(), 1);
-    auto it = weights.find("test_layer_weight");
-    TS_ASSERT(it != weights.end());
-    for (size_t i = 0; i < it->second.size(); ++i) {
-      TS_ASSERT_EQUALS(it->second.data()[i], static_cast<float>(i));
-    }
+        // TODO: Assert the config values?
 
-    // TODO: Assert the config values?
-
-    return std::move(mock_nn_model);
-  };
+        return std::move(mock_nn_model);
+      };
   mock_context->create_object_detector_calls_.push_back(
       create_object_detector_impl);
 
   auto create_compute_context_impl = [&] { return std::move(mock_context); };
   model.create_compute_context_calls_.push_back(create_compute_context_impl);
 
-  // Training will trigger a call to evaluation, to compute training metrics.
-  auto perform_evaluation_impl = [&](gl_sframe data, std::string metric) {
-    std::map<std::string, variant_type> result;
-    result["mean_average_precision"] = 0.80f;
-    return result;
-  };
-  model.perform_evaluation_calls_.push_back(perform_evaluation_impl);
-
   // Create an arbitrary SFrame with test_num_examples rows, since
   // object_detector uses the number of rows to compute num_examples, which is
   // used as a normalizer.
   gl_sframe data({{"ignored", gl_sarray::from_sequence(0, test_num_examples)}});
 
-  // Now, actually invoke object_detector::train. This will trigger all the
-  // assertions registered above.
-  model.train(data, test_annotations_name, test_image_name, gl_sframe(),
-              { { "mlmodel_path",   test_mlmodel_path   },
-                { "batch_size",     test_batch_size     },
-                { "max_iterations", test_max_iterations }, });
+  // Now, actually invoke object_detector::init_training. This will trigger all
+  // the assertions registered above.
+  model.init_training(data, test_annotations_name, test_image_name, gl_sframe(),
+                      {
+                          {"mlmodel_path", test_mlmodel_path},
+                          {"batch_size", test_batch_size},
+                          {"max_iterations", test_max_iterations},
+                      });
 
   // Verify model fields.
   TS_ASSERT_EQUALS(model.get_field<flex_int>("batch_size"), test_batch_size);
@@ -524,17 +438,73 @@ BOOST_AUTO_TEST_CASE(test_object_detector_train) {
                    test_class_labels.size());
   TS_ASSERT_EQUALS(model.get_field<flex_int>("num_examples"),
                    test_num_examples);
-  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"),
-                   test_max_iterations);
-  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_epochs"),
-                   test_max_iterations * test_batch_size / test_num_examples);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"), 0);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_epochs"), 0);
+
+  // Deconstructing `model` here will assert that every expected call to a
+  // mocked-out method has been called.
+}
+
+BOOST_AUTO_TEST_CASE(test_object_detector_finalize_training) {
+  // Most of this test body will be spent setting up the mock objects that we'll
+  // inject into the object_detector implementation. These mock objects will
+  // make assertions about their inputs along the way and provide the outputs
+  // that we manually pre-program. At the end will be a single call to
+  // object_detector::finalize_training that will trigger the actual testing.
+
+  // Allocate the mock dependencies. We'll transfer ownership when the toolkit
+  // code attempts to instantiate these dependencies.
+  std::unique_ptr<mock_data_iterator> mock_iterator(new mock_data_iterator);
+  std::unique_ptr<mock_image_augmenter> mock_augmenter(
+      new mock_image_augmenter);
+  std::unique_ptr<mock_model_backend> mock_nn_model(new mock_model_backend);
+  std::unique_ptr<mock_compute_context> mock_context(new mock_compute_context);
+
+  // We'll request 4 training iterations, since the learning rate schedule
+  // kicks in at the 50% and 75% points.
+  static constexpr size_t test_batch_size = 2;
+  const std::vector<std::string> test_class_labels = {"label1", "label2"};
+  static constexpr size_t test_num_instances = 123;
+  static constexpr size_t test_num_examples = 100;
+
+  mock_iterator->class_labels_ = test_class_labels;
+  mock_iterator->num_instances_ = test_num_instances;
+
+  test_object_detector model({{"batch_size", test_batch_size},
+                              {"grid_height", 13},
+                              {"grid_width", 13},
+                              {"max_iterations", 4},
+                              {"num_examples", test_num_examples},
+                              {"training_iterations", 0}},
+                             std::unique_ptr<model_spec>(new model_spec),
+                             std::move(mock_context), std::move(mock_iterator),
+                             std::move(mock_augmenter),
+                             std::move(mock_nn_model));
+
+  // finalize_training will trigger a call to evaluation, to compute training
+  // metrics.
+  auto perform_evaluation_impl = [&](gl_sframe data, std::string metric) {
+    std::map<std::string, variant_type> result;
+    result["mean_average_precision"] = 0.80f;
+    return result;
+  };
+  model.perform_evaluation_calls_.push_back(perform_evaluation_impl);
+
+  // Now, actually invoke object_detector::finalize_training. This will trigger
+  // all the assertions registered above.
+  model.finalize_training();
+
+  // Verify model fields.
   TS_ASSERT_EQUALS(
       model.get_field<flex_float>("training_mean_average_precision"), 0.8f);
 
   // Deconstructing `model` here will assert that every expected call to a
   // mocked-out method has been called.
 }
-  
+
+// TODO: Add a unit test for object_detector::train, in terms of the
+// checkpointing API.
+
 BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
 
   // Most of this test body will be spent setting up the mock objects that we'll
@@ -676,8 +646,10 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   // object_detector attempts to initialize weights from that path, just return
   // some arbitrary dummy params.
   const std::string test_mlmodel_path = "/test/foo.mlmodel";
-  model.init_model_calls_.emplace_back([=](const std::string& model_path) {
+  model.init_model_calls_.emplace_back([=](const std::string& model_path,
+                                           size_t num_classes) {
     TS_ASSERT_EQUALS(model_path, test_mlmodel_path);
+    TS_ASSERT_EQUALS(num_classes, test_class_labels.size());
 
     std::unique_ptr<model_spec> nn_spec(new model_spec);
     nn_spec->add_convolution("test_layer", "test_input", 16, 16, 3, 3, 1, 1,
@@ -689,7 +661,6 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
                              });
     return nn_spec;
   });
-
 
   auto create_object_detector_impl = [&](int n, int c_in, int h_in, int w_in,
                                     int c_out, int h_out, int w_out,
@@ -891,7 +862,8 @@ BOOST_AUTO_TEST_CASE(test_object_detector_predict) {
   // object_detector attempts to initialize weights from that path, just return
   // some arbitrary dummy params.
   const std::string test_mlmodel_path = "/test/foo.mlmodel";
-  model.init_model_calls_.emplace_back([=](const std::string& model_path) {
+  model.init_model_calls_.emplace_back([=](const std::string& model_path,
+                                           size_t num_classes) {
     std::unique_ptr<model_spec> nn_spec(new model_spec);
     nn_spec->add_convolution("test_layer", "test_input", 16, 16, 3, 3, 1, 1,
                              model_spec::padding_type::SAME,


### PR DESCRIPTION
While everyone is wrapping their head around unit tests and mocks, I thought this would be an opportune time to merge a PR with a preliminary stab at checkpointing support for OD, taking this opportunity to clean up the OD tests a bit. With `object_detector::train` now split into smaller pieces, especially `init_training` and `iterating_training`, the previous monolithic test can be decomposed a bit too.

Also moved all the task-agnostic mocks to a header, where they can be used by tests for ST, DC, etc.