### PR TITLE
[OD] 6.0 inference regression between CPU and GPU.

### DIFF
--- a/src/python/turicreate/toolkits/_image_feature_extractor.py
+++ b/src/python/turicreate/toolkits/_image_feature_extractor.py
@@ -175,11 +175,11 @@ class TensorFlowFeatureExtractor(ImageFeatureExtractor):
 
 
 
-        # These two arrays will swap off to avoid unnecessary allocations.
+        # These two arrays will swap off to avoid unnecessary allocations.  
         state['batch_store'] = []
         def get_batch_array():
             batch_store = state['batch_store']
-
+            
             if not batch_store:
                 batch_store.append(np.zeros((batch_size,) + self.ptModel.input_image_shape, dtype=np.float32))
 
@@ -191,26 +191,26 @@ class TensorFlowFeatureExtractor(ImageFeatureExtractor):
 
         # Seed the iteration
         batch_info = next_batch(get_batch_array())
-
+            
         # Iterate through the image batches, converting them into batches
-        # of feature vectors.  Do the
+        # of feature vectors.  Do the 
         while batch_info is not None:
 
             # Get the now ready batch to process
             batch = ready_batch(batch_info)
 
-            # Start the next one in the background.
+            # Start the next one in the background.  
             # Returns None if done.
             batch_info = next_batch(get_batch_array())
 
-            # Now, process all this.
+            # Now, process all this. 
             predictions_from_tf = handle_request(batch)
             consume_response(predictions_from_tf)
 
-            # Requeue the batch array now that we're done.
+            # Requeue the batch array now that we're done.  
             batch_array_done(batch)
 
-        # Now we have this compiled in
+        # Now we have this compiled in 
         return state['out']
 
     def get_coreml_model(self):

--- a/src/python/turicreate/toolkits/_image_feature_extractor.py
+++ b/src/python/turicreate/toolkits/_image_feature_extractor.py
@@ -175,11 +175,11 @@ class TensorFlowFeatureExtractor(ImageFeatureExtractor):
 
 
 
-        # These two arrays will swap off to avoid unnecessary allocations.  
+        # These two arrays will swap off to avoid unnecessary allocations.
         state['batch_store'] = []
         def get_batch_array():
             batch_store = state['batch_store']
-            
+
             if not batch_store:
                 batch_store.append(np.zeros((batch_size,) + self.ptModel.input_image_shape, dtype=np.float32))
 
@@ -191,26 +191,26 @@ class TensorFlowFeatureExtractor(ImageFeatureExtractor):
 
         # Seed the iteration
         batch_info = next_batch(get_batch_array())
-            
+
         # Iterate through the image batches, converting them into batches
-        # of feature vectors.  Do the 
+        # of feature vectors.  Do the
         while batch_info is not None:
 
             # Get the now ready batch to process
             batch = ready_batch(batch_info)
 
-            # Start the next one in the background.  
+            # Start the next one in the background.
             # Returns None if done.
             batch_info = next_batch(get_batch_array())
 
-            # Now, process all this. 
+            # Now, process all this.
             predictions_from_tf = handle_request(batch)
             consume_response(predictions_from_tf)
 
-            # Requeue the batch array now that we're done.  
+            # Requeue the batch array now that we're done.
             batch_array_done(batch)
 
-        # Now we have this compiled in 
+        # Now we have this compiled in
         return state['out']
 
     def get_coreml_model(self):

--- a/src/python/turicreate/toolkits/object_detector/_tf_image_augmenter.py
+++ b/src/python/turicreate/toolkits/object_detector/_tf_image_augmenter.py
@@ -99,7 +99,7 @@ def resize_augmenter(image, annotation,
         np_img /= 255.
         return np_img
 
-    def resize_turicretae_image(image, output_shape):
+    def resize_turicreate_image(image, output_shape):
         image *= 255.
         image = image.astype('uint8')
         FORMAT_RAW = 2
@@ -127,7 +127,7 @@ def resize_augmenter(image, annotation,
         image_scaled = tf.numpy_function(func=resize_PIL_image, inp=[image, output_shape], Tout=[tf.float32])
 
     elif resize_method == 'turicreate':
-        image_scaled = tf.numpy_function(func=resize_turicretae_image, inp=[image, output_shape], Tout=[tf.float32])
+        image_scaled = tf.numpy_function(func=resize_turicreate_image, inp=[image, output_shape], Tout=[tf.float32])
 
     else:
         raise Exception('Non-supported resize method.')

--- a/src/python/turicreate/toolkits/object_detector/_tf_image_augmenter.py
+++ b/src/python/turicreate/toolkits/object_detector/_tf_image_augmenter.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import as _
 
 import numpy as np
 from PIL import Image
-import PIL
 import tensorflow.compat.v1 as tf
 from tensorflow.python.ops import array_ops
 from tensorflow.python.framework import ops
@@ -93,7 +92,7 @@ def resize_augmenter(image, annotation,
         image *= 255.
         image = image.astype('uint8')
         pil_img = Image.fromarray(image)
-        resize_img = pil_img.resize((output_shape[1], output_shape[0]), resample=PIL.Image.BILINEAR)
+        resize_img = pil_img.resize((output_shape[1], output_shape[0]), resample=Image.BILINEAR)
         np_img = np.array(resize_img)
         np_img = np_img.astype(np.float32)
         np_img /= 255.

--- a/src/python/turicreate/toolkits/object_detector/_tf_image_augmenter.py
+++ b/src/python/turicreate/toolkits/object_detector/_tf_image_augmenter.py
@@ -8,6 +8,7 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 
 import numpy as np
+import cv2
 import tensorflow.compat.v1 as tf
 from tensorflow.python.ops import array_ops
 from tensorflow.python.framework import ops
@@ -38,7 +39,8 @@ _DEFAULT_AUG_PARAMS = {
   'skip_probability_pad' : 0.1,
   'skip_probability_crop' : 0.1,
   'min_object_covered': 0.0,
-  'min_eject_coverage': 0.5
+  'min_eject_coverage': 0.5,
+  'resize_method': 'opencv',
 }
 
 def hue_augmenter(image, annotation,
@@ -82,14 +84,24 @@ def color_augmenter(image, annotation,
 
 def resize_augmenter(image, annotation,
                      output_shape):
-    
 
-    new_height = tf.cast(output_shape[0], dtype=tf.int32)
-    new_width = tf.cast(output_shape[1], dtype=tf.int32)
+    resize_method = _DEFAULT_AUG_PARAMS['resize_method']
 
-    # Determine the affine transform to apply and apply to the image itself.
-    image_scaled = tf.squeeze(tf.image.resize_bilinear(
-                          tf.expand_dims(image, 0), [new_height, new_width]), [0])
+    if resize_method == 'opencv':
+        def resize_cv2(image, output_shape):
+            return cv2.resize(image, (output_shape[1], output_shape[0]))
+        image_scaled = tf.numpy_function(func=resize_cv2, inp=[image, output_shape], Tout=[tf.float32])
+
+    elif resize_method == 'tensorflow':
+        new_height = tf.cast(output_shape[0], dtype=tf.int32)
+        new_width = tf.cast(output_shape[1], dtype=tf.int32)
+
+        # Determine the affine transform to apply and apply to the image itself.
+        image_scaled = tf.squeeze(tf.image.resize_bilinear(
+                            tf.expand_dims(image, 0), [new_height, new_width]), [0])
+    else:
+        raise Exception('Non-supported resize method.')
+
     image_clipped = tf.clip_by_value(image_scaled, 0.0, 1.0)
     annotation = tf.clip_by_value(annotation, 0.0, 1.0)
 
@@ -101,10 +113,10 @@ def horizontal_flip_augmenter(image, annotation, skip_probability=_DEFAULT_AUG_P
 
     if np.random.uniform(0.0, 1.0) < skip_probability:
         return image, annotation
-    
+
     image_height, image_width, _ = image.shape
     flipped_image = np.flip(image, 1)
-    
+
     # One image can have more than one annotation. so loop through annotations and flip across the horizontal axis
     for i in range(len(annotation)):
         # Only flip if the annotation is not an empty annotation.
@@ -123,11 +135,11 @@ def padding_augmenter(image,
                       max_attempts=_DEFAULT_AUG_PARAMS["max_attempts"]):
     if np.random.uniform(0.0, 1.0) < skip_probability:
         return np.array(image), annotation
-    
+
     image_height, image_width, _ = image.shape
 
     # Randomly sample aspect ratios until one derives a non-empty range of
-    # compatible heights, or until reaching the upper limit on attempts.    
+    # compatible heights, or until reaching the upper limit on attempts.
     for i in range(max_attempts):
         # Randomly sample an aspect ratio.
         aspect_ratio = np.random.uniform(min_aspect_ratio, max_aspect_ratio)
@@ -135,55 +147,55 @@ def padding_augmenter(image,
         # The padded height must be at least as large as the original height.
         # h' >= h
         min_height = float(image_height)
-        
+
         # The padded width must be at least as large as the original width.
         # w' >= w IMPLIES ah' >= w IMPLIES h' >= w / a
         min_height_from_width = float(image_width) / aspect_ratio
         if min_height < min_height_from_width:
             min_height = min_height_from_width
-        
+
         # The padded area must attain the minimum area fraction.
         # w'h' >= fhw IMPLIES ah'h' >= fhw IMPLIES h' >= sqrt(fhw/a)
         min_height_from_area = np.sqrt(image_height * image_width * min_area_fraction / aspect_ratio)
         if min_height < min_height_from_area:
             min_height = min_height_from_area
-        
+
         # The padded area must not exceed the maximum area fraction.
         max_height = np.sqrt(image_height * image_width *  max_area_fraction / aspect_ratio)
-        
+
         if min_height >= max_height:
             break
-    
+
     # We did not find a compatible aspect ratio. Just return the original data.
     if (min_height > max_height):
         return np.array(image), annotation
-    
+
     # Sample a final size, given the sampled aspect ratio and range of heights.
     padded_height = np.random.uniform(min_height, max_height)
     padded_width = padded_height * aspect_ratio;
-    
+
     # Sample the offset of the source image inside the padded image.
     x_offset = np.random.uniform(0.0, (padded_width - image_width))
     y_offset = np.random.uniform(0.0, (padded_height - image_height))
-    
+
     # Compute padding needed on the image
     after_padding_width = padded_width - image_width - x_offset
     after_padding_height = padded_height - image_height - y_offset
-    
+
     # Pad the image
     npad = ((int(y_offset), int(after_padding_height)), (int(x_offset), int(after_padding_width)), (0, 0))
     padded_image = np.pad(image, pad_width=npad, mode='constant', constant_values=0.5)
-    
+
     ty = float(y_offset)
     tx = float(x_offset)
-    
+
     # Transformation matrix for the annotations
     transformation_matrix = np.array([
                                 [1.0,     0.0,     ty],
                                 [0.0,     1.0,     tx],
                                 [0.0,     0.0,    1.0]
                             ])
-    
+
     # Use transformation matrix to augment annotations
     formatted_annotation = []
     for aug in annotation:
@@ -194,33 +206,33 @@ def padding_augmenter(image,
         if not np.any(bounds):
             formatted_annotation.append(np.concatenate([identifier, np.array([0, 0, 0, 0]), confidence]))
             continue
-            
+
         width = bounds[2]
         height = bounds[3]
-            
+
         x1 = bounds[0] * image_width
         y1 = bounds[1] * image_height
         x2 = (bounds[0] + width) * image_width
         y2 = (bounds[1] + height) * image_height
-        
+
         augmentation_coordinates = np.array([y1, x1, y2, x2], dtype=np.float32)
-        
+
         v = np.concatenate([augmentation_coordinates.reshape((2, 2)), np.ones((2, 1), dtype=np.float32)], axis=1)
         transposed_v = np.dot(v, np.transpose(transformation_matrix))
         t_intersection = np.squeeze(transposed_v[:, :2].reshape(-1, 4))
-        
-        # Sort the points top, left, bottom, right     
+
+        # Sort the points top, left, bottom, right
         if t_intersection[0] > t_intersection[2]:
             t_intersection[0], t_intersection[2] = t_intersection[2], t_intersection[0]
         if t_intersection[1] > t_intersection[3]:
             t_intersection[1], t_intersection[3] = t_intersection[3], t_intersection[1]
-        
-        # Normalize the elements to the cropped width and height        
+
+        # Normalize the elements to the cropped width and height
         ele_1 = t_intersection[1] / padded_width
         ele_2 = t_intersection[0] / padded_height
         ele_3 = (t_intersection[3] - t_intersection[1]) /padded_width
         ele_4 = (t_intersection[2] - t_intersection[0]) / padded_height
-        
+
         formatted_annotation.append(np.concatenate([identifier, np.array([ele_1, ele_2, ele_3, ele_4]), confidence]))
 
     return np.array(padded_image), np.array(formatted_annotation, dtype=np.float32)
@@ -235,7 +247,7 @@ def crop_augmenter(image,
                    min_object_covered=_DEFAULT_AUG_PARAMS["min_object_covered"],
                    max_attempts=_DEFAULT_AUG_PARAMS["max_attempts"],
                    min_eject_coverage=_DEFAULT_AUG_PARAMS["min_eject_coverage"]):
-    
+
     if np.random.uniform(0.0, 1.0) < skip_probability:
         return np.array(image), annotation
 
@@ -262,15 +274,15 @@ def crop_augmenter(image,
         max_height_from_width = float(image_width) / aspect_ratio
         if max_height > max_height_from_width:
             max_height = max_height_from_width
-        
+
         # The cropped area must not exceed the maximum area fraction.
         max_height_from_area = np.sqrt(image_height * image_width * max_area_fraction / aspect_ratio)
         if max_height > max_height_from_area:
             max_height = max_height_from_area
-        
+
         # The padded area must attain the minimum area fraction.
         min_height = np.sqrt(image_height * image_width * min_area_fraction / aspect_ratio)
-        
+
         # If the range is empty, then crops with the sampled aspect ratio cannot
         # satisfy the area constraint.
         if min_height > max_height:
@@ -280,31 +292,31 @@ def crop_augmenter(image,
         # Sample a position for the crop, constrained to lie within the image.
         cropped_height = np.random.uniform(min_height, max_height)
         cropped_width = cropped_height * aspect_ratio;
-        
+
         x_offset = np.random.uniform(0.0, (image_width - cropped_width))
         y_offset = np.random.uniform(0.0, (image_height - cropped_height))
-        
+
         crop_bounds_x1 = x_offset
         crop_bounds_y1 = y_offset
         crop_bounds_x2 = x_offset + cropped_width
         crop_bounds_y2 = y_offset + cropped_height
-        
+
         formatted_annotation = []
         is_min_object_covered = True
         for aug in annotation:
             identifier = aug[0:1]
             bounds = aug[1:5]
             confidence = aug[5:6]
-            
+
             width = bounds[2]
             height = bounds[3]
-            
+
             x1 = bounds[0] * image_width
             y1 = bounds[1] * image_height
-            
+
             x2 = (bounds[0] + width) * image_width
             y2 = (bounds[1] + height) * image_height
-            
+
             # This tests whether the crop bounds are out of the annotated bounds, if not it returns an empty annotation
             if crop_bounds_x1 < x2 and crop_bounds_y1 < y2 and x1 < crop_bounds_x2 and y1 < crop_bounds_y2:
                 x_bounds = [x1, x2, x_offset, x_offset + cropped_width]
@@ -312,22 +324,22 @@ def crop_augmenter(image,
 
                 x_bounds.sort()
                 y_bounds.sort()
-                
+
                 x_pairs = x_bounds[1:3]
                 y_pairs = y_bounds[1:3]
-                
+
                 intersection = np.array([y_pairs[0], x_pairs[0], y_pairs[1], x_pairs[1]])
-                
+
                 intersection_area = (intersection[3] - intersection[1]) * (intersection[2] - intersection[0])
                 annotation_area = (y2 - y1) * (x2 - x1)
-                
+
                 area_coverage = intersection_area / annotation_area
-                
+
                 # Invalidate the crop if it did not sufficiently overlap each annotation and try again.
                 if area_coverage < min_object_covered:
                     is_min_object_covered = False
                     break
-                
+
 
                 # If the area coverage is greater the min_eject_coverage, then actually keep the annotation
                 if area_coverage >= min_eject_coverage:
@@ -337,30 +349,30 @@ def crop_augmenter(image,
                         [0.0,     1.0,     -x_offset],
                         [0.0,     0.0,    1.0]
                     ])
-                    
+
                     v = np.concatenate([intersection.reshape((2, 2)), np.ones((2, 1), dtype=np.float32)], axis=1)
                     transposed_v = np.dot(v, np.transpose(transformation_matrix))
                     t_intersection = np.squeeze(transposed_v[:, :2].reshape(-1, 4))
 
-                    # Sort the points top, left, bottom, right    
+                    # Sort the points top, left, bottom, right
                     if t_intersection[0] > t_intersection[2]:
                         t_intersection[0], t_intersection[2] = t_intersection[2], t_intersection[0]
                     if t_intersection[1] > t_intersection[3]:
                         t_intersection[1], t_intersection[3] = t_intersection[3], t_intersection[1]
-                    
-                    # Normalize the elements to the cropped width and height  
+
+                    # Normalize the elements to the cropped width and height
                     ele_1 = t_intersection[1] / cropped_width
                     ele_2 = t_intersection[0] / cropped_height
                     ele_3 = (t_intersection[3] - t_intersection[1]) /cropped_width
                     ele_4 = (t_intersection[2] - t_intersection[0]) / cropped_height
-                    
+
                     formatted_annotation.append(np.concatenate([identifier, np.array([ele_1, ele_2, ele_3, ele_4]), confidence]))
                 else:
                     formatted_annotation.append(np.concatenate([identifier, np.array([0.0, 0.0, 0.0, 0.0]), confidence]))
             else:
                 formatted_annotation.append(np.concatenate([identifier, np.array([0.0, 0.0, 0.0, 0.0]), confidence]))
-        
-        
+
+
         if not is_min_object_covered:
             continue
 
@@ -368,11 +380,11 @@ def crop_augmenter(image,
         x_offset = int(x_offset)
         end_y = int(cropped_height + y_offset)
         end_x = int(cropped_width + x_offset)
-            
+
         image_cropped = image[y_offset:end_y, x_offset:end_x]
-            
+
         return np.array(image_cropped), np.array(formatted_annotation, dtype=np.float32)
-    
+
     return np.array(image), annotation
 
 def complete_augmenter(img_tf, ann_tf, output_height, output_width):
@@ -423,4 +435,4 @@ class DataAugmenter(object):
             processed_images = np.ascontiguousarray(processed_images, dtype=np.float32)
             return (processed_images, processed_annotations)
 
-    
+


### PR DESCRIPTION
close #2865 

6.0's CPU and GPU has prediction regression.
For the same image,
GPU:
```
#predictions
{'confidence': 0.6841502785682678, 'type': 'rectangle', 'coordinates': {'y': 167.98015236854553, 'x': 289.0607535839081, 'height': 238.21115112304688, 'width': 301.1848449707031}, 'label': 'Croissant'}
{'confidence': 0.5636424422264099, 'type': 'rectangle', 'coordinates': {'y': 168.73490810394287, 'x': 351.99418142437935, 'height': 183.61944580078125, 'width': 161.6607208251953}, 'label': 'Croissant'}
{'confidence': 0.5182375311851501, 'type': 'rectangle', 'coordinates': {'y': 101.34550631046295, 'x': 123.91261160373688, 'height': 176.6996612548828, 'width': 241.56607055664062}, 'label': 'Croissant'}
{'confidence': 0.4028134346008301, 'type': 'rectangle', 'coordinates': {'y': 210.60317158699036, 'x': 199.7049316763878, 'height': 175.12136840820312, 'width': 237.15415954589844}, 'label': 'Croissant'}
{'confidence': 0.1619817614555359, 'type': 'rectangle', 'coordinates': {'y': 106.30784332752228, 'x': 233.0048382282257, 'height': 219.98683166503906, 'width': 288.35015869140625}, 'label': 'Croissant'}
{'confidence': 0.10118640214204788, 'type': 'rectangle', 'coordinates': {'y': 213.20754289627075, 'x': 361.471713334322, 'height': 101.99461364746094, 'width': 127.2068862915039}, 'label': 'Croissant'}
{'confidence': 0.027622569352388382, 'type': 'rectangle', 'coordinates': {'y': 65.32773971557617, 'x': 268.4330843389034, 'height': 119.54254913330078, 'width': 164.8693084716797}, 'label': 'Croissant'}
{'confidence': 0.010357137769460678, 'type': 'rectangle', 'coordinates': {'y': 84.39711928367615, 'x': 118.78975331783295, 'height': 107.74749755859375, 'width': 172.99261474609375}, 'label': 'Croissant'}
{'confidence': 0.00467892037704587, 'type': 'rectangle', 'coordinates': {'y': 90.58223068714142, 'x': 315.67183434963226, 'height': 175.4208984375, 'width': 256.6126708984375}, 'label': 'Croissant'}

#evaluation
{'average_precision': {'Coffee': 0.0, 'Croissant': 0.23888888955116272, 'Waffle': 0.0, 'Bagel': 0.0, 'Egg': 0.0, 'Banana': 0.0}}
```

CPU:
```
{'confidence': 0.6783925890922546, 'type': 'rectangle', 'coordinates': {'y': 167.71613359451294, 'x': 288.49523663520813, 'height': 239.19659423828125, 'width': 301.3323974609375}, 'label': 'Croissant'}
{'confidence': 0.5581294298171997, 'type': 'rectangle', 'coordinates': {'y': 101.20467245578766, 'x': 123.50158989429474, 'height': 175.7798309326172, 'width': 240.85716247558594}, 'label': 'Croissant'}
{'confidence': 0.5499178171157837, 'type': 'rectangle', 'coordinates': {'y': 168.42872500419617, 'x': 351.87367647886276, 'height': 183.6824951171875, 'width': 160.7376708984375}, 'label': 'Croissant'}
{'confidence': 0.4112585783004761, 'type': 'rectangle', 'coordinates': {'y': 210.60165166854858, 'x': 200.05664974451065, 'height': 175.11065673828125, 'width': 237.96539306640625}, 'label': 'Croissant'}
{'confidence': 0.18294312059879303, 'type': 'rectangle', 'coordinates': {'y': 106.45350515842438, 'x': 233.51837396621704, 'height': 220.2215576171875, 'width': 289.7857971191406}, 'label': 'Croissant'}
{'confidence': 0.11228813976049423, 'type': 'rectangle', 'coordinates': {'y': 213.52950632572174, 'x': 361.25523895025253, 'height': 100.96805572509766, 'width': 126.85247039794922}, 'label': 'Croissant'}
{'confidence': 0.06214667111635208, 'type': 'rectangle', 'coordinates': {'y': 88.37236762046814, 'x': 264.0897363424301, 'height': 159.9544677734375, 'width': 179.37753295898438}, 'label': 'Croissant'}
{'confidence': 0.010909981094300747, 'type': 'rectangle', 'coordinates': {'y': 84.82984900474548, 'x': 119.08041089773178, 'height': 108.2442855834961, 'width': 171.14401245117188}, 'label': 'Croissant'}
{'confidence': 0.004227335564792156, 'type': 'rectangle', 'coordinates': {'y': 109.82267260551453, 'x': 322.89858385920525, 'height': 192.29393005371094, 'width': 212.18304443359375}, 'label': 'Croissant'}

#evaluation
{'average_precision': {'Coffee': 0.0, 'Croissant': 0.28333333134651184, 'Waffle': 0.0, 'Bagel': 0.0, 'Egg': 0.0, 'Banana': 0.0}}
```
The regression from both `predict()` and `evaluate()` are not neglectable.

[First Step] Compare 5.8's CPU, GPU and 6.0's CPU, GPU
I found that only 6.0's CPU has inference regression, that is to say we have issue in tensorflow.

[Second Step] Compare tensorflow with mxnet
I loaded the same weight to tf and mxnet model, and compare the output layer by layer,
the max error for the output feature tensor is `5 * 1e-5` magnitude, which is good.

[Third Step] Compare raw output from tensorflow and mxnet through tc's API
I compared the raw output tensor before the nms for tensorflow and mxnet through tc's API,
surprising the output tensor it self has error up to `0.7`.

[Fourth Step] Compare raw input for tensorfow and mxnet model
I compared the input tensor for tensorflow and mxnet and found out they have error up to `0.17` hmm.

[Fifth Step] Mock out the augmenter
I resize all images to `412 * 412` beforehand to mock out the effect of the tf image augmenter, and observed perfect aligned result across tf and mxnet.

[Sixth Step] TF's resize bilinear has regression haha
Found some existing issue report for tensorflow's resize bilinear has regression from other open source API like cv2, mxnet haha.
So I replace the tf resize by cv2.

Now finally we got the same predictions and map!!
GPU:
```
{'confidence': 0.6841502785682678, 'type': 'rectangle', 'coordinates': {'y': 167.98015236854553, 'x': 289.0607535839081, 'height': 238.21115112304688, 'width': 301.1848449707031}, 'label': 'Croissant'}
{'confidence': 0.5636424422264099, 'type': 'rectangle', 'coordinates': {'y': 168.73490810394287, 'x': 351.99418142437935, 'height': 183.61944580078125, 'width': 161.6607208251953}, 'label': 'Croissant'}
{'confidence': 0.5182375311851501, 'type': 'rectangle', 'coordinates': {'y': 101.34550631046295, 'x': 123.91261160373688, 'height': 176.6996612548828, 'width': 241.56607055664062}, 'label': 'Croissant'}
{'confidence': 0.4028134346008301, 'type': 'rectangle', 'coordinates': {'y': 210.60317158699036, 'x': 199.7049316763878, 'height': 175.12136840820312, 'width': 237.15415954589844}, 'label': 'Croissant'}
{'confidence': 0.1619817614555359, 'type': 'rectangle', 'coordinates': {'y': 106.30784332752228, 'x': 233.0048382282257, 'height': 219.98683166503906, 'width': 288.35015869140625}, 'label': 'Croissant'}
{'confidence': 0.10118640214204788, 'type': 'rectangle', 'coordinates': {'y': 213.20754289627075, 'x': 361.471713334322, 'height': 101.99461364746094, 'width': 127.2068862915039}, 'label': 'Croissant'}
{'confidence': 0.027622569352388382, 'type': 'rectangle', 'coordinates': {'y': 65.32773971557617, 'x': 268.4330843389034, 'height': 119.54254913330078, 'width': 164.8693084716797}, 'label': 'Croissant'}
{'confidence': 0.010357137769460678, 'type': 'rectangle', 'coordinates': {'y': 84.39711928367615, 'x': 118.78975331783295, 'height': 107.74749755859375, 'width': 172.99261474609375}, 'label': 'Croissant'}
{'confidence': 0.00467892037704587, 'type': 'rectangle', 'coordinates': {'y': 90.58223068714142, 'x': 315.67183434963226, 'height': 175.4208984375, 'width': 256.6126708984375}, 'label': 'Croissant'}
{'average_precision': {'Coffee': 0.0, 'Croissant': 0.23888888955116272, 'Waffle': 0.0, 'Bagel': 0.0, 'Egg': 0.0, 'Banana': 0.0}}
```

CPU:
```
{'confidence': 0.6868035197257996, 'type': 'rectangle', 'coordinates': {'y': 167.95871257781982, 'x': 289.0740305185318, 'height': 238.32237243652344, 'width': 301.1378479003906}, 'label': 'Croissant'}
{'confidence': 0.5671409368515015, 'type': 'rectangle', 'coordinates': {'y': 168.71926188468933, 'x': 351.95813924074173, 'height': 183.58172607421875, 'width': 161.74087524414062}, 'label': 'Croissant'}
{'confidence': 0.5187163352966309, 'type': 'rectangle', 'coordinates': {'y': 101.33549273014069, 'x': 123.91094863414764, 'height': 176.7119598388672, 'width': 241.39181518554688}, 'label': 'Croissant'}
{'confidence': 0.4052538275718689, 'type': 'rectangle', 'coordinates': {'y': 210.60553193092346, 'x': 199.70719814300537, 'height': 175.0858612060547, 'width': 237.0017547607422}, 'label': 'Croissant'}
{'confidence': 0.1624731868505478, 'type': 'rectangle', 'coordinates': {'y': 106.30392730236053, 'x': 233.04037749767303, 'height': 220.01197814941406, 'width': 288.4682312011719}, 'label': 'Croissant'}
{'confidence': 0.10168814659118652, 'type': 'rectangle', 'coordinates': {'y': 213.19506168365479, 'x': 361.4436239004135, 'height': 101.99732971191406, 'width': 127.12554931640625}, 'label': 'Croissant'}
{'confidence': 0.027944037690758705, 'type': 'rectangle', 'coordinates': {'y': 65.33297896385193, 'x': 268.4473067522049, 'height': 119.56062316894531, 'width': 164.90599060058594}, 'label': 'Croissant'}
{'confidence': 0.010488401167094707, 'type': 'rectangle', 'coordinates': {'y': 84.40530896186829, 'x': 118.79546642303467, 'height': 107.73643493652344, 'width': 173.0646209716797}, 'label': 'Croissant'}
{'confidence': 0.004655329044908285, 'type': 'rectangle', 'coordinates': {'y': 90.5926376581192, 'x': 315.64265191555023, 'height': 175.38531494140625, 'width': 256.51568603515625}, 'label': 'Croissant'}
{'average_precision': {'Coffee': 0.0, 'Croissant': 0.23888888955116272, 'Waffle': 0.0, 'Bagel': 0.0, 'Egg': 0.0, 'Banana': 0.0}}
```