### PR TITLE
Added Fixes For single Scale value in CoreML

### DIFF
--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -817,6 +817,20 @@ void model_spec::add_exp(const std::string& name, const std::string& input) {
 }
 
 void model_spec::add_scale(const std::string& name, const std::string& input,
+                           weight_initializer scale_initializer_fn) {
+  NeuralNetworkLayer* layer = impl_->add_layers();
+
+  layer->set_name(name);
+  layer->add_input(input);
+  layer->add_output(name);
+
+  CoreML::Specification::ScaleLayerParams* params = layer->mutable_scale();
+  params->add_shapescale(1);
+
+  init_weight_params(params->mutable_scale(), 1, scale_initializer_fn);
+}
+
+void model_spec::add_scale(const std::string& name, const std::string& input,
                            const std::array<size_t, 3>& shape_c_h_w,
                            weight_initializer scale_initializer_fn) {
 

--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -817,21 +817,7 @@ void model_spec::add_exp(const std::string& name, const std::string& input) {
 }
 
 void model_spec::add_scale(const std::string& name, const std::string& input,
-                           weight_initializer scale_initializer_fn) {
-  NeuralNetworkLayer* layer = impl_->add_layers();
-
-  layer->set_name(name);
-  layer->add_input(input);
-  layer->add_output(name);
-
-  CoreML::Specification::ScaleLayerParams* params = layer->mutable_scale();
-  params->add_shapescale(1);
-
-  init_weight_params(params->mutable_scale(), 1, scale_initializer_fn);
-}
-
-void model_spec::add_scale(const std::string& name, const std::string& input,
-                           const std::array<size_t, 3>& shape_c_h_w,
+                           const std::vector<size_t>& shape_c_h_w,
                            weight_initializer scale_initializer_fn) {
 
   NeuralNetworkLayer* layer = impl_->add_layers();

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -306,17 +306,6 @@ public:
 
 
   /**
-   * Appends a layer that scales an entire batch with a single value
-   *
-   * \param name The name of the layer and its output
-   * \param input The name of the layer's input
-   * \param shape_c The shape of the channel
-   * \param weight_initializer_fn Callback used to initialize the weights
-   */
-  void add_scale(const std::string& name, const std::string& input,
-                 weight_initializer scale_initializer_fn);
-
-  /**
    * Appends a layer that performs elementwise multiplication between its input
    * and some fixed weights.
    *
@@ -326,7 +315,7 @@ public:
    * \param weight_initializer_fn Callback used to initialize the weights
    */
   void add_scale(const std::string& name, const std::string& input,
-                 const std::array<size_t, 3>& shape_c_h_w,
+                 const std::vector<size_t>& shape_c_h_w,
                  weight_initializer scale_initializer_fn);
 
   /**

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -306,6 +306,17 @@ public:
 
 
   /**
+   * Appends a layer that scales an entire batch with a single value
+   *
+   * \param name The name of the layer and its output
+   * \param input The name of the layer's input
+   * \param shape_c The shape of the channel
+   * \param weight_initializer_fn Callback used to initialize the weights
+   */
+  void add_scale(const std::string& name, const std::string& input,
+                 weight_initializer scale_initializer_fn);
+
+  /**
    * Appends a layer that performs elementwise multiplication between its input
    * and some fixed weights.
    *

--- a/src/toolkits/style_transfer/style_transfer_model_definition.cpp
+++ b/src/toolkits/style_transfer/style_transfer_model_definition.cpp
@@ -944,7 +944,6 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
   nn_spec.add_scale(
       /* name */ "stylizedImage",
       /* input */ "transformer_activation5",
-      /* shape_c_h_w */ {1},
       /* weight_init_fn */ scalar_weight_initializer(255.0));
 }
 

--- a/src/toolkits/style_transfer/style_transfer_model_definition.cpp
+++ b/src/toolkits/style_transfer/style_transfer_model_definition.cpp
@@ -944,6 +944,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
   nn_spec.add_scale(
       /* name */ "stylizedImage",
       /* input */ "transformer_activation5",
+      /* shape_c */ {1},
       /* weight_init_fn */ scalar_weight_initializer(255.0));
 }
 

--- a/test/toolkits/style_transfer/utils.mm
+++ b/test/toolkits/style_transfer/utils.mm
@@ -1206,6 +1206,7 @@ std::string get_resnet_model() {
   nn_spec->add_scale(
       /* name */ "stylizedImage",
       /* input */ "transformer_activation5",
+      /* shape_c_h_w */ {1},
       /* weight_init_fn */ scalar_weight_initializer(255.0));
 
   const std::string TRANSFORMER_NAME = "./transformer.mlmodel";

--- a/test/toolkits/style_transfer/utils.mm
+++ b/test/toolkits/style_transfer/utils.mm
@@ -1206,7 +1206,6 @@ std::string get_resnet_model() {
   nn_spec->add_scale(
       /* name */ "stylizedImage",
       /* input */ "transformer_activation5",
-      /* shape_c_h_w */ {1, 1, 1},
       /* weight_init_fn */ scalar_weight_initializer(255.0));
 
   const std::string TRANSFORMER_NAME = "./transformer.mlmodel";


### PR DESCRIPTION
- The scale used in OD and Style Transfer are slightly different. To handle theses different use_cases, and match the CoreML specs a new `add_scale` is proposed.