### PR TITLE
Fix flakey 1SOD test

### DIFF
--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -157,9 +157,6 @@ class OneObjectDetectorSmokeTest(unittest.TestCase):
                 max_iterations=1,
             )
 
-    @pytest.mark.xfail(
-        reason="Non-deterministic test failure tracked in https://github.com/apple/turicreate/issues/2936"
-    )
     def test_create_with_empty_dataset(self):
         with self.assertRaises(_ToolkitError):
             tc.one_shot_object_detector.create(self.train[:0], target=self.target)

--- a/src/python/turicreate/toolkits/_data_zoo.py
+++ b/src/python/turicreate/toolkits/_data_zoo.py
@@ -41,14 +41,22 @@ class OneShotObjectDetectorBackgroundData(object):
         }
 
     def get_backgrounds(self):
+        # Download tar file, if not already downloaded
+        # Get tar file path
         tarfile_path = _download_and_checksum_files(
             self.sarray_url_md5_pairs, _get_cache_dir("data")
         )[0]
 
+        # Extract from tar file, if not already extracted
+        if _os.path.exists(self.destination_sarray_path):
+            backgrounds_tar = _tarfile.open(tarfile_path)
+            backgrounds_tar.extractall(_get_cache_dir("data"))
+
+        # Verify and load the extracted SArray
         try:
             # Check we extracted the file we expected
             expected_extracted_files = set(self.extracted_file_to_md5.keys())
-            extracted_files = set(_os.listdir(foo.destination_sarray_path))
+            extracted_files = set(_os.listdir(self.destination_sarray_path))
             assert expected_extracted_files == extracted_files
 
             # Check each of the files is what we expect

--- a/src/python/turicreate/toolkits/_data_zoo.py
+++ b/src/python/turicreate/toolkits/_data_zoo.py
@@ -47,7 +47,7 @@ class OneShotObjectDetectorBackgroundData(object):
             self.sarray_url_md5_pairs, _get_cache_dir("data")
         )[0]
 
-        # Extract from tar file, if not already extracted
+        # Extract SArray from tar file, if not already extracted
         if _os.path.exists(self.destination_sarray_path):
             backgrounds_tar = _tarfile.open(tarfile_path)
             backgrounds_tar.extractall(_get_cache_dir("data"))

--- a/src/python/turicreate/toolkits/_data_zoo.py
+++ b/src/python/turicreate/toolkits/_data_zoo.py
@@ -7,6 +7,7 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 
+import hashlib as _hashlib
 import os as _os
 import turicreate as _tc
 import shutil as _shutil
@@ -32,18 +33,37 @@ class OneShotObjectDetectorBackgroundData(object):
             (self.sarray_url, "08830e90771897c1cd187a07cdcb52b4")
         ]
 
+        self.extracted_file_to_md5 = {
+            'dir_archive.ini': '160fe6e7cb81cb0a29fd09239fdb2559',
+            'm_d761047844237e5d.0000': 'd29b68f8ba196f60e0ad115f7bfde863',
+            'm_d761047844237e5d.sidx': '22b0c297aabb836a21d3179c05c9c455',
+            'objects.bin': 'd41d8cd98f00b204e9800998ecf8427e'
+        }
+
     def get_backgrounds(self):
         tarfile_path = _download_and_checksum_files(
             self.sarray_url_md5_pairs, _get_cache_dir("data")
         )[0]
-        backgrounds_tar = _tarfile.open(tarfile_path)
+
         try:
+            # Check we extracted the file we expected
+            expected_extracted_files = set(self.extracted_file_to_md5.keys())
+            extracted_files = set(_os.listdir(foo.destination_sarray_path))
+            assert expected_extracted_files == extracted_files
+
+            # Check each of the files is what we expect
+            for filename, expected_md5 in self.extracted_file_to_md5.items():
+                full_path = _os.path.join(_get_cache_dir("data"), filename)
+                md5 = hashlib.md5(full_path).hexdigest()
+                assert md5 == expected_md5
+
             backgrounds = _tc.SArray(self.destination_sarray_path)
         except:
-            # delete the incompletely extracted tarball bits on disk
+            # delete the incompletely/incorrectly extracted tarball bits on disk
             if _os.path.exists(self.destination_sarray_path):
                 _shutil.rmtree(self.destination_sarray_path)
             # and re-extract
+            backgrounds_tar = _tarfile.open(tarfile_path)
             backgrounds_tar.extractall(_get_cache_dir("data"))
             backgrounds = _tc.SArray(self.destination_sarray_path)
 

--- a/src/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
@@ -62,18 +62,22 @@ def create(
         >>> test_data['predictions'] = model.predict(test_data)
     """
     if not isinstance(data, _tc.SFrame) and not isinstance(data, _tc.Image):
-        raise TypeError("'data' must be of type SFrame or Image.")
+        raise TypeError("'data' must be of type SFrame or tc.Image.")
+
     augmented_data = _preview_synthetic_training_data(data, target, backgrounds)
+
     model = _tc.object_detector.create(
         augmented_data,
         batch_size=batch_size,
         max_iterations=max_iterations,
         verbose=verbose,
     )
+
     if isinstance(data, _tc.SFrame):
         num_starter_images = len(data)
     else:
         num_starter_images = 1
+
     state = {
         "detector": model,
         "target": target,

--- a/src/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/one_shot_object_detector.py
@@ -8,7 +8,9 @@
 import turicreate as _tc
 from turicreate import extensions as _extensions
 from turicreate.toolkits._model import CustomModel as _CustomModel
-from turicreate.toolkits._model import PythonProxy as _PythonProxy
+from turicreate.toolkits._model import (
+    PythonProxy as _PythonProxy, ToolkitError as _ToolkitError
+)
 from turicreate.toolkits.object_detector.object_detector import (
     ObjectDetector as _ObjectDetector,
 )
@@ -63,6 +65,8 @@ def create(
     """
     if not isinstance(data, _tc.SFrame) and not isinstance(data, _tc.Image):
         raise TypeError("'data' must be of type SFrame or tc.Image.")
+    if isinstance(data, _tc.SFrame) and len(data) == 0:
+        raise _ToolkitError("'data' can not be an empty SFrame")
 
     augmented_data = _preview_synthetic_training_data(data, target, backgrounds)
 

--- a/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
+++ b/src/python/turicreate/toolkits/one_shot_object_detector/util/_augmentation.py
@@ -36,6 +36,9 @@ def preview_synthetic_training_data(
         A list of backgrounds used for synthetic data generation. When set to
         None, a set of default backgrounds are downloaded and used.
 
+    verbose : bool optional
+        If True, print progress updates and details.
+
     Returns
     -------
     out : SFrame
@@ -45,8 +48,7 @@ def preview_synthetic_training_data(
         data, target, backgrounds
     )
     _tkutl._handle_missing_values(dataset_to_augment, image_column_name, "dataset")
-    one_shot_model = _extensions.one_shot_object_detector()
-    seed = kwargs["seed"] if "seed" in kwargs else _random.randint(0, 2 ** 32 - 1)
+
     if backgrounds is None:
         backgrounds_downloader = _data_zoo.OneShotObjectDetectorBackgroundData()
         backgrounds = backgrounds_downloader.get_backgrounds()
@@ -60,7 +62,10 @@ def preview_synthetic_training_data(
         )
     # Option arguments to pass in to C++ Object Detector, if we use it:
     # {'mlmodel_path':'darknet.mlmodel', 'max_iterations' : 25}
+    seed = kwargs["seed"] if "seed" in kwargs else _random.randint(0, 2 ** 32 - 1)
     options_for_augmentation = {"seed": seed, "verbose": verbose}
+
+    one_shot_model = _extensions.one_shot_object_detector()
     augmented_data = one_shot_model.augment(
         dataset_to_augment,
         image_column_name,


### PR DESCRIPTION
Fixes: #2936

This is in many ways just an extension of #2901. There is [evidence](https://github.com/apple/turicreate/issues/2936#issuecomment-582182773) to suggest it's possible for an SArray to be incorrect extracted from a tar file and still be loadable.

This change checks the md5 of each extracted file.

This change also remove the xfail from the unit test and makes other minor changes. 