### PR TITLE
OD iterator fixed: missing annotations and invalid labels.

### DIFF
--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -980,8 +980,7 @@ std::unique_ptr<data_iterator> object_detector::create_iterator(
   // Check if data has annotations column
   std::string annotations_column_name = read_state<flex_string>("annotations");
   if (data.contains_column(annotations_column_name)) {
-    iterator_params.annotations_column_name =
-        read_state<flex_string>("annotations");
+    iterator_params.annotations_column_name = annotations_column_name;
   }
 
   iterator_params.data = std::move(data);

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -635,7 +635,6 @@ variant_type object_detector::predict(
   } else {
     final_result = to_variant(result_sarray[0]);
   }
-
   return final_result;
 }
 

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -635,6 +635,7 @@ variant_type object_detector::predict(
   } else {
     final_result = to_variant(result_sarray[0]);
   }
+
   return final_result;
 }
 
@@ -976,9 +977,15 @@ std::unique_ptr<data_iterator> object_detector::create_iterator(
     gl_sframe data, std::vector<std::string> class_labels, bool repeat) const
 {
   data_iterator::parameters iterator_params;
+
+  // Check if data has annotations column
+  std::string annotations_column_name = read_state<flex_string>("annotations");
+  if (data.contains_column(annotations_column_name)) {
+    iterator_params.annotations_column_name =
+        read_state<flex_string>("annotations");
+  }
+
   iterator_params.data = std::move(data);
-  iterator_params.annotations_column_name =
-      read_state<flex_string>("annotations");
   iterator_params.image_column_name = read_state<flex_string>("feature");
   iterator_params.class_labels = std::move(class_labels);
   iterator_params.repeat = repeat;

--- a/src/toolkits/object_detection/od_data_iterator.cpp
+++ b/src/toolkits/object_detection/od_data_iterator.cpp
@@ -218,8 +218,6 @@ std::pair<gl_sarray, size_t> get_annotation_info(const gl_sarray& annotations) {
 
   // Construct an SFrame with one row per bounding box.
   gl_sframe instances;
-  gl_sarray classes;
-  size_t num_instances;
 
   if (annotations.dtype() == flex_type_enum::LIST) {
     gl_sframe unstacked_instances({{"annotations", annotations}});
@@ -234,13 +232,7 @@ std::pair<gl_sarray, size_t> get_annotation_info(const gl_sarray& annotations) {
                                {flex_type_enum::STRING},
                                /* na_value */ FLEX_UNDEFINED, {"label"});
 
-  // Determine the list of unique class labels,
-  classes = instances["label"].unique().sort();
-
-  // Record the number of labeled bounding boxes.
-  num_instances = instances.size();
-
-  return std::make_pair(classes, num_instances);
+  return std::make_pair(instances["label"].unique().sort(), instances.size());
 }
 
 }  // namespace
@@ -265,13 +257,6 @@ simple_data_iterator::compute_properties(
       result.class_to_index_map[label] = i++;
     }
   } else {
-    // Make sure the expected labels are unique and sorted.
-    std::sort(expected_class_labels.begin(), expected_class_labels.end());
-    std::vector<std::string>::iterator it;
-    it =
-        std::unique(expected_class_labels.begin(), expected_class_labels.end());
-    expected_class_labels.resize(
-        std::distance(expected_class_labels.begin(), it));
 
     // Construct the class-to-index map from the expected labels.
     result.classes = std::move(expected_class_labels);

--- a/src/toolkits/object_detection/od_data_iterator.cpp
+++ b/src/toolkits/object_detection/od_data_iterator.cpp
@@ -360,7 +360,6 @@ std::vector<labeled_image> simple_data_iterator::next_batch(size_t batch_size) {
   }
 
   std::vector<labeled_image> result(raw_batch.size());
-
   for (size_t i = 0; i < raw_batch.size(); ++i) {
     flexible_type raw_image, raw_annotations, raw_predictions;
     std::tie(raw_image, raw_annotations, raw_predictions) = raw_batch[i];

--- a/src/toolkits/object_detection/od_data_iterator.cpp
+++ b/src/toolkits/object_detection/od_data_iterator.cpp
@@ -29,7 +29,6 @@ flex_image get_image(const flexible_type& image_feature) {
 
 gl_sframe get_data(const data_iterator::parameters& params) {
 
-  gl_sarray annotations = params.data[params.annotations_column_name];
   gl_sarray images = params.data[params.image_column_name];
 
   if (images.dtype() == flex_type_enum::IMAGE) {
@@ -39,12 +38,16 @@ gl_sframe get_data(const data_iterator::parameters& params) {
     images = images.apply(image_util::encode_image, flex_type_enum::IMAGE);
   }
 
-  gl_sframe result({ { params.annotations_column_name, annotations },
-                     { params.image_column_name,       images      }  });
+  gl_sframe result({{params.image_column_name, images}});
 
   if (!params.predictions_column_name.empty()) {
     result[params.predictions_column_name] =
         params.data[params.predictions_column_name];
+  }
+
+  if (!params.annotations_column_name.empty()) {
+    result[params.annotations_column_name] =
+        params.data[params.annotations_column_name];
   }
 
   return result;
@@ -57,7 +60,6 @@ std::vector<image_annotation> parse_annotations(
     annotation_origin_enum annotation_origin,
     annotation_scale_enum annotation_scale,
     annotation_position_enum annotation_position) {
-
   std::vector<image_annotation> result;
   result.reserve(flex_annotations.size());
 
@@ -73,10 +75,12 @@ std::vector<image_annotation> parse_annotations(
       const flex_string& key = kv.first.get<flex_string>();
 
       if (key == "label") {
-
-        annotation.identifier =
-            class_to_index_map.at(kv.second.get<flex_string>());
-        has_label = true;
+        // If the label in invalid (not in class_to_index_map) then ignore it.
+        const flex_string& label = kv.second.get<flex_string>();
+        if (class_to_index_map.find(label) != class_to_index_map.end()) {
+          annotation.identifier = class_to_index_map.at(label);
+          has_label = true;
+        }
 
       } else if (key == "coordinates") {
 
@@ -215,24 +219,29 @@ simple_data_iterator::compute_properties(
     std::vector<std::string> expected_class_labels) {
 
   annotation_properties result;
+  gl_sarray classes;
+  if (annotations.size() > 0) {
+    // Construct an SFrame with one row per bounding box.
+    gl_sframe instances;
+    if (annotations.dtype() == flex_type_enum::LIST) {
+      gl_sframe unstacked_instances({{"annotations", annotations}});
+      instances = unstacked_instances.stack("annotations", "bbox",
+                                            /* drop_na */ true);
+    } else {
+      instances["bbox"] = annotations;
+    }
 
-  // Construct an SFrame with one row per bounding box.
-  gl_sframe instances;
-  if (annotations.dtype() == flex_type_enum::LIST) {
-    gl_sframe unstacked_instances({{"annotations", annotations}});
-    instances = unstacked_instances.stack("annotations", "bbox",
-                                          /* drop_na */ true);
-  } else {
-    instances["bbox"] = annotations;
+    // Extract the label for each bounding box.
+    instances = instances.unpack("bbox", /* column_name_prefix */ "",
+                                 {flex_type_enum::STRING},
+                                 /* na_value */ FLEX_UNDEFINED, {"label"});
+
+    // Determine the list of unique class labels,
+    classes = instances["label"].unique().sort();
+
+    // Record the number of labeled bounding boxes.
+    result.num_instances = instances.size();
   }
-
-  // Extract the label for each bounding box.
-  instances = instances.unpack("bbox", /* column_name_prefix */ "",
-                               { flex_type_enum::STRING },
-                               /* na_value */ FLEX_UNDEFINED, { "label" });
-
-  // Determine the list of unique class labels,
-  gl_sarray classes = instances["label"].unique().sort();
 
   if (expected_class_labels.empty()) {
 
@@ -244,6 +253,13 @@ simple_data_iterator::compute_properties(
       result.class_to_index_map[label] = i++;
     }
   } else {
+    // Make sure the expected labels are unique and sorted.
+    std::sort(expected_class_labels.begin(), expected_class_labels.end());
+    std::vector<std::string>::iterator it;
+    it =
+        std::unique(expected_class_labels.begin(), expected_class_labels.end());
+    expected_class_labels.resize(
+        std::distance(expected_class_labels.begin(), it));
 
     // Construct the class-to-index map from the expected labels.
     result.classes = std::move(expected_class_labels);
@@ -252,17 +268,7 @@ simple_data_iterator::compute_properties(
       result.class_to_index_map[label] = i++;
     }
 
-    // Use the map to verify that we only encountered expected labels.
-    for (const flexible_type& ft : classes.range_iterator()) {
-      std::string label(ft);  // Ensures correct overload resolution below.
-      if (result.class_to_index_map.count(label) == 0) {
-        log_and_throw("Annotations contained unexpected class label " + label);
-      }
-    }
   }
-
-  // Record the number of labeled bounding boxes.
-  result.num_instances = instances.size();
 
   return result;
 }
@@ -270,34 +276,41 @@ simple_data_iterator::compute_properties(
 simple_data_iterator::simple_data_iterator(const parameters& params)
 
     // Reduce SFrame to the two columns we care about.
-  : data_(get_data(params)),
+    : data_(get_data(params)),
 
-    // Determine which column is which within each (ordered) row.
-    annotations_index_(data_.column_index(params.annotations_column_name)),
-    predictions_index_(params.predictions_column_name.empty()
-                       ? -1
-                       : data_.column_index(params.predictions_column_name)),
-    image_index_(data_.column_index(params.image_column_name)),
+      // Determine which column is which within each (ordered) row.
+      annotations_index_(
+          params.annotations_column_name.empty()
+              ? -1
+              : data_.column_index(params.annotations_column_name)),
 
-    annotation_origin_(params.annotation_origin),
-    annotation_scale_(params.annotation_scale),
-    annotation_position_(params.annotation_position),
+      predictions_index_(
+          params.predictions_column_name.empty()
+              ? -1
+              : data_.column_index(params.predictions_column_name)),
+      image_index_(data_.column_index(params.image_column_name)),
 
-    // Whether to traverse the SFrame more than once, and whether to shuffle.
-    repeat_(params.repeat),
-    shuffle_(params.shuffle),
+      annotation_origin_(params.annotation_origin),
+      annotation_scale_(params.annotation_scale),
+      annotation_position_(params.annotation_position),
 
-    // Identify/verify the class labels and other annotation properties.
-    annotation_properties_(
-        compute_properties(data_[params.annotations_column_name],
-                           params.class_labels)),
+      // Whether to traverse the SFrame more than once, and whether to shuffle.
+      repeat_(params.repeat),
+      shuffle_(params.shuffle),
 
-    // Start an iteration through the entire SFrame.
-    range_iterator_(data_.range_iterator()),
-    next_row_(range_iterator_.begin()),
+      // Identify/verify the class labels and other annotation properties.
+      annotation_properties_(
+          compute_properties(params.annotations_column_name.empty()
+                                 ? gl_sarray()
+                                 : data_[params.annotations_column_name],
+                             params.class_labels)),
 
-    // Initialize random number generator.
-    random_engine_(params.random_seed)
+      // Start an iteration through the entire SFrame.
+      range_iterator_(data_.range_iterator()),
+      next_row_(range_iterator_.begin()),
+
+      // Initialize random number generator.
+      random_engine_(params.random_seed)
 
 {}
 
@@ -307,14 +320,16 @@ std::vector<labeled_image> simple_data_iterator::next_batch(size_t batch_size) {
   std::vector<std::tuple<flexible_type,flexible_type,flexible_type>> raw_batch;
   raw_batch.reserve(batch_size);
   while (raw_batch.size() < batch_size && next_row_ != range_iterator_.end()) {
-
     const sframe_rows::row& row = *next_row_;
     flexible_type preds = FLEX_UNDEFINED;
+    flexible_type annotations = FLEX_UNDEFINED;
     if (predictions_index_ >= 0) {
       preds = row[predictions_index_];
     }
-    raw_batch.emplace_back(row[image_index_], row[annotations_index_], preds);
-
+    if (annotations_index_ >= 0) {
+      annotations = row[annotations_index_];
+    }
+    raw_batch.emplace_back(row[image_index_], annotations, preds);
     if (++next_row_ == range_iterator_.end() && repeat_) {
 
       if (shuffle_) {
@@ -345,6 +360,7 @@ std::vector<labeled_image> simple_data_iterator::next_batch(size_t batch_size) {
   }
 
   std::vector<labeled_image> result(raw_batch.size());
+
   for (size_t i = 0; i < raw_batch.size(); ++i) {
     flexible_type raw_image, raw_annotations, raw_predictions;
     std::tie(raw_image, raw_annotations, raw_predictions) = raw_batch[i];
@@ -353,10 +369,12 @@ std::vector<labeled_image> simple_data_iterator::next_batch(size_t batch_size) {
     // TODO: Investigate parallelizing this file I/O.
     result[i].image = get_image(raw_image);
 
-    result[i].annotations = parse_annotations(
-        raw_annotations, result[i].image.m_width, result[i].image.m_height,
-        annotation_properties_.class_to_index_map, annotation_origin_, annotation_scale_,
-        annotation_position_);
+    if (raw_annotations != FLEX_UNDEFINED) {
+      result[i].annotations = parse_annotations(
+          raw_annotations, result[i].image.m_width, result[i].image.m_height,
+          annotation_properties_.class_to_index_map, annotation_origin_,
+          annotation_scale_, annotation_position_);
+    }
 
     if (raw_predictions != FLEX_UNDEFINED) {
       result[i].predictions = parse_annotations(
@@ -365,7 +383,6 @@ std::vector<labeled_image> simple_data_iterator::next_batch(size_t batch_size) {
           annotation_position_);
     }
   }
-
   return result;
 }
 

--- a/src/toolkits/object_detection/od_data_iterator.hpp
+++ b/src/toolkits/object_detection/od_data_iterator.hpp
@@ -172,7 +172,7 @@ private:
       std::vector<std::string> expected_class_labels);
 
   gl_sframe data_;
-  const size_t annotations_index_;
+  const ssize_t annotations_index_;
   const ssize_t predictions_index_;
   const size_t image_index_;
 

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -422,11 +422,9 @@ BOOST_AUTO_TEST_CASE(test_object_detector_init_training) {
   // Now, actually invoke object_detector::init_training. This will trigger all
   // the assertions registered above.
   model.init_training(data, test_annotations_name, test_image_name, gl_sframe(),
-                      {
-                          {"mlmodel_path", test_mlmodel_path},
-                          {"batch_size", test_batch_size},
-                          {"max_iterations", test_max_iterations},
-                      });
+                      {{"mlmodel_path", test_mlmodel_path},
+                       {"batch_size", test_batch_size},
+                       {"max_iterations", test_max_iterations}});
 
   // Verify model fields.
   TS_ASSERT_EQUALS(model.get_field<flex_int>("batch_size"), test_batch_size);

--- a/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
+++ b/test/unity/toolkits/object_detection/test_od_data_iterator.cxx
@@ -282,8 +282,9 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_unexpected_classes) {
   params.class_labels = { "bar" };
 
   // The data contains the label "foo", which is not among the expected class
-  // labels.
-  TS_ASSERT_THROWS_ANYTHING(simple_data_iterator unused_var(params));
+  // labels. SHOULDN'T throw anything.
+  simple_data_iterator it_unexpected(params);
+  TS_ASSERT_EQUALS(it_unexpected.class_labels().size(), 1);
 }
 
 }  // namespace


### PR DESCRIPTION
Modify OD data iterator in order to read data with no annotations.
And also skip the data which has invalid labels.