### PR TITLE
Style Transfer MPS to CoreML and CoreML to MPS converters

### DIFF
--- a/src/ml/neural_net/CMakeLists.txt
+++ b/src/ml/neural_net/CMakeLists.txt
@@ -42,6 +42,7 @@ if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
       style_transfer/mps_style_transfer_vgg_16_block_1_node.mm
       style_transfer/mps_style_transfer_vgg_16_block_2_node.mm
       style_transfer/mps_style_transfer_vgg_16_network.m
+      style_transfer/mps_style_transfer_weights.m
     REQUIRES
       unity_core
       ${ACCELERATE}

--- a/src/ml/neural_net/mps_weight.h
+++ b/src/ml/neural_net/mps_weight.h
@@ -107,6 +107,7 @@ API_AVAILABLE(macos(10.14))
 - (void *__nonnull)weights;
 - (float *__nullable)biasTerms;
 - (size_t)weightSize;
+- (NSArray<NSNumber *> *)weightShape;
 - (size_t)biasSize;
 - (void)loadWeight:(float *__nullable)src;
 - (void)loadBias:(float *__nullable)src;

--- a/src/ml/neural_net/mps_weight.mm
+++ b/src/ml/neural_net/mps_weight.mm
@@ -350,6 +350,11 @@ NS_ASSUME_NONNULL_END
 - (size_t)weightSize{
     return sizeWeights / sizeof(float);
 }
+
+- (NSArray<NSNumber *> *)weightShape{
+  return @[@(_outputFeatureChannels), @(_kernelHeight), @(_kernelWidth), @(_inputFeatureChannels)];
+}
+
 - (size_t)biasSize{
     return sizeBias / sizeof(float);
 }

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.h
@@ -10,6 +10,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
 
 #import <ml/neural_net/mps_descriptor_utils.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,10 +32,10 @@ API_AVAILABLE(macos(10.15))
                      weights:(NSDictionary<NSString *, NSData *> *) weights
                    numStyles:(NSUInteger) numStyles;
 
-- (NSDictionary<NSString *, NSData *> *) exportWeights;
-- (NSDictionary<NSString *, NSData *> *) predict:(NSDictionary<NSString *, NSData *> *)inputs;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) exportWeights;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) predict:(NSDictionary<NSString *, NSData *> *)inputs;
 - (void) setLearningRate:(float)lr;
-- (NSDictionary<NSString *, NSData *> *) train:(NSDictionary<NSString *, NSData *> *)inputs;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) train:(NSDictionary<NSString *, NSData *> *)inputs;
 - (void) checkpoint;
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -314,14 +314,14 @@
   TCMPSStyleTransferWeights *imagesOut = [[TCMPSStyleTransferWeights alloc] init];
 
   /**
-  * TODO: write what needs to be done for batching
+  * TODO: Implement batching for multiple images
   **/
-  for (MPSImage *image in stylizedImages) {
-    NSMutableData* styleData = [NSMutableData dataWithLength:(NSUInteger)sizeof(float) * _imgWidth * _imgHeight * 3];
-    [image readBytes:styleData.mutableBytes dataLayout:(MPSDataLayoutHeightxWidthxFeatureChannels)imageIndex:0];
-    imagesOut.data = styleData;
-    imagesOut.shape = @[@(_batchSize), @(_imgHeight), @(_imgWidth), @(3)];
-  }
+  MPSImage *image = [stylizedImages firstObject];
+
+  NSMutableData* styleData = [NSMutableData dataWithLength:(NSUInteger)sizeof(float) * _imgWidth * _imgHeight * 3];
+  [image readBytes:styleData.mutableBytes dataLayout:(MPSDataLayoutHeightxWidthxFeatureChannels)imageIndex:0];
+  imagesOut.data = styleData;
+  imagesOut.shape = @[@(_batchSize), @(_imgHeight), @(_imgWidth), @(3)];
 
   return @{@"output": imagesOut};
 }

--- a/src/ml/neural_net/style_transfer/mps_style_transfer.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer.m
@@ -251,12 +251,12 @@
   return self;
 }
 
-- (NSDictionary<NSString *, NSData *> *) exportWeights {
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) exportWeights {
   [self checkpoint];
   return [_model exportWeights:@"transformer_"];
 }
 
-- (NSDictionary<NSString *, NSData *> *) predict:(NSDictionary<NSString *, NSData *> *)inputs {
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) predict:(NSDictionary<NSString *, NSData *> *)inputs {
   // TODO: Change for testing
   _batchSize = 1;
 
@@ -311,31 +311,19 @@
   [cb commit];
   [cb waitUntilCompleted];
 
-  NSMutableDictionary<NSString *, NSData *> *imagesOut = [[NSMutableDictionary alloc] init];;
+  TCMPSStyleTransferWeights *imagesOut = [[TCMPSStyleTransferWeights alloc] init];
 
   /**
   * TODO: write what needs to be done for batching
   **/
   for (MPSImage *image in stylizedImages) {
-    // NSString* key = [NSString stringWithFormat:@"%@%lu", @"stylizedImage", [stylizedImages indexOfObject:image]];
-    NSString* key = @"output";
     NSMutableData* styleData = [NSMutableData dataWithLength:(NSUInteger)sizeof(float) * _imgWidth * _imgHeight * 3];
     [image readBytes:styleData.mutableBytes dataLayout:(MPSDataLayoutHeightxWidthxFeatureChannels)imageIndex:0];
-    imagesOut[key] = styleData;
+    imagesOut.data = styleData;
+    imagesOut.shape = @[@(_batchSize), @(_imgHeight), @(_imgWidth), @(3)];
   }
 
-  float imageChannels = 3.0;
-  NSData* imageChannelsData = [NSData dataWithBytes:&imageChannels length:sizeof(float)];
-
-  float imageBatchSize = _batchSize;
-  NSData* imageBatchSizeData = [NSData dataWithBytes:&imageBatchSize length:sizeof(float)];
-
-  imagesOut[@"width"] = imageWidthData;
-  imagesOut[@"height"] = imageHeightData;
-  imagesOut[@"channels"] = imageChannelsData;
-  imagesOut[@"batch_size"] = imageBatchSizeData;
-
-  return [imagesOut copy];
+  return @{@"output": imagesOut};
 }
 
 - (void) setLearningRate:(float)lr {
@@ -345,7 +333,7 @@
   [_contentVggLoss setLearningRate:lr];
 }
 
-- (NSDictionary<NSString *, NSData *> *) train:(NSDictionary<NSString *, NSData *> *)inputs {
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) train:(NSDictionary<NSString *, NSData *> *)inputs {
   _batchSize = 1;
 
   NSData* imageWidthData = inputs[@"width"];
@@ -463,10 +451,12 @@
   NSMutableData * lossData = [NSMutableData data];
   [lossData appendBytes:&lossValue length:sizeof(float)];
 
-  NSMutableDictionary<NSString *, NSData *> *lossDict = [[NSMutableDictionary alloc] init];
-  lossDict[@"loss"] = [NSData dataWithData:lossData];
+  TCMPSStyleTransferWeights *lossWrapper = [[TCMPSStyleTransferWeights alloc] init];
 
-  return [lossDict copy];
+  lossWrapper.data = lossData;
+  lossWrapper.shape = @[@(1)];
+
+  return @{@"loss": lossWrapper};
 }
 
 /**

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.h
@@ -10,6 +10,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
 
 #import <ml/neural_net/mps_descriptor_utils.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ API_AVAILABLE(macos(10.14))
 - (void) setStyleIndex:(NSUInteger)styleIndex;
 - (MPSNNImageNode *) backwardPass:(MPSNNImageNode *) inputNode;
 - (void) setLearningRate:(float)lr;
-- (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *)exportWeights:(NSString *)prefix;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_decoding_node.mm
@@ -86,8 +86,8 @@
   [_instNorm.tc_weightsData setLearningRate:lr];
 }
 
-- (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
-  NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *)exportWeights:(NSString *)prefix {
+  NSMutableDictionary<NSString *, TCMPSStyleTransferWeights *> *weights = [[NSMutableDictionary alloc] init];
 
   NSUInteger convWeightSize = (NSUInteger)([_conv.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* convDataWeight = [NSMutableData dataWithLength:convWeightSize];
@@ -95,7 +95,14 @@
 
   NSString* convWeight = [NSString stringWithFormat:@"%@%@", prefix, @"conv_weight"];
 
-  weights[convWeight] = convDataWeight;
+  NSArray<NSNumber *>* convWeightShape = [_conv.tc_weightsData weightShape];
+
+  TCMPSStyleTransferWeights* convWeightWrapper = [[TCMPSStyleTransferWeights alloc] init];
+
+  convWeightWrapper.data = convDataWeight;
+  convWeightWrapper.shape = convWeightShape;
+
+  weights[convWeight] = convWeightWrapper;
 
   NSUInteger instNormSize = (NSUInteger)([_instNorm.tc_weightsData styles] * [_instNorm.tc_weightsData numberOfFeatureChannels] * sizeof(float));
   NSMutableData* instNormDataGamma = [NSMutableData dataWithLength:instNormSize];
@@ -104,13 +111,25 @@
   memcpy(instNormDataGamma.mutableBytes, [_instNorm.tc_weightsData gamma], instNormSize);
   memcpy(instNormDataBeta.mutableBytes, [_instNorm.tc_weightsData beta], instNormSize);
 
+  NSArray<NSNumber *>* instNormGammaShape = @[@([_instNorm.tc_weightsData styles]), @([_instNorm.tc_weightsData numberOfFeatureChannels])];
+  NSArray<NSNumber *>* instNormBetaShape = @[@([_instNorm.tc_weightsData styles]), @([_instNorm.tc_weightsData numberOfFeatureChannels])];
+
+  TCMPSStyleTransferWeights* instNormGammaWrapper = [[TCMPSStyleTransferWeights alloc] init];
+  TCMPSStyleTransferWeights* instNormBetaWrapper = [[TCMPSStyleTransferWeights alloc] init];
+
+  instNormGammaWrapper.data = instNormDataGamma;
+  instNormGammaWrapper.shape = instNormGammaShape;
+
+  instNormBetaWrapper.data = instNormDataBeta;
+  instNormBetaWrapper.shape = instNormBetaShape;
+
   NSString* instNormGamma = [NSString stringWithFormat:@"%@%@", prefix, @"inst_gamma_weight"];
   NSString* instNormBeta = [NSString stringWithFormat:@"%@%@", prefix, @"inst_beta_weight"];
 
-  weights[instNormGamma] = instNormDataGamma;
-  weights[instNormBeta] = instNormDataBeta;
+  weights[instNormGamma] = instNormGammaWrapper;
+  weights[instNormBeta] = instNormBetaWrapper;
 
-  return [weights copy];
+  return weights;
 }
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_encoding_node.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_encoding_node.h
@@ -10,6 +10,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
 
 #import <ml/neural_net/mps_descriptor_utils.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ API_AVAILABLE(macos(10.14))
 - (void) setStyleIndex:(NSUInteger)styleIndex;
 - (MPSNNImageNode *) backwardPass:(MPSNNImageNode *)inputNode;
 - (void) setLearningRate:(float)lr;
-- (NSDictionary<NSString *, NSData *> *) exportWeights:(NSString *)prefix;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) exportWeights:(NSString *)prefix;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.h
@@ -10,6 +10,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
 
 #import <ml/neural_net/mps_descriptor_utils.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ API_AVAILABLE(macos(10.14))
 - (void) setStyleIndex:(NSUInteger)styleIndex;
 - (MPSNNImageNode *) backwardPass:(MPSNNImageNode *) inputNode;
 - (void) setLearningRate:(float)lr;
-- (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *)exportWeights:(NSString *)prefix;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_residual_node.mm
@@ -120,22 +120,36 @@
   [_instNorm2.tc_weightsData setLearningRate:lr];
 }
 
-- (NSDictionary<NSString *, NSData *> *)exportWeights:(NSString *)prefix {
-  NSMutableDictionary<NSString *, NSData *> *weights = [[NSMutableDictionary alloc] init];;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *)exportWeights:(NSString *)prefix {
+  NSMutableDictionary<NSString *, TCMPSStyleTransferWeights *> *weights = [[NSMutableDictionary alloc] init];;
 
   NSString* conv1Keys = [NSString stringWithFormat:@"%@%@", prefix, @"conv_1_weight"];
   NSUInteger conv1WeightSize = (NSUInteger)([_conv1.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* conv1DataWeight = [NSMutableData dataWithLength:conv1WeightSize];
   memcpy(conv1DataWeight.mutableBytes, [_conv1.tc_weightsData weights], conv1WeightSize);
 
-  weights[conv1Keys] = conv1DataWeight;
+  NSArray<NSNumber *>* conv1WeightShape = [_conv1.tc_weightsData weightShape];
+
+  TCMPSStyleTransferWeights* conv1WeightWrapper = [[TCMPSStyleTransferWeights alloc] init];
+
+  conv1WeightWrapper.data = conv1DataWeight;
+  conv1WeightWrapper.shape = conv1WeightShape;
+
+  weights[conv1Keys] = conv1WeightWrapper;
 
   NSString* conv2Keys = [NSString stringWithFormat:@"%@%@", prefix, @"conv_2_weight"];
   NSUInteger conv2WeightSize = (NSUInteger)([_conv2.tc_weightsData weightSize] * sizeof(float));
   NSMutableData* conv2DataWeight = [NSMutableData dataWithLength:conv2WeightSize];
   memcpy(conv2DataWeight.mutableBytes, [_conv2.tc_weightsData weights], conv2WeightSize);
 
-  weights[conv2Keys] = conv2DataWeight;
+  NSArray<NSNumber *>* conv2WeightShape = [_conv2.tc_weightsData weightShape];
+
+  TCMPSStyleTransferWeights* conv2WeightWrapper = [[TCMPSStyleTransferWeights alloc] init];
+
+  conv2WeightWrapper.data = conv2DataWeight;
+  conv2WeightWrapper.shape = conv2WeightShape;
+
+  weights[conv2Keys] = conv2WeightWrapper;
 
   NSString* instNorm1GammaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_1_gamma_weight"];
   NSString* instNorm1BetaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_1_beta_weight"];
@@ -148,8 +162,20 @@
   memcpy(instNorm1DataGamma.mutableBytes, [_instNorm1.tc_weightsData gamma], instNorm1Size);
   memcpy(instNorm1DataBeta.mutableBytes, [_instNorm1.tc_weightsData beta], instNorm1Size);
 
-  weights[instNorm1GammaKeys] = instNorm1DataGamma;
-  weights[instNorm1BetaKeys] = instNorm1DataBeta;
+  NSArray<NSNumber *>* inst1NormGammaShape = @[@([_instNorm1.tc_weightsData styles]), @([_instNorm1.tc_weightsData numberOfFeatureChannels])];
+  NSArray<NSNumber *>* inst1NormBetaShape = @[@([_instNorm1.tc_weightsData styles]), @([_instNorm1.tc_weightsData numberOfFeatureChannels])];
+
+  TCMPSStyleTransferWeights* inst1NormGammaWrapper = [[TCMPSStyleTransferWeights alloc] init];
+  TCMPSStyleTransferWeights* inst1NormBetaWrapper = [[TCMPSStyleTransferWeights alloc] init];
+
+  inst1NormGammaWrapper.data = instNorm1DataGamma;
+  inst1NormGammaWrapper.shape = inst1NormGammaShape;
+
+  inst1NormBetaWrapper.data = instNorm1DataBeta;
+  inst1NormBetaWrapper.shape = inst1NormBetaShape;
+
+  weights[instNorm1GammaKeys] = inst1NormGammaWrapper;
+  weights[instNorm1BetaKeys] = inst1NormBetaWrapper;
 
   NSString* instNorm2GammaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_2_gamma_weight"];
   NSString* instNorm2BetaKeys = [NSString stringWithFormat:@"%@%@", prefix, @"inst_2_beta_weight"];
@@ -162,10 +188,23 @@
   memcpy(instNorm2DataGamma.mutableBytes, [_instNorm2.tc_weightsData gamma], instNorm2Size);
   memcpy(instNorm2DataBeta.mutableBytes, [_instNorm2.tc_weightsData beta], instNorm2Size);
 
-  weights[instNorm2GammaKeys] = instNorm2DataGamma;
-  weights[instNorm2BetaKeys] = instNorm2DataBeta;
+
+  NSArray<NSNumber *>* inst2NormGammaShape = @[@([_instNorm2.tc_weightsData styles]), @([_instNorm2.tc_weightsData numberOfFeatureChannels])];
+  NSArray<NSNumber *>* inst2NormBetaShape = @[@([_instNorm2.tc_weightsData styles]), @([_instNorm2.tc_weightsData numberOfFeatureChannels])];
+
+  TCMPSStyleTransferWeights* inst2NormGammaWrapper = [[TCMPSStyleTransferWeights alloc] init];
+  TCMPSStyleTransferWeights* inst2NormBetaWrapper = [[TCMPSStyleTransferWeights alloc] init];
+
+  inst2NormGammaWrapper.data = instNorm2DataGamma;
+  inst2NormGammaWrapper.shape = inst2NormGammaShape;
+
+  inst2NormBetaWrapper.data = instNorm2DataBeta;
+  inst2NormBetaWrapper.shape = inst2NormBetaShape;
+
+  weights[instNorm2GammaKeys] = inst2NormGammaWrapper;
+  weights[instNorm2BetaKeys] = inst2NormBetaWrapper;
   
-  return [weights copy];
+  return weights;
 }
 
 @end

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_transformer_network.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_transformer_network.h
@@ -10,6 +10,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
 
 #import <ml/neural_net/mps_descriptor_utils.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,7 @@ API_AVAILABLE(macos(10.14))
 - (void) setStyleIndex:(NSUInteger)styleIndex;
 - (MPSNNImageNode * _Nullable) backwardPass:(MPSNNImageNode *) inputNode;
 - (void) setLearningRate:(float)lr;
-- (NSDictionary<NSString *, NSData *> *) exportWeights:(NSString *) prefix;
+- (NSDictionary<NSString *, TCMPSStyleTransferWeights *> *) exportWeights:(NSString *) prefix;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_weights.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_weights.h
@@ -1,0 +1,19 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#import <Accelerate/Accelerate.h>
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
+
+#ifdef HAS_MACOS_10_15
+
+@interface TCMPSStyleTransferWeights : NSObject 
+@property (nonatomic) NSData *data;
+@property (nonatomic) NSArray<NSNumber *> *shape;
+@end
+
+#endif // #ifdef HAS_MACOS_10_15

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_weights.h
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_weights.h
@@ -4,10 +4,7 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 
-#import <Accelerate/Accelerate.h>
 #import <Foundation/Foundation.h>
-#import <Metal/Metal.h>
-#import <MetalPerformanceShaders/MetalPerformanceShaders.h> 
 
 #ifdef HAS_MACOS_10_15
 

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_weights.m
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_weights.m
@@ -1,0 +1,12 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifdef HAS_MACOS_10_15
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
+
+@implementation TCMPSStyleTransferWeights
+@end
+
+#endif // #ifdef HAS_MACOS_10_15


### PR DESCRIPTION
## Overview
- converting weights from MPS and CoreML and CoreML and MPS in style transfer.

## Diagnosis
- MPS and CoreML are in different weight formats. CoreML is `OIHW` and MPS is in `OHWI`.

## Additional Issues

- `NSData*` wasn't enough information to make the transposes work. All data now in TCMPS has a shape associated with it. This includes all input and output images as well as the weights being shuttled in and out of TCMPS Style Transfer.

- `TCMPSStyleTransferWeights` couldn't be in `mps_style_transfer_utils.mm` because an interface in that file extends an interface and we need `TCMPSStyleTransferWeights` before we define the interface. Therefore we place `TCMPSStyleTransferWeights` in it's own file so that it can be imported with ease.