### PR TITLE
Handle error message with path info

### DIFF
--- a/src/core/storage/fileio/fileio_constants.cpp
+++ b/src/core/storage/fileio/fileio_constants.cpp
@@ -85,8 +85,10 @@ static bool check_cache_file_location(std::string val) {
   if (paths.size() == 0)
     throw std::string("Value cannot be empty");
   for (std::string path: paths) {
-    if (!boost::filesystem::is_directory(path))
+    if (!boost::filesystem::is_directory(path)){
+      std::cerr<<"Could not write to the turicreate file cache, which is currently set to '" + path + "' Default path is set to : "<<std::endl;
       throw std::string("Directory: ") + path + " does not exist";
+    }
   }
   return true;
 }

--- a/src/core/storage/fileio/fileio_constants.cpp
+++ b/src/core/storage/fileio/fileio_constants.cpp
@@ -86,7 +86,7 @@ static bool check_cache_file_location(std::string val) {
     throw std::string("Value cannot be empty");
   for (std::string path: paths) {
     if (!boost::filesystem::is_directory(path)){
-      std::cerr<<"Could not write to the turicreate file cache, which is currently set to '" + path + "' Default path is set to : "<<std::endl;
+      std::cerr<<"Could not write to the turicreate file cache, which is currently set to '" + path + "' Using path : "<<std::endl;
       throw std::string("Directory: ") + path + " does not exist";
     }
   }


### PR DESCRIPTION
This PR resolves #789 
Default value used for TURI_CACHE_FILE_LOCATIONS if that path does not exist