### PR TITLE
Additional arguments for OD's predict and evaluate function

### DIFF
--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1644,7 +1644,7 @@ class ObjectDetector_beta(_Model):
         return self.__proxy__.export_to_coreml(filename, options)
 
 
-    def predict(self, dataset, confidence_threshold=0.25, iou_threshold=None):
+    def predict(self, dataset, confidence_threshold=0.25, iou_threshold=0.45):
         """
         Predict object instances in an SFrame of images.
 
@@ -1693,11 +1693,10 @@ class ObjectDetector_beta(_Model):
         """
         options = {}
         options["confidence_threshold"] = confidence_threshold
-        if iou_threshold != None:
-            options["iou_threshold"] = iou_threshold
+        options["iou_threshold"] = iou_threshold
         return  self.__proxy__.predict(dataset, options)
 
-    def evaluate(self, dataset, metric='auto', output_type='dict', confidence_threshold = None, iou_threshold = None):
+    def evaluate(self, dataset, metric='auto', output_type='dict', confidence_threshold = 0.001, iou_threshold = 0.45):
         """
         Evaluate the model by making predictions and comparing these to ground
         truth bounding box annotations.
@@ -1743,8 +1742,6 @@ class ObjectDetector_beta(_Model):
         mAP: 43.2%
         """
         options = {}
-        if confidence_threshold != None:
-            options["confidence_threshold"] = confidence_threshold
-        if iou_threshold != None:
-            options["iou_threshold"] = iou_threshold
+        options["confidence_threshold"] = confidence_threshold
+        options["iou_threshold"] = iou_threshold
         return self.__proxy__.evaluate(dataset, metric, output_type, options)

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -445,7 +445,6 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         }
         model = _tc.extensions.object_detector()
         model.train(data=dataset, annotations_column_name=annotations, image_column_name=feature, options=tf_config)
-        print(annotations)
         return ObjectDetector_beta(model_proxy=model, name="object_detector")
 
     else:  # Use MxNet
@@ -1645,7 +1644,7 @@ class ObjectDetector_beta(_Model):
         return self.__proxy__.export_to_coreml(filename, options)
 
 
-    def predict(self, dataset, confidence_threshold=0.45, iou_threshold=0.45):
+    def predict(self, dataset, confidence_threshold=0.25, iou_threshold=0.45):
         """
         Predict object instances in an SFrame of images.
 
@@ -1692,10 +1691,9 @@ class ObjectDetector_beta(_Model):
             # Visualize predictions by generating a new column of marked up images
             >>> data['image_pred'] = turicreate.object_detector.util.draw_bounding_boxes(data['image'], data['predictions'])
         """
-        print("shit")
         return  self.__proxy__.predict(dataset, confidence_threshold, iou_threshold)
 
-    def evaluate(self, dataset, metric='auto'):
+    def evaluate(self, dataset, metric='auto', confidence_threshold = 0.001, iou_threshold = 0.45):
         """
         Evaluate the model by making predictions and comparing these to ground
         truth bounding box annotations.
@@ -1740,5 +1738,4 @@ class ObjectDetector_beta(_Model):
         >>> print('mAP: {:.1%}'.format(results['mean_average_precision']))
         mAP: 43.2%
         """
-        print("shit 2 ")
-        return self.__proxy__.evaluate(dataset, metric)
+        return self.__proxy__.evaluate(dataset, metric, confidence_threshold, iou_threshold)

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1693,7 +1693,7 @@ class ObjectDetector_beta(_Model):
         """
         return  self.__proxy__.predict(dataset, confidence_threshold, iou_threshold)
 
-    def evaluate(self, dataset, metric='auto', confidence_threshold = 0.001, iou_threshold = 0.45):
+    def evaluate(self, dataset, metric='auto', output_type='dict', confidence_threshold = 0.001, iou_threshold = 0.45):
         """
         Evaluate the model by making predictions and comparing these to ground
         truth bounding box annotations.

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -264,7 +264,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         # the SFrame shuffle operation that can occur after each epoch.
         'io_thread_buffer_size': 8,
         'mlmodel_path': pretrained_model_path,
-        'use_tensorflow': True
+        'use_tensorflow': False
     }
 
     if '_advanced_parameters' in kwargs:

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1738,4 +1738,4 @@ class ObjectDetector_beta(_Model):
         >>> print('mAP: {:.1%}'.format(results['mean_average_precision']))
         mAP: 43.2%
         """
-        return self.__proxy__.evaluate(dataset, metric, confidence_threshold, iou_threshold)
+        return self.__proxy__.evaluate(dataset, metric, output_type, confidence_threshold, iou_threshold)

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -264,7 +264,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         # the SFrame shuffle operation that can occur after each epoch.
         'io_thread_buffer_size': 8,
         'mlmodel_path': pretrained_model_path,
-        'use_tensorflow': False
+        'use_tensorflow': True
     }
 
     if '_advanced_parameters' in kwargs:
@@ -445,6 +445,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         }
         model = _tc.extensions.object_detector()
         model.train(data=dataset, annotations_column_name=annotations, image_column_name=feature, options=tf_config)
+        print(annotations)
         return ObjectDetector_beta(model_proxy=model, name="object_detector")
 
     else:  # Use MxNet
@@ -1691,23 +1692,9 @@ class ObjectDetector_beta(_Model):
             # Visualize predictions by generating a new column of marked up images
             >>> data['image_pred'] = turicreate.object_detector.util.draw_bounding_boxes(data['image'], data['predictions'])
         """
-        dataset, unpack = self._canonize_input(dataset)
-        stacked_pred = self.__proxy__.predict(dataset, confidence_threshold, iou_threshold)
-        from . import util
-        return unpack(util.unstack_annotations(stacked_pred, num_rows=len(dataset)))
-    def _canonize_input(self, dataset):
-        """
-        Takes input and returns tuple of the input in canonical form (SFrame)
-        along with an unpack callback function that can be applied to
-        prediction results to "undo" the canonization.
-        """
-        unpack = lambda x: x
-        if isinstance(dataset, _tc.SArray):
-            dataset = _tc.SFrame({self.feature: dataset})
-        elif isinstance(dataset, _tc.Image):
-            dataset = _tc.SFrame({self.feature: [dataset]})
-            unpack = lambda x: x[0]
-        return dataset, unpack
+        print("shit")
+        return  self.__proxy__.predict(dataset, confidence_threshold, iou_threshold)
+
     def evaluate(self, dataset, metric='auto'):
         """
         Evaluate the model by making predictions and comparing these to ground
@@ -1753,4 +1740,5 @@ class ObjectDetector_beta(_Model):
         >>> print('mAP: {:.1%}'.format(results['mean_average_precision']))
         mAP: 43.2%
         """
+        print("shit 2 ")
         return self.__proxy__.evaluate(dataset, metric)

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -264,7 +264,7 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         # the SFrame shuffle operation that can occur after each epoch.
         'io_thread_buffer_size': 8,
         'mlmodel_path': pretrained_model_path,
-        'use_tensorflow': False
+        'use_tensorflow': True
     }
 
     if '_advanced_parameters' in kwargs:
@@ -1644,7 +1644,7 @@ class ObjectDetector_beta(_Model):
         return self.__proxy__.export_to_coreml(filename, options)
 
 
-    def predict(self, dataset, confidence_threshold=0.25, iou_threshold=0.45):
+    def predict(self, dataset, confidence_threshold=0.25, iou_threshold=None):
         """
         Predict object instances in an SFrame of images.
 
@@ -1691,9 +1691,13 @@ class ObjectDetector_beta(_Model):
             # Visualize predictions by generating a new column of marked up images
             >>> data['image_pred'] = turicreate.object_detector.util.draw_bounding_boxes(data['image'], data['predictions'])
         """
-        return  self.__proxy__.predict(dataset, confidence_threshold, iou_threshold)
+        options = {}
+        options["confidence_threshold"] = confidence_threshold
+        if iou_threshold != None:
+            options["iou_threshold"] = iou_threshold
+        return  self.__proxy__.predict(dataset, options)
 
-    def evaluate(self, dataset, metric='auto', output_type='dict', confidence_threshold = 0.001, iou_threshold = 0.45):
+    def evaluate(self, dataset, metric='auto', output_type='dict', confidence_threshold = None, iou_threshold = None):
         """
         Evaluate the model by making predictions and comparing these to ground
         truth bounding box annotations.
@@ -1738,4 +1742,9 @@ class ObjectDetector_beta(_Model):
         >>> print('mAP: {:.1%}'.format(results['mean_average_precision']))
         mAP: 43.2%
         """
-        return self.__proxy__.evaluate(dataset, metric, output_type, confidence_threshold, iou_threshold)
+        options = {}
+        if confidence_threshold != None:
+            options["confidence_threshold"] = confidence_threshold
+        if iou_threshold != None:
+            options["iou_threshold"] = iou_threshold
+        return self.__proxy__.evaluate(dataset, metric, output_type, options)

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -476,7 +476,6 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
                                        std::string output_type,
                                        float confidence_threshold,
                                        float iou_threshold) {
-  std::cout << "enter evaluate\n";
   std::vector<std::string> metrics;
   static constexpr char AP[] = "average_precision";
   static constexpr char MAP[] = "mean_average_precision";
@@ -493,13 +492,8 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
   } else {
     log_and_throw("Metric " + metric + " not supported");
   }
-  std::cout << "try to read labels..\n";
-  for (auto& zz : state) {
-    std::cout << zz.first << '\n';
-  }
 
   flex_list class_labels = read_state<flex_list>("classes");
-  std::cout << "finish reading labels..\n";
   // Initialize the metric calculator
   average_precision_calculator calculator(class_labels);
 
@@ -507,7 +501,7 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
                       const std::vector<image_annotation>& groundtruth_row) {
     calculator.add_row(predicted_row, groundtruth_row);
   };
-  // std::cout << "fuck!\n";
+
   perform_predict(data, consumer, confidence_threshold, iou_threshold);
 
   // Compute the average precision (area under the precision-recall curve) for
@@ -1282,13 +1276,11 @@ void object_detector::update_model_metrics(gl_sframe data,
   std::map<std::string, variant_type> metrics;
 
   // Compute training metrics.
-  std::cout << data.size() << "gg\n";
-  variant_type training_metrics_raw = evaluate(data, "all", "dict");
-  std::cout << "finish evaluate!\n";
+  variant_type training_metrics_raw =
+      perform_evaluation(data, "all", "dict", 0.001, 0.45);
   variant_map_type training_metrics =
       variant_get_value<variant_map_type>(training_metrics_raw);
   for (const auto& kv : training_metrics) {
-    std::cout << kv.first << "zzzz\n";
     metrics["training_" + kv.first] = kv.second;
   }
 

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -99,8 +99,6 @@ constexpr float DEFAULT_NON_MAXIMUM_SUPPRESSION_THRESHOLD = 0.45f;
 // Predictions with confidence scores below this threshold will be discarded
 // before generation precision-recall curves.
 
-//constexpr float EVAL_CONFIDENCE_THRESHOLD = 0.001f;
-
 // Each bounding box is evaluated relative to a list of pre-defined sizes.
 const std::vector<std::pair<float, float>>& anchor_boxes() {
   static const std::vector<std::pair<float, float>>* const default_boxes =
@@ -607,8 +605,6 @@ void object_detector::perform_predict(gl_sframe data,
   size_t batch_size = read_state<size_t>("batch_size");
   size_t grid_height = read_state<size_t>("grid_height");
   size_t grid_width = read_state<size_t>("grid_width");
-  //float iou_threshold =
-  //    read_state<flex_float>("non_maximum_suppression_threshold");
 
   // return if the data is empty
   if (data.size() == 0) return;

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -521,6 +521,11 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
     result_map.erase(MAP);
   }
 
+  // Handle different output types here
+  // If output_type = "dict", just return the result_map.
+  // If output_type = "sframe", construct a sframe,
+  // whose rows indicate class labels, and columns denote different metric
+  // scores. Note that the "sframe" output only shows AP or AP50.
   variant_type final_result;
 
   if (output_type == "dict") {
@@ -572,8 +577,9 @@ gl_sarray object_detector::predict(variant_type data, float confidence_threshold
     result.write(predicted_row_ft, 0);
   };
 
-  //check input type of data
-  //and convert them all to sframe.
+  // check input type of data
+  // and convert them all to sframe.
+  // "SFrame", "Sarray" and a single image "flexible_type" are accepted.
   gl_sframe sframe_data;
   std::string image_column_name = read_state<flex_string>("feature");
   if (variant_is<gl_sframe>(data)) {

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -1287,7 +1287,7 @@ void object_detector::update_model_metrics(gl_sframe data,
   // Compute validation metrics if necessary.
   if (!validation_data.empty()) {
     variant_type validation_metrics_raw =
-        evaluate(validation_data, "all", "dict");
+        perform_evaluation(validation_data, "all", "dict", 0.001, 0.45);
     variant_map_type validation_metrics =
         variant_get_value<variant_map_type>(validation_metrics_raw);
     for (const auto& kv : validation_metrics) {

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -476,6 +476,7 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
                                        std::string output_type,
                                        float confidence_threshold,
                                        float iou_threshold) {
+  std::cout << "enter evaluate\n";
   std::vector<std::string> metrics;
   static constexpr char AP[] = "average_precision";
   static constexpr char MAP[] = "mean_average_precision";
@@ -492,9 +493,13 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
   } else {
     log_and_throw("Metric " + metric + " not supported");
   }
+  std::cout << "try to read labels..\n";
+  for (auto& zz : state) {
+    std::cout << zz.first << '\n';
+  }
 
   flex_list class_labels = read_state<flex_list>("classes");
-
+  std::cout << "finish reading labels..\n";
   // Initialize the metric calculator
   average_precision_calculator calculator(class_labels);
 
@@ -502,7 +507,7 @@ variant_type object_detector::evaluate(gl_sframe data, std::string metric,
                       const std::vector<image_annotation>& groundtruth_row) {
     calculator.add_row(predicted_row, groundtruth_row);
   };
-
+  // std::cout << "fuck!\n";
   perform_predict(data, consumer, confidence_threshold, iou_threshold);
 
   // Compute the average precision (area under the precision-recall curve) for
@@ -1277,10 +1282,13 @@ void object_detector::update_model_metrics(gl_sframe data,
   std::map<std::string, variant_type> metrics;
 
   // Compute training metrics.
+  std::cout << data.size() << "gg\n";
   variant_type training_metrics_raw = evaluate(data, "all", "dict");
+  std::cout << "finish evaluate!\n";
   variant_map_type training_metrics =
       variant_get_value<variant_map_type>(training_metrics_raw);
   for (const auto& kv : training_metrics) {
+    std::cout << kv.first << "zzzz\n";
     metrics["training_" + kv.first] = kv.second;
   }
 

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -483,7 +483,7 @@ void object_detector::finalize_training() {
 }
 
 variant_map_type object_detector::evaluate(
-    gl_sframe data, std::string metric, float confidence_threshold,
+    gl_sframe data, std::string metric, std::string output_type, float confidence_threshold,
     float iou_threshold) {
   std::vector<std::string> metrics;
   static constexpr char AP[] = "average_precision";
@@ -531,6 +531,10 @@ variant_map_type object_detector::evaluate(
   }
   if (std::find(metrics.begin(), metrics.end(), MAP) == metrics.end()) {
     result_map.erase(MAP);
+  }
+
+  if( output_type != "dict" && output_type != "sframe"){
+    log_and_throw("Invalid 'output_type' argument! Only 'dict' and 'sframe' are accepted.");
   }
 
   return result_map;
@@ -708,9 +712,10 @@ void object_detector::perform_predict(gl_sframe data,
 // existing backend is available?
 variant_map_type object_detector::perform_evaluation(gl_sframe data,
                                                      std::string metric,
+                                                     std::string output_type,
                                                      float confidence_threshold,
                                                      float iou_threshold) {
-  return evaluate(data, metric, confidence_threshold, iou_threshold);
+  return evaluate(data, metric, output_type, confidence_threshold, iou_threshold);
 }
 
 std::vector<neural_net::image_annotation>

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -482,9 +482,10 @@ void object_detector::finalize_training() {
   update_model_metrics(training_data_, validation_data_);
 }
 
-variant_map_type object_detector::evaluate(
-    gl_sframe data, std::string metric, std::string output_type, float confidence_threshold,
-    float iou_threshold) {
+variant_map_type object_detector::evaluate(gl_sframe data, std::string metric,
+                                           std::string output_type,
+                                           float confidence_threshold,
+                                           float iou_threshold) {
   std::vector<std::string> metrics;
   static constexpr char AP[] = "average_precision";
   static constexpr char MAP[] = "mean_average_precision";
@@ -533,8 +534,10 @@ variant_map_type object_detector::evaluate(
     result_map.erase(MAP);
   }
 
-  if( output_type != "dict" && output_type != "sframe"){
-    log_and_throw("Invalid 'output_type' argument! Only 'dict' and 'sframe' are accepted.");
+  if (output_type != "dict" && output_type != "sframe") {
+    log_and_throw(
+        "Invalid 'output_type' argument! Only 'dict' and 'sframe' are "
+        "accepted.");
   }
 
   return result_map;
@@ -715,7 +718,8 @@ variant_map_type object_detector::perform_evaluation(gl_sframe data,
                                                      std::string output_type,
                                                      float confidence_threshold,
                                                      float iou_threshold) {
-  return evaluate(data, metric, output_type, confidence_threshold, iou_threshold);
+  return evaluate(data, metric, output_type, confidence_threshold,
+                  iou_threshold);
 }
 
 std::vector<neural_net::image_annotation>

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -532,10 +532,7 @@ variant_map_type object_detector::evaluate(
   if (std::find(metrics.begin(), metrics.end(), MAP) == metrics.end()) {
     result_map.erase(MAP);
   }
-  for (auto& shit : result_map) {
-    std::cout << shit.first << '\n';
-  }
-  std::cout << "====\n";
+
   return result_map;
 }
 

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -109,9 +109,10 @@ class EXPORT object_detector: public ml_model_base {
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric",
     "confidence_threshold", "iou_threshold");
-  register_defaults("evaluate",
-      {{"metric", std::string("auto")},{"output_type","dict"},{"confidence_threshold", 0.001},
-      {"iou_threshold", 0.45}});
+  register_defaults("evaluate", {{"metric", std::string("auto")},
+                                 {"output_type", "dict"},
+                                 {"confidence_threshold", 0.001},
+                                 {"iou_threshold", 0.45}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data",
    "confidence_threshold", "iou_threshold");

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -41,11 +41,9 @@ class EXPORT object_detector: public ml_model_base {
              std::string image_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
   variant_type evaluate(gl_sframe data, std::string metric,
-                        std::string output_type = "dict",
-                        float confidence_threshold = 0.001,
-                        float iou_threshold = 0.45);
-  gl_sarray predict(variant_type data, float confidence_threshold,
-   float iou_threshold);
+                        std::string output_type,
+                        std::map<std::string, flexible_type> opts);
+  gl_sarray predict(variant_type data, std::map<std::string, flexible_type> opts);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename, std::map<std::string, flexible_type> opts);
   void import_from_custom_model(variant_map_type model_data, size_t version);
@@ -108,17 +106,13 @@ class EXPORT object_detector: public ml_model_base {
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::finalize_training);
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric",
-                                 "output_type", "confidence_threshold",
-                                 "iou_threshold");
+                                 "output_type", "options");
   register_defaults("evaluate", {{"metric", std::string("auto")},
                                  {"output_type", std::string("dict")},
-                                 {"confidence_threshold", 0.001},
-                                 {"iou_threshold", 0.45}});
+                                 });
 
-  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data",
-   "confidence_threshold", "iou_threshold");
-  register_defaults("predict",{{"confidence_threshold", 0.25},
-    {"iou_threshold", 0.45}});
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data", "options");
+  register_defaults("predict",{});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename",
     "options");
@@ -219,6 +213,8 @@ class EXPORT object_detector: public ml_model_base {
   flex_int get_max_iterations() const;
   flex_int get_training_iterations() const;
   flex_int get_num_classes() const;
+
+  variant_type convert_map_to_types(variant_map_type& result_map, std::string output_type);
 
   // Sets certain user options heuristically (from the data).
   void infer_derived_options();

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -41,6 +41,7 @@ class EXPORT object_detector: public ml_model_base {
              std::string image_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
   variant_map_type evaluate(gl_sframe data, std::string metric,
+                            std::string output_type = "dict",
                             float confidence_threshold = 0.001,
                             float iou_threshold = 0.45);
   gl_sarray predict(variant_type data, float confidence_threshold,
@@ -109,7 +110,7 @@ class EXPORT object_detector: public ml_model_base {
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric",
     "confidence_threshold", "iou_threshold");
   register_defaults("evaluate",
-      {{"metric", std::string("auto")},{"confidence_threshold", 0.001},
+      {{"metric", std::string("auto")},{"output_type","dict"},{"confidence_threshold", 0.001},
       {"iou_threshold", 0.45}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data",
@@ -190,6 +191,7 @@ class EXPORT object_detector: public ml_model_base {
 
   virtual variant_map_type perform_evaluation(gl_sframe data,
                                               std::string metric,
+                                              std::string output_type,
                                               float confidence_threshold,
                                               float iou_threshold);
 

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -40,8 +40,9 @@ class EXPORT object_detector: public ml_model_base {
   void train(gl_sframe data, std::string annotations_column_name,
              std::string image_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
-  variant_map_type evaluate(gl_sframe data, std::string metric);
-  gl_sarray predict(gl_sframe data, float confidence_threshold,
+  variant_map_type evaluate(gl_sframe data, std::string metric, float
+    confidence_threshold, float iou_threshold);
+  gl_sarray predict(variant_type data, float confidence_threshold,
    float iou_threshold);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename, std::map<std::string, flexible_type> opts);
@@ -104,9 +105,11 @@ class EXPORT object_detector: public ml_model_base {
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::synchronize_training);
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::finalize_training);
 
-  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric");
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric",
+    "confidence_threshold", "iou_threshold");
   register_defaults("evaluate",
-      {{"metric", std::string("auto")}});
+      {{"metric", std::string("auto")},{"confidence_threshold", 0.001},
+      {"iou_threshold", 0.45}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data",
    "confidence_threshold", "iou_threshold");

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -194,7 +194,8 @@ class EXPORT object_detector: public ml_model_base {
       gl_sframe data,
       std::function<void(const std::vector<neural_net::image_annotation>&,
                          const std::vector<neural_net::image_annotation>&)>
-          consumer, float confidence_threshold = 0.001, float iou_threshold = 0.45);
+          consumer,
+      float confidence_threshold, float iou_threshold);
 
   // Utility code
 
@@ -214,8 +215,10 @@ class EXPORT object_detector: public ml_model_base {
   flex_int get_training_iterations() const;
   flex_int get_num_classes() const;
 
-  variant_type convert_map_to_types(variant_map_type& result_map, std::string output_type);
-
+  static variant_type convert_map_to_types(const variant_map_type& result_map,
+                                           const std::string& output_type);
+  static gl_sframe convert_types_to_sframe(const variant_type& data,
+                                           const std::string& column_name);
   // Sets certain user options heuristically (from the data).
   void infer_derived_options();
 

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -41,7 +41,8 @@ class EXPORT object_detector: public ml_model_base {
              std::string image_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
   variant_map_type evaluate(gl_sframe data, std::string metric);
-  gl_sarray predict(gl_sframe data);
+  gl_sarray predict(gl_sframe data, float confidence_threshold,
+   float iou_threshold);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
       std::string filename, std::map<std::string, flexible_type> opts);
   void import_from_custom_model(variant_map_type model_data, size_t version);
@@ -107,7 +108,10 @@ class EXPORT object_detector: public ml_model_base {
   register_defaults("evaluate",
       {{"metric", std::string("auto")}});
 
-  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data");
+  REGISTER_CLASS_MEMBER_FUNCTION(object_detector::predict, "data",
+   "confidence_threshold", "iou_threshold");
+  register_defaults("predict",{{"confidence_threshold", 0.25},
+    {"iou_threshold", 0.45}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename",
     "options");
@@ -187,7 +191,7 @@ class EXPORT object_detector: public ml_model_base {
       gl_sframe data,
       std::function<void(const std::vector<neural_net::image_annotation>&,
                          const std::vector<neural_net::image_annotation>&)>
-          consumer);
+          consumer, float confidence_threshold = 0.001, float iou_threshold = 0.45);
 
   // Utility code
 

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -40,10 +40,10 @@ class EXPORT object_detector: public ml_model_base {
   void train(gl_sframe data, std::string annotations_column_name,
              std::string image_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
-  variant_map_type evaluate(gl_sframe data, std::string metric,
-                            std::string output_type = "dict",
-                            float confidence_threshold = 0.001,
-                            float iou_threshold = 0.45);
+  variant_type evaluate(gl_sframe data, std::string metric,
+                        std::string output_type = "dict",
+                        float confidence_threshold = 0.001,
+                        float iou_threshold = 0.45);
   gl_sarray predict(variant_type data, float confidence_threshold,
    float iou_threshold);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
@@ -108,9 +108,10 @@ class EXPORT object_detector: public ml_model_base {
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::finalize_training);
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::evaluate, "data", "metric",
-    "confidence_threshold", "iou_threshold");
+                                 "output_type", "confidence_threshold",
+                                 "iou_threshold");
   register_defaults("evaluate", {{"metric", std::string("auto")},
-                                 {"output_type", "dict"},
+                                 {"output_type", std::string("dict")},
                                  {"confidence_threshold", 0.001},
                                  {"iou_threshold", 0.45}});
 
@@ -190,11 +191,10 @@ class EXPORT object_detector: public ml_model_base {
       const std::vector<std::pair<float, float>>& anchor_boxes,
       float min_confidence);
 
-  virtual variant_map_type perform_evaluation(gl_sframe data,
-                                              std::string metric,
-                                              std::string output_type,
-                                              float confidence_threshold,
-                                              float iou_threshold);
+  virtual variant_type perform_evaluation(gl_sframe data, std::string metric,
+                                          std::string output_type,
+                                          float confidence_threshold,
+                                          float iou_threshold);
 
   void perform_predict(
       gl_sframe data,

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -40,8 +40,9 @@ class EXPORT object_detector: public ml_model_base {
   void train(gl_sframe data, std::string annotations_column_name,
              std::string image_column_name, variant_type validation_data,
              std::map<std::string, flexible_type> opts);
-  variant_map_type evaluate(gl_sframe data, std::string metric, float
-    confidence_threshold, float iou_threshold);
+  variant_map_type evaluate(gl_sframe data, std::string metric,
+                            float confidence_threshold = 0.001,
+                            float iou_threshold = 0.45);
   gl_sarray predict(variant_type data, float confidence_threshold,
    float iou_threshold);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
@@ -188,7 +189,9 @@ class EXPORT object_detector: public ml_model_base {
       float min_confidence);
 
   virtual variant_map_type perform_evaluation(gl_sframe data,
-                                              std::string metric);
+                                              std::string metric,
+                                              float confidence_threshold,
+                                              float iou_threshold);
 
   void perform_predict(
       gl_sframe data,

--- a/test/unity/toolkits/neural_net/neural_net_mocks.hpp
+++ b/test/unity/toolkits/neural_net/neural_net_mocks.hpp
@@ -112,12 +112,12 @@ class mock_compute_context : public compute_context {
           const float_array_map& config, const float_array_map& weights)>;
 
   using create_drawing_classifier_call =
-      std::function<std::unique_ptr<model_backend>(
-          /* TODO: const float_array_map& weights,
-           *       const float_array_map& config.
-           * Until the nn_spec in C++ isn't ready, do not pass in any weights.
-           */
-          size_t batch_size, size_t num_classes)>;
+       std::function<std::unique_ptr<model_backend>(
+           /* TODO: const float_array_map& weights, 
+            *       const float_array_map& config.
+            * Until the nn_spec in C++ isn't ready, do not pass in any weights.
+            */
+           size_t batch_size, size_t num_classes)>;
 
   ~mock_compute_context() {
     TS_ASSERT(create_augmenter_calls_.empty());
@@ -171,6 +171,21 @@ class mock_compute_context : public compute_context {
     return nullptr;
   }
 
+  std::unique_ptr<model_backend> create_drawing_classifier(
+       /* TODO: const float_array_map& weights, const float_array_map& config.
+        * Until the nn_spec in C++ isn't ready, do not pass in any weights.
+        */
+       size_t batch_size, size_t num_classes) override {
+     TS_ASSERT(!create_drawing_classifier_calls_.empty());
+     create_drawing_classifier_call expected_call =
+         std::move(create_drawing_classifier_calls_.front());
+     create_drawing_classifier_calls_.pop_front();
+     return expected_call(
+       /* TODO: const float_array_map& weights, const float_array_map& config.
+        * Until the nn_spec in C++ isn't ready, do not pass in any weights.
+        */
+       batch_size, num_classes);
+  }
 
   std::unique_ptr<model_backend> create_style_transfer(
       const float_array_map& config, const float_array_map& weights) override {

--- a/test/unity/toolkits/neural_net/neural_net_mocks.hpp
+++ b/test/unity/toolkits/neural_net/neural_net_mocks.hpp
@@ -112,12 +112,12 @@ class mock_compute_context : public compute_context {
           const float_array_map& config, const float_array_map& weights)>;
 
   using create_drawing_classifier_call =
-       std::function<std::unique_ptr<model_backend>(
-           /* TODO: const float_array_map& weights, 
-            *       const float_array_map& config.
-            * Until the nn_spec in C++ isn't ready, do not pass in any weights.
-            */
-           size_t batch_size, size_t num_classes)>;
+      std::function<std::unique_ptr<model_backend>(
+          /* TODO: const float_array_map& weights,
+           *       const float_array_map& config.
+           * Until the nn_spec in C++ isn't ready, do not pass in any weights.
+           */
+          size_t batch_size, size_t num_classes)>;
 
   ~mock_compute_context() {
     TS_ASSERT(create_augmenter_calls_.empty());
@@ -171,21 +171,6 @@ class mock_compute_context : public compute_context {
     return nullptr;
   }
 
-  std::unique_ptr<model_backend> create_drawing_classifier(
-       /* TODO: const float_array_map& weights, const float_array_map& config.
-        * Until the nn_spec in C++ isn't ready, do not pass in any weights.
-        */
-       size_t batch_size, size_t num_classes) override {
-     TS_ASSERT(!create_drawing_classifier_calls_.empty());
-     create_drawing_classifier_call expected_call =
-         std::move(create_drawing_classifier_calls_.front());
-     create_drawing_classifier_calls_.pop_front();
-     return expected_call(
-       /* TODO: const float_array_map& weights, const float_array_map& config.
-        * Until the nn_spec in C++ isn't ready, do not pass in any weights.
-        */
-       batch_size, num_classes);
-  }
 
   std::unique_ptr<model_backend> create_style_transfer(
       const float_array_map& config, const float_array_map& weights) override {

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -91,8 +91,9 @@ public:
   using init_model_call = std::function<std::unique_ptr<model_spec>(
       const std::string& pretrained_mlmodel_path, size_t num_classes)>;
 
-  using perform_evaluation_call = std::function<variant_map_type(
-      gl_sframe data, std::string metric, float, float)>;
+  using perform_evaluation_call =
+      std::function<variant_type(gl_sframe data, std::string metric,
+                                 std::string output_type, float, float)>;
 
   using convert_yolo_to_annotations_call =
       std::function<std::vector<image_annotation>(
@@ -148,14 +149,16 @@ public:
     return expected_call(pretrained_mlmodel_path, num_classes);
   }
 
-  variant_map_type perform_evaluation(gl_sframe data, std::string metric,
-                                      float confidence_threshold,
-                                      float iou_threshold) override {
+  variant_type perform_evaluation(gl_sframe data, std::string metric,
+                                  std::string output_type,
+                                  float confidence_threshold,
+                                  float iou_threshold) override {
     TS_ASSERT(!perform_evaluation_calls_.empty());
     perform_evaluation_call expected_call =
         std::move(perform_evaluation_calls_.front());
     perform_evaluation_calls_.pop_front();
-    return expected_call(data, metric, confidence_threshold, iou_threshold);
+    return expected_call(data, metric, output_type, confidence_threshold,
+                         iou_threshold);
   }
 
   std::vector<neural_net::image_annotation> convert_yolo_to_annotations(
@@ -484,13 +487,13 @@ BOOST_AUTO_TEST_CASE(test_object_detector_finalize_training) {
 
   // finalize_training will trigger a call to evaluation, to compute training
   // metrics.
-  auto perform_evaluation_impl = [&](gl_sframe data, std::string metric,
-                                     float confidence_threshold,
-                                     float iou_threshold) {
-    std::map<std::string, variant_type> result;
-    result["mean_average_precision"] = 0.80f;
-    return result;
-  };
+  auto perform_evaluation_impl =
+      [&](gl_sframe data, std::string metric, std::string output_type,
+          float confidence_threshold, float iou_threshold) {
+        std::map<std::string, variant_type> result;
+        result["mean_average_precision"] = 0.80f;
+        return to_variant(result);
+      };
   model.perform_evaluation_calls_.push_back(perform_evaluation_impl);
 
   // Now, actually invoke object_detector::finalize_training. This will trigger
@@ -698,13 +701,13 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
   model.create_compute_context_calls_.push_back(create_compute_context_impl);
 
   // Training will trigger a call to evaluation, to compute training metrics.
-  auto perform_evaluation_impl = [&](gl_sframe data, std::string metric,
-                                     float confidence_threshold,
-                                     float iou_threshold) {
-    std::map<std::string, variant_type> result;
-    result["mean_average_precision"] = 0.80f;
-    return result;
-  };
+  auto perform_evaluation_impl =
+      [&](gl_sframe data, std::string metric, std::string output_type,
+          float confidence_threshold, float iou_threshold) {
+        std::map<std::string, variant_type> result;
+        result["mean_average_precision"] = 0.80f;
+        return to_variant(result);
+      };
 
   // The two evaluation calls are performed for train data as well as validation
   // data.
@@ -891,13 +894,13 @@ BOOST_AUTO_TEST_CASE(test_object_detector_predict) {
   model.create_compute_context_calls_.push_back(create_compute_context_impl);
 
   // Training will trigger a call to evaluation, to compute training metrics.
-  auto perform_evaluation_impl = [&](gl_sframe data, std::string metric,
-                                     float confidence_threshold,
-                                     float iou_threshold) {
-    std::map<std::string, variant_type> result;
-    result["mean_average_precision"] = 0.80f;
-    return result;
-  };
+  auto perform_evaluation_impl =
+      [&](gl_sframe data, std::string metric, std::string output_type,
+          float confidence_threshold, float iou_threshold) {
+        std::map<std::string, variant_type> result;
+        result["mean_average_precision"] = 0.80f;
+        return to_variant(result);
+      };
   model.perform_evaluation_calls_.push_back(perform_evaluation_impl);
 
   // Now, actually invoke object_detector::train. This will trigger all the

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -1091,8 +1091,8 @@ BOOST_AUTO_TEST_CASE(test_object_detector_predict) {
   for (size_t i = 0; i < 2 * test_batch_size; ++i) {
     model.convert_yolo_to_annotations_calls_.push_back(convert_yolo_impl);
   }
-
-  gl_sarray result = model.predict(data, 0.25, 0.45);
+  std::map<std::string, flexible_type> opts{{"confidence_threshold",0.25}, {"iou_threshold",0.45}};
+  gl_sarray result = model.predict(data, opts);
   for (size_t j = 0; j < result.size(); ++j) {
     TS_ASSERT_EQUALS(result[j].size(), num_prediction_instances);
   }


### PR DESCRIPTION
Change several things in this PR:
1.Add confidence_threshold, iou_threshold arguments for predict() and evaluate().
2.Enable different input data types (sframe, array, image) for predict().
3.Enable different output data types (dict, sframe) for evaluate().
4.Change the output attribute "bounding box" to "coordinate" for predict() in order to pass the python unit test.
5.Add output attribute "type" for predict() in order to pass the python unit test. 
6.Change several lines in the unit test for OD regarding the additional arguments for perform_evaluation()