### PR TITLE
Fix Linux build in style_transfer/utils

### DIFF
--- a/test/toolkits/style_transfer/CMakeLists.txt
+++ b/test/toolkits/style_transfer/CMakeLists.txt
@@ -2,7 +2,7 @@ project(neural_net_test)
 
 make_library(style_transfer_toolkit_test_utils
   SOURCES
-    utils.mm 
+    utils.cpp
   REQUIRES
   	unity_style_transfer
     unity_shared_for_testing

--- a/test/toolkits/style_transfer/utils.cpp
+++ b/test/toolkits/style_transfer/utils.cpp
@@ -7,8 +7,6 @@
 
 #include "utils.hpp"
 
-#import <Foundation/Foundation.h>
-
 #include <ml/neural_net/weight_init.hpp>
 #include <model_server/lib/image_util.hpp>
 #include <toolkits/coreml_export/mlmodel_include.hpp>


### PR DESCRIPTION
Rename .mm to .cpp and remove inclusion of Foundation; this file doesn't
appear to need ObjC at all, and we don't need to introduce an ObjC
compiler dependency on Linux.

This fixes the build for any Linux machines that don't have an ObjC
compiler toolchain.