### PR TITLE
Adding __repr__ in AC_beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ cache:
 
 language: python
 
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-
 matrix:
   include:
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ python:
   - "3.5"
   - "3.6"
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 addons:
   apt:
     update: true

--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -438,8 +438,8 @@ class Model(ExposeAttributesFromProxy):
         if field in self._list_fields():
             return self.__proxy__.get_value(field)
         else:
-            raise KeyError('Field \"%s\" not in model. Available fields are'
-                         '%s.') % (field, ', '.join(self.list_fields()))
+            raise KeyError(('Field \"%s\" not in model. Available fields are '
+                         '%s.') % (field, ', '.join(self._list_fields())))
 
     @classmethod
     def _native_name(cls):
@@ -501,7 +501,6 @@ class Model(ExposeAttributesFromProxy):
             print(self.__repr__())
         except:
             return self.__class__.__name__
-
 
     def __repr__(self):
         raise NotImplementedError

--- a/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
+++ b/src/python/turicreate/toolkits/activity_classifier/_activity_classifier.py
@@ -370,22 +370,20 @@ class ActivityClassifier_beta(_Model):
         Returns
         -------
         out : string
-            A description of the model.
+            A description of the ActivityClassifier.
         """
-        return self.__class__.__name__
+        return self.__repr__()
 
     def __repr__(self):
         """
-        Returns a string description of the model, including (where relevant)
-        the schema of the training data, description of the training data,
-        training statistics, and model hyperparameters.
-
-        Returns
-        -------
-        out : string
-            A description of the model.
+        Print a string description of the model when the model name is entered
+        in the terminal.
         """
-        return self.__class__.__name__
+        width = 40
+        sections, section_titles = self._get_summary_struct()
+        out = _tkutl._toolkit_repr_print(self, sections, section_titles,
+                                         width=width)
+        return out
 
     def _get_version(self):
         return self._CPP_ACTIVITY_CLASSIFIER_VERSION
@@ -647,6 +645,38 @@ class ActivityClassifier_beta(_Model):
         >>> classes = model.classify(data)
         """
         return self.__proxy__.classify(dataset, output_frequency);
+
+    def _get_summary_struct(self):
+        """
+        Returns a structured description of the model, including (where
+        relevant) the schema of the training data, description of the training
+        data, training statistics, and model hyperparameters.
+
+        Returns
+        -------
+        sections : list (of list of tuples)
+            A list of summary sections.
+              Each section is a list.
+                Each item in a section list is a tuple of the form:
+                  ('<label>','<field>')
+        section_titles: list
+            A list of section titles.
+              The order matches that of the 'sections' object.
+        """
+        model_fields = [
+            ('Number of examples', 'num_examples'),
+            ('Number of sessions', 'num_sessions'),
+            ('Number of classes', 'num_classes'),
+            ('Number of feature columns', 'num_features'),
+            ('Prediction window', 'prediction_window'),
+        ]
+        training_fields = [
+            ('Log-likelihood', 'training_log_loss'),
+            ('Training time (sec)', 'training_time'),
+        ]
+
+        section_titles = ['Schema', 'Training summary']
+        return([model_fields, training_fields], section_titles)
 
 class ActivityClassifier(_CustomModel):
     """


### PR DESCRIPTION
This will check off the box for AC in the issue #2606

```
In [4]: model                                                                                                                                                        
Out[4]: 
Class                                    : ActivityClassifier_beta

Schema
------
Number of examples                       : 748406
Number of sessions                       : 56
Number of classes                        : 6
Number of feature columns                : 6
Prediction window                        : 100

Training summary
----------------
Log-likelihood                           : 1.3202
Training time (sec)                      : 35.9083
```