### PR TITLE
Fix build in release mode

### DIFF
--- a/src/visualization/annotation/image_classification.cpp
+++ b/src/visualization/annotation/image_classification.cpp
@@ -284,9 +284,8 @@ void ImageClassification::_addAnnotationToSFrame(size_t index,
                                                  std::string label) {
   /* Assert that the column type is indeed of type flex_enum::STRING */
   size_t annotation_column_index = m_data->column_index(m_annotation_column);
-  flex_type_enum annotation_column_type = m_data->dtype().at(annotation_column_index);
   if (m_data->select_column(annotation_column_index)->any()) {
-    DASSERT_EQ(annotation_column_type,
+    DASSERT_EQ(m_data->dtype().at(annotation_column_index),
               flex_type_enum::STRING);
   }
 


### PR DESCRIPTION
Break caused by #2715 -- in release mode, the unused variable causes a
warning-as-error.