### PR TITLE
Pytest `test_stylize_success` removed xfail

### DIFF
--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -260,6 +260,16 @@
   // TODO: Change for testing
   _batchSize = 1;
 
+  NSData* imageWidthData = inputs[@"width"];
+  float imageWidth;
+  [imageWidthData getBytes:&imageWidth length:sizeof(float)];
+  _imgWidth = (NSInteger) imageWidth;
+
+  NSData* imageHeightData = inputs[@"height"];
+  float imageHeight;
+  [imageHeightData getBytes:&imageHeight length:sizeof(float)];
+  _imgHeight = (NSInteger) imageHeight;
+
   MPSImageDescriptor *imgDesc = [MPSImageDescriptor
     imageDescriptorWithChannelFormat:MPSImageFeatureChannelFormatFloat32
                                width:_imgWidth
@@ -326,6 +336,16 @@
 
 - (NSDictionary<NSString *, NSData *> *) train:(NSDictionary<NSString *, NSData *> *)inputs {
   _batchSize = 1;
+
+  NSData* imageWidthData = inputs[@"width"];
+  float imageWidth;
+  [imageWidthData getBytes:&imageWidth length:sizeof(float)];
+  _imgWidth = (NSInteger) imageWidth;
+
+  NSData* imageHeightData = inputs[@"height"];
+  float imageHeight;
+  [imageHeightData getBytes:&imageHeight length:sizeof(float)];
+  _imgHeight = (NSInteger) imageHeight;
 
   NSString* indexKey = @"index";
 

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -271,7 +271,6 @@ class StyleTransferTest(unittest.TestCase):
         self.assertEqual(type(str(model)), str)
         self.assertEqual(type(model.__repr__()), str)
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_save_and_load(self):
         with test_util.TempDirectory() as filename:
             self.model.save(filename)

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -162,7 +162,6 @@ class StyleTransferTest(unittest.TestCase):
             with self.assertRaises(_ToolkitError):
                 model.stylize(self.content_sf[0:1], style=style)
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason='Requires MXNet')
     def test_stylize_success(self):
         sf = self.content_sf[0:1]
         model = self.model

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -216,24 +216,16 @@ float_array_map prepare_batch(std::vector<st_example>& batch, size_t width,
 
   float_array_map map;
 
-  shared_float_array content_wrap = shared_float_array::wrap(
+  map["input"] = shared_float_array::wrap(
       std::move(content_array), {batch_size, height, width, channels});
-  map.emplace("input", content_wrap);
+  map["index"] = shared_float_array::wrap(std::move(index_array), {batch_size});
 
-  shared_float_array index_wrap =
-      shared_float_array::wrap(std::move(index_array), {batch_size});
-  map.emplace("index", index_wrap);
-
-  shared_float_array image_width_wrap = shared_float_array::wrap(width);
-  map.emplace("width", image_width_wrap);
-
-  shared_float_array image_height_wrap = shared_float_array::wrap(height);
-  map.emplace("height", image_height_wrap);
+  map["width"] = shared_float_array::wrap(width);
+  map["height"] = shared_float_array::wrap(height);
 
   if (train) {
-    shared_float_array style_wrap = shared_float_array::wrap(
+    map["labels"] = shared_float_array::wrap(
         std::move(style_array), {batch_size, height, width, channels});
-    map.emplace("labels", style_wrap);
   }
 
   return map;

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -224,6 +224,12 @@ float_array_map prepare_batch(std::vector<st_example>& batch, size_t width,
       shared_float_array::wrap(std::move(index_array), {batch_size});
   map.emplace("index", index_wrap);
 
+  shared_float_array image_width_wrap = shared_float_array::wrap(width);
+  map.emplace("width", image_width_wrap);
+
+  shared_float_array image_height_wrap = shared_float_array::wrap(height);
+  map.emplace("height", image_height_wrap);
+
   if (train) {
     shared_float_array style_wrap = shared_float_array::wrap(
         std::move(style_array), {batch_size, height, width, channels});
@@ -231,6 +237,22 @@ float_array_map prepare_batch(std::vector<st_example>& batch, size_t width,
   }
 
   return map;
+}
+
+// Preparing Batch for prediction. Since the tensorflow implementation of style
+// transfer doesn't have multiple batches supported in predict this function
+// takes exactly one st_example as an argument.
+float_array_map prepare_predict(st_example& example) {
+  ASSERT_EQ(3, example.content_image.m_channels);
+  
+  size_t image_width = example.content_image.m_width;
+  size_t image_height = example.content_image.m_height;
+  std::vector<st_example> batch = { example };
+
+  return prepare_batch(batch,
+                       image_width,
+                       image_height,
+                       /* train */ false);
 }
 
 flex_int estimate_max_iterations(flex_int num_styles, flex_int batch_size) {
@@ -496,8 +518,6 @@ void style_transfer::perform_predict(gl_sarray data, gl_sframe_writer& result,
 
   flex_int batch_size = read_state<flex_int>("batch_size");
   flex_int num_styles = read_state<flex_int>("num_styles");
-  flex_int image_width = read_state<flex_int>("image_width");
-  flex_int image_height = read_state<flex_int>("image_height");
 
   // Since we aren't training the style_images are irrelevant
   std::unique_ptr<data_iterator> data_iter =
@@ -529,10 +549,14 @@ void style_transfer::perform_predict(gl_sarray data, gl_sframe_writer& result,
       // setting the style index for each batch
       std::for_each(batch.begin(), batch.end(),
                     [i](st_example& example) { example.style_index = i; });
+      
+      // predict only works with a batch size of one now. This is because images
+      // have varied width and height and since the style transfer network
+      // is size invariant, resizing the inputs isn't an option.
+      ASSERT_EQ(batch.size(), 1);
 
       // prepare batch for prediction
-      float_array_map prepared_batch =
-          prepare_batch(batch, image_width, image_height, /* train */ false);
+      float_array_map prepared_batch = prepare_predict(batch.front());
 
       // perform prediction
       float_array_map result_batch = model->predict(prepared_batch);
@@ -543,7 +567,8 @@ void style_transfer::perform_predict(gl_sarray data, gl_sframe_writer& result,
       // populate gl_sframe_writer
       std::vector<std::pair<flex_int, flex_image>> processed_batch =
           process_output(out_shared_float_array, i, actual_batch_size,
-                         image_width, image_height);
+                         batch.front().content_image.m_width,
+                         batch.front().content_image.m_height);
 
       // Write result to gl_sframe_writer
       for (const auto& row : processed_batch) {

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -242,7 +242,7 @@ float_array_map prepare_batch(std::vector<st_example>& batch, size_t width,
 // Preparing Batch for prediction. Since the tensorflow implementation of style
 // transfer doesn't have multiple batches supported in predict this function
 // takes exactly one st_example as an argument.
-float_array_map prepare_predict(st_example& example) {
+float_array_map prepare_predict(const st_example& example) {
   ASSERT_EQ(3, example.content_image.m_channels);
   
   size_t image_width = example.content_image.m_width;


### PR DESCRIPTION
- Added a batch size of one to predict due to Tensorflow ND array limitations.