### PR TITLE
make bulding python_source fast again

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -9,10 +9,6 @@ add_subdirectory(turicreate)
 # source is processed directly.  To handle this, we reproduce the availability
 # of the source files in the build tree.
 
-# Copy all the open source python stuff over first
-
-# Overwrite with the proprietary stuff
-
 make_copy_target(python_source
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt
@@ -24,9 +20,8 @@ make_copy_target(python_source
   DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/turicreate
 )
-add_dependencies(python_source numpy_integration tctensorflow)
 
-add_custom_target (clean_python)
+add_custom_target(clean_python)
 add_dependencies(clean_python clean_turicreate_binaries clean_cython)
 
 add_custom_command(

--- a/src/python/turicreate/CMakeLists.txt
+++ b/src/python/turicreate/CMakeLists.txt
@@ -1,11 +1,5 @@
 project(Turi)
 
-# We depend on the open source src/python/turicreate
-# to fill
-#  - INSTALLATION_BINARY_FILES
-#  - INSTALLATION_EXTENSIONS
-#
-# These can be amended locally to set up alternative behavior
 
 if(UNIX AND NOT APPLE)
   set(LINUX TRUE)
@@ -26,7 +20,7 @@ make_copy_target(copy_unity_shared
   FILES
   $<TARGET_FILE:unity_shared>
 )
-add_dependencies(copy_unity_shared unity_shared)
+add_dependencies(copy_unity_shared tctensorflow unity_shared)
 
 if(APPLE AND HAS_COREML_CUSTOM_MODEL)
   make_copy_target(copy_coreml_dylibs
@@ -46,7 +40,7 @@ make_copy_target(release_binaries
         ${INSTALLATION_SYSTEM_BINARY_FILES}
         )
 
-ADD_CUSTOM_TARGET (clean_turicreate_binaries)
+ADD_CUSTOM_TARGET(clean_turicreate_binaries)
 ADD_CUSTOM_COMMAND(
   COMMENT "clean turicreate binaries"
   COMMAND rm -f *.so *.dylib *.dll *.jar


### PR DESCRIPTION
Fixes #2477 
Removes a dependency on a target which no longer exists (`numpy_integration`).
Also removes some very outdated comments.