### PR TITLE
OD tf missing annotation.

### DIFF
--- a/src/ml/neural_net/image_augmentation.cpp
+++ b/src/ml/neural_net/image_augmentation.cpp
@@ -35,6 +35,11 @@ shared_float_array convert_to_shared_float_array(
 
 std::vector<image_annotation> convert_to_image_annotation(
     shared_float_array augmented_annotation) {
+  // Check if the annotation is empty
+  if (augmented_annotation.size() == 1) {
+    return std::vector<image_annotation>();
+  }
+
   const size_t* shape = augmented_annotation.shape();
   size_t num_annotations_per_image = shape[0];
   std::vector<image_annotation> augmented_ann(num_annotations_per_image);

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -231,10 +231,17 @@ tf_image_augmenter::prepare_augmented_images(
 
     for (size_t i = 0; i < aug_annotations.size(); i++) {
       pybind11::buffer_info buf_ann = aug_annotations[i].request();
-      turi::neural_net::shared_float_array annotate =
-          turi::neural_net::shared_float_array::copy(
-              static_cast<float*>(buf_ann.ptr),
-              std::vector<size_t>(buf_ann.shape.begin(), buf_ann.shape.end()));
+      size_t num_annotations = buf_ann.shape[0];
+      turi::neural_net::shared_float_array annotate;
+      if (num_annotations > 0) {
+        annotate = turi::neural_net::shared_float_array::copy(
+            static_cast<float*>(buf_ann.ptr),
+            std::vector<size_t>(buf_ann.shape.begin(), buf_ann.shape.end()));
+      } else {
+        std::vector<float> data = {0};
+        std::vector<size_t> shape = {1};
+        annotate = turi::neural_net::shared_float_array::wrap(data, shape);
+      }
       annotations_per_batch.push_back(annotate);
     }
     image_annotations.annotations = annotations_per_batch;


### PR DESCRIPTION
The model crash when it meets an image with no annotations.
In the test case the number of bounding boxed are randomly generated between (0,10).
So this PR fixes several test cases.