### PR TITLE
[WIP] Fixes AC `list_fields()` and adapted python test

### DIFF
--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -392,6 +392,23 @@ class Model(ExposeAttributesFromProxy):
         def _native_name(cls):
             return ["nearest_neighbors_ball_tree", "nearest_neighbors_brute_force", "nearest_neighbors_lsh"]
     """
+    def list_fields(self):
+        return list(self._list_fields())
+
+    def name(self):
+        """
+        Returns the name of the model class.
+
+        Returns
+        -------
+        out : str
+            The name of the model class.
+
+        Examples
+        --------
+        >>> model_name = m._name()
+        """
+        return self.__class__.__name__
 
     def _name(self):
         """

--- a/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -356,7 +356,10 @@ class ActivityClassifier_beta(_Model):
 
     @classmethod
     def _native_name(cls):
-        return None
+        if USE_CPP:
+            return "activity_classifier"
+        else:
+            return None
 
     def __str__(self):
         """
@@ -595,7 +598,10 @@ class ActivityClassifier(_CustomModel):
 
     @classmethod
     def _native_name(cls):
-        return "activity_classifier"
+        if not USE_CPP:
+            return "activity_classifier"
+        else:
+            return None
 
     def _get_version(self):
         return self._PYTHON_ACTIVITY_CLASSIFIER_VERSION

--- a/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -190,6 +190,8 @@ def create(dataset, session_id, target, features=None, prediction_window=100,
         options['prediction_window'] = prediction_window
         options['batch_size'] = batch_size
         options['max_iterations'] = max_iterations
+        options['verbose'] = verbose
+        options['num_examples'] = len(dataset)
 
         model.train(dataset, target, session_id, validation_set, options)
         return ActivityClassifier_beta(model_proxy=model, name=name)
@@ -358,8 +360,7 @@ class ActivityClassifier_beta(_Model):
     def _native_name(cls):
         if USE_CPP:
             return "activity_classifier"
-        else:
-            return None
+        return None
 
     def __str__(self):
         """
@@ -600,8 +601,7 @@ class ActivityClassifier(_CustomModel):
     def _native_name(cls):
         if not USE_CPP:
             return "activity_classifier"
-        else:
-            return None
+        return None
 
     def _get_version(self):
         return self._PYTHON_ACTIVITY_CLASSIFIER_VERSION

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -526,7 +526,9 @@ class ObjectDetector(_CustomModel):
 
     @classmethod
     def _native_name(cls):
-        return "object_detector"
+        if not USE_CPP:
+            return "object_detector"
+        return None
 
     def _get_native_state(self):
         from .._mxnet import _mxnet_utils
@@ -1547,6 +1549,8 @@ class ObjectDetector_beta(_Model):
 
     @classmethod
     def _native_name(cls):
+        if USE_CPP:
+            return "object_detector"
         return None
 
     def __str__(self):

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -18,6 +18,7 @@
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 #include <toolkits/evaluation/metrics.hpp>
 #include <toolkits/util/training_utils.hpp>
+#include <timer/timer.hpp>
 
 namespace turi {
 namespace activity_classification {
@@ -186,6 +187,25 @@ void activity_classifier::init_options(
       FLEX_UNDEFINED,
       std::numeric_limits<int>::min(),
       std::numeric_limits<int>::max());
+  options.create_boolean_option(
+      "verbose",
+      "If set to False, the progress table is hidden.",
+      true,
+      true);
+  options.create_integer_option(
+      "num_examples",
+      "Number of examples in the dataset",
+      FLEX_UNDEFINED,
+      0, // should it be?
+      std::numeric_limits<int>::max(),
+      true);
+  options.create_integer_option(
+      "num_sessions",
+      "Number of sessions.",
+      FLEX_UNDEFINED,
+      0,
+      std::numeric_limits<int>::max(),
+      true);
 
   // Validate user-provided options.
   options.set_options(opts);
@@ -330,6 +350,9 @@ void activity_classifier::train(
     std::string session_id_column_name, variant_type validation_data,
     std::map<std::string, flexible_type> opts)
 {
+
+  turi::timer time_object;
+  time_object.start();
   // Instantiate the training dependencies: data iterator, compute context,
   // backend NN model.
   init_train(data, target_column_name, session_id_column_name, validation_data,
@@ -375,6 +398,11 @@ void activity_classifier::train(
       state_update["validation_" + p.first] = p.second;
     }
   }
+
+  state_update["verbose"] = read_state<bool>("verbose");
+  state_update["num_sessions"] = data[session_id_column_name].unique().size();
+  state_update["num_examples"] = read_state<flex_int>("num_examples");
+  state_update["training_time"] = time_object.current_time();
 
   add_or_update_state(state_update);
 


### PR DESCRIPTION
`list_fields()` now has attributes `num_sessions`, `verbose`, `training_time` and `num_examples`. AC python test is adapted so that `test__list_fields()` queries and validates model attributes specific to C++ and Python given the codepath chosen.


[WIP] because I need to remove the load model fix changes.
TODO: Replicate changes for `list_fields()` in OD