### PR TITLE
Align numpy memory view when exporting weights from TF to TC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ cache:
 
 language: python
 
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 addons:
   apt:

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -155,7 +155,14 @@ float_array_map tf_model_backend::export_weights() const {
   float_array_map result;
   call_pybind_function([&]() {
     // Call export_weights method on the TensorFLowModel
-    pybind11::object exported_weights = model_.attr("export_weights")();
+    pybind11::dict exported_weights = model_.attr("export_weights")();
+
+    // it should be trivial to call this if we use the same interpreter process
+    pybind11::module np = pybind11::module::import("numpy");
+    for (auto& kv : exported_weights) {
+      exported_weights[kv.first] = np.attr("ascontiguousarray")((kv.second));
+    }
+
     std::map<std::string, pybind11::buffer> buf_output =
         exported_weights.cast<std::map<std::string, pybind11::buffer>>();
 

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -160,11 +160,9 @@ float_array_map tf_model_backend::export_weights() const {
     // it should be trivial to call this if we use the same interpreter process
     pybind11::module np = pybind11::module::import("numpy");
     for (auto& kv : exported_weights) {
-      // defensively call ascontiguousarray to force the
+      // defensively call ascontiguousarray to force to reorganize
       // underlying numpy memory layout using the real strides
-      // after this, stride should be vector of 1s
-      exported_weights[kv.first] = np.attr("ascontiguousarray")(
-          pybind11::reinterpret_borrow<pybind11::object>(kv.second));
+      exported_weights[kv.first] = np.attr("ascontiguousarray")(kv.second);
     }
 
     std::map<std::string, pybind11::buffer> buf_output =

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -166,6 +166,20 @@ float_array_map tf_model_backend::export_weights() const {
               static_cast<float*>(buf.ptr),
               std::vector<size_t>(buf.shape.begin(), buf.shape.end()));
       result[kv.first] = value;
+
+      if (kv.first == "dummy") {
+        std::cout << kv.first << std::endl;
+        auto ndim = value.dim();
+        std::cout << "(";
+        for (size_t i = 0; i < ndim; i++) {
+          std::cout << value.shape()[i] << ", ";
+        }
+        std::cout << ")" << std::endl;
+
+        for (size_t i = 0; i < std::min<size_t>(10U, value.size()); i++) {
+          std::cout << value.data()[i] << std::endl;
+        }
+      }
     }
   });
 
@@ -346,7 +360,6 @@ std::unique_ptr<model_backend> tf_compute_context::create_style_transfer(
  * TODO: Add proper arguments to create_drawing_classifier
  */
 std::unique_ptr<model_backend> tf_compute_context::create_drawing_classifier(
-    /* TODO: const float_array_map& config if needed */
     const float_array_map& weights,
     size_t batch_size, size_t num_classes) {
   std::unique_ptr<tf_model_backend> result;

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -298,7 +298,9 @@ class DrawingClassifierTest(unittest.TestCase):
                 prefix = "pretrained" + str(test_number)
             else:
                 prefix = "scratch" + str(test_number)
-            filename = _mkstemp(prefix + ".mlmodel")[1]
+            # filename = _mkstemp(prefix + ".mlmodel")[1]
+            import os
+            filename = os.path.join(os.path.expanduser('~'), "coreml_weight.mlmodel")
             model.export_coreml(filename)
             mlmodel = _coremltools.models.MLModel(filename)
 

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -301,14 +301,13 @@ class DrawingClassifierTest(unittest.TestCase):
             filename = _mkstemp(prefix + ".mlmodel")[1]
             model.export_coreml(filename)
             mlmodel = _coremltools.models.MLModel(filename)
-
             tc_preds = model.predict(sf)
+
             if test_number == 1:
                 # stroke input
                 sf[feature] = _tc.drawing_classifier.util.draw_strokes(
                     sf[self.feature])
 
-            print("coreml predictions")
             for row_number in range(len(sf)):
                 core_ml_preds = mlmodel.predict({
                     "drawing": sf[feature][row_number]._to_pil_image()

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -304,17 +304,19 @@ class DrawingClassifierTest(unittest.TestCase):
             model.export_coreml(filename)
             mlmodel = _coremltools.models.MLModel(filename)
 
+            print("test number is :", test_number)
+
             tc_preds = model.predict(sf)
-            print(test_number)
-            print(tc_preds)
+            print("tc prediction (label)", tc_preds)
             tc_probs = model.predict(sf, output_type="probability")
-            print(tc_probs)
+            print("tc prediction (prob_vec)", tc_probs)
 
             if test_number == 1:
                 # stroke input
                 sf[feature] = _tc.drawing_classifier.util.draw_strokes(
                     sf[self.feature])
 
+            print("coreml predictions")
             for row_number in range(len(sf)):
                 core_ml_preds = mlmodel.predict({
                     "drawing": sf[feature][row_number]._to_pil_image()

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -298,19 +298,11 @@ class DrawingClassifierTest(unittest.TestCase):
                 prefix = "pretrained" + str(test_number)
             else:
                 prefix = "scratch" + str(test_number)
-            # filename = _mkstemp(prefix + ".mlmodel")[1]
-            import os
-            filename = os.path.join(os.path.expanduser('~'), "coreml_weight.mlmodel")
+            filename = _mkstemp(prefix + ".mlmodel")[1]
             model.export_coreml(filename)
             mlmodel = _coremltools.models.MLModel(filename)
 
-            print("test number is :", test_number)
-
             tc_preds = model.predict(sf)
-            print("tc prediction (label)", tc_preds)
-            tc_probs = model.predict(sf, output_type="probability")
-            print("tc prediction (prob_vec)", tc_probs)
-
             if test_number == 1:
                 # stroke input
                 sf[feature] = _tc.drawing_classifier.util.draw_strokes(
@@ -321,7 +313,6 @@ class DrawingClassifierTest(unittest.TestCase):
                 core_ml_preds = mlmodel.predict({
                     "drawing": sf[feature][row_number]._to_pil_image()
                     })
-                print(core_ml_preds)
                 assert (core_ml_preds[self.target] == tc_preds[row_number])
 
             if test_number == 1:
@@ -357,14 +348,14 @@ class DrawingClassifierTest(unittest.TestCase):
             model.summary()
 
 
-# class DrawingClassifierFromScratchTest(DrawingClassifierTest):
-#     @classmethod
-#     def setUpClass(self):
-#         super(DrawingClassifierFromScratchTest, self).setUpClass(
-#             warm_start=None)
+class DrawingClassifierFromScratchTest(DrawingClassifierTest):
+    @classmethod
+    def setUpClass(self):
+        super(DrawingClassifierFromScratchTest, self).setUpClass(
+            warm_start=None)
 
-# class DrawingClassifierUsingQuickdraw245(DrawingClassifierTest):
-#     @classmethod
-#     def setUpClass(self):
-#         super(DrawingClassifierUsingQuickdraw245, self).setUpClass(
-#             warm_start="quickdraw_245_v0")
+class DrawingClassifierUsingQuickdraw245(DrawingClassifierTest):
+    @classmethod
+    def setUpClass(self):
+        super(DrawingClassifierUsingQuickdraw245, self).setUpClass(
+            warm_start="quickdraw_245_v0")

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -301,7 +301,12 @@ class DrawingClassifierTest(unittest.TestCase):
             filename = _mkstemp(prefix + ".mlmodel")[1]
             model.export_coreml(filename)
             mlmodel = _coremltools.models.MLModel(filename)
+
             tc_preds = model.predict(sf)
+            print(test_number)
+            print(tc_preds)
+            tc_probs = model.predict(sf, output_type="probability")
+            print(tc_probs)
 
             if test_number == 1:
                 # stroke input
@@ -312,6 +317,7 @@ class DrawingClassifierTest(unittest.TestCase):
                 core_ml_preds = mlmodel.predict({
                     "drawing": sf[feature][row_number]._to_pil_image()
                     })
+                print(core_ml_preds)
                 assert (core_ml_preds[self.target] == tc_preds[row_number])
 
             if test_number == 1:
@@ -347,14 +353,14 @@ class DrawingClassifierTest(unittest.TestCase):
             model.summary()
 
 
-class DrawingClassifierFromScratchTest(DrawingClassifierTest):
-    @classmethod
-    def setUpClass(self):
-        super(DrawingClassifierFromScratchTest, self).setUpClass(
-            warm_start=None)
+# class DrawingClassifierFromScratchTest(DrawingClassifierTest):
+#     @classmethod
+#     def setUpClass(self):
+#         super(DrawingClassifierFromScratchTest, self).setUpClass(
+#             warm_start=None)
 
-class DrawingClassifierUsingQuickdraw245(DrawingClassifierTest):
-    @classmethod
-    def setUpClass(self):
-        super(DrawingClassifierUsingQuickdraw245, self).setUpClass(
-            warm_start="quickdraw_245_v0")
+# class DrawingClassifierUsingQuickdraw245(DrawingClassifierTest):
+#     @classmethod
+#     def setUpClass(self):
+#         super(DrawingClassifierUsingQuickdraw245, self).setUpClass(
+#             warm_start="quickdraw_245_v0")

--- a/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
@@ -19,6 +19,8 @@ _tf.disable_v2_behavior()
 # for debug purpose
 import os
 from pprint import pprint
+import numpy
+numpy.set_printoptions(threshold=18)
 
 class DrawingClassifierTensorFlowModel(TensorFlowModel):
     count = 0
@@ -120,8 +122,7 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
             for key in net_params.keys():
                 pprint(net_params[key].shape, f)
                 pprint(key, f)
-                pprint(net_params[key], f)
-
+                print(net_params[key], file=f)
 
         # Assign the initialised weights from MXNet to tensorflow
         layers = ['drawing_conv0_weight', 'drawing_conv0_bias', 'drawing_conv1_weight', 'drawing_conv1_bias',
@@ -256,15 +257,25 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
                 else:
                     # TODO: Call _utils.convert_conv2d_tf_to_coreml once #2513 is merged.
                     net_params.update(
-                        {var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1))})
+                        {var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1)).copy()})
 
         fname = os.path.join(os.path.expanduser('~'), "tf_weight_end_{}.txt".format(
             DrawingClassifierTensorFlowModel.count))
+
+        DrawingClassifierTensorFlowModel.count += 1
+
+        # a simple demo on reading memory view in tc cpp side
+        net_params['dummy'] = _np.arange(10).reshape(2, 5).astype(_np.float32)
+        print(net_params['dummy'])
+        net_params['dummy'] = _np.transpose(net_params['dummy'], (1, 0))
+        # comment out this
+        # net_params['dummy'] = _np.transpose(net_params['dummy'], (1, 0)).copy()
+        print(net_params['dummy'])
 
         with open(fname, 'w') as f:
             for key in net_params.keys():
                 pprint(net_params[key].shape, f)
                 pprint(key, f)
-                pprint(net_params[key], f)
+                print(net_params[key], file=f)
 
         return net_params

--- a/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
@@ -237,7 +237,9 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
                             {var.name.replace(":0", ""): val.transpose(1, 0)})
                 else:
                     # TODO: Call _utils.convert_conv2d_tf_to_coreml once #2513 is merged.
+                    # np.transpose won't change the underlying memory layout
+                    # but in turicreate we will force it.
                     net_params.update(
-                        {var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1)).copy()})
+                        {var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1))})
 
         return net_params

--- a/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
@@ -20,8 +20,8 @@ _tf.disable_v2_behavior()
 import os
 from pprint import pprint
 
-
 class DrawingClassifierTensorFlowModel(TensorFlowModel):
+    count = 0
 
     def __init__(self, net_params, batch_size, num_classes):
         """
@@ -113,9 +113,14 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
         self.sess = _tf.Session()
         self.sess.run(_tf.global_variables_initializer())
 
-        fname = os.path.join(os.path.expanduser('~'), "tf_weight_init.txt")
+        fname = os.path.join(os.path.expanduser('~'), "tf_weight_init_{}.txt".format(
+            DrawingClassifierTensorFlowModel.count))
+        DrawingClassifierTensorFlowModel.count += 1
         with open(fname, 'w') as f:
-            pprint(net_params, f)
+            for key in net_params.keys():
+                pprint(net_params[key].shape, f)
+                pprint(key, f)
+                pprint(net_params[key], f)
 
 
         # Assign the initialised weights from MXNet to tensorflow
@@ -253,8 +258,13 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
                     net_params.update(
                         {var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1))})
 
-        fname = os.path.join(os.path.expanduser('~'), "tf_weight_end.txt")
+        fname = os.path.join(os.path.expanduser('~'), "tf_weight_end_{}.txt".format(
+            DrawingClassifierTensorFlowModel.count))
+
         with open(fname, 'w') as f:
-            pprint(net_params, f)
+            for key in net_params.keys():
+                pprint(net_params[key].shape, f)
+                pprint(key, f)
+                pprint(net_params[key], f)
 
         return net_params


### PR DESCRIPTION
TL;DR, `ascontiguousarray` is preferrable over `copy`.

---

~This is [WIP] because I want to leave my debug trace for people who want to repro and have a deep understanding of the issue is.~

The root cause for inconsistency of weights exported from TF to TC is:
```
net_params.update({var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1))})
```

The numpy `ufunc` transpose doesn't change the memory layout of numpy array. When we load the python object to TC CPP backend, we use this logic here
```
      pybind11::buffer_info buf = kv.second.request();
      turi::neural_net::shared_float_array value =
          turi::neural_net::shared_float_array::copy(
              static_cast<float*>(buf.ptr),
              std::vector<size_t>(buf.shape.begin(), buf.shape.end()));
```
The shape is correct but the `buf.ptr` points to the actually memory storage of numpy array, which has the layout of the original layout before being transposed.

It's similar to the lazy evaluation of our SFrame. You can apply different operations on the SFrame but the underlying storage layout won't change unless you call to `materialize`. 

The solution is to call `copy()` to enfore numpy to materialize the new memory view of applying lazy-evaluated `ufunc`s.
```
net_params.update({var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1)).copy()})
```

This is a critical bug and it's worthy of our attention.

If you want. to repro, check out hash `51b7b2dcb42`. Without solidating to new memory layout (original layout with C order, transposed, TC interpretation of memory layout of numpy), the output is
```
[[0. 1. 2. 3. 4.]
 [5. 6. 7. 8. 9.]]
[[0. 5.]
 [1. 6.]
 [2. 7.]
 [3. 8.]
 [4. 9.]]
dummy
(5, 2, )
0
1
2
3
4
5
6
7
8
9
```
After solidating by calling `copy`,
```
dummy
(5, 2, )
0
5
1
6
2
7
3
8
4
9
```