### PR TITLE
Python based export-coreml toolkits now have consistent version info

### DIFF
--- a/src/python/turicreate/test/test_coreml_export.py
+++ b/src/python/turicreate/test/test_coreml_export.py
@@ -63,23 +63,19 @@ class CoreMLExportTest(unittest.TestCase):
         if predict_topk is None:
             predict_topk = not is_regression
 
-
         # Act & Assert
         with tempfile.NamedTemporaryFile(mode='w', suffix = '.mlmodel') as mlmodel_file:
             mlmodel_filename = mlmodel_file.name
             model.export_coreml(mlmodel_filename)
             coreml_model = coremltools.models.MLModel(mlmodel_filename)
+            self.assertDictEqual({
+                'com.github.apple.turicreate.version': tc.__version__
+                }, dict(coreml_model.user_defined_metadata)
+            )
 
             if _mac_ver() < (10, 13):
                 print("Skipping export test; model not supported on this platform.")
                 return
-
-            # print(coreml_model.get_spec())
-
-            # import shutil
-            # shutil.copyfile(mlmodel_filename, "./bt.mlmodel")
-
-            # model.save("./bt.model")
 
             def array_to_numpy(row):
                 import array
@@ -91,13 +87,9 @@ class CoreMLExportTest(unittest.TestCase):
                         row[r] = numpy.array(row[r])
                 return row
 
-
             for row in test_sf:
 
-                # print(row)
-
                 coreml_prediction = coreml_model.predict(array_to_numpy(row))
-
                 tc_prediction = model.predict(row)[0]
 
                 if (is_regression == False) and (type(model.classes[0]) == str):

--- a/src/python/turicreate/test/test_image_classifier.py
+++ b/src/python/turicreate/test/test_image_classifier.py
@@ -168,13 +168,23 @@ class ImageClassifierTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             predictions = model.classify("more junk")
 
-    @unittest.skipIf(sys.platform == 'darwin', 'test_export_coreml_with_predict(...) covers this functionality and more')
     def test_export_coreml(self):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 
+        coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            u'com.github.apple.turicreate.version': tc.__version__,
+            'type': 'ImageClassifier',
+            'version': '1'
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Image classifier (%s) created by Turi Create (version %s)' % (
+                self.model.model, tc.__version__)
+        self.assertEquals(expected_result, coreml_model.short_description)
+
     @unittest.skipIf(sys.platform != 'darwin', 'Core Ml only supported on Mac')
-    def test_export_coreml_with_predict(self):
+    def test_export_coreml_predict(self):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 

--- a/src/python/turicreate/test/test_image_similarity.py
+++ b/src/python/turicreate/test/test_image_similarity.py
@@ -196,6 +196,14 @@ class ImageSimilarityTest(unittest.TestCase):
 
         # Load the model back from the CoreML model file
         coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            u'com.github.apple.turicreate.version': tc.__version__,
+            'type': 'ImageSimilarityModel',
+            'version': '1'
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Image similarity (%s) created by Turi Create (version %s)' % (
+                self.model.model, tc.__version__)
 
         # Get model distances for comparison
         img = data[0:1][self.feature][0]

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -94,6 +94,13 @@ class TextClassifierTest(unittest.TestCase):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 
+        coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        self.assertTrue('Text classifier created by Turi Create' in coreml_model.short_description)
+
     @unittest.skipIf(_mac_ver() < (10, 13), 'Only supported on macOS 10.13+')
     def test_export_coreml_with_predict(self):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -99,7 +99,8 @@ class TextClassifierTest(unittest.TestCase):
             'com.github.apple.turicreate.version': tc.__version__
             }, dict(coreml_model.user_defined_metadata)
         )
-        self.assertTrue('Text classifier created by Turi Create' in coreml_model.short_description)
+        expected_result = 'Text classifier created by Turi Create (version %s)' % tc.__version__
+        self.assertEquals(expected_result, coreml_model.short_description)
 
     @unittest.skipIf(_mac_ver() < (10, 13), 'Only supported on macOS 10.13+')
     def test_export_coreml_with_predict(self):

--- a/src/python/turicreate/toolkits/_coreml_utils.py
+++ b/src/python/turicreate/toolkits/_coreml_utils.py
@@ -29,7 +29,8 @@ def _get_model_metadata(model_class, metadata, version=None):
     info['type'] = model_class
     if version is not None:
         info['version'] = str(version)
-    info.update(metadata)
+    if metadata is not None:
+        info.update(metadata)
     return info
 
 def _set_model_metadata(mlmodel, model_class, metadata, version=None):

--- a/src/python/turicreate/toolkits/_coreml_utils.py
+++ b/src/python/turicreate/toolkits/_coreml_utils.py
@@ -13,21 +13,24 @@ def _mlmodel_short_description(model_type):
     from turicreate import __version__
     return '%s created by Turi Create (version %s)' % (model_type.capitalize(), __version__)
 
+def _get_tc_version_info():
+    """
+    Return metadata related to the package to be added to the CoreML model
+    """
+    from turicreate import __version__
+    return {'com.github.apple.turicreate.version': __version__}
+
 def _get_model_metadata(model_class, metadata, version=None):
     """
     Returns user-defined metadata, making sure information all models should
     have is also available, as a dictionary
     """
-    from turicreate import __version__
-    info = {
-        'com.github.apple.turicreate.version': __version__,
-        'type': model_class,
-    }
+    info = _get_tc_version_info()
+    info['type'] = model_class
     if version is not None:
         info['version'] = str(version)
     info.update(metadata)
     return info
-
 
 def _set_model_metadata(mlmodel, model_class, metadata, version=None):
     """

--- a/src/python/turicreate/toolkits/_coreml_utils.py
+++ b/src/python/turicreate/toolkits/_coreml_utils.py
@@ -20,7 +20,7 @@ def _get_model_metadata(model_class, metadata, version=None):
     """
     from turicreate import __version__
     info = {
-        'turicreate_version': __version__,
+        'com.github.apple.turicreate.version': __version__,
         'type': model_class,
     }
     if version is not None:

--- a/src/python/turicreate/toolkits/_internal_utils.py
+++ b/src/python/turicreate/toolkits/_internal_utils.py
@@ -750,9 +750,3 @@ def _print_neural_compute_device(cuda_gpus, use_mps, cuda_mem_req=None, has_mps_
         print('Using CPU to create model')
         if sys.platform == 'darwin' and _mac_ver() < (10, 14) and has_mps_impl:
             print('NOTE: If available, an AMD GPU can be leveraged on macOS 10.14+ for faster model creation')
-
-def _get_tc_version_info_export_coreml():
-    """
-    Return metadata related to the package to be added to the CoreML model
-    """
-    return {'com.github.apple.turicreate.version': _turicreate.__version__}

--- a/src/python/turicreate/toolkits/_internal_utils.py
+++ b/src/python/turicreate/toolkits/_internal_utils.py
@@ -25,7 +25,7 @@ from ..toolkits._main import ToolkitError
 import json
 import logging as _logging
 import six as _six
-
+import turicreate as _turicreate
 
 _proxy_map = {UnitySFrameProxy: (lambda x: _SFrame(_proxy=x)),
               UnitySArrayProxy: (lambda x: _SArray(_proxy=x)),
@@ -750,3 +750,9 @@ def _print_neural_compute_device(cuda_gpus, use_mps, cuda_mem_req=None, has_mps_
         print('Using CPU to create model')
         if sys.platform == 'darwin' and _mac_ver() < (10, 14) and has_mps_impl:
             print('NOTE: If available, an AMD GPU can be leveraged on macOS 10.14+ for faster model creation')
+
+def _get_tc_version_info_export_coreml():
+    """
+    Return metadata related to the package to be added to the CoreML model
+    """
+    return {'com.github.apple.turicreate.version': _turicreate.__version__}

--- a/src/python/turicreate/toolkits/_internal_utils.py
+++ b/src/python/turicreate/toolkits/_internal_utils.py
@@ -25,7 +25,7 @@ from ..toolkits._main import ToolkitError
 import json
 import logging as _logging
 import six as _six
-import turicreate as _turicreate
+
 
 _proxy_map = {UnitySFrameProxy: (lambda x: _SFrame(_proxy=x)),
               UnitySArrayProxy: (lambda x: _SArray(_proxy=x)),

--- a/src/python/turicreate/toolkits/_tree_model_mixin.py
+++ b/src/python/turicreate/toolkits/_tree_model_mixin.py
@@ -7,9 +7,9 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 import turicreate as tc
-from turicreate.toolkits._internal_utils import _get_tc_version_info_export_coreml
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
 from turicreate.toolkits._supervised_learning import select_default_missing_value_policy
+from turicreate.toolkits import _coreml_utils
 
 class TreeModelMixin(object):
     """
@@ -316,6 +316,5 @@ class TreeModelMixin(object):
         return ([data_fields, training_fields], ["Schema", "Settings"])
 
     def _export_coreml_impl(self, filename, context):
-        tc_version_info = _get_tc_version_info_export_coreml()
-        context['user_defined'].update(tc_version_info)
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         tc.extensions._xgboost_export_as_model_asset(self.__proxy__, filename, context)

--- a/src/python/turicreate/toolkits/_tree_model_mixin.py
+++ b/src/python/turicreate/toolkits/_tree_model_mixin.py
@@ -7,6 +7,7 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 import turicreate as tc
+from turicreate.toolkits._internal_utils import _get_tc_version_info_export_coreml
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
 from turicreate.toolkits._supervised_learning import select_default_missing_value_policy
 
@@ -315,4 +316,6 @@ class TreeModelMixin(object):
         return ([data_fields, training_fields], ["Schema", "Settings"])
 
     def _export_coreml_impl(self, filename, context):
+        tc_version_info = _get_tc_version_info_export_coreml()
+        context['user_defined'].update(tc_version_info)
         tc.extensions._xgboost_export_as_model_asset(self.__proxy__, filename, context)

--- a/src/python/turicreate/toolkits/_tree_model_mixin.py
+++ b/src/python/turicreate/toolkits/_tree_model_mixin.py
@@ -316,5 +316,9 @@ class TreeModelMixin(object):
         return ([data_fields, training_fields], ["Schema", "Settings"])
 
     def _export_coreml_impl(self, filename, context):
-        context['user_defined'] = _coreml_utils._get_tc_version_info()
+        tc_version_info = _coreml_utils._get_tc_version_info()
+        if 'user_defined' not in context:
+            context['user_defined'] = tc_version_info
+        else:
+            context['user_defined'].update(tc_version_info)
         tc.extensions._xgboost_export_as_model_asset(self.__proxy__, filename, context)

--- a/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
@@ -433,7 +433,6 @@ class BoostedTreesClassifier(_Classifier, _TreeModelMixin):
                    "model_type" : "boosted_trees",
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
@@ -431,12 +431,9 @@ class BoostedTreesClassifier(_Classifier, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "classification",
                    "model_type" : "boosted_trees",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
@@ -423,7 +423,6 @@ class DecisionTreeClassifier(_Classifier, _TreeModelMixin):
                    "model_type" : "decision_tree",
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                 }
 
         self._export_coreml_impl(filename, context)

--- a/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
@@ -421,12 +421,9 @@ class DecisionTreeClassifier(_Classifier, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "classification",
                    "model_type" : "decision_tree",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                 }
 
         self._export_coreml_impl(filename, context)

--- a/src/python/turicreate/toolkits/classifier/logistic_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/logistic_classifier.py
@@ -17,8 +17,8 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _raise_error_if_not_sframe, \
                                         _check_categorical_option_type, \
                                         _raise_error_evaluation_metric_is_valid, \
-                                        _summarize_coefficients
-
+                                        _summarize_coefficients, \
+                                        _get_tc_version_info_export_coreml
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -478,12 +478,11 @@ class LogisticClassifier(_Classifier):
         display_name = "logistic classifier"
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
-                   "version": _turicreate.__version__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined': {}
                 }
+        tc_version_info = _get_tc_version_info_export_coreml()
+        context['user_defined'].update(tc_version_info)
         _logistic_classifier_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/classifier/logistic_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/logistic_classifier.py
@@ -17,8 +17,8 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _raise_error_if_not_sframe, \
                                         _check_categorical_option_type, \
                                         _raise_error_evaluation_metric_is_valid, \
-                                        _summarize_coefficients, \
-                                        _get_tc_version_info_export_coreml
+                                        _summarize_coefficients
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -479,10 +479,8 @@ class LogisticClassifier(_Classifier):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined': {}
-                }
-        tc_version_info = _get_tc_version_info_export_coreml()
-        context['user_defined'].update(tc_version_info)
+                  }
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         _logistic_classifier_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
@@ -426,7 +426,6 @@ class RandomForestClassifier(_Classifier, _TreeModelMixin):
                    "model_type" : "random_forest",
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
@@ -424,12 +424,9 @@ class RandomForestClassifier(_Classifier, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "classification",
                    "model_type" : "random_forest",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/classifier/svm_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/svm_classifier.py
@@ -385,7 +385,6 @@ class SVMClassifier(_Classifier):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                 }
         context['user_defined'] = _coreml_utils._get_tc_version_info()
         _linear_svm_export_as_model_asset(self.__proxy__, filename, context)

--- a/src/python/turicreate/toolkits/classifier/svm_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/svm_classifier.py
@@ -16,7 +16,8 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _toolkit_get_topk_bottomk, \
                                         _raise_error_evaluation_metric_is_valid, \
                                         _check_categorical_option_type, \
-                                        _summarize_coefficients
+                                        _summarize_coefficients, \
+                                        _get_tc_version_info_export_coreml
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -383,12 +384,11 @@ class SVMClassifier(_Classifier):
         display_name = "svm classifier"
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
-                   "version": _turicreate.__version__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                 }
+        tc_version_info = _get_tc_version_info_export_coreml()
+        context['user_defined'].update(tc_version_info)
         _linear_svm_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/classifier/svm_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/svm_classifier.py
@@ -16,8 +16,8 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _toolkit_get_topk_bottomk, \
                                         _raise_error_evaluation_metric_is_valid, \
                                         _check_categorical_option_type, \
-                                        _summarize_coefficients, \
-                                        _get_tc_version_info_export_coreml
+                                        _summarize_coefficients
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -387,8 +387,7 @@ class SVMClassifier(_Classifier):
                    "short_description": short_description,
                    'user_defined':{}
                 }
-        tc_version_info = _get_tc_version_info_export_coreml()
-        context['user_defined'].update(tc_version_info)
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         _linear_svm_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -26,6 +26,7 @@ from .. import _image_feature_extractor
 from ._evaluation import Evaluation as _Evaluation
 from turicreate.toolkits._internal_utils import (_raise_error_if_not_sframe,
                                                  _numeric_param_check_range)
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -912,19 +913,21 @@ class ImageClassifier(_CustomModel):
             mlmodel.input_description[self.feature] = u'Input image'
             mlmodel.output_description[prob_name] = 'Prediction probabilities'
             mlmodel.output_description[label_name] = 'Class label of top prediction'
+
             model_metadata = {
-                'model': self.model,
-                'target': self.target,
-                'features': self.feature,
-                'max_iterations': str(self.max_iterations),
+                 'model': self.model,
+                 'target': self.target,
+                 'features': self.feature,
+                 'max_iterations': str(self.max_iterations),
             }
             user_defined_metadata = model_metadata.update(
-                    _get_tc_version_info_export_coreml())
-            _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, user_defined_metadata,
-                    version=imageclassifier._python_image_classifier_version)
+                    _coreml_utils._get_tc_version_info())
+            _coreml_utils._set_model_metadata(mlmodel,
+                    self.__class__.__name__,
+                    user_defined_metadata,
+                    version=ImageClassifier._PYTHON_IMAGE_CLASSIFIER_VERSION)
 
             return mlmodel
-
 
         # main part of the export_coreml function
         if self.model in _pre_trained_models.IMAGE_MODELS:

--- a/src/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -912,12 +912,16 @@ class ImageClassifier(_CustomModel):
             mlmodel.input_description[self.feature] = u'Input image'
             mlmodel.output_description[prob_name] = 'Prediction probabilities'
             mlmodel.output_description[label_name] = 'Class label of top prediction'
-            _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, {
+            model_metadata = {
                 'model': self.model,
                 'target': self.target,
                 'features': self.feature,
                 'max_iterations': str(self.max_iterations),
-            }, version=ImageClassifier._PYTHON_IMAGE_CLASSIFIER_VERSION)
+            }
+            user_defined_metadata = model_metadata.update(
+                    _get_tc_version_info_export_coreml())
+            _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, user_defined_metadata,
+                    version=imageclassifier._python_image_classifier_version)
 
             return mlmodel
 

--- a/src/python/turicreate/toolkits/image_similarity/image_similarity.py
+++ b/src/python/turicreate/toolkits/image_similarity/image_similarity.py
@@ -22,6 +22,7 @@ from .. import _pre_trained_models
 from .. import _image_feature_extractor
 from turicreate.toolkits._internal_utils import (_raise_error_if_not_sframe,
                                                  _numeric_param_check_range)
+from turicreate.toolkits import _coreml_utils
 
 
 def create(dataset, label = None, feature = None, model = 'resnet-50', verbose = True,
@@ -629,9 +630,15 @@ class ImageSimilarityModel(_CustomModel):
         mlmodel.input_description[self.feature] = u'Input image'
         mlmodel.output_description[output_name] = u'Distances between the input and reference images'
 
-        _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, {
-            'model': self.model,
-            'num_examples': str(self.num_examples)
-        }, version=ImageSimilarityModel._PYTHON_IMAGE_SIMILARITY_VERSION)
+        model_metadata = {
+             'model': self.model,
+             'num_examples': str(self.num_examples),
+        }
+        user_defined_metadata = model_metadata.update(
+                    _coreml_utils._get_tc_version_info())
+        _coreml_utils._set_model_metadata(mlmodel,
+                self.__class__.__name__,
+                user_defined_metadata,
+                version=ImageSimilarityModel._PYTHON_IMAGE_SIMILARITY_VERSION)
 
         mlmodel.save(filename)

--- a/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
+++ b/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
@@ -220,7 +220,6 @@ class BoostedTreesRegression(_SupervisedLearningModel, _TreeModelMixin):
                    "model_type" : "boosted_trees",
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
+++ b/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
@@ -218,12 +218,9 @@ class BoostedTreesRegression(_SupervisedLearningModel, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "regression",
                    "model_type" : "boosted_trees",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/regression/decision_tree_regression.py
+++ b/src/python/turicreate/toolkits/regression/decision_tree_regression.py
@@ -247,9 +247,7 @@ class DecisionTreeRegression(_SupervisedLearningModel, _TreeModelMixin):
                    "model_type" : "decision_tree",
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                 }
-
         self._export_coreml_impl(filename, context)
 
     def predict(self, dataset, missing_value_action='auto'):

--- a/src/python/turicreate/toolkits/regression/decision_tree_regression.py
+++ b/src/python/turicreate/toolkits/regression/decision_tree_regression.py
@@ -245,12 +245,9 @@ class DecisionTreeRegression(_SupervisedLearningModel, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "regression",
                    "model_type" : "decision_tree",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                 }
 
         self._export_coreml_impl(filename, context)

--- a/src/python/turicreate/toolkits/regression/linear_regression.py
+++ b/src/python/turicreate/toolkits/regression/linear_regression.py
@@ -16,8 +16,8 @@ from turicreate.toolkits._supervised_learning import SupervisedLearningModel as 
 from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _toolkit_get_topk_bottomk, \
                                         _summarize_coefficients, \
-                                        _raise_error_evaluation_metric_is_valid, \
-                                        _get_tc_version_info_export_coreml
+                                        _raise_error_evaluation_metric_is_valid
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -443,10 +443,8 @@ class LinearRegression(_SupervisedLearningModel):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{}
                   }
-        tc_version_info = _get_tc_version_info_export_coreml()
-        context['user_defined'].update(tc_version_info)
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         _linear_regression_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/regression/linear_regression.py
+++ b/src/python/turicreate/toolkits/regression/linear_regression.py
@@ -16,8 +16,8 @@ from turicreate.toolkits._supervised_learning import SupervisedLearningModel as 
 from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _toolkit_get_topk_bottomk, \
                                         _summarize_coefficients, \
-                                        _raise_error_evaluation_metric_is_valid
-
+                                        _raise_error_evaluation_metric_is_valid, \
+                                        _get_tc_version_info_export_coreml
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -442,12 +442,11 @@ class LinearRegression(_SupervisedLearningModel):
         display_name = "linear regression"
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
-                   "version": _turicreate.__version__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
+                   'user_defined':{}
                   }
+        tc_version_info = _get_tc_version_info_export_coreml()
+        context['user_defined'].update(tc_version_info)
         _linear_regression_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/regression/random_forest_regression.py
+++ b/src/python/turicreate/toolkits/regression/random_forest_regression.py
@@ -290,11 +290,8 @@ class RandomForestRegression(_SupervisedLearningModel, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "regression",
                    "model_type" : "random_forest",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   },
+                   'user_defined':{},
                    "short_description": short_description}
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/regression/random_forest_regression.py
+++ b/src/python/turicreate/toolkits/regression/random_forest_regression.py
@@ -291,7 +291,6 @@ class RandomForestRegression(_SupervisedLearningModel, _TreeModelMixin):
         context = {"mode" : "regression",
                    "model_type" : "random_forest",
                    "class": self.__class__.__name__,
-                   'user_defined':{},
                    "short_description": short_description}
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/text_classifier/_text_classifier.py
+++ b/src/python/turicreate/toolkits/text_classifier/_text_classifier.py
@@ -11,8 +11,9 @@ import turicreate as _tc
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
 from turicreate.toolkits._model import CustomModel as _CustomModel
 from turicreate.toolkits._model import PythonProxy as _PythonProxy
-from turicreate.toolkits._internal_utils import _toolkit_repr_print, _get_tc_version_info_export_coreml
+from turicreate.toolkits._internal_utils import _toolkit_repr_print
 from turicreate.toolkits import text_analytics as _text_analytics
+from turicreate.toolkits import _coreml_utils
 
 
 def _BOW_FEATURE_EXTRACTOR(sf, target=None):
@@ -357,10 +358,8 @@ class TextClassifier(_CustomModel):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {'class': self.__class__.__name__,
                    'short_description': short_description,
-                   'user_defined':{}
-                }
-        tc_version_info = _get_tc_version_info_export_coreml()
-        context['user_defined'].update(tc_version_info)
+                  }
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
 
         model = self.__proxy__['classifier'].__proxy__
         _logistic_classifier_export_as_model_asset(model, filename, context)

--- a/src/python/turicreate/toolkits/text_classifier/_text_classifier.py
+++ b/src/python/turicreate/toolkits/text_classifier/_text_classifier.py
@@ -11,7 +11,7 @@ import turicreate as _tc
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
 from turicreate.toolkits._model import CustomModel as _CustomModel
 from turicreate.toolkits._model import PythonProxy as _PythonProxy
-from turicreate.toolkits._internal_utils import _toolkit_repr_print
+from turicreate.toolkits._internal_utils import _toolkit_repr_print, _get_tc_version_info_export_coreml
 from turicreate.toolkits import text_analytics as _text_analytics
 
 
@@ -356,18 +356,14 @@ class TextClassifier(_CustomModel):
         display_name = 'text classifier'
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {'class': self.__class__.__name__,
-                   'version': _tc.__version__,
                    'short_description': short_description,
-                   'user_defined':{
-                    'turicreate_version': _tc.__version__
-                   }
+                   'user_defined':{}
                 }
-
+        tc_version_info = _get_tc_version_info_export_coreml()
+        context['user_defined'].update(tc_version_info)
 
         model = self.__proxy__['classifier'].__proxy__
-
         _logistic_classifier_export_as_model_asset(model, filename, context)
-
 
 def _get_str_columns(sf):
     """


### PR DESCRIPTION
- Fixes #2562 for all Python based toolkits. 
- Added unit tests to check correctness
- Behavior is intended to match 5.8 as closely as possible 

C++ based toolkits will come in an other PR.