### PR TITLE
SC MXNet to TF Regression Fix

### DIFF
--- a/src/python/turicreate/toolkits/sound_classifier/_tf_sound_classifier.py
+++ b/src/python/turicreate/toolkits/sound_classifier/_tf_sound_classifier.py
@@ -78,8 +78,7 @@ class SoundClassifierTensorFlowModel(TensorFlowModel):
             labels=self.y))
 
         # Optimizer
-        self.optimizer = _tf.train.MomentumOptimizer(learning_rate=0.01, momentum=0.9,
-            use_nesterov=True).minimize(self.cost)
+        self.optimizer = _tf.train.AdamOptimizer(learning_rate=0.01).minimize(self.cost)
 
         # Predictions
         correct_prediction = _tf.equal(_tf.argmax(self.predictions, 1), _tf.argmax(self.y, 1))

--- a/src/python/turicreate/toolkits/sound_classifier/_tf_sound_classifier.py
+++ b/src/python/turicreate/toolkits/sound_classifier/_tf_sound_classifier.py
@@ -74,11 +74,12 @@ class SoundClassifierTensorFlowModel(TensorFlowModel):
         self.predictions = out
 
         # Loss
-        self.cost = _tf.reduce_mean(_tf.nn.softmax_cross_entropy_with_logits_v2(logits=self.predictions,
+        self.cost = _tf.reduce_mean(_tf.nn.softmax_cross_entropy_with_logits_v2(logits=curr_dense,
             labels=self.y))
 
         # Optimizer
-        self.optimizer = _tf.train.AdamOptimizer(learning_rate=0.01).minimize(self.cost)
+        self.optimizer = _tf.train.MomentumOptimizer(learning_rate=0.01, momentum=0.9,
+            use_nesterov=True).minimize(self.cost)
 
         # Predictions
         correct_prediction = _tf.equal(_tf.argmax(self.predictions, 1), _tf.argmax(self.y, 1))


### PR DESCRIPTION
Closes #2688 

1) Softmax was being applied twice: `self.predictions` which had softmax activation applied on it was being passed to `tf.nn.softmax_cross_entropy_with_logits_v2` to compute loss. Fixed this by passing last layer activations to `softmax_cross_entropy_with_logits_v2` instead.

2) Optimizer for TF changed from Adam to NAG to match MXNET. 

**ESC-10 on MXNet 6.0**
```
+-------------------+-------------------+-------------------+
| Iteration         | Training Accuracy | Elapsed Time      |
+-------------------+-------------------+-------------------+
| 1                 | 0.372             | 451.111           |
+-------------------+-------------------+-------------------+
| 2                 | 0.592             | 451.459           |
+-------------------+-------------------+-------------------+
| 3                 | 0.675             | 451.871           |
+-------------------+-------------------+-------------------+
| 4                 | 0.782             | 452.249           |
+-------------------+-------------------+-------------------+
| 5                 | 0.819             | 452.664           |
+-------------------+-------------------+-------------------+
| 6                 | 0.846             | 453.045           |
+-------------------+-------------------+-------------------+
| 7                 | 0.864             | 453.435           |
+-------------------+-------------------+-------------------+
| 8                 | 0.886             | 453.875           |
+-------------------+-------------------+-------------------+
| 9                 | 0.908             | 454.272           |
+-------------------+-------------------+-------------------+
| 10                | 0.911             | 454.647           |
+-------------------+-------------------+-------------------+
```

**ESC-10 on TF 6.0**
```
+-------------------+-------------------+-------------------+
| Iteration         | Training Accuracy | Elapsed Time      |
+-------------------+-------------------+-------------------+
| 1                 | 0.163             | 317.240           |
+-------------------+-------------------+-------------------+
| 2                 | 0.708             | 317.564           |
+-------------------+-------------------+-------------------+
| 3                 | 0.746             | 317.916           |
+-------------------+-------------------+-------------------+
| 4                 | 0.772             | 318.248           |
+-------------------+-------------------+-------------------+
| 5                 | 0.801             | 318.589           |
+-------------------+-------------------+-------------------+
| 6                 | 0.826             | 318.936           |
+-------------------+-------------------+-------------------+
| 7                 | 0.850             | 319.254           |
+-------------------+-------------------+-------------------+
| 8                 | 0.878             | 319.577           |
+-------------------+-------------------+-------------------+
| 9                 | 0.893             | 319.916           |
+-------------------+-------------------+-------------------+
| 10                | 0.905             | 320.255           |
+-------------------+-------------------+-------------------+
```

**Using pre-computed ESC-10 deep features on MXNET 6.0**
```
+-------------------+-------------------+-------------------+
| Iteration         | Training Accuracy | Elapsed Time      |
+-------------------+-------------------+-------------------+
| 1                 | 0.371             | 161.865           |
+-------------------+-------------------+-------------------+
| 2                 | 0.591             | 162.535           |
+-------------------+-------------------+-------------------+
| 3                 | 0.677             | 163.186           |
+-------------------+-------------------+-------------------+
| 4                 | 0.781             | 163.839           |
+-------------------+-------------------+-------------------+
| 5                 | 0.820             | 164.504           |
+-------------------+-------------------+-------------------+
| 6                 | 0.846             | 165.188           |
+-------------------+-------------------+-------------------+
| 7                 | 0.864             | 165.874           |
+-------------------+-------------------+-------------------+
| 8                 | 0.886             | 166.535           |
+-------------------+-------------------+-------------------+
| 9                 | 0.900             | 167.130           |
+-------------------+-------------------+-------------------+
| 10                | 0.911             | 167.723           |
+-------------------+-------------------+-------------------+
```

**Using pre-computed ESC-10 deep features on TF 6.0**
```
+-------------------+-------------------+-------------------+
| Iteration         | Training Accuracy | Elapsed Time      |
+-------------------+-------------------+-------------------+
| 1                 | 0.347             | 257.007           |
+-------------------+-------------------+-------------------+
| 2                 | 0.605             | 257.468           |
+-------------------+-------------------+-------------------+
| 3                 | 0.674             | 257.904           |
+-------------------+-------------------+-------------------+
| 4                 | 0.784             | 258.343           |
+-------------------+-------------------+-------------------+
| 5                 | 0.802             | 258.788           |
+-------------------+-------------------+-------------------+
| 6                 | 0.831             | 259.237           |
+-------------------+-------------------+-------------------+
| 7                 | 0.859             | 259.691           |
+-------------------+-------------------+-------------------+
| 8                 | 0.879             | 260.118           |
+-------------------+-------------------+-------------------+
| 9                 | 0.896             | 260.571           |
+-------------------+-------------------+-------------------+
| 10                | 0.910             | 261.044           |
+-------------------+-------------------+-------------------+
```
(TF performs better when passed pre-computed deep features - investigating this currently)