### PR TITLE
enable case-insensitive protocol

### DIFF
--- a/src/core/storage/fileio/dmlcio/filesys.h
+++ b/src/core/storage/fileio/dmlcio/filesys.h
@@ -13,6 +13,7 @@
 #define DMLC_IO_FILESYS_H_
 
 #include <core/logging/assertions.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <algorithm>
 #include <cstring>
@@ -44,9 +45,7 @@ struct URI {
     } else {
       protocol = std::string(uri, p - uri + 3);
       // defensive, in case caller forget to lower case the protocol
-      std::transform(protocol.begin(), protocol.begin() + protocol.size() - 3,
-                     protocol.begin(),
-                     [](unsigned char c) { return std::tolower(c); });
+      boost::algorithm::to_lower_copy(protocol.begin(), protocol);
       uri = p + 3;
       p = std::strchr(uri, '/');
       if (p == NULL) {

--- a/src/core/storage/fileio/dmlcio/filesys.h
+++ b/src/core/storage/fileio/dmlcio/filesys.h
@@ -12,8 +12,11 @@
 #ifndef DMLC_IO_FILESYS_H_
 #define DMLC_IO_FILESYS_H_
 
+#include <core/logging/assertions.hpp>
+
 #include <cstring>
 #include <string>
+
 #include "io.h"
 
 namespace dmlc {
@@ -39,6 +42,8 @@ struct URI {
       name = uri;
     } else {
       protocol = std::string(uri, p - uri + 3);
+      protocol.front() = std::tolower(protocol.front());
+      ASSERT_MSG((protocol == "s3://"), "Invalid protocol for s3 file system");
       uri = p + 3;
       p = std::strchr(uri, '/');
       if (p == NULL) {

--- a/src/core/storage/fileio/dmlcio/filesys.h
+++ b/src/core/storage/fileio/dmlcio/filesys.h
@@ -14,6 +14,7 @@
 
 #include <core/logging/assertions.hpp>
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 
@@ -42,8 +43,10 @@ struct URI {
       name = uri;
     } else {
       protocol = std::string(uri, p - uri + 3);
-      protocol.front() = std::tolower(protocol.front());
-      ASSERT_MSG((protocol == "s3://"), "Invalid protocol for s3 file system");
+      // defensive, in case caller forget to lower case the protocol
+      std::transform(protocol.begin(), protocol.begin() + protocol.size() - 3,
+                     protocol.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
       uri = p + 3;
       p = std::strchr(uri, '/');
       if (p == NULL) {

--- a/src/core/storage/fileio/fs_utils.cpp
+++ b/src/core/storage/fileio/fs_utils.cpp
@@ -440,8 +440,7 @@ EXPORT std::string get_protocol(std::string path) {
   size_t proto = path.find("://");
   if (proto != std::string::npos) {
     std::string ret = boost::algorithm::to_lower_copy(path.substr(0, proto));
-    std::transform(ret.begin(), ret.end(), ret.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+    boost::algorithm::to_lower_copy(ret.begin(), ret);
     return ret;
   } else {
     // denote this is a local file

--- a/src/core/storage/fileio/fs_utils.cpp
+++ b/src/core/storage/fileio/fs_utils.cpp
@@ -133,7 +133,7 @@ std::tuple<std::string, std::string, std::string> parse_hdfs_url(std::string url
 
 EXPORT std::pair<file_status, std::string> get_file_status(const std::string& path) {
   std::string err_msg;
-  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+  if (boost::istarts_with(path, fileio::get_cache_prefix())) {
     // this is a cache file. it is only REGULAR or MISSING
     try {
       fixed_size_cache_manager::get_instance().get_cache(path);
@@ -182,7 +182,7 @@ EXPORT std::pair<file_status, std::string> get_file_status(const std::string& pa
 std::vector<std::pair<std::string, file_status>>
 get_directory_listing(const std::string& path) {
   std::vector<std::pair<std::string, file_status> > ret;
-  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+  if (boost::istarts_with(path, fileio::get_cache_prefix())) {
     // this is a cache file. There is no filesystem.
     // it is only REGULAR or MISSING
     return ret;
@@ -340,7 +340,7 @@ bool delete_path_impl(const std::string& path,
     return false;
   }
   logstream(LOG_INFO) << "Deleting " << sanitize_url(path) << std::endl;
-  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+  if (boost::istarts_with(path, fileio::get_cache_prefix())) {
     try {
       // we ignore recursive here. since the cache can't hold directories
       auto cache_entry = fixed_size_cache_manager::get_instance().get_cache(path);
@@ -393,7 +393,7 @@ EXPORT bool delete_path_recursive(const std::string& path) {
     return true;
   }
 
-  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+  if (boost::istarts_with(path, fileio::get_cache_prefix())) {
     // recursive deletion not possible with cache
     return true;
 #ifndef TC_DISABLE_REMOTEFS
@@ -442,14 +442,9 @@ EXPORT std::string get_protocol(std::string path) {
     std::string ret = boost::algorithm::to_lower_copy(path.substr(0, proto));
     std::transform(ret.begin(), ret.end(), ret.begin(),
                    [](unsigned char c) { return std::tolower(c); });
-    // Strip out file as a specific protocol
-    if(ret == "file") {
-      return "";
-    } else {
-      return ret;
-    }
-
+    return ret;
   } else {
+    // denote this is a local file
     return "";
   }
 }
@@ -720,7 +715,7 @@ bool change_file_mode(const std::string path, short mode) {
 #else
       return false;
 #endif
-  } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
+  } else if (boost::istarts_with(path, fileio::get_cache_prefix())) {
     // this is a cache file. There is no filesystem.
     return true;
   } else if (get_protocol(path) == "s3") {

--- a/src/core/storage/fileio/fs_utils.cpp
+++ b/src/core/storage/fileio/fs_utils.cpp
@@ -159,7 +159,7 @@ EXPORT std::pair<file_status, std::string> get_file_status(const std::string& pa
       // failure for some reason. fail with missing
       return {file_status::MISSING, ex.what()};
     }
-  } else if (get_protocol(path) == "s3")) {
+  } else if (get_protocol(path) == "s3") {
     auto ret = is_directory(path);
     return {ret.first, ret.second.error};
   } else if (is_web_protocol(get_protocol(path))) {
@@ -370,7 +370,7 @@ bool delete_path_impl(const std::string& path,
       // failure for some reason. return with nothing
       return false;
     }
-  } else if (get_protocol(path) == "s3")) {
+  } else if (get_protocol(path) == "s3") {
     return delete_object(path).empty();
 #endif
   } else {

--- a/src/core/storage/fileio/fs_utils.cpp
+++ b/src/core/storage/fileio/fs_utils.cpp
@@ -61,7 +61,7 @@ std::tuple<std::string, std::string, std::string> parse_hdfs_url(std::string url
     return std::make_tuple(default_host, default_port, default_path);
   };
 
-  if (get_protocol(url) != "hdfs://") {
+  if (get_protocol(url) != "hdfs") {
     return warn_and_return_default();
   };
 

--- a/src/core/storage/fileio/fs_utils.cpp
+++ b/src/core/storage/fileio/fs_utils.cpp
@@ -61,7 +61,7 @@ std::tuple<std::string, std::string, std::string> parse_hdfs_url(std::string url
     return std::make_tuple(default_host, default_port, default_path);
   };
 
-  if (!boost::starts_with(url, "hdfs://")) {
+  if (get_protocol(url) != "hdfs://") {
     return warn_and_return_default();
   };
 
@@ -142,7 +142,7 @@ EXPORT std::pair<file_status, std::string> get_file_status(const std::string& pa
       return std::make_pair(file_status::MISSING, std::string(ex.what()));
     }
 #ifndef TC_DISABLE_REMOTEFS
-  } else if(boost::starts_with(path, "hdfs://")) {
+  } else if(get_protocol(path) == "hdfs") {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -159,7 +159,7 @@ EXPORT std::pair<file_status, std::string> get_file_status(const std::string& pa
       // failure for some reason. fail with missing
       return {file_status::MISSING, ex.what()};
     }
-  } else if (boost::starts_with(path, "s3://")) {
+  } else if (get_protocol(path) == "s3")) {
     auto ret = is_directory(path);
     return {ret.first, ret.second.error};
   } else if (is_web_protocol(get_protocol(path))) {
@@ -187,7 +187,7 @@ get_directory_listing(const std::string& path) {
     // it is only REGULAR or MISSING
     return ret;
 #ifndef TC_DISABLE_REMOTEFS
-  } else if(boost::starts_with(path, "hdfs://")) {
+  } else if(get_protocol(path) == "hdfs") {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -207,7 +207,7 @@ get_directory_listing(const std::string& path) {
     } catch(...) {
       // failure for some reason. return with nothing
     }
-  } else if (boost::starts_with(path, "s3://")) {
+  } else if (get_protocol(path) == "s3") {
     list_objects_response response = list_directory(path);
     for (auto dir: response.directories) {
       ret.push_back({dir, file_status::DIRECTORY});
@@ -248,7 +248,7 @@ EXPORT bool create_directory(const std::string& path) {
     // this is a cache file. There is no filesystem.
     return true;
 #ifndef TC_DISABLE_REMOTEFS
-  } else if(boost::starts_with(path, "hdfs://")) {
+  } else if(get_protocol(path) == "hdfs") {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -261,7 +261,7 @@ EXPORT bool create_directory(const std::string& path) {
       // failure for some reason. return with nothing
       return false;
     }
-  } else if (boost::starts_with(path, "s3://")) {
+  } else if (get_protocol(path) == "s3") {
     // S3 doesn't need directories
     return true;
 #endif
@@ -281,7 +281,7 @@ EXPORT bool create_directory_or_throw(const std::string& path) {
 
   // this function throws if the directory still doesn't exist
   // at that location
-  if (!boost::starts_with(path, "s3://")) {
+  if (get_protocol(path) == "s3") {
     auto status = get_file_status(path);
     switch (status.first) {
       case file_status::MISSING:
@@ -350,7 +350,7 @@ bool delete_path_impl(const std::string& path,
       return false;
     }
 #ifndef TC_DISABLE_REMOTEFS
-  } else if(boost::starts_with(path, "hdfs://")) {
+  } else if(get_protocol(path) == "hdfs") {
     // hdfs only has a recursive deleter. we need to make this safe
     // if the current path is a non-empty directory, fail
     if (stat == file_status::DIRECTORY) {
@@ -370,7 +370,7 @@ bool delete_path_impl(const std::string& path,
       // failure for some reason. return with nothing
       return false;
     }
-  } else if (boost::starts_with(path, "s3://")) {
+  } else if (get_protocol(path) == "s3")) {
     return delete_object(path).empty();
 #endif
   } else {
@@ -397,7 +397,7 @@ EXPORT bool delete_path_recursive(const std::string& path) {
     // recursive deletion not possible with cache
     return true;
 #ifndef TC_DISABLE_REMOTEFS
-  } else if(boost::starts_with(path, "hdfs://")) {
+  } else if(get_protocol(path) == "hdfs") {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -410,7 +410,7 @@ EXPORT bool delete_path_recursive(const std::string& path) {
       // failure for some reason. return with nothing
       return false;
     }
-  } else if(boost::starts_with(path, "s3://")) {
+  } else if(get_protocol(path) == "s3") {
     return delete_prefix(path).empty();
 #endif
   } else {
@@ -440,6 +440,8 @@ EXPORT std::string get_protocol(std::string path) {
   size_t proto = path.find("://");
   if (proto != std::string::npos) {
     std::string ret = boost::algorithm::to_lower_copy(path.substr(0, proto));
+    std::transform(ret.begin(), ret.end(), ret.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
     // Strip out file as a specific protocol
     if(ret == "file") {
       return "";
@@ -701,7 +703,7 @@ bool change_file_mode(const std::string path, short mode) {
     return false;
   }
 
-  if(boost::starts_with(path, "hdfs://")) {
+  if(get_protocol(path) == "hdfs") {
 #ifdef HAS_HADOOP
     // hdfs
     std::string host, port, hdfspath;
@@ -721,7 +723,7 @@ bool change_file_mode(const std::string path, short mode) {
   } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
     // this is a cache file. There is no filesystem.
     return true;
-  } else if (boost::starts_with(path, "s3://")) {
+  } else if (get_protocol(path) == "s3") {
     // S3 doesn't need directories
     return true;
   } else {

--- a/src/core/storage/fileio/fs_utils.hpp
+++ b/src/core/storage/fileio/fs_utils.hpp
@@ -127,12 +127,16 @@ bool is_writable_protocol(std::string protocol);
  * Returns true if the protocol is a protocol we will make curl handle.
  */
 bool is_web_protocol(std::string protocol);
+
 /**
  * Returns the protocol header. (everything before the ://).
+ *
+ * local file can have protocol "file" or ""
  *
  * get_protocol("http://www.google.com") == "http"
  * get_protocol("s3://www.google.com") == "s3"
  * get_protocol("/root/test") == ""
+ * get_protocol("file:///root/test") == "file"
  */
 std::string get_protocol(std::string path);
 
@@ -140,9 +144,10 @@ std::string get_protocol(std::string path);
  * \ingroup fileio
  * Returns the path removing the protocol header if there is one. .
  *
- * get_protocol("http://www.google.com") == "www.google.com"
- * get_protocol("s3://www.google.com") == "www.google.com"
- * get_protocol("/root/test") == "/root/test"
+ * remove_protocol("http://www.google.com") == "www.google.com"
+ * remove_protocol("s3://www.google.com") == "www.google.com"
+ * remove_protocol("/root/test") == "/root/test"
+ * remove_protocol("file:///root/test") == "/root/test"
  */
 std::string remove_protocol(std::string path);
 

--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -138,7 +138,7 @@ const std::vector<std::string> S3Operation::_enum_to_str = {
  */
 bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
   // must begin with s3://
-  if (!boost::algorithm::starts_with(url, "s3://")) {
+  if (fileio::get_protocol(url) != "s3") {
     err_msg = url + " doesn't start with 's3://'";
     return false;
   }
@@ -150,34 +150,36 @@ bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
   std::stringstream ss;
   size_t splitpos = url.find(':');
   if (splitpos == std::string::npos) {
-    ss << "Cannot find AWS_ACCESS_KEY_ID in the s3 url." << __FILE__ << " at " << __LINE__;
+    ss << "Cannot find AWS_ACCESS_KEY_ID in the s3 url." << __FILE__ << " at "
+       << __LINE__;
     err_msg = ss.str();
     logstream(LOG_WARNING) << err_msg << std::endl;
     return false;
   } else {
     ret.access_key_id = url.substr(0, splitpos);
-    url= url.substr(splitpos + 1);
+    url = url.substr(splitpos + 1);
   }
   // Extract the secret key
   splitpos = url.find(':');
   if (splitpos == std::string::npos) {
-    ss << "Cannot find SECRET_AWS_ACCESS_KEY in the s3 url." << __LINE__ << " at " << __FILE__;
+    ss << "Cannot find SECRET_AWS_ACCESS_KEY in the s3 url." << __LINE__
+       << " at " << __FILE__;
     err_msg = ss.str();
     logstream(LOG_WARNING) << err_msg << std::endl;
     return false;
   } else {
-    ret.secret_key= url.substr(0, splitpos);
-    url= url.substr(splitpos + 1);
+    ret.secret_key = url.substr(0, splitpos);
+    url = url.substr(splitpos + 1);
   }
 
   // The rest is parsed using boost::tokenizer
-  typedef boost::tokenizer<boost::char_separator<char> >
-    tokenizer;
+  typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
   boost::char_separator<char> sep("/");
   tokenizer tokens(url, sep);
   tokenizer::iterator iter = tokens.begin();
   if (iter == tokens.end()) {
-    ss << "missing endpoint or bucket or object key in " << url << __FILE__ << "at" << __LINE__;
+    ss << "missing endpoint or bucket or object key in " << url << __FILE__
+       << "at" << __LINE__;
     err_msg = ss.str();
     return false;
   }
@@ -214,7 +216,7 @@ bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
 
   ret.object_name = *iter;
   ++iter;
-  while(iter != tokens.end()) {
+  while (iter != tokens.end()) {
     ret.object_name += "/" + *iter;
     ++iter;
   }
@@ -226,7 +228,6 @@ bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
   //           << "Endpoint: " << ret.endpoint << "\n";
   return true;
 }
-
 
 // The options we pass to aws cli for s3 commands
 // "us-east-1" is the us-standard and it works with buckets from all regions
@@ -709,7 +710,7 @@ std::string delete_prefix(std::string url,
 
 std::string sanitize_s3_url_aggressive(std::string url) {
   // must begin with s3://
-  if (!boost::algorithm::starts_with(url, "s3://")) {
+  if (fileio::get_protocol(url) != "s3") {
     return url;
   }
   // strip the s3://

--- a/src/core/storage/fileio/sanitize_url.cpp
+++ b/src/core/storage/fileio/sanitize_url.cpp
@@ -9,6 +9,7 @@
 #include <core/storage/fileio/sanitize_url.hpp>
 #include <core/export.hpp>
 #ifndef TC_DISABLE_REMOTEFS
+#include <core/storage/fileio/fs_utils.hpp>
 #include <core/storage/fileio/s3_api.hpp>
 #endif
 
@@ -16,7 +17,7 @@ namespace turi {
 
 EXPORT std::string sanitize_url(std::string url) {
 #ifndef TC_DISABLE_REMOTEFS
-  if (boost::algorithm::starts_with(url, "s3://")) {
+  if (fileio::get_protocol(url) == "s3") {
 #ifdef TC_BUILD_IOS
     log_and_throw_io_failure("Not implemented: compiled without support for s3:// URLs.");
 #else

--- a/src/core/storage/fileio/union_fstream.cpp
+++ b/src/core/storage/fileio/union_fstream.cpp
@@ -44,8 +44,9 @@ union_fstream::union_fstream(std::string url,
   }
 
   bool is_output_stream = (mode & std::ios_base::out);
-
-  if (fileio::get_protocol(url) == fileio::get_cache_prefix()) {
+  // since there's temp cache file starts with protocol cache,
+  // we need special scrutiny to use the full prefix
+  if (boost::algorithm::istarts_with(url, fileio::get_cache_prefix())) {
     // Cache file type
     type = CACHE;
     if (is_output_stream) {
@@ -102,7 +103,7 @@ union_fstream::union_fstream(std::string url,
 #endif
   } else {
     // Remove the preceeding file:// if it's a local URL.
-    if(boost::algorithm::starts_with(url, "file://")) {
+    if(fileio::get_protocol(url) == "file") {
       url = url.substr(7);
     }
 

--- a/src/core/storage/fileio/union_fstream.cpp
+++ b/src/core/storage/fileio/union_fstream.cpp
@@ -105,15 +105,16 @@ union_fstream::union_fstream(std::string url,
       log_and_throw_io_failure("Cannot open " + url + " for reading; Remote FS support disabled.");
 #endif
   } else {
-    // Remove the preceeding file:// if it's a local URL.
+    // Remove the preceeding file:// if it's a local URL starting with file://
     if(protocol == "file") {
       url = url.substr(7);
-    } else {
-      ASSERT_MSG(protocol.empty(),
-                 ("unspported protocol: " + protocol).c_str());
     }
 
-    // must be local file
+    /*
+     * now, it can be
+     * 1. local file
+     * 2. http or https
+     */
     if (is_output_stream) {
       // Output stream must be a local openable file.
       output_stream.reset(new std::ofstream(url, std::ofstream::binary));
@@ -121,6 +122,7 @@ union_fstream::union_fstream(std::string url,
         log_and_throw_current_io_failure();
       }
     } else {
+      // handles http and https cases
       url = file_download_cache::get_instance().get_file(url);
       input_stream.reset(new std::ifstream(url, std::ifstream::binary));
       if (!input_stream->good()) {

--- a/test/fileio/general_fstream_test.cxx
+++ b/test/fileio/general_fstream_test.cxx
@@ -107,7 +107,7 @@ struct general_fstream_test {
       TS_ASSERT_EQUALS(get_protocol("hdfs://"), "hdfs");
       TS_ASSERT_EQUALS(get_protocol("s3://pikachu"), "s3");
       TS_ASSERT_EQUALS(get_protocol("/pikachu"), "");
-      TS_ASSERT_EQUALS(get_protocol("file:///pikachu"), "");
+      TS_ASSERT_EQUALS(get_protocol("file:///pikachu"), "file");
       TS_ASSERT_EQUALS(get_protocol("http://pikachu"), "http");
 
       TS_ASSERT_EQUALS(remove_protocol("hdfs://"), "");


### PR DESCRIPTION
resolve #394 

protocol in the url remains its original case, which should be handled by the remote fs.

```cpp
dir_archive_impl::archive_index_information read_index_file(std::string index_file) {
  general_ifstream fin(index_file);
...
```