### PR TITLE
FIx for CoreML import issues: Finer grain CoreML namespace mangling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,6 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 
 # Defines to avoid symbol collisions
 add_definitions(-Dgoogle=_tc_google)
-add_definitions(-DCoreML=_tc_CoreML)
 
 #**************************************************************************/
 #*                                                                        */

--- a/src/external/coremltools_wrap/CMakeLists.txt
+++ b/src/external/coremltools_wrap/CMakeLists.txt
@@ -17,6 +17,6 @@ make_library(coremltools_mlmodel
   EXTERNAL_VISIBILITY
   )
 
-target_compile_options(coremltools_mlmodel INTERFACE "-w")
+target_compile_options(coremltools_mlmodel INTERFACE "-w -DCoreML=__tc_coreml")
 
 


### PR DESCRIPTION
Currently, we hide the CoreML:: namespace in order to allow our internal source drop of coremltools to exist alongside the coremltools python package in the same python process.  However, this needs to be done carefully in order to allow us to still call into the CoreML framework.  When this is messed up, then the CoreML framework has issues loading.  