### PR TITLE
Changed macros to test_tools from test

### DIFF
--- a/src/core/util/test_macros.hpp
+++ b/src/core/util/test_macros.hpp
@@ -14,7 +14,7 @@ static std::recursive_mutex __b_lock__;
 #define TS_ASSERT_DIFFERS(x,y)           do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) != (y)); } while(0)
 #define TS_ASSERT_LESS_THAN_EQUALS(x,y)  do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) <= (y)); } while(0)
 #define TS_ASSERT_LESS_THAN(x,y)         do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) < (y)); } while(0)
-#define TS_ASSERT_DELTA(x,y,e)           do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) == (y), boost::test::tolerance(e)); } while(0)
+#define TS_ASSERT_DELTA(x,y,e)           do { _TS_ADD_LOCK_GUARD; BOOST_TEST((x) == (y), boost::test_tools::tolerance(e)); } while(0)
 #define TS_ASSERT_THROWS_NOTHING(expr)   do { _TS_ADD_LOCK_GUARD; BOOST_CHECK_NO_THROW(expr); } while(0)
 #define TS_ASSERT_THROWS_ANYTHING(expr)  \
 do { \

--- a/test/timer/timer_test.cxx
+++ b/test/timer/timer_test.cxx
@@ -24,7 +24,7 @@ public:
     int t = timer::approx_time_seconds();
     sleep(3);
     int t2 = timer::approx_time_seconds();
-    TS_ASSERT_DELTA(double(t2 - t), 3.0, 2);
+    TS_ASSERT_DELTA(double(t2 - t), 3.0, 2.0);
   }
 
 


### PR DESCRIPTION
Changed namespace of `boost::test` to `boost::test_tools`.

Running pipelines internally and on Travis CI to see if there are any issues with the namespace changes.