### PR TITLE
DC: Sanitize validation_data value passed in to C++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
       dist: xenial
       sudo: true
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 addons:
   apt:
     update: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ matrix:
       dist: xenial
       sudo: true
 
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
-
 addons:
   apt:
     update: true

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -237,7 +237,6 @@ class DrawingClassifierTest(unittest.TestCase):
                 preds = model.predict(sf[self.feature], output_type="probability")
                 assert (preds.dtype == float)
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason="Coming soon in a later PR")
     def test_evaluate_without_ground_truth(self):
         for index in range(len(self.trains)):
             model = self.models[index]
@@ -267,7 +266,6 @@ class DrawingClassifierTest(unittest.TestCase):
                     assert (metric in evaluation)
                     assert (individual_run_results[metric] == evaluation[metric])
 
-    @pytest.mark.xfail(IS_PRE_6_0_RC, reason="Coming soon in a later PR")
     def test_evaluate_with_unsupported_metric(self):
         for index in range(len(self.trains)):
             model = self.models[index]

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -21,8 +21,6 @@ from . import util as test_util
 import unittest
 import pytest
 
-IS_PRE_6_0_RC = float(_tc.__version__) < 6.0
-
 def _build_bitmap_data():
     '''
     Build an SFrame from 10 saved drawings.
@@ -148,6 +146,11 @@ class DrawingClassifierTest(unittest.TestCase):
             })
         with self.assertRaises(_ToolkitError):
             _tc.drawing_classifier.create(sf, self.target, feature=self.feature)
+
+    def test_create_with_validation_set_None(self):
+        for data in self.trains:
+            model = _tc.drawing_classifier.create(data, self.target,
+                feature=self.feature, validation_set=None, max_iterations=1)
 
     def test_create_with_empty_drawing_in_stroke_input(self):
         drawing = []

--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -171,6 +171,8 @@ def create(input_dataset, target, feature=None, validation_set='auto',
         options = dict()
         options["batch_size"] = batch_size
         options["max_iterations"] = max_iterations
+        if validation_set is None:
+            validation_set = _tc.SFrame()
         # Enable the following line when #2524 is merged
         # options["warm_start"] = warm_start
         model.train(input_dataset, target, feature, validation_set, options)


### PR DESCRIPTION
Since the C++ layer can only accept values = "auto", an SFrame, or an empty SFrame (so no validation info is computed), we sanitize the `validation_data` value passed in to the C++ layer from Python by translating a `None` on the Python side into an empty SFrame on the C++ side.

Fixes #2605 