### PR TITLE
Updated Initialization for Style Transfer

### DIFF
--- a/src/ml/neural_net/weight_init.cpp
+++ b/src/ml/neural_net/weight_init.cpp
@@ -35,6 +35,19 @@ void xavier_weight_initializer::operator()(float* first_weight,
   }
 }
 
+uniform_weight_initializer::uniform_weight_initializer(
+    float lower_bound, float upper_bound, std::mt19937* random_engine)
+    : dist_(std::uniform_real_distribution<float>(lower_bound, upper_bound)),
+      random_engine_(*random_engine)
+{}
+
+void uniform_weight_initializer::operator()(float* first_weight,
+                                            float* last_weight) {
+  for (float* w = first_weight; w != last_weight; ++w) {
+    *w = dist_(random_engine_);
+  }
+}
+
 scalar_weight_initializer::scalar_weight_initializer(float scalar) 
     : scalar_(scalar) {}
 

--- a/src/ml/neural_net/weight_init.hpp
+++ b/src/ml/neural_net/weight_init.hpp
@@ -55,8 +55,8 @@ class uniform_weight_initializer {
   /**
    * Creates a weight initializer that performs Uniform initialization
    *
-   * \param lower_bound The number of inputs that affect each output from the layer
-   * \param upper_bound The number of outputs affected by each input to the layer
+   * \param lower_bound The lower bound of the uniform distribution to be sampled
+   * \param upper_bound The upper bound of the uniform distribution to be sampled
    * \param random_engine The random number generator to use, which must remain
    *     valid for the lifetime of this instance.
    */

--- a/src/ml/neural_net/weight_init.hpp
+++ b/src/ml/neural_net/weight_init.hpp
@@ -48,6 +48,32 @@ private:
   std::mt19937& random_engine_;
 };
 
+
+class uniform_weight_initializer {
+  public:
+
+  /**
+   * Creates a weight initializer that performs Uniform initialization
+   *
+   * \param lower_bound The number of inputs that affect each output from the layer
+   * \param upper_bound The number of outputs affected by each input to the layer
+   * \param random_engine The random number generator to use, which must remain
+   *     valid for the lifetime of this instance.
+   */
+  uniform_weight_initializer(float lower_bound, float upper_bound,
+                            std::mt19937* random_engine);
+
+  /**
+   * Initializes each value in uniformly at random in the range [-lower_bound, upper_bound]
+   */
+  void operator()(float* first_weight, float* last_weight);
+
+private:
+
+  std::uniform_real_distribution<float> dist_;
+  std::mt19937& random_engine_;
+};
+
 struct scalar_weight_initializer {
   /**
    * Creates a weight initializer that initializes all of the weights to a

--- a/src/python/turicreate/toolkits/style_transfer/style_transfer.py
+++ b/src/python/turicreate/toolkits/style_transfer/style_transfer.py
@@ -247,6 +247,7 @@ def create(
     options["num_styles"] = len(style_dataset)
     options["resnet_mlmodel_path"] = pretrained_resnet_model.get_model_path("coreml")
     options["vgg_mlmodel_path"] = pretrained_vgg16_model.get_model_path("coreml")
+    options["pretrained_weights"] = params["pretrained_weights"]
 
     model.train(style_dataset[style_feature], content_dataset[content_feature], options)
     return StyleTransfer(model_proxy=model, name=name)

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -686,6 +686,12 @@ void style_transfer::init_train(gl_sarray style, gl_sarray content,
   }
   size_t num_styles = num_styles_iter->second;
 
+  auto pretrained_weights_iter = opts.find("pretrained_weights");
+  bool pretrained_weights = false;
+  if (pretrained_weights_iter != opts.end()) {
+    pretrained_weights = pretrained_weights_iter->second;
+  }
+  
   init_options(opts);
 
   if (read_state<flexible_type>("random_seed") == FLEX_UNDEFINED) {
@@ -694,9 +700,11 @@ void style_transfer::init_train(gl_sarray style, gl_sarray content,
     add_or_update_state({{"random_seed", random_seed}});
   }
 
+  int random_seed = read_state<int>("random_seed");
+
   m_training_data_iterator =
       create_iterator(content, style, /* repeat */ true,
-                      /* training */ true, static_cast<int>(num_styles));
+                      /* training */ true, random_seed);
 
   m_training_compute_context = create_compute_context();
   if (m_training_compute_context == nullptr) {
@@ -709,7 +717,13 @@ void style_transfer::init_train(gl_sarray style, gl_sarray content,
                        {"styles", style_sframe_with_index(style)},
                        {"num_content_images", content.size()}});
 
-  m_resnet_spec = init_resnet(resnet_mlmodel_path, num_styles);
+  // TODO: change to include random seed.
+  if (pretrained_weights) {
+    m_resnet_spec = init_resnet(resnet_mlmodel_path, num_styles);
+  } else {
+    m_resnet_spec = init_resnet(num_styles, random_seed);
+  }
+
   m_vgg_spec = init_vgg_16(vgg_mlmodel_path);
 
   float_array_map weight_params = m_resnet_spec->export_params_view();

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -691,6 +691,7 @@ void style_transfer::init_train(gl_sarray style, gl_sarray content,
   if (pretrained_weights_iter != opts.end()) {
     pretrained_weights = pretrained_weights_iter->second;
   }
+  opts.erase(pretrained_weights_iter);
   
   init_options(opts);
 

--- a/src/toolkits/style_transfer/style_transfer_model_definition.cpp
+++ b/src/toolkits/style_transfer/style_transfer_model_definition.cpp
@@ -31,25 +31,24 @@ using padding_type = model_spec::padding_type;
 
 namespace {
 
-constexpr float LOWER_BOUND = -0.07; 
-constexpr float UPPER_BOUND = 0.07; 
+constexpr float LOWER_BOUND = -0.07;
+constexpr float UPPER_BOUND = 0.07;
 
 // TODO: refactor code to be more readable with loops
 void define_resnet(model_spec& nn_spec, size_t num_styles, bool initialize=false, int random_seed=0) {
+  std::mt19937 random_engine;
+  std::seed_seq seed_seq{random_seed};
+  random_engine = std::mt19937(seed_seq);
+
   weight_initializer initializer;
 
   // This is to make sure that when the uniform initialization is not needed extra work is avoided
   if (initialize) {
-    std::mt19937 random_engine;
-    std::seed_seq seed_seq{random_seed};
-    random_engine = std::mt19937(seed_seq);
-
     initializer = uniform_weight_initializer(LOWER_BOUND, UPPER_BOUND, &random_engine);
   } else {
     initializer = zero_weight_initializer();
   }
- 
-  
+
   nn_spec.add_padding(
       /* name */ "transformer_pad0",
       /* input */ "image",

--- a/src/toolkits/style_transfer/style_transfer_model_definition.cpp
+++ b/src/toolkits/style_transfer/style_transfer_model_definition.cpp
@@ -22,15 +22,15 @@ using CoreML::Specification::NeuralNetworkLayer;
 using turi::neural_net::float_array_map;
 using turi::neural_net::model_spec;
 using turi::neural_net::scalar_weight_initializer;
-using turi::neural_net::xavier_weight_initializer;
+using turi::neural_net::uniform_weight_initializer;
 using turi::neural_net::zero_weight_initializer;
 
 using padding_type = model_spec::padding_type;
 
 namespace {
 
-constexpr float LOWER_BOUND = -0.7; 
-constexpr float UPPER_BOUND = 0.7; 
+constexpr float LOWER_BOUND = -0.07; 
+constexpr float UPPER_BOUND = 0.07; 
 
 // TODO: refactor code to be more readable with loops
 void define_resnet(model_spec& nn_spec, size_t num_styles, int random_seed=0) {
@@ -38,7 +38,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles, int random_seed=0) {
   std::seed_seq seed_seq{random_seed};
   random_engine = std::mt19937(seed_seq);
 
-  auto initializer = xavier_weight_initializer(LOWER_BOUND, UPPER_BOUND, &random_engine);
+  auto initializer = uniform_weight_initializer(LOWER_BOUND, UPPER_BOUND, &random_engine);
   
   nn_spec.add_padding(
       /* name */ "transformer_pad0",

--- a/src/toolkits/style_transfer/style_transfer_model_definition.cpp
+++ b/src/toolkits/style_transfer/style_transfer_model_definition.cpp
@@ -7,6 +7,8 @@
 
 #include <toolkits/style_transfer/style_transfer_model_definition.hpp>
 
+#include <random>
+
 #include <ml/neural_net/weight_init.hpp>
 #include <toolkits/coreml_export/mlmodel_include.hpp>
 
@@ -20,14 +22,24 @@ using CoreML::Specification::NeuralNetworkLayer;
 using turi::neural_net::float_array_map;
 using turi::neural_net::model_spec;
 using turi::neural_net::scalar_weight_initializer;
+using turi::neural_net::xavier_weight_initializer;
 using turi::neural_net::zero_weight_initializer;
 
 using padding_type = model_spec::padding_type;
 
 namespace {
 
+constexpr float LOWER_BOUND = -0.7; 
+constexpr float UPPER_BOUND = 0.7; 
+
 // TODO: refactor code to be more readable with loops
-void define_resnet(model_spec& nn_spec, size_t num_styles) {
+void define_resnet(model_spec& nn_spec, size_t num_styles, int random_seed=0) {
+  std::mt19937 random_engine;
+  std::seed_seq seed_seq{random_seed};
+  random_engine = std::mt19937(seed_seq);
+
+  auto initializer = xavier_weight_initializer(LOWER_BOUND, UPPER_BOUND, &random_engine);
+  
   nn_spec.add_padding(
       /* name */ "transformer_pad0",
       /* input */ "image",
@@ -46,7 +58,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_encode_1_inst_gamma",
@@ -102,7 +114,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 2,
       /* stride_width */ 2,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_encode_2_inst_gamma",
@@ -158,7 +170,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 2,
       /* stride_width */ 2,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_encode_3_inst_gamma",
@@ -214,7 +226,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_1_inst_1_gamma",
@@ -270,7 +282,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_1_inst_2_gamma",
@@ -327,7 +339,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_2_inst_1_gamma",
@@ -383,7 +395,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_2_inst_2_gamma",
@@ -440,7 +452,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_3_inst_1_gamma",
@@ -496,7 +508,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_3_inst_2_gamma",
@@ -553,7 +565,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_4_inst_1_gamma",
@@ -609,7 +621,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_4_inst_2_gamma",
@@ -666,7 +678,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_5_inst_1_gamma",
@@ -722,7 +734,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_residual_5_inst_2_gamma",
@@ -785,7 +797,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_decoding_1_inst_gamma",
@@ -847,7 +859,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_decoding_2_inst_gamma",
@@ -903,7 +915,7 @@ void define_resnet(model_spec& nn_spec, size_t num_styles) {
       /* stride_height */ 1,
       /* stride_width */ 1,
       /* padding */ padding_type::VALID,
-      /* weight_init_fn */ zero_weight_initializer());
+      /* weight_init_fn */ initializer);
 
   nn_spec.add_inner_product(
       /* name */ "transformer_instancenorm5_gamma",
@@ -1164,9 +1176,10 @@ std::unique_ptr<model_spec> init_resnet(const std::string& path) {
   return spec;
 }
 
-std::unique_ptr<neural_net::model_spec> init_resnet(size_t num_styles) {
+std::unique_ptr<neural_net::model_spec> init_resnet(size_t num_styles,
+                                                    int random_seed) {
   std::unique_ptr<model_spec> nn_spec(new model_spec());
-  define_resnet(*nn_spec, num_styles);
+  define_resnet(*nn_spec, num_styles, random_seed);
   return nn_spec;
 }
 

--- a/src/toolkits/style_transfer/style_transfer_model_definition.hpp
+++ b/src/toolkits/style_transfer/style_transfer_model_definition.hpp
@@ -17,7 +17,8 @@ namespace turi {
 namespace style_transfer {
 
 std::unique_ptr<neural_net::model_spec> init_resnet(const std::string& path);
-std::unique_ptr<neural_net::model_spec> init_resnet(size_t num_styles);
+std::unique_ptr<neural_net::model_spec> init_resnet(size_t num_styles,
+													int random_seed=0);
 std::unique_ptr<neural_net::model_spec> init_resnet(const std::string& path,
                                                     size_t num_styles);
 std::unique_ptr<neural_net::model_spec> init_vgg_16();


### PR DESCRIPTION
# Overview
Initialization for style transfer is a uniform between -0.7 and 0.7. Previously only pertained weights were used for this in TensorFlow.

# Fixes
- Weight initialization in style transfer to use uniform between -0.7 and 0.7
- Random Seed values for initialization