### PR TITLE
Never call tensorflow.compat.v1.reset_default_graph

### DIFF
--- a/src/python/turicreate/toolkits/activity_classifier/_tf_model_architecture.py
+++ b/src/python/turicreate/toolkits/activity_classifier/_tf_model_architecture.py
@@ -29,8 +29,6 @@ class ActivityTensorFlowModel(TensorFlowModel):
         for key in net_params.keys():
             net_params[key] = _utils.convert_shared_float_array_to_numpy(net_params[key])
 
-        _tf.reset_default_graph()
-
         self.num_classes = num_classes
         self.batch_size = batch_size
         self.seq_len = seq_len

--- a/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
@@ -26,8 +26,6 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
         for key in net_params.keys():
             net_params[key] = _utils.convert_shared_float_array_to_numpy(net_params[key])
 
-        _tf.reset_default_graph()
-
         self.num_classes = num_classes
         self.batch_size = batch_size
 

--- a/src/python/turicreate/toolkits/object_detector/_tf_model_architecture.py
+++ b/src/python/turicreate/toolkits/object_detector/_tf_model_architecture.py
@@ -20,9 +20,6 @@ class ODTensorFlowModel(TensorFlowModel):
 
     def __init__(self, input_h, input_w, batch_size, output_size, init_weights, config, is_train=True):
 
-        #reset tensorflow graph when a new model is created
-        _tf.reset_default_graph()
-
         # Converting incoming weights from shared_float_array to numpy
         for key in init_weights.keys():
             init_weights[key] = _utils.convert_shared_float_array_to_numpy(init_weights[key])

--- a/src/python/turicreate/toolkits/sound_classifier/_tf_sound_classifier.py
+++ b/src/python/turicreate/toolkits/sound_classifier/_tf_sound_classifier.py
@@ -25,8 +25,6 @@ class SoundClassifierTensorFlowModel(TensorFlowModel):
 
         """
 
-        _tf.reset_default_graph()
-
         self.num_classes = num_classes
 
         self.x = _tf.placeholder("float", [None, 12288])

--- a/src/python/turicreate/toolkits/style_transfer/_tf_model_architecture.py
+++ b/src/python/turicreate/toolkits/style_transfer/_tf_model_architecture.py
@@ -466,8 +466,6 @@ def define_style_transfer_network(content_image,
 
 class StyleTransferTensorFlowModel(TensorFlowModel):
     def __init__(self, config, net_params):
-        
-        _tf.reset_default_graph()
 
         for key in net_params.keys():
             net_params[key] = _utils.convert_shared_float_array_to_numpy(net_params[key])


### PR DESCRIPTION
The default graph contains other instances of TuriCreate model as well as other TensorFlow models the user might have created. 