### PR TITLE
[WIP] Pre-commit hooks for cpp files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+#
+# excludes: regex
+#
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://github.com/psf/black
+  rev: 19.10b0
+  hooks:
+  - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,23 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.4.0
   hooks:
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-yaml
-  - id: check-added-large-files
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
 - repo: https://github.com/psf/black
   rev: 19.10b0
   hooks:
-  - id: black
+    - id: black
+#
+# TODO: need to resolve external dependencies
+#
+# - repo: https://github.com/pocc/pre-commit-hooks
+#   sha: master
+#   hooks:
+#     - id: clang-format
+#       args: [--style=Google, -i]
+#     - id: clang-tidy
+#       args: [-checks=*, -warnings-as-errors=*]
+#     - id: oclint
+#       args: [-enable-clang-static-analyzer, -enable-global-analysis]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,5 @@ exclude = '''
   | buck-out
   | build
   | dist
-  # The following are specific to Black, you probably don't want those.
-  | blib2to3
-  | tests/data
-  | profiling
 )/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+####################### Black ########################
+#
+# Example configuration for Black.
+# https://github.com/psf/black/blob/master/pyproject.toml
+
+# NOTE: you have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+line-length = 88
+target-version = ['py27', 'py35', 'py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+  | profiling
+)/
+'''

--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # has to be run from root of the repo
-set -x
-set -e
+set -eux pipefail
 
 if [[ -z $VIRTUALENV ]]; then
   VIRTUALENV=virtualenv
@@ -38,6 +37,9 @@ function linux_patch_sigfpe_handler {
 $PIP install --upgrade "pip>=8.1"
 $PIP install -r scripts/requirements.txt
 
+# install hooks for git
+$PYTHON -m pre_commit install
+
 mkdir -p deps/local/lib
 mkdir -p deps/local/include
 
@@ -55,4 +57,3 @@ done
 popd
 
 linux_patch_sigfpe_handler
-

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -24,3 +24,4 @@ pyOpenSSL==19.0.0
 ndg-httpsclient==0.5.1
 pyasn1==0.4.5
 hypothesis==4.24.3
+pre-commit==1.21.0


### PR DESCRIPTION
Downstream of #2955, #2965

To achieve Cpp pre-commit, I  need to install external dependencies, which is kind of troublesome since those dependencies I have are distributed as binaries. I can rely on the local system to install them. So I need further discussion here.

Otherwise, I should make this pre-commit check optional so that developers can opt-in and opt-out.