### PR TITLE
Introduce a minimal reactive streams framework, inspired somewhat by Swift's Combine

### DIFF
--- a/src/ml/neural_net/combine.hpp
+++ b/src/ml/neural_net/combine.hpp
@@ -19,8 +19,6 @@
 #include <ml/neural_net/combine_base.hpp>
 #include <ml/neural_net/combine_futures_subscriber.hpp>
 #include <ml/neural_net/combine_iterator.hpp>
-
-}  // namespace neural_net
-}  // namespace turi
+#include <ml/neural_net/combine_map.hpp>
 
 #endif  // ML_NEURAL_NET_COMBINE_HPP_

--- a/src/ml/neural_net/combine.hpp
+++ b/src/ml/neural_net/combine.hpp
@@ -1,0 +1,26 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef ML_NEURAL_NET_COMBINE_HPP_
+#define ML_NEURAL_NET_COMBINE_HPP_
+
+/**
+ * \file combine.hpp
+ *
+ * Defines a reactive-streams library inspired by the Swift Combine
+ * framework. Its intent is to simplify reasoning about and testing of NN
+ * model-training pipelines.
+ */
+
+#include <ml/neural_net/combine_base.hpp>
+#include <ml/neural_net/combine_futures_subscriber.hpp>
+#include <ml/neural_net/combine_iterator.hpp>
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // ML_NEURAL_NET_COMBINE_HPP_

--- a/src/ml/neural_net/combine_base.hpp
+++ b/src/ml/neural_net/combine_base.hpp
@@ -1,0 +1,243 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef ML_NEURAL_NET_COMBINE_BASE_HPP_
+#define ML_NEURAL_NET_COMBINE_BASE_HPP_
+
+/**
+ * \file combine_base.hpp
+ *
+ * Defines the core data types for a reactive-streams library inspired by the
+ * Swift Combine framework. Client code should generally import combine.hpp.
+ */
+
+#include <exception>
+#include <memory>
+
+namespace turi {
+namespace neural_net {
+
+// Forward declarations for types defined by other headers included by
+// combine.hpp.
+
+template <typename T>
+class FuturesStream;
+
+template <typename T>
+class FuturesSubscriber;
+
+template <typename T, typename U>
+class MapPublisher;
+
+template <typename T, typename U>
+class Transform;
+
+/**
+ * Simple type expressing how many values a Subscriber is ready to receive
+ * from its Publisher.
+ */
+class Demand {
+ public:
+  static Demand Unlimited() { return Demand(-1); }
+  static Demand None() { return Demand(0); }
+
+  /** Any negative value is interpreted as "unlimited". */
+  explicit Demand(int max) : max_(max) {}
+
+  bool IsUnlimited() const { return max_ < 0; }
+  bool IsNone() const { return max_ == 0; }
+
+  /** Returns a negative number to indicate "unlimited." */
+  int max() const { return max_; }
+
+  /** Additively combines another Demand value into this one. */
+  Demand& Add(Demand other) {
+    if (IsUnlimited() || other.IsUnlimited()) {
+      max_ = -1;
+    } else {
+      max_ += other.max_;
+    }
+    return *this;
+  }
+
+  /** Decrease this demand by one if the current max is positive and finite. */
+  Demand& Decrement() {
+    if (max_ > 0) {
+      --max_;
+    }
+    return *this;
+  }
+
+ private:
+  int max_ = 0;
+};
+
+/**
+ * Interface for objects that Publishers send to Subscribers to allow the
+ * Subscribers to (potentially asynchronously) control the flow of values that
+ * the Subscriber receives from the Publisher.
+ */
+class Subscription {
+ public:
+  virtual ~Subscription() = default;
+
+  /**
+   * Requests the Publisher to stop sending anything to the Subscriber.
+   *
+   * After receiving Cancel() from a Subscriber, a Publisher should thereafter
+   * ignore all future messages from that Subscriber, including future calls to
+   * Cancel.
+   *
+   * Publishers must support Subscribers calling Cancel() from inside
+   * Subscriber::Receive(...).
+   */
+  virtual void Cancel() = 0;
+
+  /**
+   * Requests the Publisher to send the indicated number of values to the
+   * Subscriber.
+   *
+   * Publishers must support Subscribers calling Request(Demand) from inside
+   * Subscriber::Receive(Subscription), but Subscribers should avoid calling
+   * Request(Demand) inside Subscriber::Receive(Input). Instead, they should
+   * send additional Demand via the return value of Subscriber::Receive(Input)
+   * (to help prevent infinite recursion).
+   */
+  virtual void Request(Demand demand) = 0;
+};
+
+/**
+ * Type representing a message from a Publisher to a Subscriber indicating that
+ * the Subscriber will no longer receive any further messages.
+ */
+class Completion {
+ public:
+  /** Returns an instance that signals successful completion. */
+  static Completion Finished() { return Completion(); }
+
+  /**
+   * Returns an instance that signals failure, described by the given
+   * exception.
+   */
+  static Completion Failure(std::exception_ptr e) { return Completion(e); }
+
+  bool IsFinished() const { return failure_ == nullptr; }
+
+  /** Returns the exception if a failure and a null pointer otherwise. */
+  std::exception_ptr failure() const { return failure_; }
+
+ private:
+  explicit Completion(std::exception_ptr e = nullptr) : failure_(e) {}
+
+  std::exception_ptr failure_;
+};
+
+/**
+ * Interface for objects that consume values from a Publisher.
+ *
+ * Unless otherwise specified by the concrete implementation, external
+ * synchronization must be used to avoid concurrent calls the Subscriber
+ * interface from different threads.
+ */
+template <typename T>
+class Subscriber {
+ public:
+  /** The type of the values that this Subscriber consumes. */
+  using Input = T;
+
+  virtual ~Subscriber() = default;
+
+  /**
+   * The first signal that a Subscriber receives from a Publisher, passing the
+   * Subscription that the Subscriber can use to control the flow of values.
+   *
+   * A Subscriber may only have one Publisher. If it somehow receives more than
+   * one Subscription, it should call Subscription::Cancel() on any instances
+   * received after the first.
+   *
+   * A Subscriber is explictly allowed to demand values synchronously from
+   * within its implementation of this method.
+   */
+  virtual void Receive(std::shared_ptr<Subscription> subscription) = 0;
+
+  /**
+   * Transmits a value from the Publisher to this Subscriber.
+   *
+   * A Subcriber should never receive more calls to this method than the total
+   * Demand it has requested from its publisher. Subscribers should only demand
+   * more elements from within this method via its return value.
+   */
+  virtual Demand Receive(Input element) = 0;
+
+  /**
+   * Signals completion of the stream of values from the Publisher.
+   *
+   * A Subscriber should not receive any further signals of any kind after
+   * receiving a Completion.
+   */
+  virtual void Receive(Completion completion) = 0;
+};
+
+/**
+ * Interface for objects that produce values on demand from its Subscribers.
+ *
+ * Unless otherwise specified by the concrete implementation, external
+ * synchronization must be used to avoid concurrent calls on multiple threads to
+ * a Publisher, including via the Subscriptions that it passes to its
+ * Subscribers.
+ *
+ * Each concrete implementation defines whether it is unicast or multicast:
+ * whether multiple Subscribers observe the same values or not. (An
+ * implementation might only support one Subscriber, by passing an immediate
+ * Completion to each Subscriber after the first.)
+ */
+template <typename T>
+class Publisher : public std::enable_shared_from_this<Publisher<T>> {
+ public:
+  /** The type of values that this Publisher produces. */
+  using Output = T;
+
+  virtual ~Publisher() = default;
+
+  /**
+   * Establishes a connection between this Publisher and the given Subcriber.
+   *
+   * The Publisher must eventually call Subscriber::Receive(Subscription) on the
+   * given Subscriber (and may do so synchronously). The Publisher must then
+   * conform to the protocol established by the Subscription.
+   */
+  virtual void Receive(std::shared_ptr<Subscriber<Output>> subscriber) = 0;
+
+  // Convenienience methods, supporting the chaining together of operations.
+  // Many of these rely on the forward declarations above. Client code should
+  // include combine.hpp to ensure these are defined before they are used.
+
+  void Subscribe(std::shared_ptr<Subscriber<Output>> subscriber) {
+    Receive(std::move(subscriber));
+  }
+
+  std::shared_ptr<FuturesStream<Output>> AsFutures() {
+    auto subscriber =
+        std::make_shared<FuturesSubscriber<Output>>(this->shared_from_this());
+    Subscribe(subscriber);
+    return std::make_shared<FuturesStream<Output>>(std::move(subscriber));
+  }
+
+  template <typename Transform>
+  std::shared_ptr<Publisher<typename Transform::Output>> Map(
+      std::shared_ptr<Transform> transform) {
+    using TransformInput = typename Transform::Input;
+    using TransformOutput = typename Transform::Output;
+    return std::make_shared<MapPublisher<TransformInput, TransformOutput>>(
+        this->shared_from_this(), std::move(transform));
+  }
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // ML_NEURAL_NET_COMBINE_BASE_HPP_

--- a/src/ml/neural_net/combine_base.hpp
+++ b/src/ml/neural_net/combine_base.hpp
@@ -197,6 +197,10 @@ class Subscriber {
  * whether multiple Subscribers observe the same values or not. (An
  * implementation might only support one Subscriber, by passing an immediate
  * Completion to each Subscriber after the first.)
+ *
+ * Note: instances of this class are intended to be stored using shared_ptr.
+ * Many of the operators rely on generating strong references to the instance
+ * being augmented.
  */
 template <typename T>
 class Publisher : public std::enable_shared_from_this<Publisher<T>> {

--- a/src/ml/neural_net/combine_futures_subscriber.hpp
+++ b/src/ml/neural_net/combine_futures_subscriber.hpp
@@ -8,6 +8,7 @@
 #ifndef ML_NEURAL_NET_COMBINE_FUTURES_SUBSCRIBER_HPP_
 #define ML_NEURAL_NET_COMBINE_FUTURES_SUBSCRIBER_HPP_
 
+#include <cassert>
 #include <future>
 #include <memory>
 #include <queue>
@@ -82,6 +83,10 @@ class FuturesSubscriber : public Subscriber<T> {
   }
 
   void Receive(std::shared_ptr<Subscription> subscription) override {
+    // It is a programmer error to attach the same Subscriber to more than one
+    // Publisher.
+    assert(subscription_ == nullptr);
+
     // Reject any subscriptions after the first. Reject the first subscription
     // if we cancelled before it could start.
     if (subscription_ || completed_) {

--- a/src/ml/neural_net/combine_futures_subscriber.hpp
+++ b/src/ml/neural_net/combine_futures_subscriber.hpp
@@ -1,0 +1,160 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef ML_NEURAL_NET_COMBINE_FUTURES_SUBSCRIBER_HPP_
+#define ML_NEURAL_NET_COMBINE_FUTURES_SUBSCRIBER_HPP_
+
+#include <future>
+#include <memory>
+#include <queue>
+
+#include <ml/neural_net/combine_base.hpp>
+
+namespace turi {
+namespace neural_net {
+
+/**
+ * Subscriber that synchronously produces futures for promises to be fulfilled
+ * by its publisher.
+ *
+ * This type is useful for integrating Publishers into existing code bases that
+ * rely on synchronous behavior or futures.
+ *
+ * Client code MUST call FuturesSubscriber::Cancel() to tear down a
+ * FuturesSubscriber instance. This requirement can be handled automatically
+ * using the FuturesStream wrapper class below.
+ */
+template <typename T>
+class FuturesSubscriber : public Subscriber<T> {
+ public:
+  using Input = T;
+
+  /**
+   * Submits a request for a value to the Publisher but immediately returns a
+   * future for that value.
+   *
+   * If the publisher returned a failure for this request or any previous
+   * request from this subscriber, then the future will store that exception. If
+   * the publisher returned Completion::IsFinished() for this request or any
+   * previous request, or if Cancel is called, then the future will store null.
+   *
+   * \todo Use an Optional<T> type instead of unique_ptr to avoid allocation.
+   */
+  std::future<std::unique_ptr<T>> Request() {
+    std::promise<std::unique_ptr<T>> promise;
+    auto future = promise.get_future();
+    if (failure_) {
+      // We've already observed an exception. Set it now.
+      promise.set_exception(failure_);
+    } else if (completed_) {
+      // We've already observed the end of the sequence. Signal completion now.
+      promise.set_value(nullptr);
+    } else {
+      // Enqueue this promise and submit a request to the Publisher.
+      promises_.push(std::move(promise));
+      if (subscription_) {
+        subscription_->Request(Demand(1));
+      }
+    }
+    return future;
+  }
+
+  void Cancel() {
+    if (completed_) return;
+
+    completed_ = true;
+
+    // Cancel the subscription if active.
+    if (subscription_) {
+      subscription_->Cancel();
+      subscription_.reset();
+    }
+
+    // Fulfill any outstanding promises.
+    while (!promises_.empty()) {
+      promises_.front().set_value(nullptr);
+      promises_.pop();
+    }
+  }
+
+  void Receive(std::shared_ptr<Subscription> subscription) override {
+    // Reject any subscriptions after the first. Reject the first subscription
+    // if we cancelled before it could start.
+    if (subscription_ || completed_) {
+      subscription->Cancel();
+      return;
+    }
+
+    subscription_ = std::move(subscription);
+
+    // If we already have promises queued, request their values now.
+    if (!promises_.empty()) {
+      Demand demand(static_cast<int>(promises_.size()));
+      subscription_->Request(demand);
+    }
+  }
+
+  Demand Receive(Input element) override {
+    // Do nothing if we were cancelled.
+    if (completed_) return Demand::None();
+
+    // Wrap the value in a unique_ptr and fulfill the promise.
+    std::unique_ptr<Input> input(new Input(std::move(element)));
+    promises_.front().set_value(std::move(input));
+    promises_.pop();
+    return Demand::None();
+  }
+
+  void Receive(Completion completion) override {
+    completed_ = true;
+    if (!completion.IsFinished()) {
+      failure_ = completion.failure();
+    }
+
+    // Fulfill any outstanding promises.
+    while (!promises_.empty()) {
+      auto promise = std::move(promises_.front());
+      promises_.pop();
+      if (failure_) {
+        promise.set_exception(completion.failure());
+      } else {
+        promise.set_value(nullptr);
+      }
+    }
+  }
+
+ private:
+  std::shared_ptr<Subscription> subscription_;
+
+  std::queue<std::promise<std::unique_ptr<T>>> promises_;
+
+  bool completed_ = false;
+  std::exception_ptr failure_;
+};
+
+/**
+ * Simple wrapper class around FuturesSubscriber that calls Cancel() on
+ * destruction of the wrapper.
+ */
+template <typename T>
+class FuturesStream {
+ public:
+  explicit FuturesStream(std::shared_ptr<FuturesSubscriber<T>> subscriber)
+      : subscriber_(std::move(subscriber)) {}
+
+  ~FuturesStream() { subscriber_->Cancel(); }
+
+  std::future<std::unique_ptr<T>> Next() { return subscriber_->Request(); }
+
+ private:
+  std::shared_ptr<FuturesSubscriber<T>> subscriber_;
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // ML_NEURAL_NET_COMBINE_FUTURES_SUBSCRIBER_HPP_

--- a/src/ml/neural_net/combine_iterator.hpp
+++ b/src/ml/neural_net/combine_iterator.hpp
@@ -1,0 +1,147 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
+#define ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
+
+#include <exception>
+#include <memory>
+#include <type_traits>
+
+#include <ml/neural_net/combine_base.hpp>
+
+namespace turi {
+namespace neural_net {
+
+template <typename T>
+class IteratorPublisher;
+
+/**
+ * Interface for objects that produce a sequence of values, using the
+ * conventional iterator interface.
+ *
+ * This type facilitates wrapping traditional iterator-style code as a
+ * Publisher.
+ */
+template <typename T>
+class Iterator : public std::enable_shared_from_this<Iterator<T>> {
+ public:
+  using Output = T;
+
+  virtual ~Iterator() = default;
+
+  /**
+   * Returns true as long as the underlying sequence contains more values.
+   *
+   * \todo If we have Optional<T>, we can remove this method and have Next()
+   *       instead return Optional<Output>.
+   */
+  virtual bool HasNext() const = 0;
+
+  /** Returns the next value in the sequence. May throw on error. */
+  virtual Output Next() = 0;
+
+  /** Returns a Publisher wrapping this Iterator. */
+  std::shared_ptr<IteratorPublisher<T>> AsPublisher() {
+    return std::make_shared<IteratorPublisher<T>>(this->shared_from_this());
+  }
+};
+
+/**
+ * Concrete Publisher that wraps an Iterator.
+ *
+ * The resulting Publisher is unicast: each iterated value will go only to
+ * whichever Subscriber triggered the iteration.
+ */
+template <typename T>
+class IteratorPublisher : public Publisher<T> {
+ public:
+  using Output = T;
+
+  explicit IteratorPublisher(std::shared_ptr<Iterator<Output>> iterator)
+      : iterator_(std::move(iterator)) {}
+
+  void Receive(std::shared_ptr<Subscriber<Output>> subscriber) override {
+    auto subscription =
+        std::make_shared<IteratorSubscription>(subscriber, iterator_);
+    subscriber->Receive(std::move(subscription));
+  }
+
+ private:
+  // All of the logic lives in the implementation of Subscription, which relies
+  // on the assumption that only one Subscription at a time will access the
+  // shared Iterator.
+  class IteratorSubscription : public Subscription {
+   public:
+    IteratorSubscription(std::shared_ptr<Subscriber<Output>> subscriber,
+                         std::shared_ptr<Iterator<Output>> iterator)
+        : subscriber_(std::move(subscriber)), iterator_(std::move(iterator)) {}
+
+    bool IsActive() const { return subscriber_ != nullptr; }
+
+    void Cancel() override { subscriber_.reset(); }
+
+    void Request(Demand demand) override {
+      // Keep sending signals to the Subscriber until we're cancelled or we
+      // exhaust the demand.
+      while (IsActive() && !demand.IsNone()) {
+        // Invoke the iterator to determine what signal we'll send.
+
+        // Don't assume that Output has a (cheap) default constructor.
+        // TODO: Use an Optional type instead.
+        using OutputStorage =
+            typename std::aligned_storage<sizeof(Output),
+                                          alignof(Output)>::type;
+        OutputStorage value_storage;
+        Output* value = nullptr;     // Track whether we have a value.
+        std::exception_ptr failure;  // Track whether we have a failure.
+        try {
+          if (iterator_->HasNext()) {
+            // Use placement new to initialize our value from the iterator.
+            value = reinterpret_cast<Output*>(&value_storage);
+            new (value) Output(iterator_->Next());
+          }
+        } catch (...) {
+          // On any exception, *value was not initialized, since it was the last
+          // statement in the try block.
+          value = nullptr;
+          failure = std::current_exception();
+        }
+
+        // Send the appropriate signal.
+        if (failure) {
+          // Signal failure and ensure we don't send any more signals.
+          subscriber_->Receive(Completion::Failure(failure));
+          Cancel();
+        } else if (!value) {
+          // Signal finished and ensure we don't send any more signals.
+          subscriber_->Receive(Completion::Finished());
+          Cancel();
+        } else {
+          // Pass the value to the Subscriber, adding any new demand.
+          demand.Decrement();
+          Demand new_demand = subscriber_->Receive(std::move(*value));
+          demand.Add(new_demand);
+
+          // We must manually destroy the (moved-from) value.
+          value->~Output();
+        }
+      }
+    }
+
+   private:
+    std::shared_ptr<Subscriber<Output>> subscriber_;
+    std::shared_ptr<Iterator<Output>> iterator_;
+  };
+
+  std::shared_ptr<Iterator<Output>> iterator_;
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // ML_NEURAL_NET_COMBINE_ITERATOR_HPP_

--- a/src/ml/neural_net/combine_map.hpp
+++ b/src/ml/neural_net/combine_map.hpp
@@ -5,8 +5,8 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
-#define ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
+#ifndef ML_NEURAL_NET_COMBINE_MAP_HPP_
+#define ML_NEURAL_NET_COMBINE_MAP_HPP_
 
 #include <exception>
 #include <functional>
@@ -34,6 +34,24 @@ class Transform {
 
   /** Returns the next value in the sequence. May throw on error. */
   virtual Output Invoke(Input value) = 0;
+};
+
+/**
+ * Templated implementation of Transform that wraps an arbitrary callable type.
+ */
+template <typename T, typename Callable>
+class CallableTransform
+    : public Transform<T, typename std::result_of<Callable(T)>::type> {
+ public:
+  using Input = T;
+  using Output = typename std::result_of<Callable(T)>::type;
+
+  CallableTransform(Callable impl) : impl_(std::move(impl)) {}
+
+  Output Invoke(Input input) override { return impl_(std::move(input)); }
+
+ private:
+  Callable impl_;
 };
 
 /**
@@ -126,4 +144,4 @@ class MapPublisher : public Publisher<U> {
 }  // namespace neural_net
 }  // namespace turi
 
-#endif  // ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
+#endif  // ML_NEURAL_NET_COMBINE_MAP_HPP_

--- a/src/ml/neural_net/combine_map.hpp
+++ b/src/ml/neural_net/combine_map.hpp
@@ -1,0 +1,129 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
+#define ML_NEURAL_NET_COMBINE_ITERATOR_HPP_
+
+#include <exception>
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include <ml/neural_net/combine_base.hpp>
+
+namespace turi {
+namespace neural_net {
+
+template <typename T>
+class IteratorPublisher;
+
+/**
+ * Interface for objects that apply a transform to a value.
+ */
+template <typename T, typename U>
+class Transform {
+ public:
+  using Input = T;
+  using Output = U;
+
+  virtual ~Transform() = default;
+
+  /** Returns the next value in the sequence. May throw on error. */
+  virtual Output Invoke(Input value) = 0;
+};
+
+/**
+ * Concrete operator Publisher that wraps a Transform.
+ *
+ * The resulting Publisher inherits the semantics of the upstream Publisher that
+ * it subscribes to, with regard to the semantics of multiple downstream
+ * subscribers. It simply applies the Transform to each value from the upstream.
+ */
+template <typename T, typename U>
+class MapPublisher : public Publisher<U> {
+ public:
+  using Input = T;
+  using Output = U;
+
+  MapPublisher(std::shared_ptr<Publisher<T>> upstream,
+               std::shared_ptr<Transform<T, U>> transform)
+      : upstream_(std::move(upstream)), transform_(std::move(transform)) {}
+
+  void Receive(std::shared_ptr<Subscriber<Output>> subscriber) override {
+    auto impl =
+        std::make_shared<MapSubscriber>(transform_, std::move(subscriber));
+    upstream_->Subscribe(std::move(impl));
+  }
+
+ private:
+  class MapSubscriber : public Subscriber<Input> {
+   public:
+    MapSubscriber(std::shared_ptr<Transform<Input, Output>> transform,
+                  std::shared_ptr<Subscriber<Output>> downstream)
+        : transform_(std::move(transform)),
+          downstream_(std::move(downstream)) {}
+
+    void Receive(std::shared_ptr<Subscription> subscription) override {
+      if (downstream_) {
+        downstream_->Receive(std::move(subscription));
+      }
+    }
+
+    Demand Receive(Input element) override {
+      // Do nothing if we are already cancelled.
+      if (!downstream_) return Demand::None();
+
+      // TODO: Define Optional<T>. (Or require C++17 for std::optional?)
+      using OutputStorage =
+          typename std::aligned_storage<sizeof(Output), alignof(Output)>::type;
+      OutputStorage value_storage;
+      Output* value = nullptr;     // Track whether we have a value.
+      std::exception_ptr failure;  // Track whether we have a failure.
+      try {
+        // Use placement new to initialize the value from the transform output.
+        // Placement new must be the last statement of the try block, so that
+        // the catch block can assume the value is not initialized.
+        value = reinterpret_cast<Output*>(&value_storage);
+        new (value) Output(transform_->Invoke(std::move(element)));
+      } catch (...) {
+        value = nullptr;
+        failure = std::current_exception();
+      }
+
+      Demand demand = Demand::None();
+      if (failure) {
+        // Leave downstream_ as nullptr to avoid sending any further signals.
+        auto downstream = std::move(downstream_);
+        downstream->Receive(Completion::Failure(failure));
+      } else {
+        demand = downstream_->Receive(std::move(*value));
+        value->~Output();
+      }
+
+      return demand;
+    }
+
+    void Receive(Completion completion) override {
+      if (downstream_) {
+        downstream_->Receive(std::move(completion));
+      }
+    }
+
+   private:
+    std::shared_ptr<Transform<Input, Output>> transform_;
+    std::shared_ptr<Subscriber<Output>> downstream_;
+    std::exception_ptr failure_;
+  };
+
+  std::shared_ptr<Publisher<Input>> upstream_;
+  std::shared_ptr<Transform<Input, Output>> transform_;
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // ML_NEURAL_NET_COMBINE_ITERATOR_HPP_

--- a/src/ml/neural_net/combine_mock.hpp
+++ b/src/ml/neural_net/combine_mock.hpp
@@ -1,0 +1,84 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef ML_NEURAL_NET_COMBINE_MOCK_HPP_
+#define ML_NEURAL_NET_COMBINE_MOCK_HPP_
+
+#include <ml/neural_net/combine_base.hpp>
+
+#include <functional>
+#include <queue>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+
+namespace turi {
+namespace neural_net {
+
+/**
+ * Helper function to reduce verbosity of writing mocks.
+ *
+ * Pops the first callback from the given queue and invokes it with the provided
+ * arguments.
+ */
+template <typename R, typename... Args>
+R Call(std::queue<std::function<R(Args...)>> *callbacks, Args &&... args) {
+  TS_ASSERT(!callbacks->empty());
+  auto callback = std::move(callbacks->front());
+  callbacks->pop();
+  return callback(std::forward<Args>(args)...);
+}
+
+class MockSubscription : public Subscription {
+ public:
+  void Cancel() override { return Call(&cancel_callbacks); }
+  std::queue<std::function<void()>> cancel_callbacks;
+
+  void Request(Demand demand) override {
+    return Call(&demand_callbacks, std::move(demand));
+  }
+  std::queue<std::function<void(Demand)>> demand_callbacks;
+};
+
+template <typename T>
+class MockSubscriber : public Subscriber<T> {
+ public:
+  using Input = T;
+
+  void Receive(std::shared_ptr<Subscription> subscription) override {
+    return Call(&subscription_callbacks, std::move(subscription));
+  }
+  std::queue<std::function<void(std::shared_ptr<Subscription>)>>
+      subscription_callbacks;
+
+  Demand Receive(Input element) override {
+    return Call(&input_callbacks, std::move(element));
+  }
+  std::queue<std::function<Demand(Input)>> input_callbacks;
+
+  void Receive(Completion completion) override {
+    return Call(&completion_callbacks, std::move(completion));
+  }
+  std::queue<std::function<void(Completion)>> completion_callbacks;
+};
+
+template <typename T>
+class MockPublisher : public Publisher<T> {
+ public:
+  using Output = T;
+
+  void Receive(std::shared_ptr<Subscriber<Output>> subscriber) override {
+    return Call(&subscriber_callbacks, std::move(subscriber));
+  }
+  std::queue<std::function<void(std::shared_ptr<Subscriber<Output>>)>>
+      subscriber_callbacks;
+};
+
+}  // namespace neural_net
+}  // namespace turi
+
+#endif  // ML_NEURAL_NET_COMBINE_MOCK_HPP_

--- a/test/unity/toolkits/neural_net/CMakeLists.txt
+++ b/test/unity/toolkits/neural_net/CMakeLists.txt
@@ -1,11 +1,11 @@
 project(Turi)
 
-make_boost_test(test_model_spec.cxx
-  REQUIRES
-    unity_shared_for_testing
-)
-
+make_boost_test(test_combine_base.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(test_combine_futures_subscriber.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(test_combine_iterator.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(test_combine_map.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_image_augmentation.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(test_model_spec.cxx REQUIRES unity_shared_for_testing)
 
 if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
   make_boost_test(test_mps_image_augmentation.cxx REQUIRES unity_shared_for_testing)

--- a/test/unity/toolkits/neural_net/test_combine_base.cxx
+++ b/test/unity/toolkits/neural_net/test_combine_base.cxx
@@ -1,0 +1,111 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_combine
+
+#include <ml/neural_net/combine_mock.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+BOOST_AUTO_TEST_CASE(test_demand) {
+  // Test Demand::Unlimited()
+  Demand unlimited = Demand::Unlimited();
+  TS_ASSERT(unlimited.IsUnlimited());
+  TS_ASSERT(!unlimited.IsNone());
+
+  // Test Demand::None()
+  Demand none = Demand::None();
+  TS_ASSERT(!none.IsUnlimited());
+  TS_ASSERT(none.IsNone());
+  TS_ASSERT_EQUALS(none.max(), 0);
+
+  // Test Demand::Demand(int) with zero max
+  Demand zero = Demand(0);
+  TS_ASSERT(!zero.IsUnlimited());
+  TS_ASSERT(zero.IsNone());
+  TS_ASSERT_EQUALS(zero.max(), 0);
+
+  // Test Demand::Demand(int) with positive max
+  Demand seven = Demand(7);
+  TS_ASSERT(!seven.IsUnlimited());
+  TS_ASSERT(!seven.IsNone());
+  TS_ASSERT_EQUALS(seven.max(), 7);
+
+  // Test Demand::Add(...) with unlimited and unlimited
+  Demand unlimited_plus_unlimited = Demand::Unlimited().Add(unlimited);
+  TS_ASSERT(unlimited_plus_unlimited.IsUnlimited());
+  TS_ASSERT(!unlimited_plus_unlimited.IsNone());
+  TS_ASSERT_LESS_THAN(unlimited_plus_unlimited.max(), 0);
+
+  // Test Demand::Add(...) with unlimited and limited
+  Demand unlimited_plus_seven = Demand::Unlimited().Add(seven);
+  TS_ASSERT(unlimited_plus_seven.IsUnlimited());
+  TS_ASSERT(!unlimited_plus_seven.IsNone());
+  TS_ASSERT_LESS_THAN(unlimited_plus_unlimited.max(), 0);
+
+  // Test Demand::Add(...) with limited and unlimited
+  Demand seven_plus_unlimited = Demand(7).Add(unlimited);
+  TS_ASSERT(seven_plus_unlimited.IsUnlimited());
+  TS_ASSERT(!seven_plus_unlimited.IsNone());
+  TS_ASSERT_LESS_THAN(unlimited_plus_unlimited.max(), 0);
+
+  // Test Demand::Add(...) with limited and limited
+  Demand seven_plus_seven = Demand(7).Add(seven);
+  TS_ASSERT(!seven_plus_seven.IsUnlimited());
+  TS_ASSERT(!seven_plus_seven.IsNone());
+  TS_ASSERT_EQUALS(seven_plus_seven.max(), 14);
+
+  // Test Demand::Decrement() with unlimited
+  Demand unlimited_minus_one = Demand::Unlimited().Decrement();
+  TS_ASSERT(unlimited_minus_one.IsUnlimited());
+  TS_ASSERT(!unlimited_minus_one.IsNone());
+  TS_ASSERT_LESS_THAN(unlimited_plus_unlimited.max(), 0);
+
+  // Test Demand::Decrement() with none
+  Demand none_minus_one = Demand::None().Decrement();
+  TS_ASSERT(!none_minus_one.IsUnlimited());
+  TS_ASSERT(none_minus_one.IsNone());
+  TS_ASSERT_EQUALS(none_minus_one.max(), 0);
+
+  // Test Demand::Decrement() with positive
+  Demand seven_minus_one = Demand(7).Decrement();
+  TS_ASSERT(!seven_minus_one.IsUnlimited());
+  TS_ASSERT(!seven_minus_one.IsNone());
+  TS_ASSERT_EQUALS(seven_minus_one.max(), 6);
+}
+
+BOOST_AUTO_TEST_CASE(test_completion) {
+  // Test Completion::Finished()
+  Completion completion = Completion::Finished();
+  TS_ASSERT(completion.IsFinished());
+  TS_ASSERT(completion.failure() == nullptr);
+
+  // Test Completion::Failure(...) returns !IsFinished()...
+  const std::string kExceptionMessage = "Test exception";
+  try {
+    throw std::runtime_error(kExceptionMessage);
+  } catch (...) {
+    completion = Completion::Failure(std::current_exception());
+  }
+  TS_ASSERT(!completion.IsFinished());
+
+  // ... and preserves the exception passed on construction
+  try {
+    std::rethrow_exception(completion.failure());
+  } catch (const std::runtime_error& e) {
+    TS_ASSERT_EQUALS(e.what(), kExceptionMessage);
+  }
+}
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi

--- a/test/unity/toolkits/neural_net/test_combine_futures_subscriber.cxx
+++ b/test/unity/toolkits/neural_net/test_combine_futures_subscriber.cxx
@@ -1,0 +1,282 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_combine_futures_subscriber
+
+#include <ml/neural_net/combine_futures_subscriber.hpp>
+
+#include <stdexcept>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include <ml/neural_net/combine_mock.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+struct TestException : public std::exception {};
+
+// Futures generated before the Publisher has acknowledged the Subscriber should
+// still be fulfilled.
+BOOST_AUTO_TEST_CASE(test_request_before_subscription) {
+  auto subscriber = std::make_shared<FuturesSubscriber<int>>();
+  auto publisher = std::make_shared<MockPublisher<int>>();
+  auto subscription = std::make_shared<MockSubscription>();
+
+  // Register the FuturesSubscriber with a mock Publisher, but don't return a
+  // Subscription immediately.
+  publisher->subscriber_callbacks.push([&](std::shared_ptr<Subscriber<int>> s) {
+    TS_ASSERT_EQUALS(subscriber, s);
+  });
+  publisher->Subscribe(subscriber);
+  TS_ASSERT(publisher->subscriber_callbacks.empty());
+
+  // Obtain the first future.
+  std::future<std::unique_ptr<int>> result = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result.valid());
+
+  // The future should not be ready yet.
+  std::future_status status = result.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Now return a Subscription to the FuturesSubscriber. The MockPublisher
+  // should immediately expect a Demand for the first future's value.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  subscriber->Receive(subscription);
+  TS_ASSERT(subscription->demand_callbacks.empty());
+
+  // Allow the MockPublisher to return Completion::Finished(). The future
+  // should now be ready.
+  subscriber->Receive(Completion::Finished());
+  status = result.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  // The future should contain a non-value.
+  std::unique_ptr<int> value = result.get();
+  TS_ASSERT(!value);
+}
+
+std::shared_ptr<MockSubscription> PerformSetup(
+    std::shared_ptr<Subscriber<int>> subscriber) {
+  // Create a MockSubscription that test code can use to monitor the behavior of
+  // the FuturesSubscriber instance under test.
+  auto subscription = std::make_shared<MockSubscription>();
+
+  // Register the Subscriber with a MockPublisher that just injects the
+  // MockSubscription.
+  auto publisher = std::make_shared<MockPublisher<int>>();
+  publisher->subscriber_callbacks.push(
+      [&](std::shared_ptr<Subscriber<int>> subscriber) {
+        subscriber->Receive(subscription);
+      });
+  publisher->Subscribe(subscriber);
+  TS_ASSERT(publisher->subscriber_callbacks.empty());
+
+  return subscription;
+}
+
+// Requests for values after Completion should return futures that are
+// immediately ready.
+BOOST_AUTO_TEST_CASE(test_request_after_finished) {
+  auto subscriber = std::make_shared<FuturesSubscriber<int>>();
+  auto subscription = PerformSetup(subscriber);
+
+  subscriber->Receive(Completion::Finished());
+
+  std::future<std::unique_ptr<int>> result = subscriber->Request();
+  TS_ASSERT(result.valid());
+
+  std::future_status status = result.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  std::unique_ptr<int> value = result.get();
+  TS_ASSERT_EQUALS(value, nullptr);
+}
+
+// Requests for values before Completion should eventually return non-values if
+// the Publisher sends Completion::Finished() instead of values.
+BOOST_AUTO_TEST_CASE(test_request_before_finished) {
+  auto subscriber = std::make_shared<FuturesSubscriber<int>>();
+  auto subscription = PerformSetup(subscriber);
+
+  // Create the first future.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  std::future<std::unique_ptr<int>> result1 = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result1.valid());
+
+  // The first future should not be ready.
+  std::future_status status = result1.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Create the second future.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  std::future<std::unique_ptr<int>> result2 = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result2.valid());
+
+  // The second future should not be ready.
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Send Completion::Finished().
+  subscriber->Receive(Completion::Finished());
+
+  // Both futures should be ready.
+  status = result1.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  // Both futures should have non-values.
+  std::unique_ptr<int> value1 = result1.get();
+  TS_ASSERT_EQUALS(value1, nullptr);
+  std::unique_ptr<int> value2 = result2.get();
+  TS_ASSERT_EQUALS(value2, nullptr);
+}
+
+// Requesting a value should correctly fulfill the future, when the Publisher
+// sends the value synchronously on demand.
+BOOST_AUTO_TEST_CASE(test_synchronous_response) {
+  auto subscriber = std::make_shared<FuturesSubscriber<int>>();
+  auto subscription = PerformSetup(subscriber);
+
+  subscription->demand_callbacks.push([&](Demand demand) {
+    TS_ASSERT_EQUALS(demand.max(), 1);
+    subscriber->Receive(9);
+  });
+  std::future<std::unique_ptr<int>> result = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result.valid());
+
+  std::future_status status = result.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  std::unique_ptr<int> value = result.get();
+  TS_ASSERT_DIFFERS(value, nullptr);
+  TS_ASSERT_EQUALS(*value, 9);
+}
+
+// Requesting a value should correctly fulfill the future, even when the
+// Publisher sends the value later.
+BOOST_AUTO_TEST_CASE(test_asynchronous_response) {
+  auto subscriber = std::make_shared<FuturesSubscriber<int>>();
+  auto subscription = PerformSetup(subscriber);
+
+  // Create the first future.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  std::future<std::unique_ptr<int>> result1 = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result1.valid());
+
+  // The first future should not be ready yet.
+  std::future_status status = result1.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Create the second future.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  std::future<std::unique_ptr<int>> result2 = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result2.valid());
+
+  // The second future should not be ready yet.
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Send the first value.
+  subscriber->Receive(5);
+
+  // The first future should be ready.
+  status = result1.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  // The first future should contain the first value.
+  std::unique_ptr<int> value1 = result1.get();
+  TS_ASSERT_DIFFERS(value1, nullptr);
+  TS_ASSERT_EQUALS(*value1, 5);
+
+  // The second future should still not be ready.
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Send the second value.
+  subscriber->Receive(8);
+
+  // Now the second future should be ready.
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  // The second future should contain the second value.
+  std::unique_ptr<int> value2 = result2.get();
+  TS_ASSERT_DIFFERS(value2, nullptr);
+  TS_ASSERT_EQUALS(*value2, 8);
+}
+
+// Requests for values before Completion should eventually return exceptions if
+// the Publisher sends Completion::Failure(...).
+BOOST_AUTO_TEST_CASE(test_failure) {
+  auto subscriber = std::make_shared<FuturesSubscriber<int>>();
+  auto subscription = PerformSetup(subscriber);
+
+  // Create the first future.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  std::future<std::unique_ptr<int>> result1 = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result1.valid());
+
+  // The first future should not be ready yet.
+  std::future_status status = result1.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Create the second future.
+  subscription->demand_callbacks.push(
+      [&](Demand demand) { TS_ASSERT_EQUALS(demand.max(), 1); });
+  std::future<std::unique_ptr<int>> result2 = subscriber->Request();
+  TS_ASSERT(subscription->demand_callbacks.empty());
+  TS_ASSERT(result2.valid());
+
+  // The second future should not be ready yet.
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::timeout);
+
+  // Send Completion::Failure(...).
+  try {
+    throw TestException();
+  } catch (...) {
+    subscriber->Receive(Completion::Failure(std::current_exception()));
+  }
+
+  // The first future should now be ready.
+  status = result1.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  // The second future should now be ready.
+  status = result2.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+
+  // Both futures should now throw the specified exception.
+  TS_ASSERT_THROWS(result1.get(), TestException);
+  TS_ASSERT_THROWS(result2.get(), TestException);
+
+  // Subsequent futures should also throw the same exception.
+  std::future<std::unique_ptr<int>> result3 = subscriber->Request();
+  status = result3.wait_for(std::chrono::seconds(0));
+  TS_ASSERT(status == std::future_status::ready);
+  TS_ASSERT_THROWS(result3.get(), TestException);
+}
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi

--- a/test/unity/toolkits/neural_net/test_combine_iterator.cxx
+++ b/test/unity/toolkits/neural_net/test_combine_iterator.cxx
@@ -1,0 +1,308 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_combine_iterator
+
+#include <ml/neural_net/combine_iterator.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include <ml/neural_net/combine_mock.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+struct TestException : public std::exception {};
+
+template <typename T>
+class MockIterator : public Iterator<T> {
+ public:
+  using Output = T;
+  bool HasNext() const override { return !next_callbacks.empty(); }
+  Output Next() override { return Call(&next_callbacks); }
+  std::queue<std::function<Output()>> next_callbacks;
+};
+
+// Subscribers are allowed to call Subscription::Cancel() inside
+// Subscriber::Receive(Subscription).
+BOOST_AUTO_TEST_CASE(test_cancel_on_subscription) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+
+  subscriber->subscription_callbacks.emplace(
+      [&](std::shared_ptr<Subscription> subscription) {
+        subscription->Cancel();
+        subscription->Request(Demand(1));  // Should have no effect.
+      });
+  iterator->AsPublisher()->Subscribe(subscriber);
+  TS_ASSERT(subscriber->subscription_callbacks.empty());
+}
+
+// Subscribers are allowed to call Subscription::Request() inside
+// Subscriber::Receive(Subscription).
+BOOST_AUTO_TEST_CASE(test_demand_on_subscription) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+
+  subscriber->subscription_callbacks.emplace(
+      [&](std::shared_ptr<Subscription> subscription) {
+        // Program the iterator to return 8 once.
+        iterator->next_callbacks.push([] { return 8; });
+
+        // Expect the subscriber to receive 8.
+        subscriber->input_callbacks.push([](int input) {
+          TS_ASSERT_EQUALS(input, 8);
+          return Demand::None();
+        });
+
+        // Trigger the iterator.
+        subscription->Request(Demand(1));
+        TS_ASSERT(subscriber->input_callbacks.empty());
+      });
+  iterator->AsPublisher()->Subscribe(subscriber);
+  TS_ASSERT(subscriber->subscription_callbacks.empty());
+}
+
+// Handle common test setup.
+std::shared_ptr<Subscription> PerformSetup(
+    std::shared_ptr<MockIterator<int>> iterator,
+    std::shared_ptr<MockSubscriber<int>> subscriber) {
+  // Register the subscriber with the IteratorPublisher, capturing the
+  // subscription that the IteratorPublisher sends.
+  std::shared_ptr<Subscription> subscription;
+  subscriber->subscription_callbacks.emplace(
+      [&](std::shared_ptr<Subscription> s) { subscription = std::move(s); });
+  iterator->AsPublisher()->Subscribe(subscriber);
+  TS_ASSERT(subscriber->subscription_callbacks.empty());
+
+  // Return the subscription for test code to manipulate.
+  return subscription;
+}
+
+// Demanding values from an empty iterator triggers Completion::Finished().
+BOOST_AUTO_TEST_CASE(test_empty_iterator) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  subscriber->completion_callbacks.push(
+      [](Completion completion) { TS_ASSERT(completion.IsFinished()); });
+  subscription->Request(Demand(1));
+  TS_ASSERT(subscriber->completion_callbacks.empty());
+}
+
+// Demanding more values than the iterator contains yields the complete
+// sequence, followed by Completion::Finished().
+BOOST_AUTO_TEST_CASE(test_demand_too_much) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand::None();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+  subscriber->completion_callbacks.push(
+      [](Completion completion) { TS_ASSERT(completion.IsFinished()); });
+
+  subscription->Request(Demand(3));
+  TS_ASSERT(subscriber->input_callbacks.empty());
+  TS_ASSERT(subscriber->completion_callbacks.empty());
+}
+
+// Demanding fewer values than the iterator contains only yields the amount
+// requested.
+BOOST_AUTO_TEST_CASE(test_demand_too_little) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+  iterator->next_callbacks.push([] { return 8; });
+
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand::None();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+
+  subscription->Request(Demand(2));
+  TS_ASSERT(subscriber->input_callbacks.empty());
+}
+
+// Demanding the exact number of values remaining yields all the values without
+// Completion::Finished().
+BOOST_AUTO_TEST_CASE(test_demand_just_right) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand::None();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+
+  subscription->Request(Demand(2));
+  TS_ASSERT(subscriber->input_callbacks.empty());
+}
+
+// Subscribers can request more input in Subscriber::Receive(Input).
+BOOST_AUTO_TEST_CASE(test_demand_more_on_input) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand(1);
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+
+  subscription->Request(Demand(1));
+  TS_ASSERT(subscriber->input_callbacks.empty());
+}
+
+// Unlimited demand yields all values.
+BOOST_AUTO_TEST_CASE(test_demand_unlimited) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+  iterator->next_callbacks.push([] { return 8; });
+
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand::None();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 8);
+    return Demand::None();
+  });
+  subscriber->completion_callbacks.push(
+      [](Completion completion) { TS_ASSERT(completion.IsFinished()); });
+
+  subscription->Request(Demand::Unlimited());
+  TS_ASSERT(subscriber->input_callbacks.empty());
+  TS_ASSERT(subscriber->completion_callbacks.empty());
+}
+
+// Adding unlimited demand to an existing demand yields all values.
+BOOST_AUTO_TEST_CASE(test_demand_unlimited_on_input) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+  iterator->next_callbacks.push([] { return 8; });
+
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand::Unlimited();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+  subscriber->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 8);
+    return Demand::None();
+  });
+  subscriber->completion_callbacks.push(
+      [](Completion completion) { TS_ASSERT(completion.IsFinished()); });
+
+  subscription->Request(Demand(1));
+  TS_ASSERT(subscriber->input_callbacks.empty());
+  TS_ASSERT(subscriber->completion_callbacks.empty());
+}
+
+// An iterator exception propagates as a Completion::Failure(...).
+BOOST_AUTO_TEST_CASE(test_failure) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber = std::make_shared<MockSubscriber<int>>();
+  auto subscription = PerformSetup(iterator, subscriber);
+
+  iterator->next_callbacks.push([&]() -> int { throw TestException(); });
+
+  subscriber->completion_callbacks.push([&](Completion completion) {
+    TS_ASSERT(!completion.IsFinished());
+    TS_ASSERT_THROWS(std::rethrow_exception(completion.failure()),
+                     TestException);
+  });
+
+  subscription->Request(Demand(1));
+  TS_ASSERT(subscriber->completion_callbacks.empty());
+}
+
+// Two subscribers receive different portions of the iterated sequence.
+BOOST_AUTO_TEST_CASE(test_unicast) {
+  auto iterator = std::make_shared<MockIterator<int>>();
+  auto subscriber1 = std::make_shared<MockSubscriber<int>>();
+  auto subscriber2 = std::make_shared<MockSubscriber<int>>();
+  auto subscription1 = PerformSetup(iterator, subscriber1);
+  auto subscription2 = PerformSetup(iterator, subscriber2);
+
+  iterator->next_callbacks.push([] { return 3; });
+  iterator->next_callbacks.push([] { return 5; });
+  iterator->next_callbacks.push([] { return 8; });
+
+  subscriber1->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 3);
+    return Demand::None();
+  });
+  subscription1->Request(Demand(1));
+  TS_ASSERT(subscriber1->input_callbacks.empty());
+
+  subscriber2->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return Demand::None();
+  });
+  subscription2->Request(Demand(1));
+  TS_ASSERT(subscriber2->input_callbacks.empty());
+
+  subscriber1->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 8);
+    return Demand::None();
+  });
+  subscription1->Request(Demand(1));
+  TS_ASSERT(subscriber1->input_callbacks.empty());
+}
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi

--- a/test/unity/toolkits/neural_net/test_combine_map.cxx
+++ b/test/unity/toolkits/neural_net/test_combine_map.cxx
@@ -1,0 +1,159 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_combine_map
+
+#include <ml/neural_net/combine_map.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include <ml/neural_net/combine_mock.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+struct TestException : public std::exception {};
+
+template <typename T, typename U>
+class MockTransform : public Transform<T, U> {
+ public:
+  using Input = T;
+  using Output = U;
+
+  Output Invoke(Input value) {
+    return Call(&invoke_callbacks, std::move(value));
+  }
+  std::queue<std::function<Output(Input)>> invoke_callbacks;
+};
+
+// Calls to MapPublisher::Receive(Subscriber) should be forwarded to the
+// upstream Publisher.
+BOOST_AUTO_TEST_CASE(test_subscription) {
+  auto upstream = std::make_shared<MockPublisher<std::string>>();
+  auto transform = std::make_shared<MockTransform<std::string, int>>();
+  auto downstream = std::make_shared<MockSubscriber<int>>();
+  auto subscription = std::make_shared<MockSubscription>();
+
+  upstream->subscriber_callbacks.emplace(
+      [&](std::shared_ptr<Subscriber<std::string>> subscriber) {
+        TS_ASSERT(subscriber != nullptr);
+      });
+  upstream->Map(transform)->Subscribe(downstream);
+  TS_ASSERT(upstream->subscriber_callbacks.empty());
+}
+
+// Handle common test setup.
+std::shared_ptr<Subscriber<int>> PerformSetup(
+    std::shared_ptr<MockTransform<int, int>> transform,
+    std::shared_ptr<MockSubscriber<int>> downstream) {
+  // We will capture the internal Subscriber that MapPublisher generates for its
+  // upstream Publisher.
+  std::shared_ptr<Subscriber<int>> map_subscriber;
+
+  // The actual subscription and upstream are arbitrary.
+  auto subscription = std::make_shared<MockSubscription>();
+  auto upstream = std::make_shared<MockPublisher<int>>();
+
+  // The upstream should expect the internal Subscriber, save a reference to it,
+  // and pass a subscription to it.
+  upstream->subscriber_callbacks.emplace(
+      [&](std::shared_ptr<Subscriber<int>> s) {
+        map_subscriber = s;
+        map_subscriber->Receive(subscription);
+      });
+
+  // The internal Subscriber should forward the subscription to the downstream
+  // Subscriber.
+  downstream->subscription_callbacks.emplace(
+      [&](std::shared_ptr<Subscription> s) {
+        TS_ASSERT_EQUALS(s, subscription);
+      });
+
+  // Trigger subscription.
+  upstream->Map(transform)->Subscribe(downstream);
+  TS_ASSERT(upstream->subscriber_callbacks.empty());
+  TS_ASSERT(downstream->subscription_callbacks.empty());
+
+  // Return the internal subscriber for test code to manipulate.
+  return map_subscriber;
+}
+
+// Values sent (by the upstream) to the internal Subscriber should be passed
+// through the transform and on to the downstream.
+BOOST_AUTO_TEST_CASE(test_send_value) {
+  auto transform = std::make_shared<MockTransform<int, int>>();
+  auto downstream = std::make_shared<MockSubscriber<int>>();
+  auto map_subscriber = PerformSetup(transform, downstream);
+
+  // We will send 5 from upstream. The original value should enter transform.
+  transform->invoke_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 5);
+    return 25;
+  });
+
+  // And the output of the transform should reach the downstream.
+  downstream->input_callbacks.push([](int x) {
+    TS_ASSERT_EQUALS(x, 25);
+    return Demand::None();
+  });
+
+  // Trigger a value.
+  map_subscriber->Receive(5);
+  TS_ASSERT(transform->invoke_callbacks.empty());
+  TS_ASSERT(downstream->input_callbacks.empty());
+}
+
+// Completions sent (by the upstream) to the internal Subscriber should be
+// passed through to the downstream, ignoring the transform.
+BOOST_AUTO_TEST_CASE(test_upstream_failure) {
+  auto transform = std::make_shared<MockTransform<int, int>>();
+  auto downstream = std::make_shared<MockSubscriber<int>>();
+  auto map_subscriber = PerformSetup(transform, downstream);
+
+  std::exception_ptr failure;
+  try {
+    throw TestException();
+  } catch (...) {
+    failure = std::current_exception();
+  }
+
+  downstream->completion_callbacks.push([&](Completion completion) {
+    TS_ASSERT(!completion.IsFinished());
+    TS_ASSERT_THROWS(std::rethrow_exception(completion.failure()),
+                     TestException);
+  });
+
+  map_subscriber->Receive(Completion::Failure(failure));
+  TS_ASSERT(downstream->completion_callbacks.empty());
+}
+
+// Exceptions thrown by the transform should trigger a completion.
+BOOST_AUTO_TEST_CASE(test_transform_failure) {
+  auto transform = std::make_shared<MockTransform<int, int>>();
+  auto downstream = std::make_shared<MockSubscriber<int>>();
+  auto map_subscriber = PerformSetup(transform, downstream);
+
+  transform->invoke_callbacks.push([](int x) -> int { throw TestException(); });
+
+  downstream->completion_callbacks.push([&](Completion completion) {
+    TS_ASSERT(!completion.IsFinished());
+    TS_ASSERT_THROWS(std::rethrow_exception(completion.failure()),
+                     TestException);
+  });
+
+  map_subscriber->Receive(7);
+  TS_ASSERT(transform->invoke_callbacks.empty());
+  TS_ASSERT(downstream->completion_callbacks.empty());
+
+  // Subsequent inputs should not trigger any downstream signals.
+  map_subscriber->Receive(8);
+}
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi


### PR DESCRIPTION
The main goal is make it easier to reason about the various portions of our
deep-learning training pipelines. For example, in Object Detection, we have a
data iterator that produces raw training examples, an image augmenter that
performs data augmentation, and a model backend that consumes a stream of
augmented training examples and produces progress updates and models.

As we integrate this framework, it should be easier to maintain unit tests for
these evolving pipelines and to manipulate threading and concurrency. For
example, if done right, this can replace our implementations of "double
buffering" currently copied across each model toolkit.

This PR turned out to be quite large, but FWIW it introduces no additions or modifications to the Turi Create release binaries, just headers (not imported into the main codebase yet) and unit tests. I'm explicitly going to use a separate PR for anything that might affect the shipping codebase.