### PR TITLE
Fixed test build failures introduced in #2656.

### DIFF
--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -835,7 +835,7 @@ std::shared_ptr<coreml::MLModelWrapper> drawing_classifier::export_to_coreml(
     std::string filename, std::string short_description,
     std::map<std::string, flexible_type> additional_user_defined,
     bool use_default_spec) {
-  /* Add code for export_to_coreml */
+
   if (!nn_spec_) {
     // use empty nn spec if not initalized;
     // avoid test bad memory access

--- a/test/unity/toolkits/coreml_export/test_neural_nets_model_exporter.cxx
+++ b/test/unity/toolkits/coreml_export/test_neural_nets_model_exporter.cxx
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(test_object_detector_export_coreml_with_nms) {
     std::shared_ptr<coreml::MLModelWrapper> model_wrapper =
         export_object_detector_model(
             yolo_nn_spec, 13 * 32, 13 * 32, test_class_labels.size(),
-            13 * 13 * 15, std::move(user_defined_metadata),
+            13 * 13 * 15,
             std::move(t_class_labels), "image", std::move(options));
     std::shared_ptr<CoreML::Model> c_model = model_wrapper->coreml_model();
     auto p_model = c_model->getProto();

--- a/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_serialization.cxx
@@ -162,7 +162,8 @@ BOOST_AUTO_TEST_CASE(test_export_coreml) {
        {"warm_start", ""},
        {"feature", features[0]}});
 
-  auto ml_model_wrapper = dc.export_to_coreml("", /* debug no throw */ true);
+  auto ml_model_wrapper = dc.export_to_coreml("", "", {},
+                                              /* debug no throw */ true);
   TS_ASSERT(ml_model_wrapper != nullptr);
 
   const auto& my_model_spec = ml_model_wrapper->coreml_model()->getProto();


### PR DESCRIPTION
In #2656, the signature for `export_object_detector_model` and `drawing_classifier::export_to_coreml` was changed. While the PR also addressed any user-facing code paths that accessed those functions, the C++ tests were not modified to access this functionality differently. This PR makes those changes in the C++ tests to make our C++ unit tests build and run successfully. 