### PR TITLE
Fix OD max iteration bug. Fix test_create_image_image for OOD.

### DIFF
--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -112,17 +112,15 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
         }
         self.fields_ans = self.get_ans.keys()
 
-    @unittest.skip("Skipping until https://github.com/apple/turicreate/issues/2406 gets resolved")
     def test_synthesis_with_single_image(self):
         image = self.train[0][self.feature]
         data = tc.one_shot_object_detector.util.preview_synthetic_training_data(
             image, 'custom_logo', backgrounds=self.backgrounds)
 
-    @unittest.skip("Skipping until https://github.com/apple/turicreate/issues/2406 gets resolved")
     def test_create_with_single_image(self):
         image = self.train[0][self.feature]
         model = tc.one_shot_object_detector.create(
-            image, 'custom_logo', backgrounds=self.backgrounds)
+            image, 'custom_logo', backgrounds=self.backgrounds, max_iterations=1)
 
     def test_create_with_missing_value(self):
         sf = self.train.append(tc.SFrame({self.feature: tc.SArray([None], dtype=tc.Image), self.target: [self.train[self.target][0]]}))

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -269,13 +269,15 @@ def create(dataset, annotations=None, feature=None, model='darknet-yolo',
         tf_config = {
             'grid_height': params['grid_shape'][0],
             'grid_width': params['grid_shape'][1],
-            'max_iterations': max_iterations,
             'mlmodel_path' : params['mlmodel_path'],
             'classes' : classes,
             'compute_final_metrics' : False
         }
         if batch_size > 0:
             tf_config['batch_size'] = batch_size
+
+        if max_iterations > 0:
+            tf_config['max_iterations'] = max_iterations
 
         model = _tc.extensions.object_detector()
         model.train(data=dataset, annotations_column_name=annotations, image_column_name=feature, options=tf_config)


### PR DESCRIPTION
In previous, when `max_iteration` is not provide, python gives default `0` into c++, which cause an assertion error in c++.

without given as an input, for a single image the max iteration will be set to `1000`, so I just set it to 1 in order not to run `1000` iteration.

fix test_create_single_image.