### PR TITLE
Added user defined metadata to export_coreml for neural net toolkits

### DIFF
--- a/src/python/turicreate/test/test_object_detector.py
+++ b/src/python/turicreate/test/test_object_detector.py
@@ -297,6 +297,22 @@ class ObjectDetectorTest(unittest.TestCase):
             include_non_maximum_suppression=False)
 
         coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__,
+            'annotations': self.annotations,
+            'type': 'object_detector',
+            'classes': ','.join(sorted(_CLASSES)),
+            'feature': self.feature,
+            'include_non_maximum_suppression': 'False',
+            'max_iterations': '1',
+            'model': 'darknet-yolo',
+            'training_iterations': '1',
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Object Detector created by Turi Create (version %s)' \
+                                    % (tc.__version__)
+        #self.assertEquals(expected_result, coreml_model.short_description)
+
         img = self.sf[0:1][self.feature][0]
         img_fixed = tc.image_analysis.resize(img, 416, 416, 3)
         pil_img = Image.fromarray(img_fixed.pixel_data)

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1655,8 +1655,12 @@ class ObjectDetector_beta(_Model):
         options['include_non_maximum_suppression'] = include_non_maximum_suppression
         options['confidence_threshold'] = confidence_threshold
         options['iou_threshold'] = iou_threshold
+        options['iou_threshold'] = iou_threshold
+        additional_user_defined_metadata = _coreml_utils._get_tc_version_info()
+        short_description = _coreml_utils._mlmodel_short_description('Object Detector')
 
-        self.__proxy__.export_to_coreml(filename, options)
+        self.__proxy__.export_to_coreml(filename, options, short_description,
+                additional_user_defined_metadata)
 
 
     def predict(self, dataset, confidence_threshold=0.25, iou_threshold=0.45, verbose=True):

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -903,7 +903,8 @@ std::unique_ptr<model_spec> object_detector::init_model(
 }
 
 std::shared_ptr<MLModelWrapper> object_detector::export_to_coreml(
-    std::string filename, std::map<std::string, flexible_type> opts) {
+    std::string filename, std::map<std::string, flexible_type> opts,
+    std::string short_description, std::map<std::string, flexible_type> additional_user_defined) {
   // If called during training, synchronize the model first.
   if (training_model_) {
     synchronize_training();
@@ -963,15 +964,15 @@ std::shared_ptr<MLModelWrapper> object_detector::export_to_coreml(
       {"type", "object_detector"},
     };
 
+  for(const auto& kvp : additional_user_defined) {
+       user_defined_metadata.emplace_back(kvp.first, kvp.second);
+  }
 
   if (opts["include_non_maximum_suppression"].to<bool>()){
     user_defined_metadata.emplace_back("include_non_maximum_suppression", "True");
     user_defined_metadata.emplace_back("confidence_threshold", opts["confidence_threshold"]);
     user_defined_metadata.emplace_back("iou_threshold", opts["iou_threshold"]);
   }
-
-  // TODO: Should we also be adding the non-user-defined keys, such as
-  // "version" and "shortDescription", or is that up to the frontend?
 
   std::shared_ptr<MLModelWrapper> model_wrapper = export_object_detector_model(
       yolo_nn_spec, grid_width * SPATIAL_REDUCTION,

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -46,7 +46,8 @@ class EXPORT object_detector: public ml_model_base {
   variant_type predict(variant_type data,
                        std::map<std::string, flexible_type> opts);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename, std::map<std::string, flexible_type> opts);
+      std::string filename, std::map<std::string, flexible_type> opts,
+      std::string short_description, std::map<std::string, flexible_type> additional_user_defined);
   void import_from_custom_model(variant_map_type model_data, size_t version);
 
   // Support for iterative training.
@@ -118,8 +119,11 @@ class EXPORT object_detector: public ml_model_base {
   register_defaults("predict",{});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename",
-    "options");
-  register_defaults("export_to_coreml", {{"options", to_variant(std::map<std::string, flexible_type>())}});
+    "options", "short_description", "additional_user_defined");
+  register_defaults("export_to_coreml",
+          {{"options", to_variant(std::map<std::string, flexible_type>())},
+          {"short_description", ""},
+          {"additional_user_defined", to_variant(std::map<std::string, flexible_type>())}});
 
   REGISTER_CLASS_MEMBER_DOCSTRING(
       object_detector::export_to_coreml,


### PR DESCRIPTION
Fixes #2562 for neural network toolkits. I put this up as a separate PR from the python based export_coreml to keep the reviewing simpler because I think there may be more issues with how this PR is done.