### PR TITLE
Correctly test for approximate equality and usefully report issues.

### DIFF
--- a/src/core/util/test_macros.hpp
+++ b/src/core/util/test_macros.hpp
@@ -14,7 +14,7 @@ static std::recursive_mutex __b_lock__;
 #define TS_ASSERT_DIFFERS(x,y)           do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) != (y)); } while(0)
 #define TS_ASSERT_LESS_THAN_EQUALS(x,y)  do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) <= (y)); } while(0)
 #define TS_ASSERT_LESS_THAN(x,y)         do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) < (y)); } while(0)
-#define TS_ASSERT_DELTA(x,y,e)           do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_SMALL(double((x)-(y)),double(e)); } while(0)
+#define TS_ASSERT_DELTA(x,y,e)           do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) == (y), boost::test::tolerance(e)); } while(0)
 #define TS_ASSERT_THROWS_NOTHING(expr)   do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_NO_THROW(expr); } while(0)
 #define TS_ASSERT_THROWS_ANYTHING(expr)  \
 do { \


### PR DESCRIPTION
Use the correct form of the boost tests to test for approximate equality in TS_ASSERT_DELTA 