### PR TITLE
fix for test break

### DIFF
--- a/test/unity/toolkits/drawing_classifier/test_drawing_classifier.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_drawing_classifier.cxx
@@ -252,7 +252,10 @@ BOOST_AUTO_TEST_CASE(test_drawing_classifier_init_training) {
   TS_ASSERT_EQUALS(model.get_field<flex_int>("max_iterations"),
                    test_max_iterations);
   TS_ASSERT_EQUALS(model.get_field<flex_string>("target"), test_target_name);
-  TS_ASSERT_EQUALS(model.get_field<flex_string>("feature"), test_image_name);
+  TS_ASSERT_EQUALS(model.get_field<flex_list>("features").size(), 1);
+  TS_ASSERT_EQUALS(
+      model.get_field<flex_list>("features")[0].get<flex_string>(),
+      test_image_name);
   TS_ASSERT_EQUALS(model.get_field<flex_int>("num_classes"),
                    test_class_labels.size());
   TS_ASSERT_EQUALS(model.get_field<flex_int>("training_iterations"), 0);


### PR DESCRIPTION
a small fix for test break of `test_drawing_classifier.cxx` to unblock #2480.

model state `feature` type of string is changed to state `features` with type list. We should make sure all existing test cases pass in master so that we won't block other people's pipeline validation process.

one suspicious part is that there's a model state called `classes`. I'm not sure it's used. @shantanuchhabra may spend some time investigating.