### PR TITLE
clean up models name function.

### DIFF
--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -653,7 +653,7 @@ class CustomModel(ExposeAttributesFromProxy):
         --------
         >>> model_name = m.name()
         """
-        warnings.warn("CustomModel.name() is deprecated. It will be removed in the next major release. Use type(CustomModel) instead.")
+        warnings.warn("This function is deprecated. It will be removed in the next release.")
         return self.__class__.__name__
 
     def summary(self, output=None):

--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -642,7 +642,7 @@ class CustomModel(ExposeAttributesFromProxy):
         Returns the name of the model.
 
         ..WARNING:: This function is deprecated, It will be removed in the next
-        major release. Use type(CustomModel) instead.
+        release. Use type(CustomModel) instead.
 
         Returns
         -------

--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -24,6 +24,7 @@ import turicreate.util._file_util as file_util
 import os
 from copy import copy as _copy
 import six as _six
+import warnings
 
 MODEL_NAME_MAP = {}
 
@@ -636,9 +637,12 @@ class CustomModel(ExposeAttributesFromProxy):
     def __init__(self):
         pass
 
-    def _name(self):
+    def name(self):
         """
         Returns the name of the model.
+
+        ..WARNING:: This function is deprecated, It will be removed in the next
+        major release. Use type(CustomModel) instead.
 
         Returns
         -------
@@ -649,6 +653,7 @@ class CustomModel(ExposeAttributesFromProxy):
         --------
         >>> model_name = m.name()
         """
+        warnings.warn("CustomModel.name() is deprecated. It will be removed in the next major release. Use type(CustomModel) instead.")
         return self.__class__.__name__
 
     def summary(self, output=None):

--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -636,7 +636,7 @@ class CustomModel(ExposeAttributesFromProxy):
     def __init__(self):
         pass
 
-    def name(self):
+    def _name(self):
         """
         Returns the name of the model.
 

--- a/src/python/turicreate/toolkits/_model.py
+++ b/src/python/turicreate/toolkits/_model.py
@@ -653,7 +653,7 @@ class CustomModel(ExposeAttributesFromProxy):
         --------
         >>> model_name = m.name()
         """
-        warnings.warn("This function is deprecated. It will be removed in the next release.")
+        warnings.warn("This function is deprecated. It will be removed in the next release. Please use python's builtin type function instead.")
         return self.__class__.__name__
 
     def summary(self, output=None):


### PR DESCRIPTION
#2859 

change the `name()` function to `_name()` for `custom_model` class,
in order to remove the `name` function from all documentations.