### PR TITLE
Od list coordinate

### DIFF
--- a/src/python/turicreate/test/test_object_detector.py
+++ b/src/python/turicreate/test/test_object_detector.py
@@ -173,7 +173,6 @@ class ObjectDetectorTest(unittest.TestCase):
         with self.assertRaises(_ToolkitError):
             tc.object_detector.create(self.sf, feature=self.feature, annotations='wrong_annotations')
 
-    @unittest.skip('A bug in OD need to be fixed.')
     def test_create_with_invalid_annotations_list_coord(self):
         with self.assertRaises(_ToolkitError):
             sf = self.sf.head()

--- a/src/toolkits/object_detection/od_data_iterator.cpp
+++ b/src/toolkits/object_detection/od_data_iterator.cpp
@@ -113,6 +113,10 @@ std::vector<image_annotation> parse_annotations(
 
         // Scan through the nested "coordinates" keys, populating the bounding
         // box.
+        if (kv.second.get_type() != flex_type_enum::DICT){
+          log_and_throw("Annotation coordinates must have type of dictionary.");
+        }
+
         const flex_dict& coordinates = kv.second.get<flex_dict>();
         for (const auto& coord_kv : coordinates) {
 


### PR DESCRIPTION
Check if the coordinate has valid dictionary type for OD data iterator.
This should fix the segfault for `test_create_with_invalid_annotations_list_coord ` on gitlab,
but still running.....