### PR TITLE
API for allowing calls to extension functions to run on a background thread

### DIFF
--- a/src/model_server/lib/CMakeLists.txt
+++ b/src/model_server/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ make_library(unity_core OBJECT
     unity_global.cpp
     unity_global_singleton.cpp
     get_toolkit_function_from_closure.cpp
+    toolkit_function_response.cpp
     toolkit_class_registry.cpp
     toolkit_function_registry.cpp
     simple_model.cpp

--- a/src/model_server/lib/toolkit_function_response.cpp
+++ b/src/model_server/lib/toolkit_function_response.cpp
@@ -1,0 +1,33 @@
+#include <model_server/lib/toolkit_function_response.hpp>
+#include <iostream>
+
+namespace turi {
+
+toolkit_function_response_future::toolkit_function_response_future(std::function<toolkit_function_response_type()> exec_function) :
+  m_info(new response_info) {
+
+    auto captured_info = this->m_info; 
+
+m_info->response_future = std::async(std::launch::async, 
+  [=]() {
+     captured_info->response = exec_function();
+     captured_info->is_completed = true;
+     return true;
+  });
+
+ ASSERT_TRUE(m_info->response_future.valid());
+}
+
+const toolkit_function_response_type& toolkit_function_response_future::wait() const {
+  ASSERT_TRUE(m_info != nullptr); 
+  ASSERT_TRUE(m_info->response_future.valid()); 
+       
+  m_info->response_future.wait(); 
+
+  ASSERT_EQ(m_info->response_future.get(), true); 
+  ASSERT_TRUE(m_info->is_completed);
+
+  return m_info->response;
+}
+
+}

--- a/src/model_server/lib/toolkit_function_response.hpp
+++ b/src/model_server/lib/toolkit_function_response.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <model_server/lib/variant.hpp>
 #include <core/storage/serialization/serialization_includes.hpp>
+#include <future>
 
 namespace turi {
 
@@ -42,6 +43,29 @@ struct toolkit_function_response_type {
   }
 };
 
+/**
+ * \ingroup unity
+ * The response from a toolkit executed in the background.
+ */
+class toolkit_function_response_future {
+ public:
+   toolkit_function_response_future() {}
+
+   toolkit_function_response_future(std::function<toolkit_function_response_type()> exec_function);
+
+  const toolkit_function_response_type& wait() const;
+
+ private:
+  struct response_info {
+    toolkit_function_response_type response;
+    std::future<bool> response_future;
+    volatile bool is_completed = false;
+  };
+
+  // This field becomes valid and non-null when the execution has
+  // finished.
+  std::shared_ptr<response_info> m_info;
+};
 
 
 } // turicreate

--- a/src/model_server/lib/unity_global.cpp
+++ b/src/model_server/lib/unity_global.cpp
@@ -477,6 +477,19 @@ namespace turi {
     }
   }
 
+  toolkit_function_response_future unity_global::run_toolkit_background(
+      std::string toolkit_name,
+      variant_map_type& _arguments) {
+
+    auto capture_args = std::make_shared<variant_map_type>(_arguments);
+
+    return toolkit_function_response_future(
+        [=]() {
+           return this->run_toolkit(toolkit_name, *capture_args);
+        });
+  }
+
+
   flexible_type unity_global::eval_lambda(const std::string& string, const flexible_type& arg) {
     log_func_entry();
 #ifdef TC_HAS_PYTHON

--- a/src/model_server/lib/unity_global.hpp
+++ b/src/model_server/lib/unity_global.hpp
@@ -162,6 +162,19 @@ class unity_global: public unity_global_base {
   toolkit_function_response_type run_toolkit(std::string toolkit_name,
                                     variant_map_type& arguments);
 
+
+  /**
+   * Runs a toolkit of the specified name, and with the specified arguments, in
+   * the background.
+   *
+   * Returns a toolkit_function_response_future which contains the result of the toolkit
+   * execution (success/failure) as well as any additional returned state
+   * (graphs/classes/etc). Will throw an exception if the toolkit name was not
+   * found.
+   */
+  toolkit_function_response_future run_toolkit_background(std::string toolkit_name,
+                                                          variant_map_type& arguments);
+
   /**
    * Internal utility function. Gets the structure of the lazy
    * evaluation dag for the graph operations.

--- a/src/python/turicreate/_cython/cy_unity.pxd
+++ b/src/python/turicreate/_cython/cy_unity.pxd
@@ -23,6 +23,10 @@ cdef extern from "<model_server/lib/unity_global.hpp>" namespace "turi":
         string message
         variant_map_type params
 
+    cdef cppclass toolkit_function_response_future nogil:
+        toolkit_function_response_future() except +
+        toolkit_function_response_type wait() except +
+
     cdef cppclass unity_global nogil:
 
         string get_version() except +
@@ -48,6 +52,8 @@ cdef extern from "<model_server/lib/unity_global.hpp>" namespace "turi":
         void save_model2(string, variant_map_type, string) except +
 
         toolkit_function_response_type run_toolkit(string toolkit_name, variant_map_type arguments) except +
+
+        toolkit_function_response_future run_toolkit_background(string toolkit_name, variant_map_type arguments) except +
 
         # Internal testing APIs
         flexible_type eval_lambda(string, flexible_type) except +
@@ -112,6 +118,8 @@ cdef class UnityGlobalProxy:
     cpdef create_toolkit_class(self, model)
 
     cpdef run_toolkit(self, toolkit_name, object arguments)
+
+    cpdef run_toolkit_background(self, toolkit_name, object arguments)
 
     cpdef save_model(self, model, url, object sidedata=*)
 

--- a/src/python/turicreate/extensions.py
+++ b/src/python/turicreate/extensions.py
@@ -115,6 +115,46 @@ def _setattr_wrapper(mod, key, value):
     if mod == _thismodule:
         setattr(_sys.modules[__name__], key, value)
 
+def _toolkit_function_pack_args(arguments, args, kwargs):
+    """
+    Packs the arguments into the proper form.
+    """
+
+    # scan for all the arguments in args
+    num_args_got = len(args) + len(kwargs)
+    num_args_required = len(arguments)
+    if num_args_got != num_args_required:
+        raise TypeError("Expecting " + str(num_args_required) + " arguments, got " + str(num_args_got))
+
+    ## fill the dict first with the regular args
+    argument_dict = {}
+    for i in range(len(args)):
+        argument_dict[arguments[i]] = args[i]
+
+    # now fill with the kwargs.
+    for k in kwargs.keys():
+        if k in argument_dict:
+            raise TypeError("Got multiple values for keyword argument '" + k + "'")
+        argument_dict[k] = kwargs[k]
+
+    return argument_dict
+
+def _toolkit_function_unpack_return(ret):
+
+    # handle errors
+    if not ret[0]:
+        if len(ret[1]) > 0:
+            raise _ToolkitError(ret[1])
+        else:
+            raise _ToolkitError("Toolkit failed with unknown error")
+
+    ret = _wrap_function_return(ret[2])
+    if type(ret) is dict and 'return_value' in ret:
+        return ret['return_value']
+    else:
+        return ret
+
+
 def _run_toolkit_function(fnname, arguments, args, kwargs):
     """
     Dispatches arguments to a toolkit function.
@@ -133,41 +173,68 @@ def _run_toolkit_function(fnname, arguments, args, kwargs):
     kwargs : dictionary
         The keyword arguments that were passed
     """
-    # scan for all the arguments in args
-    num_args_got = len(args) + len(kwargs)
-    num_args_required = len(arguments)
-    if num_args_got != num_args_required:
-        raise TypeError("Expecting " + str(num_args_required) + " arguments, got " + str(num_args_got))
-
-    ## fill the dict first with the regular args
-    argument_dict = {}
-    for i in range(len(args)):
-        argument_dict[arguments[i]] = args[i]
-
-    # now fill with the kwargs.
-    for k in kwargs.keys():
-        if k in argument_dict:
-            raise TypeError("Got multiple values for keyword argument '" + k + "'")
-        argument_dict[k] = kwargs[k]
+    argument_dict = _toolkit_function_pack_args(arguments, args, kwargs)
 
     # unwrap it
     with cython_context():
         ret = _get_unity().run_toolkit(fnname, argument_dict)
-    # handle errors
-    if not ret[0]:
-        if len(ret[1]) > 0:
-            raise _ToolkitError(ret[1])
-        else:
-            raise _ToolkitError("Toolkit failed with unknown error")
 
-    ret = _wrap_function_return(ret[2])
-    if type(ret) is dict and 'return_value' in ret:
-        return ret['return_value']
-    else:
-        return ret
+    return _toolkit_function_unpack_return(ret)
+
+# Implementation for backgrounding function calls
+
+class ToolkitFunctionFuture(object):
+
+    def __init__(self, proxy):
+        self.__proxy__ = proxy
+
+
+    def wait(self):
+        """
+        Waits for the answer to finish processing in the background, returning
+        the result.
+        """
+
+        with cython_context():
+            ret = self.__proxy__.wait()
+
+        return _toolkit_function_unpack_return(ret)
+
+
+def _run_toolkit_function_background(fnname, arguments, args, kwargs):
+    """
+    Dispatches arguments to a toolkit function, then returns a future
+    that provides a handle to the background process.  Calling wait()
+    on the future object .
+
+    Parameters
+    ----------
+    fnname : string
+        The toolkit function to run
+
+    arguments : list[string]
+        The list of all the arguments the function takes.
+
+    args : list
+        The arguments that were passed
+
+    kwargs : dictionary
+        The keyword arguments that were passed
+    """
+    argument_dict = _toolkit_function_pack_args(arguments, args, kwargs)
+
+    with cython_context():
+        proxy = _get_unity().run_toolkit_background(fnname, argument_dict)
+
+    return ToolkitFunctionFuture(proxy)
+
 
 def _make_injected_function(fn, arguments):
     return lambda *args, **kwargs: _run_toolkit_function(fn, arguments, args, kwargs)
+
+def _make_injected_function_background(fn, arguments):
+    return lambda *args, **kwargs: _run_toolkit_function_background(fn, arguments, args, kwargs)
+
 
 def _class_instance_from_name(class_name, *arg, **kwarg):
     """
@@ -339,11 +406,14 @@ def _publish():
 
         newfunc = _make_injected_function(fn, arguments)
 
+        newfunc.run_background = _make_injected_function_background(fn, arguments)
+
         newfunc.__doc__ = "Name: " + fn + "\nParameters: " + str(arguments) + "\n"
         if 'documentation' in props:
             newfunc.__doc__ += props['documentation'] + "\n"
 
-        newfunc.__dict__['__glmeta__'] = {'extension_name':fn}
+        newfunc.__dict__['__glmeta__'] = {'extension_name':fn, 'arguments': arguments}
+
         modpath = fn.split('.')
         # walk the module tree
         mod = _thismodule

--- a/src/python/turicreate/test/test_extensions.py
+++ b/src/python/turicreate/test/test_extensions.py
@@ -10,6 +10,8 @@ import unittest
 from ..data_structures.sarray import SArray
 from ..data_structures.sframe import SFrame
 
+import turicreate as tc
+
 import sys
 if sys.version_info.major > 2:
     long = int
@@ -126,3 +128,14 @@ class VariantCheckTest(unittest.TestCase):
                     self.assertTrue(A.flextype_encodable)
                 else:
                     self.assertFalse(A.flextype_encodable)
+
+
+
+
+    def test_futures(self):
+
+        future = tc.extensions._demo_addone.run_background(1)
+
+        result = future.wait()
+
+        self.assertEqual(result, 2)

--- a/src/toolkits/style_transfer/CMakeLists.txt
+++ b/src/toolkits/style_transfer/CMakeLists.txt
@@ -10,4 +10,5 @@ make_library(unity_style_transfer OBJECT
     unity_core
     unity_ml_model
     unity_neural_net
+    vega_renderer
 )

--- a/src/visualization/vega_renderer/CMakeLists.txt
+++ b/src/visualization/vega_renderer/CMakeLists.txt
@@ -78,4 +78,8 @@ if(APPLE AND NOT TC_BUILD_IOS)
 
    target_compile_options(vega_renderer PUBLIC "-fobjc-arc")
 
+else()
+
+  make_empty_library(vega_renderer)
+
 endif()


### PR DESCRIPTION
Many of the current speed regressions are due to a lack of proper pipelining support in python.  This PR adds the ability to run extension functions on a background thread while the main python thread does other things.  This is done by using a futures interface that works on top of extension functions and can be called using a run_background method on the extension function call. 

Previously, we could run the following code:

```
for i in range(n):
    prepared_data = tc.extensions.prepared_data(data_info, i)
    run_tf_model(prepared_data)
```

The problem is that this is run in serial, meaning the CPU and GPU are not both busy.  With this API, you can replace this with: 

```
# Init for the first iteration here
data_future = tc.extensions.prepared_data.run_background(data_info, 0)

for i in range(n):
    # block until background function finishes; get result.
    prepared_data = data_future.wait()

    # start data prep for next index in background
    if i + 1 != n:
        data_future = tc.extensions.prepared_data.run_background(data_info, i + 1)
   
    run_tf_model(prepared_data)
```

This should make pipelining support much easier. 




