### PR TITLE
Implement "prediction_id" column for "per_window" prediction for AC

### DIFF
--- a/src/toolkits/activity_classification/ac_data_iterator.cpp
+++ b/src/toolkits/activity_classification/ac_data_iterator.cpp
@@ -516,10 +516,10 @@ simple_data_iterator::simple_data_iterator(const parameters &params)
       next_row_(range_iterator_.begin()),
       end_of_rows_(range_iterator_.end()),
       sample_in_row_(0),
+      num_chunks_in_row_(0),
       is_train_(params.is_train),
       use_data_augmentation_(params.use_data_augmentation),
-      random_engine_(params.random_seed)
-{}
+      random_engine_(params.random_seed) {}
 
 const flex_list& simple_data_iterator::feature_names() const {
   return data_.feature_names;
@@ -634,13 +634,16 @@ data_iterator::batch simple_data_iterator::next_batch(size_t batch_size) {
 
     batch_info.emplace_back();
     batch_info.back().session_id = row[session_id_column_index];
+    batch_info.back().chunk_index = num_chunks_in_row_;
     batch_info.back().num_samples = end - sample_in_row_;
 
     sample_in_row_ = end;
+    ++num_chunks_in_row_;
 
     if (sample_in_row_ >= static_cast<size_t>(chunk_length)) {
       ++next_row_;
       sample_in_row_ = 0;
+      num_chunks_in_row_ = 0;
     }
   }
 

--- a/src/toolkits/activity_classification/ac_data_iterator.hpp
+++ b/src/toolkits/activity_classification/ac_data_iterator.hpp
@@ -81,6 +81,9 @@ public:
       /** The session ID from which the chunk was segmented. */
       flexible_type session_id;
 
+      /** The position of this chunk within the session. */
+      size_t chunk_index;
+
       /** Number of samples (rows from the raw SFrame) comprising the chunk. */
       size_t num_samples;
     };
@@ -199,6 +202,7 @@ private:
   gl_sframe_range::iterator next_row_;
   gl_sframe_range::iterator end_of_rows_;
   size_t sample_in_row_ = 0;
+  size_t num_chunks_in_row_ = 0;
   bool is_train_ = false;
   bool use_data_augmentation_ = false;
   std::default_random_engine random_engine_;

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -461,8 +461,10 @@ gl_sframe activity_classifier::predict_per_window(gl_sframe data,
 
   // Accumulate the class probabilities for each prediction window.
   gl_sframe raw_preds_per_window = perform_inference(data_it.get());
+  std::string session_id_column_name = read_state<std::string>("session_id");
   gl_sframe result =
-      gl_sframe({{"session_id", raw_preds_per_window["session_id"]},
+      gl_sframe({{session_id_column_name, raw_preds_per_window["session_id"]},
+                 {"prediction_id", raw_preds_per_window["prediction_id"]},
                  {"probability_vector", raw_preds_per_window["preds"]}});
 
   if (output_type == "class") {
@@ -481,7 +483,8 @@ gl_sframe activity_classifier::predict_per_window(gl_sframe data,
   return result;
 }
 
-
+// TODO: This implementation would ideally just post-process the return value of
+// predict.
 gl_sframe activity_classifier::classify(gl_sframe data,
                                         std::string output_frequency) {
   if (output_frequency != "per_row" &&
@@ -524,9 +527,12 @@ gl_sframe activity_classifier::classify(gl_sframe data,
   // create the result
   gl_sframe result = gl_sframe();
   if (output_frequency == "per_window") {
-    result = gl_sframe({{"exp_id", raw_preds_per_window["session_id"]},
-                        {"class", raw_preds_per_window["class"]},
-                        {"probability", raw_preds_per_window["probability"]}});
+    std::string session_id_column_name = read_state<std::string>("session_id");
+    result =
+        gl_sframe({{session_id_column_name, raw_preds_per_window["session_id"]},
+                   {"prediction_id", raw_preds_per_window["prediction_id"]},
+                   {"class", raw_preds_per_window["class"]},
+                   {"probability", raw_preds_per_window["probability"]}});
   } else {
     size_t class_column_index = raw_preds_per_window.column_index("class");
     size_t prob_column_index = raw_preds_per_window.column_index("probability");
@@ -660,10 +666,10 @@ gl_sframe activity_classifier::predict_topk(gl_sframe data,
     stacked_rank = stacked_rank.stack("rank", "rank");
     result.add_column(stacked_rank["rank"], "rank");
   } else {
-    // add "exp_id" and "prediction_id" if the output_frequency is per_window
-    result.add_column(raw_preds_per_window["session_id"], "exp_id");
-    result.add_column(gl_sarray::from_sequence(0, raw_preds_per_window.size()),
-                      "prediction_id");
+    // add session ID and prediction ID if the output_frequency is per_window
+    result.add_column(raw_preds_per_window["session_id"],
+                      read_state<std::string>("session_id"));
+    result.add_column(raw_preds_per_window["prediction_id"], "prediction_id");
     result.add_column(raw_preds_per_window["class"], "class");
     result = result.stack("class", "class");
     gl_sframe rank_per_row = gl_sframe({{"rank", raw_preds_per_window["rank"]}})
@@ -1217,10 +1223,11 @@ void activity_classifier::perform_training_iteration() {
 
 gl_sframe activity_classifier::perform_inference(data_iterator *data) const {
   // Open a new SFrame for writing.
-  gl_sframe_writer writer({"session_id", "preds", "num_samples"},
-                          {data->session_id_type(), flex_type_enum::VECTOR,
-                           flex_type_enum::INTEGER},
-                          /* num_segments */ 1);
+  gl_sframe_writer writer(
+      {"session_id", "prediction_id", "preds", "num_samples"},
+      {data->session_id_type(), flex_type_enum::INTEGER, flex_type_enum::VECTOR,
+       flex_type_enum::INTEGER},
+      /* num_segments */ 1);
 
   size_t prediction_window = read_state<size_t>("prediction_window");
   size_t num_classes = read_state<size_t>("num_classes");
@@ -1274,11 +1281,12 @@ gl_sframe activity_classifier::perform_inference(data_iterator *data) const {
           // Compute how many samples this prediction applies to.
           size_t num_samples = std::min(prediction_window,
                                         info.num_samples - cumulative_samples);
-          cumulative_samples += prediction_window ;
-          // Add a row to the output SFrame.
-          writer.write({ info.session_id, preds, num_samples },
-                       /* segment_id */ 0);
+          cumulative_samples += prediction_window;
 
+          // Add a row to the output SFrame.
+          flex_int prediction_id = info.chunk_index;
+          writer.write({info.session_id, prediction_id, preds, num_samples},
+                       /* segment_id */ 0);
         }
       }
     }

--- a/src/toolkits/activity_classification/activity_classifier.hpp
+++ b/src/toolkits/activity_classification/activity_classifier.hpp
@@ -236,8 +236,9 @@ class EXPORT activity_classifier: public ml_model_base {
   virtual void init_table_printer(bool has_validation);
 
   // Returns an SFrame where each row corresponds to one prediction, and
-  // containing three columns: "session_id" indicating the session ID shared by
-  // the samples in the prediction window, "preds" containing the class
+  // containing four columns: "session_id" indicating the session ID shared by
+  // the samples in the prediction window, "prediction_id" indicating the index
+  // of the prediction window within the session, "preds" containing the class
   // probability vector for the prediction window, and "num_samples" indicating
   // the number of corresponding rows from the original SFrame (at most the
   // prediction window size).


### PR DESCRIPTION
Adds this column for `predict` and updates the semantics for `classify`. Unlike 5.8, this column now gives the index of the prediction within the session (instead of the index overall, which is just the row number in the result table)

Also fixes some places where the result SFrame should use the user's column name for the session ID, not the string "session_id"

Fixes #1706 