### PR TITLE
C++ code paths should only use MPS backend for supported Metal devices

### DIFF
--- a/src/ml/neural_net/mps_compute_context.hpp
+++ b/src/ml/neural_net/mps_compute_context.hpp
@@ -28,13 +28,6 @@ public:
    */
   mps_compute_context(std::unique_ptr<mps_command_queue> command_queue);
 
-  /**
-   * Constructs a context wrapping the best currently available Metal device.
-   *
-   * \todo Guard against eGPU coming and going?
-   */
-  mps_compute_context();
-
   ~mps_compute_context();
 
   std::vector<std::string> gpu_names() const override;


### PR DESCRIPTION
We never ported this Python logic, governing when to use MPS, to the C++ code path: https://github.com/apple/turicreate/blob/879e82ebcb2d3f0bc4f3694d83eff5b8063d084f/src/python/turicreate/toolkits/_mps_utils.py#L190

These changes implement that logic, as well as incorporate new support in macOS 10.15 Catalina for Skylake and later Intel integrated GPUs.

Fixes #919 