### PR TITLE
PyTest failures for `export_to_coreml` updated. 

### DIFF
--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -233,7 +233,6 @@ class StyleTransferTest(unittest.TestCase):
             img = img[..., 0:3]
             return img
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_export_coreml(self):
         import coremltools
         model = self.model

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -203,7 +203,6 @@ class StyleTransferTest(unittest.TestCase):
         self.assertTrue(isinstance(imgs, tc.SArray))
         self.assertEqual(len(imgs), len(sarray))
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_get_styles_fail(self):
         style_cases = self._get_invalid_style_cases()
         model = self.model
@@ -211,7 +210,6 @@ class StyleTransferTest(unittest.TestCase):
             with self.assertRaises(_ToolkitError):
                 model.get_styles(style=style)
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_get_styles_success(self):
         style = [0,1,2]
         model = self.model

--- a/src/toolkits/coreml_export/neural_net_models_exporter.cpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.cpp
@@ -6,6 +6,7 @@
 
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 
+#include <cctype>
 #include <sstream>
 
 #include <core/logging/assertions.hpp>
@@ -391,21 +392,35 @@ std::shared_ptr<coreml::MLModelWrapper> export_style_transfer_model(
     const neural_net::model_spec& nn_spec, size_t image_width,
     size_t image_height, bool include_flexible_shape,
     flex_dict user_defined_metadata, std::string content_feature,
-    std::string style_feature) {
+    std::string style_feature, size_t num_styles) {
   CoreML::Specification::Model model;
   model.set_specificationversion(3);
 
   ModelDescription* model_desc = model.mutable_description();
 
   FeatureDescription* model_input = model_desc->add_input();
-  ImageFeatureType* input_feat = set_image_feature(model_input, image_width, image_height, content_feature, "Input image");
+  ImageFeatureType* input_feat = set_image_feature(model_input,
+                                                   image_width,
+                                                   image_height,
+                                                   content_feature,
+                                                   "Input image");
 
   set_array_feature(
       model_desc->add_input(), "index",
-      "Style index array (set index I to 1.0 to enable Ith style)", {1});
+      "Style index array (set index I to 1.0 to enable Ith style)", {num_styles});
+  /*
+   * prefix style with stylized and capitalize the following identifier, this
+   * avoids name clashes with the `content_feature` for exporting to CoreML.
+   */
+  style_feature[0] = toupper(style_feature[0]);
+  style_feature = "stylized" + style_feature;
 
   FeatureDescription* model_output = model_desc->add_output();
-  ImageFeatureType* style_feat = set_image_feature(model_output, image_width, image_height, style_feature, "Stylized image");
+  ImageFeatureType* style_feat = set_image_feature(model_output,
+                                                   image_width,
+                                                   image_height,
+                                                   style_feature,
+                                                   "Stylized image");
 
   /**
    * The -1 indicates no upper limits for the image size

--- a/src/toolkits/coreml_export/neural_net_models_exporter.cpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.cpp
@@ -6,7 +6,7 @@
 
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 
-#include <cctype>
+#include <locale>
 #include <sstream>
 
 #include <core/logging/assertions.hpp>
@@ -412,7 +412,7 @@ std::shared_ptr<coreml::MLModelWrapper> export_style_transfer_model(
    * prefix style with stylized and capitalize the following identifier, this
    * avoids name clashes with the `content_feature` for exporting to CoreML.
    */
-  style_feature[0] = toupper(style_feature[0]);
+  style_feature[0] = std::toupper(style_feature[0]);
   style_feature = "stylized" + style_feature;
 
   FeatureDescription* model_output = model_desc->add_output();

--- a/src/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -48,7 +48,7 @@ std::shared_ptr<coreml::MLModelWrapper> export_style_transfer_model(
     const neural_net::model_spec& nn_spec, size_t image_width,
     size_t image_height, bool include_flexible_shape,
     flex_dict user_defined_metadata, std::string content_feature,
-    std::string style_feature);
+    std::string style_feature, size_t num_styles);
 
 /** Wraps a trained drawing classifier model_spec as a complete MLModel. */
 std::shared_ptr<coreml::MLModelWrapper> export_drawing_classifier_model(

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -716,7 +716,8 @@ std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
   const flex_int include_flexible_shape = read_opts<flex_int>(opts, "include_flexible_shape");
   const flex_string content_feature = read_state<flex_string>("content_feature");
   const flex_string style_feature = read_state<flex_string>("style_feature");
-  
+  const flex_int num_styles = read_state<flex_int>("num_styles");
+
   flex_dict user_defined_metadata = {
       {"model", read_state<flex_string>("model")},
       {"max_iterations", read_state<flex_int>("max_iterations")},
@@ -724,13 +725,13 @@ std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
       {"type", "StyleTransfer"},
       {"content_feature", content_feature},  // TODO: refactor to take content name and style name
       {"style_feature", style_feature},
-      {"num_styles", read_state<flex_int>("num_styles")},
+      {"num_styles", num_styles},
       {"version", get_version()},
   };
 
   std::shared_ptr<MLModelWrapper> model_wrapper = export_style_transfer_model(
       *m_resnet_spec, image_width, image_height, include_flexible_shape,
-      std::move(user_defined_metadata), content_feature, style_feature);
+      std::move(user_defined_metadata), content_feature, style_feature, num_styles);
 
   if (!filename.empty()) model_wrapper->save(filename);
 


### PR DESCRIPTION
- Added prefix to style image to avoid naming conflicts
- Added `num_styles` to index to add support for multiple styles