### PR TITLE
PyTest failures for `get_styles` updated.

### DIFF
--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -203,7 +203,6 @@ class StyleTransferTest(unittest.TestCase):
         self.assertTrue(isinstance(imgs, tc.SArray))
         self.assertEqual(len(imgs), len(sarray))
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_get_styles_fail(self):
         style_cases = self._get_invalid_style_cases()
         model = self.model
@@ -211,7 +210,6 @@ class StyleTransferTest(unittest.TestCase):
             with self.assertRaises(_ToolkitError):
                 model.get_styles(style=style)
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_get_styles_success(self):
         style = [0,1,2]
         model = self.model


### PR DESCRIPTION
    - Test failure for get_styles passes so unmarked as failures.