### PR TITLE
dict_keys and dict_values types do not work with filter_by #2221

### DIFF
--- a/src/python/turicreate/data_structures/sarray.py
+++ b/src/python/turicreate/data_structures/sarray.py
@@ -375,7 +375,7 @@ class SArray(object):
         # In Python 3, str implements '__iter__'.
         return (isinstance(obj, types.GeneratorType) or
                 (sys.version_info.major < 3 and isinstance(obj, six.moves.xrange)) or
-                sys.version_info.major >= 3 and isinstance(obj, (range, filter, map)))
+                sys.version_info.major >= 3 and isinstance(obj, (range, filter, map, collections.abc.KeysView, collections.abc.ValuesView)))
 
 
     def __init__(self, data=[], dtype=None, ignore_cast_failure=False, _proxy=None):

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -3772,6 +3772,19 @@ class SFrameTest(unittest.TestCase):
 
         _assert_sframe_equal(sf, sf_test)
 
+     
+    def test_filter_by_dict(self):
+        sf = SFrame({'check':range(10)})
+        d = {1:1}
+
+        sf = sf.filter_by(d.keys(),'check')
+        sf_test = sf.filter_by(list(d.keys()),'check')
+        _assert_sframe_equal(sf, sf_test)
+
+        sf = sf.filter_by(d.values(),'check')
+        sf_test = sf.filter_by(list(d.values()),'check')
+        _assert_sframe_equal(sf, sf_test)
+
 
 if __name__ == "__main__":
 

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -3774,6 +3774,7 @@ class SFrameTest(unittest.TestCase):
 
      
     def test_filter_by_dict(self):
+        # Check for dict in filter_by
         sf = SFrame({'check':range(10)})
         d = {1:1}
 


### PR DESCRIPTION
This PR resolves #2221 
dict_keys and dict_values types do not work with filter_by