### PR TITLE
Added model evaluate to 6.0 matching behavior from 5.8

### DIFF
--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -1204,7 +1204,69 @@ class DrawingClassifier(_Model):
           >>> results = model.evaluate(data)
           >>> print results['accuracy']
         """
-        return self.__proxy__.evaluate(dataset, metric)
+        class_label = self.__proxy__.predict(dataset, "class")
+        probability_vector = self.__proxy__.predict(dataset, "probability_vector")
+
+        predicted  = _tc.SFrame({"label": class_label, "probability": probability_vector})
+        labels = self.classes
+
+        evaluation_result = self.__proxy__.evaluate(dataset, 'auto')
+
+        from .._evaluate_utils import  (
+            entropy,
+            confidence,
+            relative_confidence,
+            get_confusion_matrix,
+            hclusterSort,
+            l2Dist
+        )
+
+        evaluation_result['num_test_examples'] = len(dataset)
+        for k in ['num_classes', 'num_examples', 'training_time', 'max_iterations']:
+            evaluation_result[k] = getattr(self, k)
+
+        #evaluation_result['input_image_shape'] = getattr(self, 'input_image_shape')
+
+        evaluation_result["model_name"] = "Drawing Classifier"
+        extended_test = dataset.add_column(predicted["probability"], 'probs')
+        extended_test['label'] = dataset[self.target]
+
+        extended_test = extended_test.add_columns( [extended_test.apply(lambda d: labels[d['probs'].index(confidence(d['probs']))]),
+            extended_test.apply(lambda d: entropy(d['probs'])),
+            extended_test.apply(lambda d: confidence(d['probs'])),
+            extended_test.apply(lambda d: relative_confidence(d['probs']))],
+            ['predicted_label', 'entropy', 'confidence', 'relative_confidence'])
+
+        extended_test = extended_test.add_column(extended_test.apply(lambda d: d['label'] == d['predicted_label']), 'correct')
+
+        sf_conf_mat = get_confusion_matrix(extended_test, labels)
+        confidence_threshold = 0.5
+        hesitant_threshold = 0.2
+        evaluation_result['confidence_threshold'] = confidence_threshold
+        evaluation_result['hesitant_threshold'] = hesitant_threshold
+        evaluation_result['confidence_metric_for_threshold'] = 'relative_confidence'
+
+        evaluation_result['conf_mat'] = list(sf_conf_mat)
+
+        vectors = map(lambda l: {'name': l, 'pos':list(sf_conf_mat[sf_conf_mat['target_label']==l].sort('predicted_label')['norm_prob'])},
+                    labels)
+        evaluation_result['sorted_labels'] = hclusterSort(vectors, l2Dist)[0]['name'].split("|")
+
+        per_l = extended_test.groupby(['label'], {'count': _tc.aggregate.COUNT, 'correct_count': _tc.aggregate.SUM('correct') })
+        per_l['recall'] = per_l.apply(lambda l: l['correct_count']*1.0 / l['count'])
+
+        per_pl = extended_test.groupby(['predicted_label'], {'predicted_count': _tc.aggregate.COUNT, 'correct_count': _tc.aggregate.SUM('correct') })
+        per_pl['precision'] = per_pl.apply(lambda l: l['correct_count']*1.0 / l['predicted_count'])
+        per_pl = per_pl.rename({'predicted_label': 'label'})
+        evaluation_result['label_metrics'] = list(per_l.join(per_pl, on='label', how='outer').select_columns(['label', 'count', 'correct_count', 'predicted_count', 'recall', 'precision']))
+        evaluation_result['labels'] = labels
+
+        extended_test = extended_test.add_row_number('__idx').rename({'label': 'target_label'})
+
+        evaluation_result['test_data'] = extended_test
+        evaluation_result['feature'] = self.feature
+
+        return _Evaluation(evaluation_result)
 
     def _get_summary_struct(self):
         """

--- a/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/drawing_classifier.py
@@ -1204,6 +1204,8 @@ class DrawingClassifier(_Model):
           >>> results = model.evaluate(data)
           >>> print results['accuracy']
         """
+
+        # TODO: fix the three passes through the data.
         class_label = self.__proxy__.predict(dataset, "class")
         probability_vector = self.__proxy__.predict(dataset, "probability_vector")
 

--- a/src/python/turicreate/toolkits/image_classifier/_evaluation.py
+++ b/src/python/turicreate/toolkits/image_classifier/_evaluation.py
@@ -33,7 +33,7 @@ class Evaluation(dict):
     for key, value in _six.iteritems(self.data):
       if (isinstance(value, float) or isinstance(value, int)) and _math.isnan(value):
         continue
-      if (key is "test_data" or key is "confusion_matrix" or key is "roc_curve"):
+      if (key == "test_data" or key == "confusion_matrix" or key == "roc_curve"):
         continue
       evaluation_dictionary[key] = value
 
@@ -47,8 +47,6 @@ class Evaluation(dict):
     evaluation_dictionary["corrects_size"] = len(self.data["test_data"].filter_by([True], "correct"))
     evaluation_dictionary["incorrects_size"] = evaluation_dictionary["table_spec"]["size"] - evaluation_dictionary["corrects_size"]
 
-    # make sure numpy.float32 is serializable
-    evaluation_dictionary["training_loss"] = float(evaluation_dictionary["training_loss"])
     return str(_json.dumps({ "evaluation_spec": evaluation_dictionary }, allow_nan = False))
 
   def explore(self):

--- a/src/python/turicreate/toolkits/image_classifier/_evaluation.py
+++ b/src/python/turicreate/toolkits/image_classifier/_evaluation.py
@@ -24,13 +24,17 @@ import math as _math
 class Evaluation(dict):
   def __init__(self, obj = {}):
     dict.__init__(self)
-    self.data = obj
-    self.update(obj)
+    self._data = obj
+
+    metrics_keys = ['f1_score', 'auc', 'recall', 'precision', 'log_loss', 'roc_curve', 'confusion_matrix', 'accuracy']
+    metrics_obj = { k: v for k, v in obj.items() if k in metrics_keys }
+
+    self.update(metrics_obj)
 
   def _get_eval_json(self):
     evaluation_dictionary = dict()
 
-    for key, value in _six.iteritems(self.data):
+    for key, value in _six.iteritems(self._data):
       if (isinstance(value, float) or isinstance(value, int)) and _math.isnan(value):
         continue
       if (key == "test_data" or key == "confusion_matrix" or key == "roc_curve"):
@@ -39,12 +43,12 @@ class Evaluation(dict):
 
     evaluation_dictionary["table_spec"] = {
       "column_names": ["path", "image", "target_label", "predicted_label"],
-      "size": len(self.data["test_data"]),
+      "size": len(self._data["test_data"]),
       "title": "",
       "column_types": ["string", "image", "string", "string"]
     }
 
-    evaluation_dictionary["corrects_size"] = len(self.data["test_data"].filter_by([True], "correct"))
+    evaluation_dictionary["corrects_size"] = len(self._data["test_data"].filter_by([True], "correct"))
     evaluation_dictionary["incorrects_size"] = evaluation_dictionary["table_spec"]["size"] - evaluation_dictionary["corrects_size"]
 
     return str(_json.dumps({ "evaluation_spec": evaluation_dictionary }, allow_nan = False))
@@ -53,12 +57,12 @@ class Evaluation(dict):
     """
     Explore model evaluation qualitatively through a GUI assisted application.
     """
-    if self.data["test_data"][self["feature"]].dtype == _tc.Image:
+    if self._data["test_data"][self._data["feature"]].dtype == _tc.Image:
       print("Resizing image data... ", end='')
-      self.data["test_data"][self["feature"]] = self.data["test_data"][self["feature"]].apply(_image_conversion)
-      self.data["test_data"].materialize()
+      self._data["test_data"][self._data["feature"]] = self._data["test_data"][self._data["feature"]].apply(_image_conversion)
+      self._data["test_data"].materialize()
       print("Done.")
-    params = (self._get_eval_json()+"\n", self.data["test_data"], self, )
+    params = (self._get_eval_json()+"\n", self._data["test_data"], self, )
     # Suppress visualization output if 'none' target is set
     from ...visualization._plot import _target
     if _target == 'none':
@@ -108,12 +112,12 @@ def _reform_sframe(sf):
   return list(sf_sending_data)
 
 def _filter_sframe(filters, row_type, mat_type, sf, evaluation):
-  conf_metric = evaluation["confidence_metric_for_threshold"]
+  conf_metric = evaluation._data["confidence_metric_for_threshold"]
 
   if mat_type == "conf_wrong":
-    sf = sf[sf[conf_metric] > evaluation["confidence_threshold"]]
+    sf = sf[sf[conf_metric] > evaluation._data["confidence_threshold"]]
   elif mat_type == "hesitant":
-    sf = sf[sf[conf_metric] < evaluation["hesitant_threshold"]]
+    sf = sf[sf[conf_metric] < evaluation._data["hesitant_threshold"]]
 
   filtered_array = None
   if row_type == "corrects":
@@ -136,7 +140,7 @@ def _filter_sframe(filters, row_type, mat_type, sf, evaluation):
   return filtered_array
 
 def __get_incorrects(label, sf, evaluation):
-  conf_metric = evaluation["confidence_metric_for_threshold"]
+  conf_metric = evaluation._data["confidence_metric_for_threshold"]
 
   sf = sf.filter_by([False], "correct")
 
@@ -149,12 +153,12 @@ def __get_incorrects(label, sf, evaluation):
   data = []
   for u in unique_predictions:
     u_filt = filtered_sframe.filter_by([u], "predicted_label")
-    data.append({"label": str(u), "images": list(u_filt[evaluation.data['feature']])})
+    data.append({"label": str(u), "images": list(u_filt[evaluation._data['feature']])})
 
   return _json.dumps({"data_spec": { "incorrects": {"target": label, "data": data }}}) + "\n"
 
 def __get_corrects(sf, evaluation):
-  conf_metric = evaluation["confidence_metric_for_threshold"]
+  conf_metric = evaluation._data["confidence_metric_for_threshold"]
 
   sf = sf.filter_by([True], "correct")
 
@@ -163,7 +167,7 @@ def __get_corrects(sf, evaluation):
   data = []
   for u in unique_predictions:
     u_filt = sf.filter_by([u], "predicted_label")
-    data.append({"target": u, "images": list(u_filt[evaluation.data['feature']])})
+    data.append({"target": u, "images": list(u_filt[evaluation._data['feature']])})
   return _json.dumps({"data_spec": { "correct": data}}) + "\n"
 
 def _process_value(value, extended_sframe, proc, evaluation):


### PR DESCRIPTION
## Overview
Previously Drawing Classifier explore was unimplemented in 6.0

## Fixed
- Parity of `.explore` with 5.8 in 6.0
- `is` to using `==` for key comparison for robustness. Compare value rather than identity.