### PR TITLE
Fixed C++ unit test failure in test_dc_serialization

### DIFF
--- a/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(test_export_coreml) {
        {"classes", labels},
        {"max_iterations", 300},
        {"random_seed", 11},
-       {"warm_start", false},
+       {"warm_start", ""},
        {"feature", features[0]}});
 
   auto ml_model_wrapper = dc.export_to_coreml("", /* debug no throw */ true);


### PR DESCRIPTION
There was a mismatch in the type of the warm start option in `drawing_classifier.cpp` versus `test_dc_serialization.cxx`.