### PR TITLE
Updated Conditional InstanceNorm

### DIFF
--- a/src/python/turicreate/toolkits/style_transfer/_tf_model_architecture.py
+++ b/src/python/turicreate/toolkits/style_transfer/_tf_model_architecture.py
@@ -79,13 +79,13 @@ def define_instance_norm(tf_input, tf_index, weights, prefix):
     """
     epsilon = 1e-5
 
-    gamma = weights[prefix + "gamma_weight"]
-    beta = weights[prefix + "beta_weight"]
-    
+    gamma = weights[prefix + 'gamma_weight']
+    beta = weights[prefix + 'beta_weight']
+
     inputs_rank = tf_input.shape.ndims
     reduction_axis = inputs_rank - 1
     moments_axes = list(range(inputs_rank))
-    
+
     del moments_axes[reduction_axis]
     del moments_axes[0]
 
@@ -96,8 +96,14 @@ def define_instance_norm(tf_input, tf_index, weights, prefix):
     expanded_beta = _tf.expand_dims(_tf.expand_dims(indexed_beta, 1), 1)
 
     mean, variance = _tf.nn.moments(tf_input, moments_axes, keep_dims=True)
-    return _tf.nn.batch_normalization(tf_input, mean, variance, expanded_beta, expanded_gamma, epsilon)
-
+    return _tf.nn.batch_normalization(
+        tf_input,
+        mean,
+        variance,
+        expanded_beta,
+        expanded_gamma,
+        epsilon)
+    
 def define_residual(tf_input, tf_index, weights, prefix):
     """
     This function defines the residual network using the tensorflow nn api.


### PR DESCRIPTION
 # Overview
- Updated the conditional InstanceNorm implementation to get a better stylization.
- Gradients in the previous stylization were incorrectly being propagated.

# Previous Implementation
All styles are merged together.

![img_111100](https://user-images.githubusercontent.com/4616962/73872206-1c4b7e00-4804-11ea-91ad-d43967e01e45.png)
![img_110600](https://user-images.githubusercontent.com/4616962/73872212-20779b80-4804-11ea-8c49-900c40d1df11.png)
![img_10000](https://user-images.githubusercontent.com/4616962/73872234-2b323080-4804-11ea-9482-394b05419744.png)

# Current Implementation
Styles have distinct seperation

![index_4_78500](https://user-images.githubusercontent.com/4616962/73872380-75b3ad00-4804-11ea-880a-cfd21b9d860f.png)
![index_3_72000](https://user-images.githubusercontent.com/4616962/73872461-9845c600-4804-11ea-8702-77dc8527c3d3.png)
![index_2_6100](https://user-images.githubusercontent.com/4616962/73872414-86642300-4804-11ea-9604-0abececacb0a.png)

# Fixes
- Removed `split` in `beta` and `gamma` in instanceNorm
- Removed loop in instanceNorm layer