### PR TITLE
Enable 10.13 macOS Tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,25 +359,23 @@ test_python_linux_python37:
     paths:
       - pytest.*
 
-# This coremltools issues needs to be resolved before we can run on macOS 10.13
-# https://github.com/apple/coremltools/issues/408
-#test_python_mac_python27_10_13:
-#  tags:
-#    - macos10.13
-#  only:
-#    variables:
-#      - $TC_HAS_MACOS_RUNNERS == "1"
-#  stage: test
-#  dependencies:
-#    - build_wheel_mac_10_15_python27
-#  script:
-#    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
-#    - bash scripts/test_wheel.sh
-#  artifacts:
-#    when: always
-#    expire_in: 2 weeks
-#    paths:
-#      - pytest.*
+test_python_mac_python27_10_13:
+  tags:
+    - macos10.13
+  only:
+    variables:
+      - $TC_HAS_MACOS_RUNNERS == "1"
+  stage: test
+  dependencies:
+    - build_wheel_mac_10_15_python27
+  script:
+    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
+    - bash scripts/test_wheel.sh
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+      - pytest.*
 
 test_python_mac_python27_10_14:
   tags:
@@ -502,21 +500,19 @@ scenario_tests_linux_python36:
     - cd scenario-tests
     - ./run_scenario_tests.sh --docker-python3.6 ../target/turicreate-*.whl
 
-# This coremltools issues needs to be resolved before we can run on macOS 10.13
-# https://github.com/apple/coremltools/issues/408
-#scenario_tests_mac_python27_10_13:
-#  tags:
-#    - macos10.13
-#  only:
-#    variables:
-#      - $TC_HAS_MACOS_RUNNERS == "1"
-#  stage: test
-#  dependencies:
-#    - build_wheel_mac_10_15_python27
-#  script:
-#    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
-#    - cd scenario-tests
-#    - ./run_scenario_tests.sh ../target/turicreate-*.whl
+scenario_tests_mac_python27_10_13:
+  tags:
+    - macos10.13
+  only:
+    variables:
+      - $TC_HAS_MACOS_RUNNERS == "1"
+  stage: test
+  dependencies:
+    - build_wheel_mac_10_15_python27
+  script:
+    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
+    - cd scenario-tests
+    - ./run_scenario_tests.sh ../target/turicreate-*.whl
 
 scenario_tests_mac_python27_10_14:
   tags:


### PR DESCRIPTION
Since [coremltools has fixed their issues with 10.13 macOS](https://github.com/apple/coremltools/issues/408) and we now depend on the most recent version, we can enable our 10.13 tests again.