### PR TITLE
Switched to decoded image

### DIFF
--- a/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
+++ b/test/toolkits/style_transfer/test_style_transfer_data_iterator.cxx
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE(test_initialization) {
 
   size_t expected_batch_size = sizeof(expected_batch_array)/sizeof(size_t);
 
+  // Test image equality for decoded images only
   turi::gl_sarray style_sarray = random_image_sarray(8);
   turi::gl_sarray content_sarray = random_image_sarray(50);
   

--- a/test/toolkits/style_transfer/utils.cpp
+++ b/test/toolkits/style_transfer/utils.cpp
@@ -57,8 +57,7 @@ turi::gl_sarray random_image_sarray(size_t length) {
   turi::gl_sarray sa;
   sa.construct_from_vector(image_column_data, turi::flex_type_enum::IMAGE);
 
-  return sa.apply(turi::image_util::encode_image, turi::flex_type_enum::IMAGE);
-  ;
+  return sa;
 }
 
 turi::gl_sframe random_sframe(size_t length, std::string image_column_name) {


### PR DESCRIPTION
## Overview

Unit test failure present in `style_transfer_data_iterator` due to images being decoded by the data_iterator. This change was brought about by realizing that the images were going to eventually be decoded anyway and calling `decode_image` on an image that was already decoded was a `no-op`.

The `style_transfer_data_iterator::test_initialization` test checked image equality. So encoded images were passed into the data iterator and previously encoded images would come out. Because of #2740, the default behavior of the data iterator changed, and encoded images were now being returned as decoded images.

This was causing the unit test failure we see in `style_transfer_data_iterator`.

## Fix

Ensure that the images being compared are either all `encoded` or all `decoded`. Since the data loader now returns the images in a `decoded` format, if the images we are comparing to are `decoded` as well, then this works and no unit-test failure present.