### PR TITLE
Save and Load for C++ codepath for OD and AC

### DIFF
--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -17,7 +17,7 @@ import turicreate._connect.main as glconnect
 from turicreate.data_structures.sframe import SFrame as _SFrame
 import turicreate.extensions as _extensions
 from turicreate.extensions import _wrap_function_return
-from turicreate.toolkits._internal_utils import _toolkit_serialize_summary_struct
+from turicreate.toolkits._internal_utils import _toolkit_serialize_summary_struct, _read_env_var_cpp
 from turicreate.util import _make_internal_url
 from turicreate.toolkits._main import ToolkitError
 import turicreate.util._file_util as file_util
@@ -28,14 +28,10 @@ import six as _six
 MODEL_NAME_MAP = {}
 
 # Object detector use C++ codepath
-OD_USE_CPP = True
-if not os.environ.has_key('od_use_cpp') or os.environ.get('od_use_cpp')=="0":
-    OD_USE_CPP = False
+OD_USE_CPP = _read_env_var_cpp('TURI_OD_USE_CPP_PATH')
 
 # Activity Classifier use C++ codepath
-AC_USE_CPP = True
-if not os.environ.has_key('ac_use_cpp') or os.environ.get('ac_use_cpp')=="0":
-    AC_USE_CPP = False
+AC_USE_CPP = _read_env_var_cpp('TURI_AC_USE_CPP_PATH')
 
 def load_model(location):
     """

--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -28,14 +28,14 @@ import six as _six
 MODEL_NAME_MAP = {}
 
 # Object detector use C++ codepath
-od_use_cpp = True
+OD_USE_CPP = True
 if not os.environ.has_key('od_use_cpp') or os.environ.get('od_use_cpp')=="0":
-    od_use_cpp = False
+    OD_USE_CPP = False
 
 # Activity Classifier use C++ codepath
-ac_use_cpp = True
+AC_USE_CPP = True
 if not os.environ.has_key('ac_use_cpp') or os.environ.get('ac_use_cpp')=="0":
-    ac_use_cpp = False
+    AC_USE_CPP = False
 
 def load_model(location):
     """
@@ -102,12 +102,12 @@ def load_model(location):
                 model_version = model_data['model_version']
                 del model_data['model_version']
 
-                if name=='activity_classifier' and ac_use_cpp:
+                if name=='activity_classifier' and AC_USE_CPP:
                     model = _extensions.activity_classifier()
                     model.import_from_custom_model(model_data, model_version)
                     return cls(model)
 
-                if name=='object_detector' and od_use_cpp:
+                if name=='object_detector' and OD_USE_CPP:
                     model = _extensions.object_detector()
                     model.import_from_custom_model(model_data, model_version)
                     return cls(model)


### PR DESCRIPTION
These changes make use of the `use_cpp` flag to define the codepath taken. 

Both C++ and Python models (i.e. from the new and old implementations) are loaded correctly with the C++ codepath. 

_PS Models from the new implementations are not loaded corrected in the old Python loaded._

