### PR TITLE
Reverting parallel augmentation change

### DIFF
--- a/src/ml/neural_net/image_augmentation.cpp
+++ b/src/ml/neural_net/image_augmentation.cpp
@@ -201,18 +201,14 @@ image_augmenter::result float_array_image_augmenter::prepare_images(
 
   // Call the virtual function to use the intermediate data structure and
   // process it
-  labeled_float_image augmented_data =
-      prepare_augmented_images(input_to_tf_aug);
+  float_array_result augmented_data = prepare_augmented_images(input_to_tf_aug);
 
   // Convert augmented_data to the data structure needed
   std::vector<float> result_array(n * h * w * c);
-  float* result_array_out = result_array.data();
-  for (const shared_float_array& image : augmented_data.images) {
-    size_t image_size = image.size();
-    const float* start_address = image.data();
-    const float* end_address = start_address + image_size;
-    result_array_out = std::copy(start_address, end_address, result_array_out);
-  }
+  size_t image_size = augmented_data.images.size();
+  const float* start_address = augmented_data.images.data();
+  const float* end_address = start_address + image_size;
+  std::copy(start_address, end_address, result_array.begin());
   res.image_batch =
       shared_float_array::wrap(std::move(result_array), {n, h, w, c});
 

--- a/src/ml/neural_net/image_augmentation.hpp
+++ b/src/ml/neural_net/image_augmentation.hpp
@@ -285,26 +285,29 @@ class float_array_image_augmenter : public image_augmenter {
   result prepare_images(std::vector<labeled_image> source_batch) override;
 
  protected:
-  /**
-   * Container for a batch of images and their annotations, represented as
-   * float arrays.
-   */
+  /** The output sent from TensorFlow after augmenting the images. */
+  struct float_array_result {
+    /** The images after augmenting sent from Tensorflow */
+    shared_float_array images;
+
+    /** The annotations associated with augmented images sent from Tensorflow */
+    std::vector<shared_float_array> annotations;
+  };
+
+  /** The output sent to TensorFlow to augment the images. */
   struct labeled_float_image {
-    /**
-     * Either a vector of N float arrays that are each stored in HWC format but
-     * with potentially different sizes, or a single float array in NHWC format.
+    /** The images to be augmented are raw images decoded
+     * and send to tf_image_augmneter as vector of shared_float_array
      */
     std::vector<shared_float_array> images;
 
-    /**
-     * The annotations of the images above. The size of this vector should equal
-     * the batch size N, but each float array may have different size, depending
-     * on the number of annotations for each image.
+    /** The annotations of the images to be augmented are raw images decoded
+     * and send to tf_image_augmneter as vector of shared_float_array
      */
     std::vector<shared_float_array> annotations;
   };
 
-  virtual labeled_float_image prepare_augmented_images(
+  virtual float_array_result prepare_augmented_images(
       labeled_float_image data_to_augment) = 0;
 
  private:

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -6,12 +6,8 @@
 #include <ml/neural_net/tf_compute_context.hpp>
 
 #include <iostream>
-#include <map>
-#include <string>
 #include <vector>
 
-#include <core/parallel/lambda_omp.hpp>
-#include <core/parallel/thread_pool.hpp>
 #include <core/util/try_finally.hpp>
 #include <ml/neural_net/image_augmentation.hpp>
 #include <ml/neural_net/model_backend.hpp>
@@ -104,27 +100,13 @@ class tf_model_backend : public model_backend {
   float_array_map export_weights() const override;
   void set_learning_rate(float lr) override;
 
-  // Setters for values needed to enable asynchronous computation, using
-  // deferred_float_array.
-  void set_train_output_shapes(
-      std::map<std::string, std::vector<size_t>> output_shapes) {
-    train_output_shapes_ = std::move(output_shapes);
-  }
-
  private:
-  float_array_map train_sync(const float_array_map& inputs);
-
   pybind11::object model_;
-  thread_pool thread_pool_;
-  parallel_task_queue task_queue_;
-
-  std::map<std::string, std::vector<size_t>> train_output_shapes_;
 };
 
-tf_model_backend::tf_model_backend(pybind11::object model)
-    : model_(model), thread_pool_(1), task_queue_(thread_pool_) {}
+tf_model_backend::tf_model_backend(pybind11::object model) : model_(model) {}
 
-float_array_map tf_model_backend::train_sync(const float_array_map& inputs) {
+float_array_map tf_model_backend::train(const float_array_map& inputs) {
   // Call train method on the TensorflowModel
   float_array_map result;
 
@@ -143,44 +125,6 @@ float_array_map tf_model_backend::train_sync(const float_array_map& inputs) {
       result[kv.first] = value;
     }
   });
-
-  return result;
-}
-
-float_array_map tf_model_backend::train(const float_array_map& inputs) {
-  // We can only use asynchronous training if we know the shapes of the outputs.
-  if (train_output_shapes_.empty()) {
-    return train_sync(inputs);
-  }
-
-  // Create a promise for each expected output.
-  std::map<std::string, std::shared_ptr<std::promise<shared_float_array>>>
-      promises;
-  for (const auto& kv : train_output_shapes_) {
-    promises[kv.first] = std::make_shared<std::promise<shared_float_array>>();
-  }
-
-  // Dispatch the call to TF to our worker thread.
-  auto perform_train = [inputs, promises, this] {
-    // Invoke TensorFlow.
-    float_array_map local_result = this->train_sync(inputs);
-
-    // Fulfill the promises we made.
-    for (const auto& kv : promises) {
-      kv.second->set_value(local_result.at(kv.first));
-    }
-  };
-  task_queue_.launch(perform_train);
-
-  // Return a result dictionary wrapping the futures for the promises dispatched
-  // to TensorFlow.
-  float_array_map result;
-  for (const auto& kv : train_output_shapes_) {
-    const std::string& key = kv.first;
-    const std::vector<size_t>& shape = kv.second;
-    result[key] = shared_float_array(std::make_shared<deferred_float_array>(
-        promises.at(key)->get_future(), shape));
-  }
 
   return result;
 }
@@ -253,69 +197,17 @@ class tf_image_augmenter : public float_array_image_augmenter {
   tf_image_augmenter(const options& opts);
   ~tf_image_augmenter() override = default;
 
-  labeled_float_image prepare_augmented_images(
+  float_array_result prepare_augmented_images(
       labeled_float_image data_to_augment) override;
-
- private:
-  labeled_float_image prepare_augmented_images_sync(
-      labeled_float_image data_to_augment);
 };
 
 tf_image_augmenter::tf_image_augmenter(const options& opts) : float_array_image_augmenter(opts) {}
 
-float_array_image_augmenter::labeled_float_image
+float_array_image_augmenter::float_array_result
 tf_image_augmenter::prepare_augmented_images(
-    labeled_float_image data_to_augment) {
-  size_t batch_size = data_to_augment.images.size();
-
-  // Allocate a result into which the worker threads can write their
-  // thread-local results in parallel.
-  labeled_float_image result;
-  result.images.resize(batch_size);
-  result.annotations.resize(batch_size);
-
-  auto perform_augmentations = [&](size_t thread_id, size_t num_threads) {
-    size_t range_start = batch_size * thread_id / num_threads;
-    size_t range_end = batch_size * (thread_id + 1) / num_threads;
-
-    // Slice out the inputs we need to augment.
-    labeled_float_image local_data_to_augment;
-    auto first_image_it = data_to_augment.images.begin();
-    auto first_annotation_it = data_to_augment.annotations.begin();
-    local_data_to_augment.images = std::vector<shared_float_array>(
-        first_image_it + range_start, first_image_it + range_end);
-    local_data_to_augment.annotations = std::vector<shared_float_array>(
-        first_annotation_it + range_start, first_annotation_it + range_end);
-
-    // Augment the slice.
-    labeled_float_image local_result =
-        this->prepare_augmented_images_sync(local_data_to_augment);
-
-    // Write the result into the appropriate slice of the shared output.
-    result.images[thread_id] = local_result.images[0];
-    for (size_t i = range_start; i < range_end; ++i) {
-      result.annotations[i] = local_result.annotations[i - range_start];
-    }
-  };
-  in_parallel(perform_augmentations);
-
-  // Trim the result images, which are populated at one element per thread, not
-  // one element per image.
-  auto unused_output = [](const shared_float_array& image) {
-    return image.dim() == 0;
-  };
-  auto new_end =
-      std::remove_if(result.images.begin(), result.images.end(), unused_output);
-  result.images.erase(new_end, result.images.end());
-
-  return result;
-}
-
-float_array_image_augmenter::labeled_float_image
-tf_image_augmenter::prepare_augmented_images_sync(
     float_array_image_augmenter::labeled_float_image data_to_augment) {
   options opts = get_options();
-  float_array_image_augmenter::labeled_float_image image_annotations;
+  float_array_image_augmenter::float_array_result image_annotations;
 
   call_pybind_function([&]() {
     // Import the module from python that does data augmentation
@@ -340,9 +232,9 @@ tf_image_augmenter::prepare_augmented_images_sync(
             .cast<std::pair<pybind11::buffer, std::vector<pybind11::buffer>>>();
 
     pybind11::buffer_info buf_img = std::get<0>(aug_data).request();
-    image_annotations.images.push_back(shared_float_array::copy(
+    image_annotations.images = turi::neural_net::shared_float_array::copy(
         static_cast<float*>(buf_img.ptr),
-        std::vector<size_t>(buf_img.shape.begin(), buf_img.shape.end())));
+        std::vector<size_t>(buf_img.shape.begin(), buf_img.shape.end()));
     std::vector<turi::neural_net::shared_float_array> annotations_per_batch;
     std::vector<pybind11::buffer> aug_annotations = std::get<1>(aug_data);
 
@@ -421,13 +313,6 @@ std::unique_ptr<model_backend> tf_compute_context::create_object_detector(
           "ODTensorFlowModel")(h_in, w_in, n, c_out, h_out, w_out, weights, config);
       result.reset(new tf_model_backend(object_detector));
     });
-
-  // Enable asynchronous training.
-  // TODO: Match the MPS implementation, which has loss shape {batch_size}
-  std::map<std::string, std::vector<size_t>> output_shapes;
-  output_shapes["loss"] = {1};
-  result->set_train_output_shapes(std::move(output_shapes));
-
   return result;
 }
 

--- a/src/ml/neural_net/tf_compute_context.cpp
+++ b/src/ml/neural_net/tf_compute_context.cpp
@@ -271,7 +271,7 @@ tf_image_augmenter::prepare_augmented_images(
   // Allocate a result into which the worker threads can write their
   // thread-local results in parallel.
   labeled_float_image result;
-  result.images.resize(thread::cpu_count());
+  result.images.resize(batch_size);
   result.annotations.resize(batch_size);
 
   auto perform_augmentations = [&](size_t thread_id, size_t num_threads) {


### PR DESCRIPTION
- Revert "Fixed typo in image augmentation. (#2816)"
- Revert "Performance improvements for TF OD (#2807)"

@nickjong @hoytak I'm putting up a PR just in case the parallel changes interact not so well with the augmentation. I'd like this change to be ready and tested just in case.