### PR TITLE
flip two lines in image_similarity documentation

### DIFF
--- a/src/python/turicreate/toolkits/image_similarity/image_similarity.py
+++ b/src/python/turicreate/toolkits/image_similarity/image_similarity.py
@@ -41,8 +41,8 @@ def create(dataset, label = None, feature = None, model = 'resnet-50', verbose =
         identify reference dataset rows when the model is queried.
 
     feature : string
-        indicates that the SFrame has only column of Image type and that will
         Name of the column containing the input images. 'None' (the default)
+        indicates that the SFrame has only column of Image type and that will
         be used for similarity.
 
     model: string, optional

--- a/src/python/turicreate/toolkits/image_similarity/image_similarity.py
+++ b/src/python/turicreate/toolkits/image_similarity/image_similarity.py
@@ -42,7 +42,7 @@ def create(dataset, label = None, feature = None, model = 'resnet-50', verbose =
 
     feature : string
         Name of the column containing the input images. 'None' (the default)
-        indicates that the SFrame has only column of Image type and that will
+        indicates that the SFrame has only one column of Image type and that will
         be used for similarity.
 
     model: string, optional


### PR DESCRIPTION
The documentation for `create` in `image_similarity` didn't make sense. I flipped two lines to make a legible sentence. Also, added the word _one_ to clarify that exactly one column of the Image type is expected.

## BEFORE:

```
   feature : string
        indicates that the SFrame has only column of Image type and that will
        Name of the column containing the input images. 'None' (the default)
        be used for similarity.
```

## AFTER:

```
   feature : string
        Name of the column containing the input images. 'None' (the default)
        indicates that the SFrame has only one column of Image type and that will
        be used for similarity.
```