### PR TITLE
DC: Add support for integer class labels in Core ML export.

### DIFF
--- a/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(test_export_coreml) {
        {"classes", labels},
        {"max_iterations", 300},
        {"random_seed", 11},
-       {"warm_start", false},
+       {"warm_start", ""},
        {"feature", features[0]}});
 
   auto ml_model_wrapper = dc.export_to_coreml("", /* debug no throw */ true);


### PR DESCRIPTION
We did not have support for integer class labels, which caused an assertion failure in `test_export_coreml_with_predict` Python unit test.

Thank you @shreyajain17 and @Jarvi-Izana for pointing this out.

For reviewers, please review src/toolkits/coreml_export/neural_net_models_exporter.cpp.

The changes in test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx are approved as of #2700