### PR TITLE
Working CoreML export with metadata version number

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,24 @@ build_wheel_linux_python36:
     paths:
       - target/
 
+build_wheel_linux_python37:
+  tags:
+    - docker
+  services:
+    - docker:18.09-dind
+  image: docker:18.09
+  stage: build
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+  script:
+    - apk add bash
+    - bash -e scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python3.7 --skip_doc
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - target/
+
 build_wheel_mac_10_15_python27:
   tags:
     - macos10.15
@@ -353,6 +371,27 @@ test_python_linux_python36:
     paths:
       - pytest.*
 
+test_python_linux_python37:
+  tags:
+    - docker
+  services:
+    - docker:18.09-dind
+  image: docker:18.09
+  stage: test
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+  dependencies:
+    - build_wheel_linux_python37
+  script:
+    - apk add bash
+    - bash -e scripts/test_wheel.sh --docker-python3.7
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+      - pytest.*
+
 # This coremltools issues needs to be resolved before we can run on macOS 10.13
 # https://github.com/apple/coremltools/issues/408
 #test_python_mac_python27_10_13:
@@ -539,6 +578,7 @@ collect_artifacts:
     - build_wheel_linux_python27
     - build_wheel_linux_python35
     - build_wheel_linux_python36
+    - build_wheel_linux_python37
     - build_wheel_mac_10_15_python27
     - build_wheel_mac_10_15_python35
     - build_wheel_mac_10_15_python36

--- a/src/python/turicreate/test/test_activity_classifier.py
+++ b/src/python/turicreate/test/test_activity_classifier.py
@@ -316,10 +316,23 @@ class ActivityClassifierTest(unittest.TestCase):
 
         # Load the model back from the CoreML model file
         coreml_model = coremltools.models.MLModel(filename)
-
-        rs = np.random.RandomState(1234)
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__,
+            'target': self.target,
+            'type': 'activity_classifier',
+            'prediction_window': str(self.prediction_window),
+            'session_id': self.session_id,
+            'features': ','.join(self.features),
+            'max_iterations': '10',
+            'version': '2',
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Activity classifier created by Turi Create (version %s)' \
+                                    % (tc.__version__)
+        self.assertEquals(expected_result, coreml_model.short_description)
 
         # Create a small dataset, and compare the models' predict() output
+        rs = np.random.RandomState(1234)
         dataset = tc.util.generate_random_sframe(column_codes='r' * 3, num_rows=10)
         dataset['session_id'] = 0
         dataset[self.target] = random_labels = [rs.randint(0, self.num_labels - 1, ) for i in range(10)]

--- a/src/python/turicreate/test/test_activity_classifier.py
+++ b/src/python/turicreate/test/test_activity_classifier.py
@@ -316,8 +316,10 @@ class ActivityClassifierTest(unittest.TestCase):
 
         # Load the model back from the CoreML model file
         coreml_model = coremltools.models.MLModel(filename)
+        import platform
         self.assertDictEqual({
             'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
             'target': self.target,
             'type': 'activity_classifier',
             'prediction_window': str(self.prediction_window),

--- a/src/python/turicreate/test/test_audio_functionality.py
+++ b/src/python/turicreate/test/test_audio_functionality.py
@@ -256,6 +256,7 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
         self.assertEqual(metadata.userDefined['sampleRate'], '16000')
 
     def test_export_core_ml_no_prediction(self):
+        import platform
         with TempDirectory() as temp_dir:
             file_name = temp_dir + '/model.mlmodel'
             self.model.export_coreml(file_name)
@@ -269,12 +270,13 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
             'com.github.apple.turicreate.version': tc.__version__,
             'com.github.apple.os.platform': platform.platform(),
             'type': 'SoundClassifier',
+            'sampleRate': '16000',
             'version': '1'
-            }, dict(coreml_model.user_defined_metadata)
+            }, dict(core_ml_model.user_defined_metadata)
         )
-        expected_result = 'Sound classifier (%s) created by Turi Create (version %s)' % (
-                self.model.model, tc.__version__)
-        self.assertEquals(expected_result, coreml_model.short_description)
+        expected_result = 'Sound classifier created by Turi Create (version %s)' % (
+                tc.__version__)
+        self.assertEquals(expected_result, core_ml_model.short_description)
 
     def test_evaluate(self):
         evaluation = self.model.evaluate(self.data)

--- a/src/python/turicreate/test/test_audio_functionality.py
+++ b/src/python/turicreate/test/test_audio_functionality.py
@@ -254,7 +254,6 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
         self.assertTrue('sampleRate' in metadata.userDefined)
         self.assertEqual(metadata.userDefined['sampleRate'], '16000')
 
-    @unittest.skipIf(_mac_ver() >= (10,14), 'Already testing export to Core ML with predictions')
     def test_export_core_ml_no_prediction(self):
         with TempDirectory() as temp_dir:
             file_name = temp_dir + '/model.mlmodel'
@@ -265,6 +264,16 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
         metadata = core_ml_model.get_spec().description.metadata
         self.assertTrue('sampleRate' in metadata.userDefined)
         self.assertEqual(metadata.userDefined['sampleRate'], '16000')
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
+            'type': 'SoundClassifier',
+            'version': '1'
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Sound classifier (%s) created by Turi Create (version %s)' % (
+                self.model.model, tc.__version__)
+        self.assertEquals(expected_result, coreml_model.short_description)
 
     def test_evaluate(self):
         evaluation = self.model.evaluate(self.data)

--- a/src/python/turicreate/test/test_coreml_export.py
+++ b/src/python/turicreate/test/test_coreml_export.py
@@ -69,7 +69,8 @@ class CoreMLExportTest(unittest.TestCase):
             model.export_coreml(mlmodel_filename)
             coreml_model = coremltools.models.MLModel(mlmodel_filename)
             self.assertDictEqual({
-                'com.github.apple.turicreate.version': tc.__version__
+                   'com.github.apple.turicreate.version': tc.__version__,
+                   'com.github.apple.os.platform': platform.platform(),
                 }, dict(coreml_model.user_defined_metadata)
             )
 

--- a/src/python/turicreate/test/test_coreml_export.py
+++ b/src/python/turicreate/test/test_coreml_export.py
@@ -63,23 +63,19 @@ class CoreMLExportTest(unittest.TestCase):
         if predict_topk is None:
             predict_topk = not is_regression
 
-
         # Act & Assert
         with tempfile.NamedTemporaryFile(mode='w', suffix = '.mlmodel') as mlmodel_file:
             mlmodel_filename = mlmodel_file.name
             model.export_coreml(mlmodel_filename)
             coreml_model = coremltools.models.MLModel(mlmodel_filename)
+            self.assertDictEqual({
+                'com.github.apple.turicreate.version': tc.__version__
+                }, dict(coreml_model.user_defined_metadata)
+            )
 
             if _mac_ver() < (10, 13):
                 print("Skipping export test; model not supported on this platform.")
                 return
-
-            # print(coreml_model.get_spec())
-
-            # import shutil
-            # shutil.copyfile(mlmodel_filename, "./bt.mlmodel")
-
-            # model.save("./bt.model")
 
             def array_to_numpy(row):
                 import array
@@ -91,13 +87,9 @@ class CoreMLExportTest(unittest.TestCase):
                         row[r] = numpy.array(row[r])
                 return row
 
-
             for row in test_sf:
 
-                # print(row)
-
                 coreml_prediction = coreml_model.predict(array_to_numpy(row))
-
                 tc_prediction = model.predict(row)[0]
 
                 if (is_regression == False) and (type(model.classes[0]) == str):

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -284,6 +284,7 @@ class DrawingClassifierTest(unittest.TestCase):
         import coremltools
         import platform
         max_iters_ans = ['20', '1']
+        warm_start_ans = '' if self.warm_start is None else self.warm_start
         for i, model in enumerate(self.models):
             filename = _mkstemp("bingo.mlmodel")[1]
             model.export_coreml(filename)
@@ -296,7 +297,7 @@ class DrawingClassifierTest(unittest.TestCase):
                 'target': self.target,
                 'feature': self.feature,
                 'type': 'drawing_classifier',
-                'warm_start': '',
+                'warm_start': warm_start_ans,
                 'max_iterations': max_iters_ans[i],
                 'version': '2',
                 }, dict(coreml_model.user_defined_metadata)

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -285,6 +285,7 @@ class DrawingClassifierTest(unittest.TestCase):
 
     def test_export_coreml(self):
         import coremltools
+        import platform
         for model in self.models:
             filename = _mkstemp("bingo.mlmodel")[1]
             model.export_coreml(filename)
@@ -293,6 +294,7 @@ class DrawingClassifierTest(unittest.TestCase):
             coreml_model = coremltools.models.MLModel(filename)
             self.assertDictEqual({
                 'com.github.apple.turicreate.version': _tc.__version__,
+                'com.github.apple.os.platform': platform.platform(),
                 'target': self.target,
                 'feature': self.feature,
                 'type': 'drawing_classifier',

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -284,9 +284,25 @@ class DrawingClassifierTest(unittest.TestCase):
                     and (new_preds == old_preds).all())
 
     def test_export_coreml(self):
+        import coremltools
         for model in self.models:
             filename = _mkstemp("bingo.mlmodel")[1]
             model.export_coreml(filename)
+
+            # Load the model back from the CoreML model file
+            coreml_model = coremltools.models.MLModel(filename)
+            self.assertDictEqual({
+                'com.github.apple.turicreate.version': _tc.__version__,
+                'target': self.target,
+                'feature': self.feature,
+                'type': 'drawing_classifier',
+                'max_iterations': '20',
+                'version': '2',
+                }, dict(coreml_model.user_defined_metadata)
+            )
+            expected_result = 'Drawing classifier created by Turi Create (version %s)' \
+                                        % (_tc.__version__)
+            self.assertEquals(expected_result, coreml_model.short_description)
 
     @unittest.skipIf(_sys.platform != "darwin", "Core ML only supported on Mac")
     def test_export_coreml_with_predict(self):

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -283,7 +283,8 @@ class DrawingClassifierTest(unittest.TestCase):
     def test_export_coreml(self):
         import coremltools
         import platform
-        for model in self.models:
+        max_iters_ans = ['20', '1']
+        for i, model in enumerate(self.models):
             filename = _mkstemp("bingo.mlmodel")[1]
             model.export_coreml(filename)
 
@@ -295,8 +296,8 @@ class DrawingClassifierTest(unittest.TestCase):
                 'target': self.target,
                 'feature': self.feature,
                 'type': 'drawing_classifier',
-                'warm_start': 'quickdraw_245_v0',
-                'max_iterations': '20',
+                'warm_start': '',
+                'max_iterations': max_iters_ans[i],
                 'version': '2',
                 }, dict(coreml_model.user_defined_metadata)
             )

--- a/src/python/turicreate/test/test_image_classifier.py
+++ b/src/python/turicreate/test/test_image_classifier.py
@@ -174,7 +174,8 @@ class ImageClassifierTest(unittest.TestCase):
 
         coreml_model = coremltools.models.MLModel(filename)
         self.assertDictEqual({
-            u'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
             'type': 'ImageClassifier',
             'version': '1'
             }, dict(coreml_model.user_defined_metadata)

--- a/src/python/turicreate/test/test_image_classifier.py
+++ b/src/python/turicreate/test/test_image_classifier.py
@@ -168,13 +168,23 @@ class ImageClassifierTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             predictions = model.classify("more junk")
 
-    @unittest.skipIf(sys.platform == 'darwin', 'test_export_coreml_with_predict(...) covers this functionality and more')
     def test_export_coreml(self):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 
+        coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            u'com.github.apple.turicreate.version': tc.__version__,
+            'type': 'ImageClassifier',
+            'version': '1'
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Image classifier (%s) created by Turi Create (version %s)' % (
+                self.model.model, tc.__version__)
+        self.assertEquals(expected_result, coreml_model.short_description)
+
     @unittest.skipIf(sys.platform != 'darwin', 'Core Ml only supported on Mac')
-    def test_export_coreml_with_predict(self):
+    def test_export_coreml_predict(self):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 

--- a/src/python/turicreate/test/test_image_similarity.py
+++ b/src/python/turicreate/test/test_image_similarity.py
@@ -196,6 +196,14 @@ class ImageSimilarityTest(unittest.TestCase):
 
         # Load the model back from the CoreML model file
         coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            u'com.github.apple.turicreate.version': tc.__version__,
+            'type': 'ImageSimilarityModel',
+            'version': '1'
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Image similarity (%s) created by Turi Create (version %s)' % (
+                self.model.model, tc.__version__)
 
         # Get model distances for comparison
         img = data[0:1][self.feature][0]

--- a/src/python/turicreate/test/test_image_similarity.py
+++ b/src/python/turicreate/test/test_image_similarity.py
@@ -196,8 +196,10 @@ class ImageSimilarityTest(unittest.TestCase):
 
         # Load the model back from the CoreML model file
         coreml_model = coremltools.models.MLModel(filename)
+        import platform
         self.assertDictEqual({
-            u'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
             'type': 'ImageSimilarityModel',
             'version': '1'
             }, dict(coreml_model.user_defined_metadata)

--- a/src/python/turicreate/test/test_object_detector.py
+++ b/src/python/turicreate/test/test_object_detector.py
@@ -297,6 +297,22 @@ class ObjectDetectorTest(unittest.TestCase):
             include_non_maximum_suppression=False)
 
         coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__,
+            'annotations': self.annotations,
+            'type': 'object_detector',
+            'classes': ','.join(sorted(_CLASSES)),
+            'feature': self.feature,
+            'include_non_maximum_suppression': 'False',
+            'max_iterations': '1',
+            'model': 'darknet-yolo',
+            'training_iterations': '1',
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Object detector created by Turi Create (version %s)' \
+                                    % (tc.__version__)
+        self.assertEquals(expected_result, coreml_model.short_description)
+
         img = self.sf[0:1][self.feature][0]
         img_fixed = tc.image_analysis.resize(img, 416, 416, 3)
         pil_img = Image.fromarray(img_fixed.pixel_data)

--- a/src/python/turicreate/test/test_object_detector.py
+++ b/src/python/turicreate/test/test_object_detector.py
@@ -292,6 +292,7 @@ class ObjectDetectorTest(unittest.TestCase):
     def test_export_coreml(self):
         from PIL import Image
         import coremltools
+        import platform
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename,
             include_non_maximum_suppression=False)
@@ -299,6 +300,7 @@ class ObjectDetectorTest(unittest.TestCase):
         coreml_model = coremltools.models.MLModel(filename)
         self.assertDictEqual({
             'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
             'annotations': self.annotations,
             'type': 'object_detector',
             'classes': ','.join(sorted(_CLASSES)),

--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -192,9 +192,28 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
         import coremltools
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename,
-            include_non_maximum_suppression=False)
+                include_non_maximum_suppression=False)
 
+        ## Test metadata
         coreml_model = coremltools.models.MLModel(filename)
+        self.maxDiff = None
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__,
+            'type': 'object_detector',
+            'classes': ','.join(sorted(_CLASSES)),
+            'feature': self.feature,
+            'include_non_maximum_suppression': 'False',
+            'annotations': 'annotation',
+            'max_iterations': '1',
+            'model': 'darknet-yolo',
+            'training_iterations': '1',
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'One shot object detector created by Turi Create (version %s)' \
+                                    % (tc.__version__)
+        self.assertEquals(expected_result, coreml_model.short_description)
+
+        ## Test prediction
         img = self.train[0:1][self.feature][0]
         img_fixed = tc.image_analysis.resize(img, 416, 416, 3)
         pil_img = Image.fromarray(img_fixed.pixel_data)
@@ -206,16 +225,12 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
             self.assertEqual(ret['coordinates'].shape[0],
                 ret['confidence'].shape[0])
 
-        # Also check if we can train a second model and export it (there could
-        # be naming issues in mxnet)
+        # Test export without non max supression
         filename2 = tempfile.mkstemp('bingo2.mlmodel')[1]
-        # We also test at the same time if we can export a model with a single
-        # class
-        sf = tc.SFrame({'image': tc.SArray([self.train[self.feature][0]]),
-                        'label': tc.SArray([self.train[self.target][0]])})
-        model2 = tc.one_shot_object_detector.create(sf, 'label', max_iterations=1)
-        model2.export_coreml(filename2,
-            include_non_maximum_suppression=False)
+        self.model.export_coreml(filename2, include_non_maximum_suppression=True)
+        coreml_model = coremltools.models.MLModel(filename)
+        self.assertTrue(
+            coreml_model.user_defined_metadata['include_non_maximum_suppression'])
 
     def test__list_fields(self):
         model = self.model

--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -190,6 +190,7 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
     def test_export_coreml(self):
         from PIL import Image
         import coremltools
+        import platform
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename,
                 include_non_maximum_suppression=False)
@@ -199,6 +200,7 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
         self.maxDiff = None
         self.assertDictEqual({
             'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
             'type': 'object_detector',
             'classes': ','.join(sorted(_CLASSES)),
             'feature': self.feature,

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -234,6 +234,7 @@ class StyleTransferTest(unittest.TestCase):
 
     def test_export_coreml(self):
         import coremltools
+        import platform
         model = self.model
         for flexible_shape_on in [True, False]:
             filename = tempfile.mkstemp('my_style_transfer.mlmodel')[1]
@@ -244,6 +245,7 @@ class StyleTransferTest(unittest.TestCase):
             coreml_model = coremltools.models.MLModel(filename)
             self.assertDictEqual({
                 'com.github.apple.turicreate.version': tc.__version__,
+                'com.github.apple.os.platform': platform.platform(),
                 'type': 'style_transfer',
                 'content_feature': self.content_feature,
                 'style_feature': self.style_feature,

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -70,6 +70,7 @@ class StyleTransferTest(unittest.TestCase):
         self.style_feature = 'style_feature_name'
         self.content_feature = 'content_feature_name'
         self.pre_trained_model = 'resnet-16'
+
         ## Create the model
         # Model
         self.style_sf = _get_data(feature=self.style_feature, num_examples=_NUM_STYLES)
@@ -238,11 +239,30 @@ class StyleTransferTest(unittest.TestCase):
             filename = tempfile.mkstemp('my_style_transfer.mlmodel')[1]
             model.export_coreml(filename,
                 include_flexible_shape = flexible_shape_on)
+
+            ## Metadata test
+            coreml_model = coremltools.models.MLModel(filename)
+            self.assertDictEqual({
+                'com.github.apple.turicreate.version': tc.__version__,
+                'type': 'style_transfer',
+                'content_feature': self.content_feature,
+                'style_feature': self.style_feature,
+                'model': self.pre_trained_model,
+                'max_iterations': '1',
+                'training_iterations': '1',
+                'num_styles': str(self.num_styles),
+                'version': '1',
+                }, dict(coreml_model.user_defined_metadata)
+            )
+            expected_result = 'Style transfer created by Turi Create (version %s)' \
+                                        % (tc.__version__)
+            self.assertEquals(expected_result, coreml_model.short_description)
+
+            ## Correctness test
             if not flexible_shape_on or _mac_ver() >= (10,14):
                 coreml_model = coremltools.models.MLModel(filename)
 
                 mac_os_version_threshold = (10,14) if flexible_shape_on else (10,13)
-
                 if _mac_ver() >= mac_os_version_threshold:
                     img = self.style_sf[0:2][self.style_feature][0]
                     img_fixed = tc.image_analysis.resize(img, 256, 256, 3)
@@ -255,15 +275,6 @@ class StyleTransferTest(unittest.TestCase):
                         img_fixed = tc.image_analysis.resize(img, 512, 512, 3)
                         img = self._coreml_python_predict(coreml_model, img_fixed)
                         self.assertEqual(img.shape, (512, 512, 3))
-
-                # Also check if we can train a second model and export it (there could
-                # be naming issues in mxnet)
-                filename2 = tempfile.mkstemp('my_style_transfer2.mlmodel')[1]
-                # We also test at the same time if we can export a model with a single
-                # class
-
-                model2 = tc.style_transfer.create(self.style_sf, self.content_sf, max_iterations=1)
-                model2.export_coreml(filename2)
 
     def test_repr(self):
         model = self.model

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -94,9 +94,11 @@ class TextClassifierTest(unittest.TestCase):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 
+        import platform
         coreml_model = coremltools.models.MLModel(filename)
         self.assertDictEqual({
-            'com.github.apple.turicreate.version': tc.__version__
+            'com.github.apple.turicreate.version': tc.__version__,
+            'com.github.apple.os.platform': platform.platform(),
             }, dict(coreml_model.user_defined_metadata)
         )
         expected_result = 'Text classifier created by Turi Create (version %s)' % tc.__version__

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -94,6 +94,14 @@ class TextClassifierTest(unittest.TestCase):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]
         self.model.export_coreml(filename)
 
+        coreml_model = coremltools.models.MLModel(filename)
+        self.assertDictEqual({
+            'com.github.apple.turicreate.version': tc.__version__
+            }, dict(coreml_model.user_defined_metadata)
+        )
+        expected_result = 'Text classifier created by Turi Create (version %s)' % tc.__version__
+        self.assertEquals(expected_result, coreml_model.short_description)
+
     @unittest.skipIf(_mac_ver() < (10, 13), 'Only supported on macOS 10.13+')
     def test_export_coreml_with_predict(self):
         filename = tempfile.mkstemp('bingo.mlmodel')[1]

--- a/src/python/turicreate/toolkits/_coreml_utils.py
+++ b/src/python/turicreate/toolkits/_coreml_utils.py
@@ -18,7 +18,11 @@ def _get_tc_version_info():
     Return metadata related to the package to be added to the CoreML model
     """
     from turicreate import __version__
-    return {'com.github.apple.turicreate.version': __version__}
+    import platform
+    return {
+       'com.github.apple.turicreate.version': __version__,
+       'com.github.apple.os.platform': platform.platform()
+    }
 
 def _get_model_metadata(model_class, metadata, version=None):
     """

--- a/src/python/turicreate/toolkits/_coreml_utils.py
+++ b/src/python/turicreate/toolkits/_coreml_utils.py
@@ -13,21 +13,25 @@ def _mlmodel_short_description(model_type):
     from turicreate import __version__
     return '%s created by Turi Create (version %s)' % (model_type.capitalize(), __version__)
 
+def _get_tc_version_info():
+    """
+    Return metadata related to the package to be added to the CoreML model
+    """
+    from turicreate import __version__
+    return {'com.github.apple.turicreate.version': __version__}
+
 def _get_model_metadata(model_class, metadata, version=None):
     """
     Returns user-defined metadata, making sure information all models should
     have is also available, as a dictionary
     """
-    from turicreate import __version__
-    info = {
-        'turicreate_version': __version__,
-        'type': model_class,
-    }
+    info = _get_tc_version_info()
+    info['type'] = model_class
     if version is not None:
         info['version'] = str(version)
-    info.update(metadata)
+    if metadata is not None:
+        info.update(metadata)
     return info
-
 
 def _set_model_metadata(mlmodel, model_class, metadata, version=None):
     """

--- a/src/python/turicreate/toolkits/_tree_model_mixin.py
+++ b/src/python/turicreate/toolkits/_tree_model_mixin.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import as _
 import turicreate as tc
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe
 from turicreate.toolkits._supervised_learning import select_default_missing_value_policy
+from turicreate.toolkits import _coreml_utils
 
 class TreeModelMixin(object):
     """
@@ -315,4 +316,9 @@ class TreeModelMixin(object):
         return ([data_fields, training_fields], ["Schema", "Settings"])
 
     def _export_coreml_impl(self, filename, context):
+        tc_version_info = _coreml_utils._get_tc_version_info()
+        if 'user_defined' not in context:
+            context['user_defined'] = tc_version_info
+        else:
+            context['user_defined'].update(tc_version_info)
         tc.extensions._xgboost_export_as_model_asset(self.__proxy__, filename, context)

--- a/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -403,7 +403,10 @@ class ActivityClassifier_beta(_Model):
         --------
         >>> model.export_coreml("MyModel.mlmodel")
         """
-        self.__proxy__.export_to_coreml(filename)
+        short_description = _coreml_utils._mlmodel_short_description('Activity classifier')
+        additional_user_defined_metadata = _coreml_utils._get_tc_version_info()
+        self.__proxy__.export_to_coreml(filename, short_description,
+                additional_user_defined_metadata)
 
 
     def predict(self, dataset, output_type='class', output_frequency='per_row'):

--- a/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/boosted_trees_classifier.py
@@ -431,12 +431,8 @@ class BoostedTreesClassifier(_Classifier, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "classification",
                    "model_type" : "boosted_trees",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/decision_tree_classifier.py
@@ -421,12 +421,8 @@ class DecisionTreeClassifier(_Classifier, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "classification",
                    "model_type" : "decision_tree",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                 }
 
         self._export_coreml_impl(filename, context)

--- a/src/python/turicreate/toolkits/classifier/logistic_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/logistic_classifier.py
@@ -18,7 +18,7 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _check_categorical_option_type, \
                                         _raise_error_evaluation_metric_is_valid, \
                                         _summarize_coefficients
-
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -478,12 +478,9 @@ class LogisticClassifier(_Classifier):
         display_name = "logistic classifier"
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
-                   "version": _turicreate.__version__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
-                }
+                  }
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         _logistic_classifier_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/random_forest_classifier.py
@@ -424,12 +424,8 @@ class RandomForestClassifier(_Classifier, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "classification",
                    "model_type" : "random_forest",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/classifier/svm_classifier.py
+++ b/src/python/turicreate/toolkits/classifier/svm_classifier.py
@@ -17,6 +17,7 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _raise_error_evaluation_metric_is_valid, \
                                         _check_categorical_option_type, \
                                         _summarize_coefficients
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -383,12 +384,9 @@ class SVMClassifier(_Classifier):
         display_name = "svm classifier"
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
-                   "version": _turicreate.__version__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                 }
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         _linear_svm_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import as _
 import turicreate as _tc
 import numpy as _np
 import time as _time
+from turicreate.toolkits import _coreml_utils
 from turicreate.toolkits._model import CustomModel as _CustomModel
 from turicreate.toolkits._model import Model as _Model
 from turicreate.toolkits._model import PythonProxy as _PythonProxy
@@ -1003,7 +1004,10 @@ class DrawingClassifier_beta(_Model):
         --------
         >>> model.export_coreml("MyModel.mlmodel")
         """
-        return self.__proxy__.export_to_coreml(filename)
+        additional_user_defined_metadata = _coreml_utils._get_tc_version_info()
+        short_description = _coreml_utils._mlmodel_short_description('Drawing Classifier')
+        self.__proxy__.export_to_coreml(filename, short_description,
+                additional_user_defined_metadata)
 
     def predict(self, dataset, output_type='class'):
         """

--- a/src/python/turicreate/toolkits/image_classifier/image_classifier.py
+++ b/src/python/turicreate/toolkits/image_classifier/image_classifier.py
@@ -26,6 +26,7 @@ from .. import _image_feature_extractor
 from ._evaluation import Evaluation as _Evaluation
 from turicreate.toolkits._internal_utils import (_raise_error_if_not_sframe,
                                                  _numeric_param_check_range)
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -912,15 +913,21 @@ class ImageClassifier(_CustomModel):
             mlmodel.input_description[self.feature] = u'Input image'
             mlmodel.output_description[prob_name] = 'Prediction probabilities'
             mlmodel.output_description[label_name] = 'Class label of top prediction'
-            _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, {
-                'model': self.model,
-                'target': self.target,
-                'features': self.feature,
-                'max_iterations': str(self.max_iterations),
-            }, version=ImageClassifier._PYTHON_IMAGE_CLASSIFIER_VERSION)
+
+            model_metadata = {
+                 'model': self.model,
+                 'target': self.target,
+                 'features': self.feature,
+                 'max_iterations': str(self.max_iterations),
+            }
+            user_defined_metadata = model_metadata.update(
+                    _coreml_utils._get_tc_version_info())
+            _coreml_utils._set_model_metadata(mlmodel,
+                    self.__class__.__name__,
+                    user_defined_metadata,
+                    version=ImageClassifier._PYTHON_IMAGE_CLASSIFIER_VERSION)
 
             return mlmodel
-
 
         # main part of the export_coreml function
         if self.model in _pre_trained_models.IMAGE_MODELS:

--- a/src/python/turicreate/toolkits/image_similarity/image_similarity.py
+++ b/src/python/turicreate/toolkits/image_similarity/image_similarity.py
@@ -22,6 +22,7 @@ from .. import _pre_trained_models
 from .. import _image_feature_extractor
 from turicreate.toolkits._internal_utils import (_raise_error_if_not_sframe,
                                                  _numeric_param_check_range)
+from turicreate.toolkits import _coreml_utils
 
 
 def create(dataset, label = None, feature = None, model = 'resnet-50', verbose = True,
@@ -629,9 +630,15 @@ class ImageSimilarityModel(_CustomModel):
         mlmodel.input_description[self.feature] = u'Input image'
         mlmodel.output_description[output_name] = u'Distances between the input and reference images'
 
-        _coreml_utils._set_model_metadata(mlmodel, self.__class__.__name__, {
-            'model': self.model,
-            'num_examples': str(self.num_examples)
-        }, version=ImageSimilarityModel._PYTHON_IMAGE_SIMILARITY_VERSION)
+        model_metadata = {
+             'model': self.model,
+             'num_examples': str(self.num_examples),
+        }
+        user_defined_metadata = model_metadata.update(
+                    _coreml_utils._get_tc_version_info())
+        _coreml_utils._set_model_metadata(mlmodel,
+                self.__class__.__name__,
+                user_defined_metadata,
+                version=ImageSimilarityModel._PYTHON_IMAGE_SIMILARITY_VERSION)
 
         mlmodel.save(filename)

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1655,7 +1655,6 @@ class ObjectDetector_beta(_Model):
         options['include_non_maximum_suppression'] = include_non_maximum_suppression
         options['confidence_threshold'] = confidence_threshold
         options['iou_threshold'] = iou_threshold
-        options['iou_threshold'] = iou_threshold
         additional_user_defined_metadata = _coreml_utils._get_tc_version_info()
         short_description = _coreml_utils._mlmodel_short_description('Object Detector')
 

--- a/src/python/turicreate/toolkits/object_detector/object_detector.py
+++ b/src/python/turicreate/toolkits/object_detector/object_detector.py
@@ -1655,8 +1655,12 @@ class ObjectDetector_beta(_Model):
         options['include_non_maximum_suppression'] = include_non_maximum_suppression
         options['confidence_threshold'] = confidence_threshold
         options['iou_threshold'] = iou_threshold
+        options['iou_threshold'] = iou_threshold
+        additional_user_defined_metadata = _coreml_utils._get_tc_version_info()
+        short_description = _coreml_utils._mlmodel_short_description('Object Detector')
 
-        self.__proxy__.export_to_coreml(filename, options)
+        self.__proxy__.export_to_coreml(filename, short_description,
+                additional_user_defined_metadata, options)
 
 
     def predict(self, dataset, confidence_threshold=0.25, iou_threshold=0.45, verbose=True):

--- a/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
+++ b/src/python/turicreate/toolkits/regression/boosted_trees_regression.py
@@ -218,12 +218,8 @@ class BoostedTreesRegression(_SupervisedLearningModel, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "regression",
                    "model_type" : "boosted_trees",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                 }
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/regression/decision_tree_regression.py
+++ b/src/python/turicreate/toolkits/regression/decision_tree_regression.py
@@ -245,14 +245,9 @@ class DecisionTreeRegression(_SupervisedLearningModel, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "regression",
                    "model_type" : "decision_tree",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                 }
-
         self._export_coreml_impl(filename, context)
 
     def predict(self, dataset, missing_value_action='auto'):

--- a/src/python/turicreate/toolkits/regression/linear_regression.py
+++ b/src/python/turicreate/toolkits/regression/linear_regression.py
@@ -17,7 +17,7 @@ from turicreate.toolkits._internal_utils import _toolkit_repr_print, \
                                         _toolkit_get_topk_bottomk, \
                                         _summarize_coefficients, \
                                         _raise_error_evaluation_metric_is_valid
-
+from turicreate.toolkits import _coreml_utils
 
 _DEFAULT_SOLVER_OPTIONS = {
 'convergence_threshold': 1e-2,
@@ -442,12 +442,9 @@ class LinearRegression(_SupervisedLearningModel):
         display_name = "linear regression"
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"class": self.__class__.__name__,
-                   "version": _turicreate.__version__,
                    "short_description": short_description,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   }
                   }
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
         _linear_regression_export_as_model_asset(self.__proxy__, filename, context)
 
     def _get(self, field):

--- a/src/python/turicreate/toolkits/regression/random_forest_regression.py
+++ b/src/python/turicreate/toolkits/regression/random_forest_regression.py
@@ -290,11 +290,7 @@ class RandomForestRegression(_SupervisedLearningModel, _TreeModelMixin):
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {"mode" : "regression",
                    "model_type" : "random_forest",
-                   "version": _turicreate.__version__,
                    "class": self.__class__.__name__,
-                   'user_defined':{
-                    'turicreate_version': _turicreate.__version__
-                   },
                    "short_description": short_description}
         self._export_coreml_impl(filename, context)
 

--- a/src/python/turicreate/toolkits/sound_classifier/sound_classifier.py
+++ b/src/python/turicreate/toolkits/sound_classifier/sound_classifier.py
@@ -831,7 +831,7 @@ class SoundClassifier(_CustomModel):
             last_output = builder.spec.neuralNetworkClassifier.layers[-1].output[0]
             builder.add_softmax('softmax', last_output, self.target)
 
-            builder.set_class_labels(self.classes)
+            builder.set_class_labels(self.classes, predicted_feature_name = self.target)
             builder.set_input([input_name], [(input_length,)])
             builder.set_output([self.target], [(self.num_classes,)])
 
@@ -852,8 +852,8 @@ class SoundClassifier(_CustomModel):
         prob_output = desc.output.add()
         prob_output.name = prob_name
         label_output = desc.output.add()
-        label_output.name = 'classLabel'
-        desc.predictedFeatureName = 'classLabel'
+        label_output.name = self.target
+        desc.predictedFeatureName = self.target
         desc.predictedProbabilitiesName = prob_name
         if type(self.classes[0]) == int:
             # Class labels are ints
@@ -900,15 +900,14 @@ class SoundClassifier(_CustomModel):
             prob_output_type.stringKeyType.MergeFromString(b'')
 
         mlmodel = coremltools.models.MLModel(top_level_spec)
-        model_type = 'sound classifier (%s)' % self.model
+        model_type = 'sound classifier'
         mlmodel.short_description = _coreml_utils._mlmodel_short_description(model_type)
         mlmodel.input_description[self.feature] = u'Input audio features'
         mlmodel.output_description[prob_name] = 'Prediction probabilities'
-        mlmodel.output_description[label_name] = 'Class label of top prediction'
+        mlmodel.output_description[self.target] = 'Class label of top prediction'
         model_metadata = {
-             'model': self.model,
-             'target': self.target,
-             'features': self.feature,
+          'target': self.target,
+          'feature': self.feature,
         }
         user_defined_metadata = model_metadata.update(
                 _coreml_utils._get_tc_version_info())

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -741,8 +741,11 @@ class StyleTransfer_beta(_Model):
         options['image_width'] = image_shape[1]
         options['image_height'] = image_shape[0]
         options['include_flexible_shape'] = include_flexible_shape
+        additional_user_defined_metadata = _coreml_utils._get_tc_version_info()
+        short_description = _coreml_utils._mlmodel_short_description('Style Transfer')
 
-        self.__proxy__.export_to_coreml(filename, options)
+        self.__proxy__.export_to_coreml(filename, short_description,
+                additional_user_defined_metadata, options)
 
 
     def stylize(self, images, style=None, verbose=True, max_size=800, batch_size = 4):

--- a/src/python/turicreate/toolkits/text_classifier/_text_classifier.py
+++ b/src/python/turicreate/toolkits/text_classifier/_text_classifier.py
@@ -13,6 +13,7 @@ from turicreate.toolkits._model import CustomModel as _CustomModel
 from turicreate.toolkits._model import PythonProxy as _PythonProxy
 from turicreate.toolkits._internal_utils import _toolkit_repr_print
 from turicreate.toolkits import text_analytics as _text_analytics
+from turicreate.toolkits import _coreml_utils
 
 
 def _BOW_FEATURE_EXTRACTOR(sf, target=None):
@@ -356,18 +357,12 @@ class TextClassifier(_CustomModel):
         display_name = 'text classifier'
         short_description = _coreml_utils._mlmodel_short_description(display_name)
         context = {'class': self.__class__.__name__,
-                   'version': _tc.__version__,
                    'short_description': short_description,
-                   'user_defined':{
-                    'turicreate_version': _tc.__version__
-                   }
-                }
-
+                  }
+        context['user_defined'] = _coreml_utils._get_tc_version_info()
 
         model = self.__proxy__['classifier'].__proxy__
-
         _logistic_classifier_export_as_model_asset(model, filename, context)
-
 
 def _get_str_columns(sf):
     """

--- a/src/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/toolkits/activity_classification/activity_classifier.hpp
@@ -45,7 +45,8 @@ class EXPORT activity_classifier: public ml_model_base {
                          std::string output_frequency);
   variant_map_type evaluate(gl_sframe data, std::string metric);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename);
+      std::string filename, std::string short_description,
+      std::map<std::string, flexible_type> additional_user_defined);
   void import_from_custom_model(variant_map_type model_data, size_t version);
 
   BEGIN_CLASS_MEMBER_REGISTRATION("activity_classifier")
@@ -195,7 +196,10 @@ class EXPORT activity_classifier: public ml_model_base {
       "                           ROC curve\n"
   );
   REGISTER_CLASS_MEMBER_FUNCTION(activity_classifier::export_to_coreml,
-                                 "filename");
+            "filename", "short_description", "additional_user_defined");
+  register_defaults("export_to_coreml",
+      {{"short_description", ""},
+       {"additional_user_defined", to_variant(std::map<std::string, flexible_type>())}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(activity_classifier::import_from_custom_model,
                                  "model_data", "version");

--- a/src/toolkits/coreml_export/neural_net_models_exporter.cpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.cpp
@@ -383,8 +383,8 @@ std::shared_ptr<MLModelWrapper> export_activity_classifier_model(
 std::shared_ptr<coreml::MLModelWrapper> export_style_transfer_model(
     const neural_net::model_spec& nn_spec, size_t image_width,
     size_t image_height, bool include_flexible_shape,
-    flex_dict user_defined_metadata, std::string content_feature,
-    std::string style_feature, size_t num_styles) {
+    std::string content_feature, std::string style_feature, size_t num_styles) {
+
   CoreML::Specification::Model model;
   model.set_specificationversion(3);
 
@@ -437,9 +437,6 @@ std::shared_ptr<coreml::MLModelWrapper> export_style_transfer_model(
 
   auto model_wrapper =
       std::make_shared<MLModelWrapper>(std::make_shared<CoreML::Model>(model));
-
-  model_wrapper->add_metadata(
-      {{"user_defined", std::move(user_defined_metadata)}});
 
   return model_wrapper;
 }

--- a/src/toolkits/coreml_export/neural_net_models_exporter.cpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.cpp
@@ -161,8 +161,7 @@ ImageFeatureType* set_image_feature(
 std::shared_ptr<MLModelWrapper> export_object_detector_model(
     const neural_net::model_spec& nn_spec, size_t image_width,
     size_t image_height, size_t num_classes, size_t num_predictions,
-    flex_dict user_defined_metadata, flex_list class_labels,
-    const std::string& input_name,
+    flex_list class_labels, const std::string& input_name,
     std::map<std::string, flexible_type> options) {
   // Set up Pipeline
   CoreML::Specification::Model model_pipeline;
@@ -226,11 +225,6 @@ std::shared_ptr<MLModelWrapper> export_object_detector_model(
     model_nn->set_specificationversion(1);
     auto model_wrapper = std::make_shared<MLModelWrapper>(
       std::make_shared<CoreML::Model>(*model_nn));
-
-    // Add metadata.
-    model_wrapper->add_metadata({
-        { "user_defined", std::move(user_defined_metadata) }
-    });
 
     return model_wrapper;
   }
@@ -323,8 +317,6 @@ std::shared_ptr<MLModelWrapper> export_object_detector_model(
     std::make_shared<CoreML::Model>(model_pipeline));
 
   // Add metadata.
-  pipeline_wrapper->add_metadata({{ "user_defined", std::move(user_defined_metadata)}});
-
   return pipeline_wrapper;
 }
 

--- a/src/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -24,17 +24,13 @@ namespace turi {
  *            with shape (3, image_height, image_width) and values in [0,1],
  *            output "confidence" with shape (num_predictions, num_classes),
  *            and "coordinates" with shape (num_predictions, 4).
- * \param user_defined_metadata Key-value pairs to add as user-defined metadata.
- *
- * \todo Should this also initialize non-user-defined metadata?
  * \todo Should model_spec include Model, not NeuralNetwork, so that the client
  *       is responsible for populating the inputs and outputs?
  */
 std::shared_ptr<coreml::MLModelWrapper> export_object_detector_model(
     const neural_net::model_spec& nn_spec, size_t image_width,
     size_t image_height, size_t num_classes, size_t num_predictions,
-    flex_dict user_defined_metadata, flex_list class_labels,
-    const std::string& input_name,
+    flex_list class_labels, const std::string& input_name,
     std::map<std::string, flexible_type> options);
 
 /** Wraps a trained activity classifier model_spec as a complete MLModel. */

--- a/src/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -43,8 +43,7 @@ std::shared_ptr<coreml::MLModelWrapper> export_activity_classifier_model(
 std::shared_ptr<coreml::MLModelWrapper> export_style_transfer_model(
     const neural_net::model_spec& nn_spec, size_t image_width,
     size_t image_height, bool include_flexible_shape,
-    flex_dict user_defined_metadata, std::string content_feature,
-    std::string style_feature, size_t num_styles);
+    std::string content_feature, std::string style_feature, size_t num_styles);
 
 /** Wraps a trained drawing classifier model_spec as a complete MLModel. */
 std::shared_ptr<coreml::MLModelWrapper> export_drawing_classifier_model(

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -829,7 +829,9 @@ variant_map_type drawing_classifier::evaluate(gl_sframe data,
 }
 
 std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(
-    std::string filename, bool use_default_spec) {
+    std::string filename, std::string short_description,
+    std::map<std::string, flexible_type> additional_user_defined,
+    bool use_default_spec) {
   /* Add code for export_to_coreml */
   if (!nn_spec_) {
     // use empty nn spec if not initalized;
@@ -860,9 +862,13 @@ std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(
       {"type", "drawing_classifier"},
       {"version", 2},
   };
-
-  model_wrapper->add_metadata(
-      {{"user_defined", std::move(user_defined_metadata)}});
+  for(const auto& kvp : additional_user_defined) {
+       user_defined_metadata.emplace_back(kvp.first, kvp.second);
+  }
+  model_wrapper->add_metadata({
+      {"short_description", short_description},
+      {"user_defined", std::move(user_defined_metadata)},
+  });
 
   if (!filename.empty()) {
     model_wrapper->save(filename);

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -857,8 +857,7 @@ std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(
       {"target", read_state<flex_string>("target")},
       {"feature", feature_column_name},
       {"max_iterations", read_state<flex_int>("max_iterations")},
-      // TODO: Uncomment as part of #2524
-      // {"warm_start", read_state<flex_int>("warm_start")},
+      {"warm_start", read_state<flex_int>("warm_start")},
       {"type", "drawing_classifier"},
       {"version", 2},
   };

--- a/src/toolkits/drawing_classifier/drawing_classifier.hpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.hpp
@@ -55,7 +55,9 @@ class EXPORT drawing_classifier : public ml_model_base {
   variant_map_type evaluate(gl_sframe data, std::string metric);
 
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename, bool use_default_spec = false);
+      std::string filename, std::string short_description,
+      std::map<std::string, flexible_type> additional_user_defined,
+      bool use_default_spec = false);
 
   // Support for iterative training.
   // TODO: Expose via forthcoming C-API checkpointing mechanism?
@@ -201,8 +203,12 @@ class EXPORT drawing_classifier : public ml_model_base {
       "                           prediction/true label combinations.\n"
       "    - 'roc_curve'        : An SFrame containing information needed for\n"
       "                           an ROC curve\n");
+
   REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::export_to_coreml,
-                                 "filename");
+            "filename", "short_description", "additional_user_defined");
+  register_defaults("export_to_coreml",
+      {{"short_description", ""},
+       {"additional_user_defined", to_variant(std::map<std::string, flexible_type>())}});
 
   REGISTER_CLASS_MEMBER_FUNCTION(drawing_classifier::init_training, "data",
                                  "target_column_name", "feature_column_name",

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -46,7 +46,9 @@ class EXPORT object_detector: public ml_model_base {
   variant_type predict(variant_type data,
                        std::map<std::string, flexible_type> opts);
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename, std::map<std::string, flexible_type> opts);
+      std::string filename, std::string short_description,
+      std::map<std::string, flexible_type> additional_user_defined,
+      std::map<std::string, flexible_type> opts);
   void import_from_custom_model(variant_map_type model_data, size_t version);
 
   // Support for iterative training.
@@ -118,8 +120,11 @@ class EXPORT object_detector: public ml_model_base {
   register_defaults("predict",{});
 
   REGISTER_CLASS_MEMBER_FUNCTION(object_detector::export_to_coreml, "filename",
-    "options");
-  register_defaults("export_to_coreml", {{"options", to_variant(std::map<std::string, flexible_type>())}});
+    "short_description", "additional_user_defined", "options");
+  register_defaults("export_to_coreml",
+         {{"short_description", ""},
+          {"additional_user_defined", to_variant(std::map<std::string, flexible_type>())},
+          {"options", to_variant(std::map<std::string, flexible_type>())}});
 
   REGISTER_CLASS_MEMBER_DOCSTRING(
       object_detector::export_to_coreml,

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -734,7 +734,10 @@ void style_transfer::train(gl_sarray style, gl_sarray content,
 }
 
 std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
-    std::string filename, std::map<std::string, flexible_type> opts) {
+    std::string filename, std::string short_desc,
+    std::map<std::string, flexible_type> additional_user_defined,
+    std::map<std::string, flexible_type> opts) {
+
   const flex_int image_width = read_opts<flex_int>(opts, "image_width");
   const flex_int image_height = read_opts<flex_int>(opts, "image_height");
   const flex_int include_flexible_shape = read_opts<flex_int>(opts, "include_flexible_shape");
@@ -746,19 +749,28 @@ std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
       {"model", read_state<flex_string>("model")},
       {"max_iterations", read_state<flex_int>("max_iterations")},
       {"training_iterations", read_state<flex_int>("training_iterations")},
-      {"type", "StyleTransfer"},
+      {"type", "style_transfer"},
       {"content_feature", content_feature},  // TODO: refactor to take content name and style name
       {"style_feature", style_feature},
       {"num_styles", num_styles},
       {"version", get_version()},
   };
+  for(const auto& kvp : additional_user_defined) {
+       user_defined_metadata.emplace_back(kvp.first, kvp.second);
+  }
 
   std::shared_ptr<MLModelWrapper> model_wrapper = export_style_transfer_model(
       *m_resnet_spec, image_width, image_height, include_flexible_shape,
-      std::move(user_defined_metadata), content_feature, style_feature, num_styles);
+      content_feature, style_feature, num_styles);
 
-  if (!filename.empty()) model_wrapper->save(filename);
+  model_wrapper->add_metadata({
+      {"user_defined", std::move(user_defined_metadata)},
+      {"short_description", short_desc}
+  });
 
+  if (!filename.empty()) {
+    model_wrapper->save(filename);
+  }
   return model_wrapper;
 }
 

--- a/src/toolkits/style_transfer/style_transfer.hpp
+++ b/src/toolkits/style_transfer/style_transfer.hpp
@@ -32,7 +32,9 @@ class EXPORT style_transfer : public ml_model_base {
   void load_version(iarchive& iarc, size_t version) override;
 
   std::shared_ptr<coreml::MLModelWrapper> export_to_coreml(
-      std::string filename, std::map<std::string, flexible_type> opts);
+      std::string filename, std::string short_description,
+      std::map<std::string, flexible_type> additional_user_defined,
+      std::map<std::string, flexible_type> opts);
 
   void train(gl_sarray style, gl_sarray content,
              std::map<std::string, flexible_type> opts);
@@ -88,7 +90,12 @@ class EXPORT style_transfer : public ml_model_base {
   REGISTER_CLASS_MEMBER_FUNCTION(style_transfer::finalize_training);
 
   REGISTER_CLASS_MEMBER_FUNCTION(style_transfer::export_to_coreml, "filename",
-                                 "options");
+    "short_description", "additional_user_defined", "options");
+  register_defaults("export_to_coreml",
+         {{"short_description", ""},
+          {"additional_user_defined", to_variant(std::map<std::string, flexible_type>())},
+          {"options", to_variant(std::map<std::string, flexible_type>())}});
+
 
   register_defaults("export_to_coreml",
                     {{"options",


### PR DESCRIPTION
- Fixes #2562 for all based toolkits.
- Added unit tests to check correctness
- Behavior is intended to match 5.8 as closely as possible

Each commit is separately reviewable to make this simpler to review. Commits are done toolkit by toolkit. 