### PR TITLE
Added support for AC to use single input feature column

### DIFF
--- a/src/python/turicreate/test/test_activity_classifier.py
+++ b/src/python/turicreate/test/test_activity_classifier.py
@@ -150,6 +150,26 @@ class ActivityClassifierCreateStressTests(unittest.TestCase):
                 validation_set=sf,
             )
 
+    def test_create_single_input_column(self):
+        sf_label = random.randint(0, self.num_labels - 1)
+        sf_session_id = max(self.data[self.session_id])
+        input_data = tc.SFrame(
+                {
+                    self.features[0]: [3.14],
+                    self.target: [sf_label],
+                    self.session_id: [sf_session_id],
+                }
+        )
+        model = tc.activity_classifier.create(
+                input_data,
+                features=["X1-r"],
+                target=self.target,
+                session_id=self.session_id,
+                prediction_window=self.prediction_window,
+        )
+        filename = tempfile.mkstemp("ActivityClassifier.mlmodel")[1]
+        model.export_coreml(filename)
+
     def test_create_invalid_batch_size(self):
         with self.assertRaises(_ToolkitError):
             tc.activity_classifier.create(

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -926,8 +926,7 @@ std::unique_ptr<model_spec> activity_classifier::init_model(
     std::string single_input_feature{feature_column_name};
     result->add_reshape("reshape", single_input_feature,
                         {{1, num_features, 1, prediction_window}});
-  }
-  else {
+  } else {
     // Multiple feature columns. Add concatenate layer to concat all columns.
     result->add_channel_concat(
         "features",

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -919,11 +919,22 @@ std::unique_ptr<model_spec> activity_classifier::init_model(
     std::seed_seq seed_seq{read_state<int>("random_seed")};
     random_engine = std::mt19937(seed_seq);
   }
-  result->add_channel_concat(
-      "features",
-      std::vector<std::string>(features_list.begin(), features_list.end()));
-  result->add_reshape("reshape", "features",
-                      {{1, num_features, 1, prediction_window}});
+
+  if (features_list.size() == 1) {
+    // Single feature column
+    const flex_string& feature_column_name = features_list.front();
+    std::string single_input_feature{feature_column_name};
+    result->add_reshape("reshape", single_input_feature,
+                        {{1, num_features, 1, prediction_window}});
+  }
+  else {
+    // Multiple feature columns. Add concatenate layer to concat all columns.
+    result->add_channel_concat(
+        "features",
+        std::vector<std::string>(features_list.begin(), features_list.end()));
+    result->add_reshape("reshape", "features",
+                        {{1, num_features, 1, prediction_window}});
+  }
 
   weight_initializer initializer = zero_weight_initializer();
   lstm_weight_initializers lstm_initializer =


### PR DESCRIPTION
Closes #2945 

Currently AC expects input data to include >=2 input feature columns. For this a concat layer is used to concatenate all input feature columns. When a single input column is provided, `export_coreml` breaks due to NN spec `validateConcatLayer` check failing.

This change checks number of input feature columns and **does not** add concat layer if feature columns are of size 1.
