### PR TITLE
Fixed C++ unit test for export-coreml

### DIFF
--- a/src/toolkits/recsys/recsys_model_base.hpp
+++ b/src/toolkits/recsys/recsys_model_base.hpp
@@ -450,6 +450,8 @@ public:
   REGISTER_NAMED_CLASS_MEMBER_FUNCTION("export_to_coreml",
                                        recsys_model_base::export_to_coreml,
                                        "filename", "additional_user_defined");
+  register_defaults("export_to_coreml",
+      {{"additional_user_defined", to_variant(std::map<std::string, flexible_type>())}});
 
   REGISTER_NAMED_CLASS_MEMBER_FUNCTION(
       "precision_recall_by_user", recsys_model_base::api_precision_recall_by_user,

--- a/test/capi/capi_models.cxx
+++ b/test/capi/capi_models.cxx
@@ -392,32 +392,55 @@ BOOST_AUTO_TEST_CASE(test_recommender) {
       }
 
       if(std::string(model_name) == "item_similarity") {
-        tc_parameters* export_args = tc_parameters_create_empty(&error);
-        CAPI_CHECK_ERROR(error);
 
         {
-          std::string url = turi::fs_util::system_temp_directory_unique_path(
-            "", "_coreml_export_test_1_tmp.mlmodel");
-          tc_flexible_type* ft_name = tc_ft_create_from_cstring(url.c_str(), &error);
-          CAPI_CHECK_ERROR(error);
-          tc_parameters_add_flexible_type(export_args, "filename", ft_name,
-                                          &error);
-          CAPI_CHECK_ERROR(error);
+            tc_parameters* export_args = tc_parameters_create_empty(&error);
+            CAPI_CHECK_ERROR(error);
+            {
+              std::string url = turi::fs_util::system_temp_directory_unique_path(
+                "", "_coreml_export_test_1_tmp.mlmodel");
+              tc_flexible_type* ft_name = tc_ft_create_from_cstring(url.c_str(), &error);
+              CAPI_CHECK_ERROR(error);
+              tc_parameters_add_flexible_type(export_args, "filename", ft_name,
+                                              &error);
+              CAPI_CHECK_ERROR(error);
 
-          tc_flex_dict* fd_user_defined = tc_flex_dict_create(&error);
-          CAPI_CHECK_ERROR(error);
-          tc_parameters_add_flex_dict(export_args,
-              "additional_user_defined", fd_user_defined, &error);
-          CAPI_CHECK_ERROR(error);
+              tc_flex_dict* fd_user_defined = tc_flex_dict_create(&error);
+              CAPI_CHECK_ERROR(error);
+              tc_parameters_add_flex_dict(export_args,
+                  "additional_user_defined", fd_user_defined, &error);
+              CAPI_CHECK_ERROR(error);
 
-          tc_release(ft_name);
-          tc_release(fd_user_defined);
+              tc_release(ft_name);
+              tc_release(fd_user_defined);
+            }
+
+            tc_model_call_method(model, "export_to_coreml",
+                                 export_args, &error);
+            CAPI_CHECK_ERROR(error);
+            tc_release(export_args);
         }
 
-        tc_model_call_method(model, "export_to_coreml",
-                             export_args, &error);
-        CAPI_CHECK_ERROR(error);
-        tc_release(export_args);
+        // Default parameter check
+        {
+            tc_parameters* export_args = tc_parameters_create_empty(&error);
+            CAPI_CHECK_ERROR(error);
+            {
+              std::string url = turi::fs_util::system_temp_directory_unique_path(
+                "", "_coreml_export_test_1_tmp.mlmodel");
+              tc_flexible_type* ft_name = tc_ft_create_from_cstring(url.c_str(), &error);
+              CAPI_CHECK_ERROR(error);
+              tc_parameters_add_flexible_type(export_args, "filename", ft_name,
+                                              &error);
+              CAPI_CHECK_ERROR(error);
+              tc_release(ft_name);
+            }
+
+            tc_model_call_method(model, "export_to_coreml",
+                                 export_args, &error);
+            CAPI_CHECK_ERROR(error);
+            tc_release(export_args);
+        }
       }
     }
 

--- a/test/capi/capi_models.cxx
+++ b/test/capi/capi_models.cxx
@@ -403,7 +403,15 @@ BOOST_AUTO_TEST_CASE(test_recommender) {
           tc_parameters_add_flexible_type(export_args, "filename", ft_name,
                                           &error);
           CAPI_CHECK_ERROR(error);
+
+          tc_flex_dict* fd_user_defined = tc_flex_dict_create(&error);
+          CAPI_CHECK_ERROR(error);
+          tc_parameters_add_flex_dict(export_args,
+              "additional_user_defined", fd_user_defined, &error);
+          CAPI_CHECK_ERROR(error);
+
           tc_release(ft_name);
+          tc_release(fd_user_defined);
         }
 
         tc_model_call_method(model, "export_to_coreml",


### PR DESCRIPTION
The PR contains 2 commits
- Fixed the C++ test for export_coreml to include calling with the user defined metadata
- Added an additional test to preserve the original behavior and added default parameters