### PR TITLE
Fix for issue #2648, SSL cert issue.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,8 @@ build_wheel_debug_linux_python27:
     DOCKER_DRIVER: overlay2
   script:
     - apk add bash
-    - bash scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --debug --docker-python2.7 --skip_doc
+    - mkdir -p /etc/ssl/certs/
+    - bash -e scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --debug --docker-python2.7 --skip_doc
   artifacts:
     expire_in: 1 day
     paths:
@@ -38,7 +39,8 @@ build_wheel_linux_python27:
     DOCKER_DRIVER: overlay2
   script:
     - apk add bash
-    - bash scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python2.7
+    - mkdir -p /etc/ssl/certs/
+    - bash -e scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python2.7
   artifacts:
     expire_in: 1 day
     paths:
@@ -56,7 +58,8 @@ build_wheel_linux_python35:
     DOCKER_DRIVER: overlay2
   script:
     - apk add bash
-    - bash scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python3.5 --skip_doc
+    - mkdir -p /etc/ssl/certs/
+    - bash -e scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python3.5 --skip_doc
   artifacts:
     expire_in: 1 day
     paths:
@@ -74,7 +77,8 @@ build_wheel_linux_python36:
     DOCKER_DRIVER: overlay2
   script:
     - apk add bash
-    - bash scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python3.6 --skip_doc
+    - mkdir -p /etc/ssl/certs/
+    - bash -e scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python3.6 --skip_doc
   artifacts:
     expire_in: 1 day
     paths:
@@ -92,6 +96,7 @@ build_wheel_linux_python37:
     DOCKER_DRIVER: overlay2
   script:
     - apk add bash
+    - mkdir -p /etc/ssl/certs/
     - bash -e scripts/make_wheel.sh --skip_test --skip_cpp_test --build_number=$CI_PIPELINE_ID --num_procs=4 --docker-python3.7 --skip_doc
   artifacts:
     expire_in: 1 day

--- a/scripts/Dockerfile-CentOS-6
+++ b/scripts/Dockerfile-CentOS-6
@@ -56,6 +56,7 @@ RUN make install
 WORKDIR /src
 RUN curl -O https://www.openssl.org/source/openssl-1.1.0j.tar.gz
 RUN tar xf openssl-1.1.0j.tar.gz
+RUN mkdir -p /etc/ssl/certs/
 WORKDIR /src/openssl-1.1.0j
 RUN ./config --prefix=/usr/local --openssldir=/usr/local && \
     make -j4 --quiet && \


### PR DESCRIPTION
The root cause of the S3 Cert issue is that during the compilation of curl, the path /etc/ssl/certs/ is only added as a search path for certificates if it is present on the machine at build time.  Without that, CURL does not build with that enabled as a search path.  When we switched our build environment to CentOS 6 to support the manylinux2010 standard, it didn't have this directory on the resulting build machine and so our resulting egg did not search that path.  