### PR TITLE
Disable test with random intermittent failure.

### DIFF
--- a/test/ml_data/CMakeLists.txt
+++ b/test/ml_data/CMakeLists.txt
@@ -8,5 +8,6 @@ make_boost_test(dml_reindexing.cxx REQUIRES unity_shared_for_testing)
 # make_boost_test(dml_stats_merge_test.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(dml_metadata_api.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(dml_schema_errors.cxx REQUIRES unity_shared_for_testing)
-make_boost_test(dml_test_row_bounds.cxx REQUIRES unity_shared_for_testing)
+# KNOWN FAILURE
+# make_boost_test(dml_test_row_bounds.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(dml_sorted_columns.cxx REQUIRES unity_shared_for_testing)


### PR DESCRIPTION
The test ml_data/dml_test_row_bounds.cxx appears to have random intermediate failures due to some threading issue.  This PR disables this test. 

Tracked by https://github.com/apple/turicreate/issues/2966. 