### PR TITLE
Performance improvements for TF OD

### DIFF
--- a/src/ml/neural_net/image_augmentation.cpp
+++ b/src/ml/neural_net/image_augmentation.cpp
@@ -205,10 +205,13 @@ image_augmenter::result float_array_image_augmenter::prepare_images(
 
   // Convert augmented_data to the data structure needed
   std::vector<float> result_array(n * h * w * c);
-  size_t image_size = augmented_data.images.size();
-  const float* start_address = augmented_data.images.data();
-  const float* end_address = start_address + image_size;
-  std::copy(start_address, end_address, result_array.begin());
+  float* result_array_out = result_array.data();
+  for (const shared_float_array& image : augmented_data.images) {
+    size_t image_size = image.size();
+    const float* start_address = image.data();
+    const float* end_address = start_address + image_size;
+    result_array_out = std::copy(start_address, end_address, result_array_out);
+  }
   res.image_batch =
       shared_float_array::wrap(std::move(result_array), {n, h, w, c});
 

--- a/src/ml/neural_net/image_augmentation.cpp
+++ b/src/ml/neural_net/image_augmentation.cpp
@@ -201,7 +201,8 @@ image_augmenter::result float_array_image_augmenter::prepare_images(
 
   // Call the virtual function to use the intermediate data structure and
   // process it
-  float_array_result augmented_data = prepare_augmented_images(input_to_tf_aug);
+  labeled_float_image augmented_data =
+      prepare_augmented_images(input_to_tf_aug);
 
   // Convert augmented_data to the data structure needed
   std::vector<float> result_array(n * h * w * c);

--- a/src/ml/neural_net/image_augmentation.hpp
+++ b/src/ml/neural_net/image_augmentation.hpp
@@ -285,29 +285,26 @@ class float_array_image_augmenter : public image_augmenter {
   result prepare_images(std::vector<labeled_image> source_batch) override;
 
  protected:
-  /** The output sent from TensorFlow after augmenting the images. */
-  struct float_array_result {
-    /** The images after augmenting sent from Tensorflow */
-    std::vector<shared_float_array> images;
-
-    /** The annotations associated with augmented images sent from Tensorflow */
-    std::vector<shared_float_array> annotations;
-  };
-
-  /** The output sent to TensorFlow to augment the images. */
+  /**
+   * Container for a batch of images and their annotations, represented as
+   * float arrays.
+   */
   struct labeled_float_image {
-    /** The images to be augmented are raw images decoded
-     * and send to tf_image_augmneter as vector of shared_float_array
+    /**
+     * Either a vector of N float arrays that are each stored in HWC format but
+     * with potentially different sizes, or a single float array in NHWC format.
      */
     std::vector<shared_float_array> images;
 
-    /** The annotations of the images to be augmented are raw images decoded
-     * and send to tf_image_augmneter as vector of shared_float_array
+    /**
+     * The annotations of the images above. The size of this vector should equal
+     * the batch size N, but each float array may have different size, depending
+     * on the number of annotations for each image.
      */
     std::vector<shared_float_array> annotations;
   };
 
-  virtual float_array_result prepare_augmented_images(
+  virtual labeled_float_image prepare_augmented_images(
       labeled_float_image data_to_augment) = 0;
 
  private:

--- a/src/ml/neural_net/image_augmentation.hpp
+++ b/src/ml/neural_net/image_augmentation.hpp
@@ -288,7 +288,7 @@ class float_array_image_augmenter : public image_augmenter {
   /** The output sent from TensorFlow after augmenting the images. */
   struct float_array_result {
     /** The images after augmenting sent from Tensorflow */
-    shared_float_array images;
+    std::vector<shared_float_array> images;
 
     /** The annotations associated with augmented images sent from Tensorflow */
     std::vector<shared_float_array> annotations;

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -253,9 +253,9 @@ tf_image_augmenter::prepare_augmented_images(
             .cast<std::pair<pybind11::buffer, std::vector<pybind11::buffer>>>();
 
     pybind11::buffer_info buf_img = std::get<0>(aug_data).request();
-    image_annotations.images = turi::neural_net::shared_float_array::copy(
+    image_annotations.images.push_back(shared_float_array::copy(
         static_cast<float*>(buf_img.ptr),
-        std::vector<size_t>(buf_img.shape.begin(), buf_img.shape.end()));
+        std::vector<size_t>(buf_img.shape.begin(), buf_img.shape.end())));
     std::vector<turi::neural_net::shared_float_array> annotations_per_batch;
     std::vector<pybind11::buffer> aug_annotations = std::get<1>(aug_data);
 

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -119,7 +119,6 @@ class tf_model_backend : public model_backend {
   parallel_task_queue task_queue_;
 
   std::map<std::string, std::vector<size_t>> train_output_shapes_;
-  std::map<std::string, std::vector<size_t>> predict_output_shapes_;
 };
 
 tf_model_backend::tf_model_backend(pybind11::object model)


### PR DESCRIPTION
- Parallelize data augmentation across CPU cores
  - Refactor `float_array_image_augmenter` to allow for map-reduce-style parallelization
- Dispatch training to a task queue, to allow augmentation to occur in parallel with NN operations

To minimize risk, the async training is only implemented for OD training, for now