### PR TITLE
Fixed Resizing issue in TensorFlow for Style Transfer

### DIFF
--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -324,6 +324,19 @@
     imagesOut[key] = styleData;
   }
 
+  NSMutableData * imageChannelsData = [NSMutableData dataWithCapacity:0];
+  float imageChannels = 3.0;
+  [imageChannelsData appendBytes:&imageChannels length:sizeof(float)];
+
+  NSMutableData * imageBatchSizeData = [NSMutableData dataWithCapacity:0];
+  float imageBatchSize = _batchSize;
+  [imageBatchSizeData appendBytes:&imageBatchSize length:sizeof(float)];
+
+  imagesOut[@"width"] = imageWidthData;
+  imagesOut[@"height"] = imageHeightData;
+  imagesOut[@"channels"] = imageChannelsData;
+  imagesOut[@"batch_size"] = imageBatchSizeData;
+
   return [imagesOut copy];
 }
 

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -324,13 +324,11 @@
     imagesOut[key] = styleData;
   }
 
-  NSMutableData * imageChannelsData = [NSMutableData dataWithCapacity:0];
   float imageChannels = 3.0;
-  [imageChannelsData appendBytes:&imageChannels length:sizeof(float)];
+  NSData* imageChannelsData = [NSData dataWithBytes:&imageChannels length:sizeof(float)];
 
-  NSMutableData * imageBatchSizeData = [NSMutableData dataWithCapacity:0];
   float imageBatchSize = _batchSize;
-  [imageBatchSizeData appendBytes:&imageBatchSize length:sizeof(float)];
+  NSData* imageBatchSizeData = [NSData dataWithBytes:&imageBatchSize length:sizeof(float)];
 
   imagesOut[@"width"] = imageWidthData;
   imagesOut[@"height"] = imageHeightData;

--- a/src/python/turicreate/toolkits/style_transfer/_tf_model_architecture.py
+++ b/src/python/turicreate/toolkits/style_transfer/_tf_model_architecture.py
@@ -529,9 +529,9 @@ class StyleTransferTensorFlowModel(TensorFlowModel):
         expected_width = feed_dict['input'].shape[2]
 
         # Crop to remove added padding
-        stylized_cropped = stylized_raw[:,:,0:expected_height,0:expected_width][0]
+        stylized_cropped = stylized_raw[:,:,0:expected_height,0:expected_width,:][0]
 
-        return { "output":  stylized_cropped }
+        return { "output":  _np.array(stylized_cropped) }
 
     def export_weights(self):
         tf_export_params = {}

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -158,16 +158,16 @@ std::vector<std::pair<flex_int, flex_image>> process_output(
   ASSERT_EQ(image_dim, 4);
 
   const size_t* content_ptr = contents.shape();
-  
-  // Note: the float array from each context's predict is expected to be in the format
-  // {batch_size, height, width, channels}.
+
+  // Note: the float array from each context's predict is expected to be in the
+  // format {batch_size, height, width, channels}.
   size_t batch_size = content_ptr[0];
   size_t height = content_ptr[1];
   size_t width = content_ptr[2];
   size_t channels = content_ptr[3];
 
   size_t image_size = contents.size() / batch_size;
-  
+
   std::vector<std::pair<flex_int, flex_image>> result;
   result.reserve(batch_size);
 
@@ -191,7 +191,7 @@ std::vector<std::pair<flex_int, flex_image>> process_output(
     image_type img(reinterpret_cast<char*>(image_data.data()), height, width,
                    channels, image_data.size(), IMAGE_TYPE_CURRENT_VERSION,
                    static_cast<int>(Format::RAW_ARRAY));
-    
+
     result.emplace_back(index, img);
   }
 
@@ -246,14 +246,12 @@ float_array_map prepare_batch(std::vector<st_example>& batch, size_t width,
 // takes exactly one st_example as an argument.
 float_array_map prepare_predict(const st_example& example) {
   ASSERT_EQ(3, example.content_image.m_channels);
-  
+
   size_t image_width = example.content_image.m_width;
   size_t image_height = example.content_image.m_height;
-  std::vector<st_example> batch = { example };
+  std::vector<st_example> batch = {example};
 
-  return prepare_batch(batch,
-                       image_width,
-                       image_height,
+  return prepare_batch(batch, image_width, image_height,
                        /* train */ false);
 }
 
@@ -555,7 +553,7 @@ void style_transfer::perform_predict(gl_sarray data, gl_sframe_writer& result,
       // setting the style index for each batch
       std::for_each(batch.begin(), batch.end(),
                     [i](st_example& example) { example.style_index = i; });
-      
+
       // predict only works with a batch size of one now. This is because images
       // have varied width and height and since the style transfer network
       // is size invariant, resizing the inputs isn't an option.
@@ -742,8 +740,10 @@ std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
     std::string filename, std::map<std::string, flexible_type> opts) {
   const flex_int image_width = read_opts<flex_int>(opts, "image_width");
   const flex_int image_height = read_opts<flex_int>(opts, "image_height");
-  const flex_int include_flexible_shape = read_opts<flex_int>(opts, "include_flexible_shape");
-  const flex_string content_feature = read_state<flex_string>("content_feature");
+  const flex_int include_flexible_shape =
+      read_opts<flex_int>(opts, "include_flexible_shape");
+  const flex_string content_feature =
+      read_state<flex_string>("content_feature");
   const flex_string style_feature = read_state<flex_string>("style_feature");
   const flex_int num_styles = read_state<flex_int>("num_styles");
 
@@ -752,7 +752,8 @@ std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
       {"max_iterations", read_state<flex_int>("max_iterations")},
       {"training_iterations", read_state<flex_int>("training_iterations")},
       {"type", "StyleTransfer"},
-      {"content_feature", content_feature},  // TODO: refactor to take content name and style name
+      {"content_feature",
+       content_feature},  // TODO: refactor to take content name and style name
       {"style_feature", style_feature},
       {"num_styles", num_styles},
       {"version", get_version()},
@@ -760,7 +761,8 @@ std::shared_ptr<MLModelWrapper> style_transfer::export_to_coreml(
 
   std::shared_ptr<MLModelWrapper> model_wrapper = export_style_transfer_model(
       *m_resnet_spec, image_width, image_height, include_flexible_shape,
-      std::move(user_defined_metadata), content_feature, style_feature, num_styles);
+      std::move(user_defined_metadata), content_feature, style_feature,
+      num_styles);
 
   if (!filename.empty()) model_wrapper->save(filename);
 
@@ -772,7 +774,8 @@ void style_transfer::import_from_custom_model(variant_map_type model_data,
   // Get relevant values from variant_map_type
   const flex_dict& model = read_opts<flex_dict>(model_data, "_model");
   const flex_int num_styles = read_opts<flex_int>(model_data, "num_styles");
-  const flex_int max_iterations = read_opts<flex_int>(model_data, "max_iterations");
+  const flex_int max_iterations =
+      read_opts<flex_int>(model_data, "max_iterations");
   const flex_string model_type = read_opts<flex_string>(model_data, "model");
 
   add_or_update_state({{"model", model_type},


### PR DESCRIPTION
## Overview

- Added shape to float array in predict.
- removed explicit shape in `process_output`
- compute_contexts should take care of sizing themselves
- Added crop to TF (It was present previously in the MxNet implementation since padding is added in both the TF and MxNet implementations from the way Reflective Padding is done)

## Fixed
- The four failing Unit Tests in the TF implementation of ST.
- Tests Passing in both TF and MPS