### PR TITLE
Added resizing to channels to get them to match for ST

### DIFF
--- a/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
@@ -18,10 +18,17 @@ namespace style_transfer {
 namespace {
 
 flex_image get_image(const flexible_type& image_feature) {
+  flex_image image;
   if (image_feature.get_type() == flex_type_enum::STRING) {
-    return read_image(image_feature, /* format_hint */ "");
+    image = read_image(image_feature, /* format_hint */ "");
   } else {
-    return image_feature;
+    image = image_feature;
+  }
+
+  if (image.m_channels != 3) {
+    return image_util::resize_image(image, image.m_width, image.m_height, 3, true);
+  } else {
+    return image;
   }
 }
 

--- a/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
+++ b/src/toolkits/style_transfer/style_transfer_data_iterator.cpp
@@ -24,12 +24,8 @@ flex_image get_image(const flexible_type& image_feature) {
   } else {
     image = image_feature;
   }
-
-  if (image.m_channels != 3) {
-    return image_util::resize_image(image, image.m_width, image.m_height, 3, true);
-  } else {
-    return image;
-  }
+  
+  return image_util::resize_image(image, image.m_width, image.m_height, 3, true);
 }
 
 gl_sarray ensure_encoded(const gl_sarray& sa) {


### PR DESCRIPTION
## Overview
- Style Transfer requires all of the channels to be of size 3 as the network depends on this.

## Solution
- Calling the resize method in image_utils get's us this functionality
- It was added upstream in the data loader because that's where the data for the style transfer model is prepared.