### PR TITLE
A bunch of bug fix for dc_iterator

### DIFF
--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -29,12 +29,12 @@ using neural_net::shared_float_array;
 void add_drawing_pixel_data_to_batch(float* next_drawing_pointer,
                                      const flex_image& bitmap) {
   image_util::copy_image_to_memory(
-      /* image input    */ bitmap,
+      /* image input */ bitmap,
       /* output pointer */ next_drawing_pointer,
       /* output strides */
       {bitmap.m_width * bitmap.m_channels, bitmap.m_channels, 1},
-      /* output shape   */ {bitmap.m_height, bitmap.m_width, bitmap.m_channels},
-      /* channel_last   */ true);
+      /* output shape */ {bitmap.m_height, bitmap.m_width, bitmap.m_channels},
+      /* channel_last */ true);
 }
 
 }  // namespace
@@ -127,8 +127,7 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
   float* next_drawing_pointer = batch_drawings.data();
   size_t real_batch_size = 0;
 
-  while (batch_targets.size() < batch_size &&
-         next_row_ != range_iterator_.end()) {
+  while (batch_targets.size() < batch_size && next_row_ != end_of_rows_) {
     real_batch_size++;
     const sframe_rows::row& row = *next_row_;
 
@@ -169,8 +168,11 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
         data_.remove_column("_random_order");
       }
 
-      // Reset iteration.
       reset();
+      /**
+       * avoid inf loop; since next_row_ and end_of_rows_ are updated;
+       * IMO, this is tricky; user should call `reset()` explicitly
+       */
       break;
     }
   }

--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -29,12 +29,11 @@ using neural_net::shared_float_array;
 void add_drawing_pixel_data_to_batch(float* next_drawing_pointer,
                                      const flex_image& bitmap) {
   image_util::copy_image_to_memory(
-      /* image input */ bitmap,
+      /* image input    */ bitmap,
       /* output pointer */ next_drawing_pointer,
-      /* output strides */
-      {bitmap.m_width * bitmap.m_channels, bitmap.m_channels, 1},
-      /* output shape */ {bitmap.m_height, bitmap.m_width, bitmap.m_channels},
-      /* channel_last */ true);
+      /* output strides */ {bitmap.m_width * bitmap.m_channels, bitmap.m_channels, 1},
+      /* output shape   */ {bitmap.m_height, bitmap.m_width, bitmap.m_channels},
+      /* channel_last   */ true);
 }
 
 }  // namespace

--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -182,6 +182,17 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
   // Wrap the buffers as float_array values.
   data_iterator::batch result;
   result.num_samples = real_batch_size;
+
+  /**
+   * soft shrink to real size to avoid error from shared_float_array::wrap
+   * since it requires `batch_drawings` to have an accurate size as the
+   * shape indicates
+   **/
+  if (real_batch_size < batch_size) {
+    auto pend = std::begin(batch_drawings) + real_batch_size * image_data_size;
+    batch_drawings.erase(pend, batch_drawings.end());
+  }
+
   result.drawings = shared_float_array::wrap(
       std::move(batch_drawings),
       {real_batch_size, kDrawingHeight, kDrawingWidth, kDrawingChannels});

--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -145,7 +145,7 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
         static_cast<float>(target_properties_.class_to_index_map.at(
             row[target_index_].to<flex_string>())));
 
-    if (++next_row_ == range_iterator_.end() && repeat_) {
+    if (++next_row_ == end_of_rows_ && repeat_) {
       if (shuffle_) {
         // Shuffle the data.
         // TODO: This heavyweight shuffle operation introduces spikes into the

--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -31,8 +31,8 @@ void add_drawing_pixel_data_to_batch(float* next_drawing_pointer,
   image_util::copy_image_to_memory(
       /* image input    */ bitmap,
       /* output pointer */ next_drawing_pointer,
-      /* output strides */ {bitmap.m_width * bitmap.m_channels,
-                            bitmap.m_channels, 1},
+      /* output strides */
+      {bitmap.m_width * bitmap.m_channels, bitmap.m_channels, 1},
       /* output shape   */ {bitmap.m_height, bitmap.m_width, bitmap.m_channels},
       /* channel_last   */ true);
 }
@@ -124,7 +124,7 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
   batch_targets.reserve(batch_size);
   batch_predictions.reserve(batch_size);
 
-  float *next_drawing_pointer = batch_drawings.data();
+  float* next_drawing_pointer = batch_drawings.data();
   size_t real_batch_size = 0;
 
   while (batch_targets.size() < batch_size &&
@@ -171,6 +171,7 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
 
       // Reset iteration.
       reset();
+      break;
     }
   }
 

--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -96,6 +96,7 @@ simple_data_iterator::simple_data_iterator(const parameters& params)
       // Start an iteration through the entire SFrame.
       range_iterator_(data_.range_iterator()),
       next_row_(range_iterator_.begin()),
+      end_of_rows_(range_iterator_.end()),
 
       // Initialize random number generator.
       random_engine_(params.random_seed)
@@ -122,7 +123,8 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
   std::vector<float> batch_predictions;
   batch_targets.reserve(batch_size);
   batch_predictions.reserve(batch_size);
-  float* next_drawing_pointer = batch_drawings.data();
+
+  float *next_drawing_pointer = batch_drawings.data();
   size_t real_batch_size = 0;
 
   while (batch_targets.size() < batch_size &&
@@ -168,8 +170,7 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
       }
 
       // Reset iteration.
-      range_iterator_ = data_.range_iterator();
-      next_row_ = range_iterator_.begin();
+      reset();
     }
   }
 

--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -167,12 +167,16 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
         data_.remove_column("_random_order");
       }
 
-      reset();
       /**
-       * avoid inf loop; since next_row_ and end_of_rows_ are updated;
-       * IMO, this is tricky; user should call `reset()` explicitly
+       * avoid updating next_row_ and end_of_rows_
+       * reset() shouldn't be called neither
+       *
+       * otherwise,
+       * `has_next_batch()` will return `true` afterwards, which will
+       * cause infinite loop of iterating the data if the client
+       * relies on `while(ditr->has_next_batch())` to terminate reading
+       * data by batches.
        */
-      break;
     }
   }
 

--- a/src/toolkits/drawing_classifier/dc_data_iterator.hpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.hpp
@@ -25,7 +25,7 @@ namespace drawing_classifier {
  *        with the other iterators!
  */
 class data_iterator {
- public:
+  public:
   /**
    * Defines the inputs to a data_iterator factory function.
    */
@@ -38,10 +38,10 @@ class data_iterator {
      *
      * If empty, then the output will not contain labels or weights.
      */
-    std::string target_column_name;
+    std::string target_column_name{"target"};
 
     /** The name of the feature column. */
-    std::string feature_column_name;
+    std::string feature_column_name{"feature"};
 
     /** The name of the predictions column. */
     std::string predictions_column_name;

--- a/src/toolkits/drawing_classifier/dc_data_iterator.hpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.hpp
@@ -25,7 +25,7 @@ namespace drawing_classifier {
  *        with the other iterators!
  */
 class data_iterator {
-  public:
+ public:
   /**
    * Defines the inputs to a data_iterator factory function.
    */

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -1,7 +1,8 @@
 /* Copyright © 2019 Apple Inc. All rights reserved.
  *
  * Use of this source code is governed by a BSD-3-clause license that can
- * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
  */
 
 #define BOOST_TEST_MODULE test_dc_data_iterator
@@ -11,8 +12,8 @@
 #include <algorithm>
 
 #include <boost/test/unit_test.hpp>
-#include <model_server/lib/image_util.hpp>
 #include <core/util/test_macros.hpp>
+#include <model_server/lib/image_util.hpp>
 
 #include "data_utils.hpp"
 
@@ -39,21 +40,24 @@ const std::vector<std::string> UNIQUE_LABELS = {"foo", "bar", "baz"};
  *
  */
 void test_simple_data_iterator_with_num_rows_and_batch_size(
-  const drawing_data_generator &data_generator,
-  size_t num_rows, size_t batch_size, bool checked_class_labels) {
+    const drawing_data_generator &data_generator, size_t num_rows,
+    size_t batch_size, bool checked_class_labels) {
   data_iterator::parameters params = data_generator.get_iterator_params();
   TS_ASSERT_EQUALS(params.data.size(), num_rows);
 
   /* Create a simple data iterator */
   simple_data_iterator data_source(params);
   std::vector<std::string> actual_class_labels = data_source.class_labels();
-  std::unordered_map<std::string, int> class_to_index_map = data_source.class_to_index_map();
+  auto class_to_index_map = data_source.class_to_index_map();
+
   /* Test class labels */
   if (!checked_class_labels) {
-    /* expected_class_labels were not passed in to the params, so we need to
+    /**
+     * expected_class_labels were not passed in to the params, so we need to
      * make sure the inferred class labels are correct
      */
-    std::vector<std::string> expected_class_labels = data_generator.get_unique_labels();
+    std::vector<std::string> expected_class_labels =
+        data_generator.get_unique_labels();
     TS_ASSERT_EQUALS(actual_class_labels.size(), expected_class_labels.size());
     for (size_t i = 0; i < actual_class_labels.size(); i++) {
       TS_ASSERT_EQUALS(actual_class_labels[i], expected_class_labels[i]);
@@ -62,6 +66,11 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
 
   /* Call next_batch */
   data_iterator::batch next_batch = data_source.next_batch(batch_size);
+
+  // get the real batch size for test now
+  if (num_rows < batch_size) {
+    batch_size = num_rows;
+  }
 
   /* Test drawing and target sizes */
   TS_ASSERT_EQUALS(next_batch.drawings.size(),
@@ -73,9 +82,10 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   size_t actual_dim = next_batch.drawings.dim();
   size_t expected_dim = 4;
   TS_ASSERT_EQUALS(actual_dim, expected_dim);
+
   size_t expected_shape[4] = {batch_size, IMAGE_WIDTH, IMAGE_HEIGHT, 1};
   const size_t *actual_shape = next_batch.drawings.shape();
-  for (size_t i=0; i<actual_dim; i++) {
+  for (size_t i = 0; i < actual_dim; i++) {
     TS_ASSERT_EQUALS(actual_shape[i], expected_shape[i]);
   }
 
@@ -83,11 +93,11 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   size_t index_in_data = 0;
   /* Test target contents */
   const float *actual_target_data = next_batch.targets.data();
-  for (size_t index_in_batch = 0; index_in_batch < batch_size; index_in_batch++) {
+  for (size_t index_in_batch = 0; index_in_batch < batch_size;
+       index_in_batch++) {
     float expected_target = static_cast<float>(
-      class_to_index_map[
-        data[params.target_column_name][index_in_data].to<flex_string>()
-      ]);
+        class_to_index_map[data[params.target_column_name][index_in_data]
+                               .to<flex_string>()]);
     float actual_target = actual_target_data[index_in_batch];
     TS_ASSERT_EQUALS(expected_target, actual_target);
     index_in_data = (index_in_data + 1) % data.size();
@@ -96,21 +106,22 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   /* Test drawing contents */
   index_in_data = 0;
   const float *actual_drawing_data = next_batch.drawings.data();
-  for (size_t index_in_batch = 0; index_in_batch < batch_size; index_in_batch++) {
+  for (size_t index_in_batch = 0; index_in_batch < batch_size;
+       index_in_batch++) {
     flex_image decoded_drawing = image_util::decode_image(
-    data[params.feature_column_name][index_in_data].to<flex_image>());
-    const unsigned char *expected_drawing_data = decoded_drawing.get_image_data();
+        data[params.feature_column_name][index_in_data].to<flex_image>());
+    const unsigned char *expected_drawing_data =
+        decoded_drawing.get_image_data();
     for (size_t row = 0; row < IMAGE_HEIGHT; row++) {
       for (size_t col = 0; col < IMAGE_WIDTH; col++) {
         // Asserting that the (row, col) index of every drawing in the batch
         // matches the (row, col) index we have in the original SFrame.
         TS_ASSERT_EQUALS(
-          static_cast<unsigned char>(actual_drawing_data[
-            index_in_batch * IMAGE_WIDTH * IMAGE_HEIGHT * 1
-            + row * IMAGE_WIDTH * 1
-            + col * 1]),
-          expected_drawing_data[row * IMAGE_WIDTH + col]
-          );
+            static_cast<unsigned char>(
+                actual_drawing_data[index_in_batch * IMAGE_WIDTH *
+                                        IMAGE_HEIGHT * 1 +
+                                    row * IMAGE_WIDTH * 1 + col * 1]),
+            expected_drawing_data[row * IMAGE_WIDTH + col]);
       }
     }
     index_in_data = (index_in_data + 1) % data.size();
@@ -126,8 +137,9 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
       drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
       data_iterator::parameters params = data_generator.get_iterator_params();
 
-      test_simple_data_iterator_with_num_rows_and_batch_size(data_generator, num_rows,
-        batch_size, false);
+      test_simple_data_iterator_with_num_rows_and_batch_size(
+          data_generator, num_rows, batch_size,
+          /* need NOT to check label */ false);
     }
   }
 }
@@ -135,10 +147,11 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
   constexpr size_t NUM_ROWS = 1;
   constexpr size_t BATCH_SIZE = 10;
-  drawing_data_generator data_generator(NUM_ROWS, UNIQUE_LABELS);
-  std::vector<std::string> class_labels = { "bar", "foo" };
 
-  // Purposely added an extraneous label here.
+  drawing_data_generator data_generator(NUM_ROWS, UNIQUE_LABELS);
+  std::vector<std::string> class_labels = {"bar", "foo"};
+
+  // Purposely added an extraneous label 'baz'.
   data_generator.set_class_labels(class_labels);
   data_iterator::parameters params = data_generator.get_iterator_params();
   simple_data_iterator data_source(params);
@@ -146,7 +159,8 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
 
   // Confirm that the extraneous label appears in the data_source class_labels.
   test_simple_data_iterator_with_num_rows_and_batch_size(
-    data_generator, NUM_ROWS, BATCH_SIZE, true);
+      data_generator, NUM_ROWS, BATCH_SIZE,
+      /* need NOT to check labels */ true);
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_has_next_batch) {
@@ -222,7 +236,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
   drawing_data_generator data_generator(NUM_ROWS, UNIQUE_LABELS);
   data_iterator::parameters params = data_generator.get_iterator_params();
 
-  params.class_labels = { "bad_class" };
+  params.class_labels = {"bad_class"};
 
   // The data contains the label "foo", which is not among the expected class
   // labels.
@@ -230,7 +244,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
 }
 
 /* TODO: Add a test to test multiple calls to next_batch on the same dataset */
-
 
 }  // namespace drawing_classifier
 }  // namespace turi

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -166,7 +166,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_has_next_batch) {
   {
     size_t num_rows = 0;
-    size_t batch_size = 0;
 
     drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
 
@@ -187,7 +186,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_has_next_batch) {
 
   {
     size_t num_rows = 0;
-    size_t batch_size = 1;
 
     drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
 
@@ -210,7 +208,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_has_next_batch) {
     // as long as num_rows is not zero,
     // the initial call of `has_next_batch` should return true
     size_t num_rows = 1;
-    size_t batch_size = 1;
 
     drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
 

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -22,7 +22,7 @@ namespace drawing_classifier {
 const std::vector<std::string> unique_labels = {"foo", "bar", "baz"};
 
 /** Runs all standard tests for a simple_data_iterator
- * 
+ *
  * Parameters
  * ----------
  *
@@ -43,13 +43,14 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   size_t num_rows, size_t batch_size, bool checked_class_labels) {
   data_iterator::parameters params = data_generator.get_iterator_params();
   TS_ASSERT_EQUALS(params.data.size(), num_rows);
+
   /* Create a simple data iterator */
   simple_data_iterator data_source(params);
   std::vector<std::string> actual_class_labels = data_source.class_labels();
   std::unordered_map<std::string, int> class_to_index_map = data_source.class_to_index_map();
   /* Test class labels */
   if (!checked_class_labels) {
-    /* expected_class_labels were not passed in to the params, so we need to 
+    /* expected_class_labels were not passed in to the params, so we need to
      * make sure the inferred class labels are correct
      */
     std::vector<std::string> expected_class_labels = data_generator.get_unique_labels();
@@ -58,12 +59,16 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
       TS_ASSERT_EQUALS(actual_class_labels[i], expected_class_labels[i]);
     }
   }
+
   /* Call next_batch */
   data_iterator::batch next_batch = data_source.next_batch(batch_size);
+
   /* Test drawing and target sizes */
   TS_ASSERT_EQUALS(next_batch.drawings.size(),
                    batch_size * IMAGE_WIDTH * IMAGE_HEIGHT * 1);
+
   TS_ASSERT_EQUALS(next_batch.targets.size(), batch_size);
+
   /* Test drawing shape */
   size_t actual_dim = next_batch.drawings.dim();
   size_t expected_dim = 4;
@@ -73,6 +78,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   for (size_t i=0; i<actual_dim; i++) {
     TS_ASSERT_EQUALS(actual_shape[i], expected_shape[i]);
   }
+
   gl_sframe data = params.data;
   size_t index_in_data = 0;
   /* Test target contents */
@@ -86,6 +92,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
     TS_ASSERT_EQUALS(expected_target, actual_target);
     index_in_data = (index_in_data + 1) % data.size();
   }
+
   /* Test drawing contents */
   index_in_data = 0;
   const float *actual_drawing_data = next_batch.drawings.data();
@@ -111,13 +118,14 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
-  static constexpr size_t MAX_NUM_ROWS = 4;
-  static constexpr size_t MAX_BATCH_SIZE = 8;
+  constexpr size_t MAX_NUM_ROWS = 4;
+  constexpr size_t MAX_BATCH_SIZE = 8;
+
   for (size_t num_rows = 1; num_rows <= MAX_NUM_ROWS; num_rows++) {
     for (size_t batch_size = 1; batch_size <= MAX_BATCH_SIZE; batch_size++) {
       drawing_data_generator data_generator(num_rows, unique_labels);
       data_iterator::parameters params = data_generator.get_iterator_params();
-  
+
       test_simple_data_iterator_with_num_rows_and_batch_size(data_generator, num_rows,
         batch_size, false);
     }
@@ -125,27 +133,28 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
-  static constexpr size_t NUM_ROWS = 1;
-  static constexpr size_t BATCH_SIZE = 10;
+  constexpr size_t NUM_ROWS = 1;
+  constexpr size_t BATCH_SIZE = 10;
   drawing_data_generator data_generator(NUM_ROWS, unique_labels);
-  std::vector<std::string> class_labels = { "bar", "foo" }; 
+  std::vector<std::string> class_labels = { "bar", "foo" };
+
   // Purposely added an extraneous label here.
   data_generator.set_class_labels(class_labels);
   data_iterator::parameters params = data_generator.get_iterator_params();
   simple_data_iterator data_source(params);
   TS_ASSERT_EQUALS(data_source.class_labels(), class_labels);
+
   // Confirm that the extraneous label appears in the data_source class_labels.
   test_simple_data_iterator_with_num_rows_and_batch_size(
     data_generator, NUM_ROWS, BATCH_SIZE, true);
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
-
-  static constexpr size_t NUM_ROWS = 1;
+  constexpr size_t NUM_ROWS = 1;
 
   drawing_data_generator data_generator(NUM_ROWS, unique_labels);
   data_iterator::parameters params = data_generator.get_iterator_params();
-  
+
   params.class_labels = { "bad_class" };
 
   // The data contains the label "foo", which is not among the expected class

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -19,7 +19,7 @@
 namespace turi {
 namespace drawing_classifier {
 
-const std::vector<std::string> unique_labels = {"foo", "bar", "baz"};
+const std::vector<std::string> UNIQUE_LABELS = {"foo", "bar", "baz"};
 
 /** Runs all standard tests for a simple_data_iterator
  *
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 
   for (size_t num_rows = 1; num_rows <= MAX_NUM_ROWS; num_rows++) {
     for (size_t batch_size = 1; batch_size <= MAX_BATCH_SIZE; batch_size++) {
-      drawing_data_generator data_generator(num_rows, unique_labels);
+      drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
       data_iterator::parameters params = data_generator.get_iterator_params();
 
       test_simple_data_iterator_with_num_rows_and_batch_size(data_generator, num_rows,
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
   constexpr size_t NUM_ROWS = 1;
   constexpr size_t BATCH_SIZE = 10;
-  drawing_data_generator data_generator(NUM_ROWS, unique_labels);
+  drawing_data_generator data_generator(NUM_ROWS, UNIQUE_LABELS);
   std::vector<std::string> class_labels = { "bar", "foo" };
 
   // Purposely added an extraneous label here.
@@ -149,10 +149,77 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
     data_generator, NUM_ROWS, BATCH_SIZE, true);
 }
 
+BOOST_AUTO_TEST_CASE(test_simple_data_iterator_has_next_batch) {
+  {
+    size_t num_rows = 0;
+    size_t batch_size = 0;
+
+    drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
+
+    // Purposely added an extraneous label here.
+    data_iterator::parameters params = data_generator.get_iterator_params();
+    {
+      params.repeat = false;
+      simple_data_iterator data_source(params);
+      TS_ASSERT_EQUALS(data_source.has_next_batch(), false);
+    }
+
+    {
+      params.repeat = true;
+      simple_data_iterator data_source(params);
+      TS_ASSERT_EQUALS(data_source.has_next_batch(), false);
+    }
+  }
+
+  {
+    size_t num_rows = 0;
+    size_t batch_size = 1;
+
+    drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
+
+    // Purposely added an extraneous label here.
+    data_iterator::parameters params = data_generator.get_iterator_params();
+    {
+      params.repeat = false;
+      simple_data_iterator data_source(params);
+      TS_ASSERT_EQUALS(data_source.has_next_batch(), false);
+    }
+
+    {
+      params.repeat = true;
+      simple_data_iterator data_source(params);
+      TS_ASSERT_EQUALS(data_source.has_next_batch(), false);
+    }
+  }
+
+  {
+    // as long as num_rows is not zero,
+    // the initial call of `has_next_batch` should return true
+    size_t num_rows = 1;
+    size_t batch_size = 1;
+
+    drawing_data_generator data_generator(num_rows, UNIQUE_LABELS);
+
+    // Purposely added an extraneous label here.
+    data_iterator::parameters params = data_generator.get_iterator_params();
+    {
+      params.repeat = false;
+      simple_data_iterator data_source(params);
+      TS_ASSERT_EQUALS(data_source.has_next_batch(), true);
+    }
+
+    {
+      params.repeat = true;
+      simple_data_iterator data_source(params);
+      TS_ASSERT_EQUALS(data_source.has_next_batch(), true);
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
   constexpr size_t NUM_ROWS = 1;
 
-  drawing_data_generator data_generator(NUM_ROWS, unique_labels);
+  drawing_data_generator data_generator(NUM_ROWS, UNIQUE_LABELS);
   data_iterator::parameters params = data_generator.get_iterator_params();
 
   params.class_labels = { "bad_class" };

--- a/test/unity/toolkits/drawing_classifier/test_drawing_classifier.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_drawing_classifier.cxx
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_drawing_classifier_init_training) {
   TS_ASSERT_EQUALS(model.get_field<flex_string>("feature"), test_image_name);
   TS_ASSERT_EQUALS(model.get_field<flex_int>("num_classes"),
                    test_class_labels.size());
-  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"), 0);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"), 500);
 
   // Deconstructing `model` here will assert that every expected call to a
   // mocked-out method has been called.

--- a/test/unity/toolkits/drawing_classifier/test_drawing_classifier.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_drawing_classifier.cxx
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_drawing_classifier_init_training) {
   TS_ASSERT_EQUALS(model.get_field<flex_string>("feature"), test_image_name);
   TS_ASSERT_EQUALS(model.get_field<flex_int>("num_classes"),
                    test_class_labels.size());
-  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"), 500);
+  TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"), 0);
 
   // Deconstructing `model` here will assert that every expected call to a
   // mocked-out method has been called.


### PR DESCRIPTION
fix the bugs in dc_iterator implementation:
* has_next_batch (original bug design flaw)
* next_batch (introduced by read_batch_size bug)

fix test break of test_dc_data_iterator.cxx.

__MY REVIEW SUGGESTION__
since I have some style change mixed in, I explicitly commented near the critical sections you need to know about all the bug fixes.

__MY SUMMERY__
* [Y] __PASS ALL RELEVANT TEST__? [Y/N]
* [Y] __CAN COMPILE__? [Y/N]