### PR TITLE
Adding weights to DC

### DIFF
--- a/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
@@ -151,10 +151,7 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
             self.cost
         )
 
-<<<<<<< HEAD
-=======
         self.sess = _tf.Session()
->>>>>>> f65e2cd45c... Adding weights to DC
         self.sess.run(_tf.global_variables_initializer())
 
         # Assign the initialised weights from C++ to tensorflow

--- a/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
+++ b/src/python/turicreate/toolkits/drawing_classifier/_tf_drawing_classifier.py
@@ -11,10 +11,11 @@ import numpy as _np
 from .._tf_model import TensorFlowModel
 import turicreate.toolkits._tf_utils as _utils
 import tensorflow.compat.v1 as _tf
+
 _tf.disable_v2_behavior()
 
-class DrawingClassifierTensorFlowModel(TensorFlowModel):
 
+class DrawingClassifierTensorFlowModel(TensorFlowModel):
     def __init__(self, net_params, batch_size, num_classes):
         """
         Defines the TensorFlow model, loss, optimisation and accuracy. Then
@@ -25,7 +26,9 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
         self.gpu_policy.start()
 
         for key in net_params.keys():
-            net_params[key] = _utils.convert_shared_float_array_to_numpy(net_params[key])
+            net_params[key] = _utils.convert_shared_float_array_to_numpy(
+                net_params[key]
+            )
 
 
         self.dc_graph = _tf.Graph()
@@ -37,109 +40,176 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
 
     def init_drawing_classifier_graph(self, net_params):
 
-        self.input = _tf.placeholder(_tf.float32, [None, 28, 28, 1])
+        self.input = _tf.placeholder(_tf.float32, [self.batch_size, 28, 28, 1])
+        self.weights = _tf.placeholder(_tf.float32, [self.batch_size, 1])
+        self.labels = _tf.placeholder(_tf.int64, [self.batch_size, 1])
 
-        self.one_hot_labels = _tf.placeholder(
-            _tf.int32, [None, self.num_classes])
+        # One hot encoding target
+        reshaped_labels = _tf.reshape(self.labels, [self.batch_size])
+        one_hot_labels = _tf.one_hot(reshaped_labels, depth=self.num_classes, axis=-1)
+
+        # Reshaping weights
+        reshaped_weights = _tf.reshape(self.weights, [self.batch_size])
+
+        self.one_hot_labels = _tf.placeholder(_tf.int32, [None, self.num_classes])
 
         # Weights
         weights = {
-            'drawing_conv0_weight': _tf.Variable(_tf.zeros([3, 3, 1, 16]), name='drawing_conv0_weight'),
-            'drawing_conv1_weight': _tf.Variable(_tf.zeros([3, 3, 16, 32]), name='drawing_conv1_weight'),
-            'drawing_conv2_weight': _tf.Variable(_tf.zeros([3, 3, 32, 64]), name='drawing_conv2_weight'),
-            'drawing_dense0_weight': _tf.Variable(_tf.zeros([576, 128]), name='drawing_dense0_weight'),
-            'drawing_dense1_weight': _tf.Variable(_tf.zeros([128, self.num_classes]), name='drawing_dense1_weight')
+            "drawing_conv0_weight": _tf.Variable(
+                _tf.zeros([3, 3, 1, 16]), name="drawing_conv0_weight"
+            ),
+            "drawing_conv1_weight": _tf.Variable(
+                _tf.zeros([3, 3, 16, 32]), name="drawing_conv1_weight"
+            ),
+            "drawing_conv2_weight": _tf.Variable(
+                _tf.zeros([3, 3, 32, 64]), name="drawing_conv2_weight"
+            ),
+            "drawing_dense0_weight": _tf.Variable(
+                _tf.zeros([576, 128]), name="drawing_dense0_weight"
+            ),
+            "drawing_dense1_weight": _tf.Variable(
+                _tf.zeros([128, self.num_classes]), name="drawing_dense1_weight"
+            ),
         }
 
         # Biases
         biases = {
-            'drawing_conv0_bias': _tf.Variable(_tf.zeros([16]), name='drawing_conv0_bias'),
-            'drawing_conv1_bias': _tf.Variable(_tf.zeros([32]), name='drawing_conv1_bias'),
-            'drawing_conv2_bias': _tf.Variable(_tf.zeros([64]), name='drawing_conv2_bias'),
-            'drawing_dense0_bias': _tf.Variable(_tf.zeros([128]), name='drawing_dense0_bias'),
-            'drawing_dense1_bias': _tf.Variable(_tf.zeros([self.num_classes]), name='drawing_dense1_bias')
+            "drawing_conv0_bias": _tf.Variable(
+                _tf.zeros([16]), name="drawing_conv0_bias"
+            ),
+            "drawing_conv1_bias": _tf.Variable(
+                _tf.zeros([32]), name="drawing_conv1_bias"
+            ),
+            "drawing_conv2_bias": _tf.Variable(
+                _tf.zeros([64]), name="drawing_conv2_bias"
+            ),
+            "drawing_dense0_bias": _tf.Variable(
+                _tf.zeros([128]), name="drawing_dense0_bias"
+            ),
+            "drawing_dense1_bias": _tf.Variable(
+                _tf.zeros([self.num_classes]), name="drawing_dense1_bias"
+            ),
         }
 
         conv_1 = _tf.nn.conv2d(
-            self.input, weights["drawing_conv0_weight"], strides=1, padding='SAME')
+            self.input, weights["drawing_conv0_weight"], strides=1, padding="SAME"
+        )
         conv_1 = _tf.nn.bias_add(conv_1, biases["drawing_conv0_bias"])
         relu_1 = _tf.nn.relu(conv_1)
-        pool_1 = _tf.nn.max_pool2d(relu_1, ksize=[1, 2, 2, 1], strides=[
-                                   1, 2, 2, 1], padding='VALID')
+        pool_1 = _tf.nn.max_pool2d(
+            relu_1, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="VALID"
+        )
 
         conv_2 = _tf.nn.conv2d(
-            pool_1, weights["drawing_conv1_weight"], strides=1, padding='SAME')
+            pool_1, weights["drawing_conv1_weight"], strides=1, padding="SAME"
+        )
         conv_2 = _tf.nn.bias_add(conv_2, biases["drawing_conv1_bias"])
         relu_2 = _tf.nn.relu(conv_2)
-        pool_2 = _tf.nn.max_pool2d(relu_2, ksize=[1, 2, 2, 1], strides=[
-                                   1, 2, 2, 1], padding='VALID')
+        pool_2 = _tf.nn.max_pool2d(
+            relu_2, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="VALID"
+        )
 
         conv_3 = _tf.nn.conv2d(
-            pool_2, weights["drawing_conv2_weight"], strides=1, padding='SAME')
+            pool_2, weights["drawing_conv2_weight"], strides=1, padding="SAME"
+        )
         conv_3 = _tf.nn.bias_add(conv_3, biases["drawing_conv2_bias"])
         relu_3 = _tf.nn.relu(conv_3)
-        pool_3 = _tf.nn.max_pool2d(relu_3, ksize=[1, 2, 2, 1], strides=[
-                                   1, 2, 2, 1], padding='VALID')
+        pool_3 = _tf.nn.max_pool2d(
+            relu_3, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="VALID"
+        )
 
         # Flatten the data to a 1-D vector for the fully connected layer
         fc1 = _tf.reshape(pool_3, (-1, 576))
 
-        fc1 = _tf.nn.xw_plus_b(fc1, weights=weights["drawing_dense0_weight"],
-            biases=biases["drawing_dense0_bias"])
+        fc1 = _tf.nn.xw_plus_b(
+            fc1,
+            weights=weights["drawing_dense0_weight"],
+            biases=biases["drawing_dense0_bias"],
+        )
 
         fc1 = _tf.nn.relu(fc1)
 
-        out = _tf.nn.xw_plus_b(fc1, weights=weights["drawing_dense1_weight"],
-            biases=biases["drawing_dense1_bias"])
+        out = _tf.nn.xw_plus_b(
+            fc1,
+            weights=weights["drawing_dense1_weight"],
+            biases=biases["drawing_dense1_bias"],
+        )
         softmax_out = _tf.nn.softmax(out)
 
         self.predictions = softmax_out
 
         # Loss
-        self.cost = _tf.losses.softmax_cross_entropy(logits=out, onehot_labels=self.one_hot_labels, reduction=_tf.losses.Reduction.NONE)
+        self.cost = _tf.losses.softmax_cross_entropy(
+            logits=out,
+            onehot_labels=one_hot_labels,
+            weights=reshaped_weights,
+            reduction=_tf.losses.Reduction.NONE,
+        )
 
         # Optimizer
-        self.optimizer = _tf.train.AdamOptimizer(
-            learning_rate=0.001).minimize(self.cost)
+        self.optimizer = _tf.train.AdamOptimizer(learning_rate=0.001).minimize(
+            self.cost
+        )
 
-        # Predictions
-        correct_prediction = _tf.equal(_tf.argmax(
-            self.predictions, 1), _tf.argmax(self.one_hot_labels, 1))
-
+<<<<<<< HEAD
+=======
+        self.sess = _tf.Session()
+>>>>>>> f65e2cd45c... Adding weights to DC
         self.sess.run(_tf.global_variables_initializer())
 
         # Assign the initialised weights from C++ to tensorflow
-        layers = ['drawing_conv0_weight', 'drawing_conv0_bias', 'drawing_conv1_weight', 'drawing_conv1_bias',
-                  'drawing_conv2_weight', 'drawing_conv2_bias', 'drawing_dense0_weight', 'drawing_dense0_bias',
-                  'drawing_dense1_weight', 'drawing_dense1_bias']
+        layers = [
+            "drawing_conv0_weight",
+            "drawing_conv0_bias",
+            "drawing_conv1_weight",
+            "drawing_conv1_bias",
+            "drawing_conv2_weight",
+            "drawing_conv2_bias",
+            "drawing_dense0_weight",
+            "drawing_dense0_bias",
+            "drawing_dense1_weight",
+            "drawing_dense1_bias",
+        ]
 
         for key in layers:
-            if 'bias' in key:
-                self.sess.run(_tf.assign(_tf.get_default_graph().get_tensor_by_name(key+":0"),
-                                         net_params[key]))
+            if "bias" in key:
+                self.sess.run(
+                    _tf.assign(
+                        _tf.get_default_graph().get_tensor_by_name(key + ":0"),
+                        net_params[key],
+                    )
+                )
             else:
-                if 'drawing_dense0_weight' in key:
-                    '''
+                if "drawing_dense0_weight" in key:
+                    """
                     To make output of CoreML pool3 (NCHW) compatible with TF (NHWC).
                     Decompose FC weights to NCHW. Transpose to NHWC. Reshape back to FC.
-                    '''
+                    """
                     coreml_128_576 = net_params[key]
-                    coreml_128_576 = _np.reshape(
-                        coreml_128_576, (128, 64, 3, 3))
-                    coreml_128_576 = _np.transpose(
-                        coreml_128_576, (0, 2, 3, 1))
+                    coreml_128_576 = _np.reshape(coreml_128_576, (128, 64, 3, 3))
+                    coreml_128_576 = _np.transpose(coreml_128_576, (0, 2, 3, 1))
                     coreml_128_576 = _np.reshape(coreml_128_576, (128, 576))
-                    self.sess.run(_tf.assign(_tf.get_default_graph().get_tensor_by_name(key+":0"),
-                                             _np.transpose(coreml_128_576, (1, 0))))
-                elif 'dense' in key:
-                    dense_weights = _utils.convert_dense_coreml_to_tf(
-                        net_params[key])
-                    self.sess.run(_tf.assign(_tf.get_default_graph().get_tensor_by_name(key+":0"),
-                                             dense_weights))
+                    self.sess.run(
+                        _tf.assign(
+                            _tf.get_default_graph().get_tensor_by_name(key + ":0"),
+                            _np.transpose(coreml_128_576, (1, 0)),
+                        )
+                    )
+                elif "dense" in key:
+                    dense_weights = _utils.convert_dense_coreml_to_tf(net_params[key])
+                    self.sess.run(
+                        _tf.assign(
+                            _tf.get_default_graph().get_tensor_by_name(key + ":0"),
+                            dense_weights,
+                        )
+                    )
                 else:
-                    # TODO: Call _utils.convert_conv2d_coreml_to_tf when #2513 is merged
-                    self.sess.run(_tf.assign(_tf.get_default_graph().get_tensor_by_name(key+":0"),
-                                             _np.transpose(net_params[key], (2, 3, 1, 0))))
+                    self.sess.run(
+                        _tf.assign(
+                            _tf.get_default_graph().get_tensor_by_name(key + ":0"),
+                            _utils.convert_conv2d_coreml_to_tf(net_params[key]),
+                        )
+                    )
 
     def __del__(self):
         self.sess.close()
@@ -148,58 +218,50 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
     def train(self, feed_dict):
 
         for key in feed_dict.keys():
-            feed_dict[key] = _utils.convert_shared_float_array_to_numpy(
-                feed_dict[key])
-
-        num_samples = float(feed_dict["num_samples"])
-        one_hot_labels = _np.zeros((int(num_samples), self.num_classes))
-
-        # convert to one hot
-        labels = feed_dict["labels"].astype("int32").T
-        one_hot_labels[_np.arange(int(num_samples)), labels] = 1
+            feed_dict[key] = _utils.convert_shared_float_array_to_numpy(feed_dict[key])
 
         _, final_train_loss, final_train_output = self.sess.run(
             [self.optimizer, self.cost, self.predictions],
             feed_dict={
-                self.input: feed_dict['input'],
-                self.one_hot_labels: one_hot_labels
-            })
+                self.input: feed_dict["input"],
+                self.labels: feed_dict["labels"],
+                self.weights: feed_dict["weights"],
+            },
+        )
 
-        result = {'loss': _np.array(final_train_loss),
-                  'output': _np.array(final_train_output)}
+        result = {
+            "loss": _np.array(final_train_loss),
+            "output": _np.array(final_train_output),
+        }
 
         return result
 
     def predict(self, feed_dict):
 
-        is_train = ("labels" in feed_dict)
+        is_train = "labels" in feed_dict
 
         for key in feed_dict.keys():
-            feed_dict[key] = _utils.convert_shared_float_array_to_numpy(
-                feed_dict[key])
+            feed_dict[key] = _utils.convert_shared_float_array_to_numpy(feed_dict[key])
 
-        num_samples = float(feed_dict["num_samples"])
-        one_hot_labels = _np.zeros((int(num_samples), self.num_classes))
+        one_hot_labels = _np.zeros((int(self.batch_size), self.num_classes))
 
         feed_dict_for_session = {self.input: feed_dict["input"]}
 
         if is_train:
-            # convert to one hot
-            labels = feed_dict["labels"].astype("int32").T
-            one_hot_labels[_np.arange(int(num_samples)), labels] = 1
 
-            feed_dict_for_session[self.one_hot_labels] = one_hot_labels
+            feed_dict_for_session[self.labels] = feed_dict["labels"]
+            feed_dict_for_session[self.weights] = feed_dict["weights"]
 
             pred_probs, loss = self.sess.run(
-                [self.predictions, self.cost],
-                feed_dict=feed_dict_for_session)
+                [self.predictions, self.cost], feed_dict=feed_dict_for_session
+            )
 
-            result = {'loss': _np.array(loss),
-                      'output': _np.array(pred_probs)}
+            result = {"loss": _np.array(loss), "output": _np.array(pred_probs)}
         else:
-            pred_probs = self.sess.run([self.predictions],
-                                       feed_dict=feed_dict_for_session)
-            result = {'output': _np.array(pred_probs)}
+            pred_probs = self.sess.run(
+                [self.predictions], feed_dict=feed_dict_for_session
+            )
+            result = {"output": _np.array(pred_probs)}
 
         return result
 
@@ -222,29 +284,39 @@ class DrawingClassifierTensorFlowModel(TensorFlowModel):
             layer_weights = self.sess.run(layer_names)
 
         for var, val in zip(layer_names, layer_weights):
-            if 'bias' in var.name:
+            if "bias" in var.name:
                 net_params.update({var.name.replace(":0", ""): val})
             else:
-                if 'dense' in var.name:
-                    if 'drawing_dense0_weight' in var.name:
-                         '''
+                if "dense" in var.name:
+                    if "drawing_dense0_weight" in var.name:
+                        """
                          To make output of TF pool3 (NHWC) compatible with CoreML (NCHW).
                          Decompose FC weights to NHWC. Transpose to NCHW. Reshape back to FC.
-                         '''
-                         tf_576_128 = val
-                         tf_576_128 = _np.reshape(tf_576_128, (3, 3, 64, 128))
-                         tf_576_128 = _np.transpose(tf_576_128, (2, 0, 1, 3))
-                         tf_576_128 = _np.reshape(tf_576_128, (576, 128))
-                         net_params.update(
-                             {var.name.replace(":0", ""): _np.transpose(tf_576_128, (1, 0))})
+                         """
+                        tf_576_128 = val
+                        tf_576_128 = _np.reshape(tf_576_128, (3, 3, 64, 128))
+                        tf_576_128 = _np.transpose(tf_576_128, (2, 0, 1, 3))
+                        tf_576_128 = _np.reshape(tf_576_128, (576, 128))
+                        net_params.update(
+                            {
+                                var.name.replace(":0", ""): _np.transpose(
+                                    tf_576_128, (1, 0)
+                                )
+                            }
+                        )
                     else:
                         net_params.update(
-                            {var.name.replace(":0", ""): val.transpose(1, 0)})
+                            {var.name.replace(":0", ""): val.transpose(1, 0)}
+                        )
                 else:
-                    # TODO: Call _utils.convert_conv2d_tf_to_coreml once #2513 is merged.
                     # np.transpose won't change the underlying memory layout
                     # but in turicreate we will force it.
                     net_params.update(
-                        {var.name.replace(":0", ""): _np.transpose(val, (3, 2, 0, 1))})
+                        {
+                            var.name.replace(
+                                ":0", ""
+                            ): _utils.convert_conv2d_tf_to_coreml(val)
+                        }
+                    )
 
         return net_params

--- a/src/toolkits/drawing_classifier/dc_data_iterator.hpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.hpp
@@ -93,6 +93,13 @@ class data_iterator {
     /**
      * An array with shape: (requested_batch_size, 1)
      *
+     * Each row is the weight associated with the target.
+     */
+    neural_net::shared_float_array weights;
+
+    /**
+     * An array with shape: (requested_batch_size, 1)
+     *
      * Each row is the prediction.
      */
     neural_net::shared_float_array predictions;

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -41,8 +41,8 @@ const flex_list UNIQUE_LABELS = {"foo", "bar", "baz"};
  *
  */
 void test_simple_data_iterator_with_num_rows_and_batch_size(
-    const drawing_data_generator &data_generator,
-    size_t batch_size, bool checked_class_labels) {
+    const drawing_data_generator &data_generator, size_t batch_size,
+    bool checked_class_labels) {
   data_iterator::parameters params = data_generator.get_iterator_params();
 
   // without applying scale factor
@@ -133,9 +133,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
-
   constexpr size_t MAX_BATCH_SIZE = 8;
-
 
     for (size_t batch_size = 1; batch_size <= MAX_BATCH_SIZE; batch_size++) {
       drawing_data_generator data_generator(/* is_bitmap_based */ true,
@@ -150,7 +148,6 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
-
   constexpr size_t BATCH_SIZE = 1;
 
   drawing_data_generator data_generator(/* is_bitmap_based */ true, BATCH_SIZE,

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -41,14 +41,14 @@ const flex_list UNIQUE_LABELS = {"foo", "bar", "baz"};
  *
  */
 void test_simple_data_iterator_with_num_rows_and_batch_size(
-    const drawing_data_generator &data_generator, size_t num_rows,
+    const drawing_data_generator &data_generator,
     size_t batch_size, bool checked_class_labels) {
   data_iterator::parameters params = data_generator.get_iterator_params();
 
   // without applying scale factor
   params.scale_factor = 1.0;
 
-  TS_ASSERT_EQUALS(params.data.size(), num_rows);
+  TS_ASSERT_EQUALS(params.data.size(), batch_size);
 
   /* Create a simple data iterator */
 
@@ -71,12 +71,6 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   /* Call next_batch */
   data_iterator::batch next_batch = data_source.next_batch(batch_size);
 
-  // get the real batch size for test now
-  size_t num_samples;
-  if (num_rows < batch_size) {
-    num_samples = num_rows;
-  }
-
   /* Test drawing and target sizes */
   TS_ASSERT_EQUALS(next_batch.drawings.size(),
                    batch_size * IMAGE_WIDTH * IMAGE_HEIGHT * 1);
@@ -98,7 +92,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   size_t index_in_data = 0;
   /* Test target contents */
   const float *actual_target_data = next_batch.targets.data();
-  for (size_t index_in_batch = 0; index_in_batch < num_samples;
+  for (size_t index_in_batch = 0; index_in_batch < batch_size;
        index_in_batch++) {
     float expected_target = static_cast<float>(
         std::find(actual_class_labels.begin(), actual_class_labels.end(),
@@ -113,7 +107,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   index_in_data = 0;
   const float *actual_drawing_data = next_batch.drawings.data();
 
-  for (size_t index_in_batch = 0; index_in_batch < num_samples;
+  for (size_t index_in_batch = 0; index_in_batch < batch_size;
        index_in_batch++) {
     flex_image decoded_drawing = image_util::decode_image(
         data[params.feature_column_name][index_in_data].to<flex_image>());
@@ -139,28 +133,27 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator) {
-  constexpr size_t MAX_NUM_ROWS = 4;
+
   constexpr size_t MAX_BATCH_SIZE = 8;
 
-  for (size_t num_rows = 1; num_rows <= MAX_NUM_ROWS; num_rows++) {
+
     for (size_t batch_size = 1; batch_size <= MAX_BATCH_SIZE; batch_size++) {
       drawing_data_generator data_generator(/* is_bitmap_based */ true,
-                                            num_rows,
+                                            batch_size,
                                             /* class_labels */ UNIQUE_LABELS);
       data_iterator::parameters params = data_generator.get_iterator_params();
 
       test_simple_data_iterator_with_num_rows_and_batch_size(
-          data_generator, num_rows, batch_size,
+          data_generator, batch_size,
           /* need NOT to check label */ false);
     }
-  }
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
-  constexpr size_t NUM_ROWS = 1;
-  constexpr size_t BATCH_SIZE = 10;
 
-  drawing_data_generator data_generator(/* is_bitmap_based */ true, NUM_ROWS,
+  constexpr size_t BATCH_SIZE = 1;
+
+  drawing_data_generator data_generator(/* is_bitmap_based */ true, BATCH_SIZE,
                                         /* class_labels */ UNIQUE_LABELS);
   flex_list class_labels = {"bar", "foo"};
 
@@ -172,7 +165,7 @@ BOOST_AUTO_TEST_CASE(test_simple_data_iterator_with_expected_class_labels) {
 
   // Confirm that the extraneous label appears in the data_source class_labels.
   test_simple_data_iterator_with_num_rows_and_batch_size(
-      data_generator, NUM_ROWS, BATCH_SIZE,
+      data_generator, BATCH_SIZE,
       /* need NOT to check labels */ true);
 }
 

--- a/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_data_iterator.cxx
@@ -72,8 +72,9 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   data_iterator::batch next_batch = data_source.next_batch(batch_size);
 
   // get the real batch size for test now
+  size_t num_samples;
   if (num_rows < batch_size) {
-    batch_size = num_rows;
+    num_samples = num_rows;
   }
 
   /* Test drawing and target sizes */
@@ -97,7 +98,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   size_t index_in_data = 0;
   /* Test target contents */
   const float *actual_target_data = next_batch.targets.data();
-  for (size_t index_in_batch = 0; index_in_batch < batch_size;
+  for (size_t index_in_batch = 0; index_in_batch < num_samples;
        index_in_batch++) {
     float expected_target = static_cast<float>(
         std::find(actual_class_labels.begin(), actual_class_labels.end(),
@@ -112,7 +113,7 @@ void test_simple_data_iterator_with_num_rows_and_batch_size(
   index_in_data = 0;
   const float *actual_drawing_data = next_batch.drawings.data();
 
-  for (size_t index_in_batch = 0; index_in_batch < batch_size;
+  for (size_t index_in_batch = 0; index_in_batch < num_samples;
        index_in_batch++) {
     flex_image decoded_drawing = image_util::decode_image(
         data[params.feature_column_name][index_in_data].to<flex_image>());

--- a/test/unity/toolkits/drawing_classifier/test_dc_prediction.cxx
+++ b/test/unity/toolkits/drawing_classifier/test_dc_prediction.cxx
@@ -135,10 +135,10 @@ gl_sframe set_up_perform_inference(
       }
 
       auto to_return =
-          shared_float_array::copy(buffer.data(), {num_of_classes, repeat});
+          shared_float_array::copy(buffer.data(), {num_of_classes, batch_size});
 
       mock_backend->predict_calls_.push_back([=](const float_array_map& input) {
-        TS_ASSERT_EQUALS(input.at("input").size(), repeat * 28 * 28);
+        TS_ASSERT_EQUALS(input.at("input").size(), batch_size * 28 * 28);
         return float_array_map({{"output", to_return}});
       });
     }


### PR DESCRIPTION
To make it consistent with all other toolkits, DC should also have consistent batch_size in the entire epoch. This can be done by using weights. Weights are arrays of 0/1 of the size of targets. For example, the last batch in the epoch is smaller than the specified batch_size then weights are zeros for the rest of the batch. While calculating loss and accuracy, the data corresponding the zeros is not taken into consideration.