### PR TITLE
Better tarfile management for OSOD.

### DIFF
--- a/src/python/turicreate/toolkits/_data_zoo.py
+++ b/src/python/turicreate/toolkits/_data_zoo.py
@@ -21,6 +21,9 @@ class OneShotObjectDetectorBackgroundData(object):
     def __init__(self):
         self.source_tar_filename = "one_shot_backgrounds.sarray.tar"
         self.destination_tar_filename = "one_shot_backgrounds.sarray.tar"
+        self.destination_sarray_filename = "one_shot_backgrounds.sarray"
+        self.destination_sarray_path = _os.path.join(_get_cache_dir("data"),
+            self.destination_sarray_filename)
         self.sarray_url = _urlparse.urljoin(
             DATA_URL_ROOT, self.source_tar_filename)
         self.sarray_url_md5_pairs = [
@@ -28,7 +31,11 @@ class OneShotObjectDetectorBackgroundData(object):
             ]
 
     def get_backgrounds_path(self):
-        backgrounds_path = _download_and_checksum_files(
+        if _os.path.exists(self.destination_sarray_path):
+            return self.destination_sarray_path
+        tarfile_path = _download_and_checksum_files(
             self.sarray_url_md5_pairs, _get_cache_dir("data")
             )[0]
-        return backgrounds_path
+        backgrounds_tar = _tarfile.open(tarfile_path)
+        backgrounds_tar.extractall(_get_cache_dir("data"))
+        return self.destination_sarray_path

--- a/src/python/turicreate/toolkits/_data_zoo.py
+++ b/src/python/turicreate/toolkits/_data_zoo.py
@@ -10,6 +10,7 @@ import os as _os
 import sys as _sys
 import requests as _requests
 import turicreate as _tc
+import tarfile as _tarfile
 import hashlib as _hashlib
 from six.moves.urllib import parse as _urlparse
 from ._pre_trained_models import _download_and_checksum_files

--- a/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
@@ -47,8 +47,7 @@ def preview_synthetic_training_data(data,
     seed = kwargs["seed"] if "seed" in kwargs else _random.randint(0, 2**32 - 1)
     if backgrounds is None:
         backgrounds_downloader = _data_zoo.OneShotObjectDetectorBackgroundData()
-        backgrounds_sarray_path = backgrounds_downloader.get_backgrounds_path()
-        backgrounds = _tc.SArray(backgrounds_sarray_path)
+        backgrounds = backgrounds_downloader.get_backgrounds()
         # We resize the background dimensions by half along each axis to reduce
         # the disk footprint during augmentation, and also reduce the time
         # taken to synthesize data. 

--- a/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
@@ -48,10 +48,8 @@ def preview_synthetic_training_data(data,
     seed = kwargs["seed"] if "seed" in kwargs else _random.randint(0, 2**32 - 1)
     if backgrounds is None:
         backgrounds_downloader = _data_zoo.OneShotObjectDetectorBackgroundData()
-        backgrounds_tar_path = backgrounds_downloader.get_backgrounds_path()
-        backgrounds_tar = _tarfile.open(backgrounds_tar_path)
-        backgrounds_tar.extractall()
-        backgrounds = _tc.SArray("one_shot_backgrounds.sarray")
+        backgrounds_sarray_path = backgrounds_downloader.get_backgrounds_path()
+        backgrounds = _tc.SArray(backgrounds_sarray_path)
         # We resize the background dimensions by half along each axis to reduce
         # the disk footprint during augmentation, and also reduce the time
         # taken to synthesize data. 

--- a/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
@@ -5,7 +5,6 @@
 # be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
 
 import random as _random
-import tarfile as _tarfile
 import turicreate as _tc
 from turicreate import extensions as _extensions
 import turicreate.toolkits._internal_utils as _tkutl


### PR DESCRIPTION
Fixes #2005 

**Summary**

- We move the logic to unzip the backgrounds tarball to when the tarball is downloaded the first time.
- We save the unzipped tarball in the data cache instead of the current directory. This facilitates looking up in the data cache and avoiding multiple downloads and unzips. 