### PR TITLE
Migrate Object Detection export to CoreML to new Checkpoint type

### DIFF
--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -20,8 +20,8 @@ namespace neural_net {
 
 namespace {
 
-using CoreML::Specification::BorderAmounts_EdgeSizes;
 using CoreML::Specification::BatchnormLayerParams;
+using CoreML::Specification::BorderAmounts_EdgeSizes;
 using CoreML::Specification::ConvolutionLayerParams;
 using CoreML::Specification::InnerProductLayerParams;
 using CoreML::Specification::Model;
@@ -29,8 +29,9 @@ using CoreML::Specification::NeuralNetwork;
 using CoreML::Specification::NeuralNetworkImageScaler;
 using CoreML::Specification::NeuralNetworkLayer;
 using CoreML::Specification::NeuralNetworkPreprocessing;
-using CoreML::Specification::PoolingLayerParams;
 using CoreML::Specification::PaddingLayerParams;
+using CoreML::Specification::Pipeline;
+using CoreML::Specification::PoolingLayerParams;
 using CoreML::Specification::SamePadding;
 using CoreML::Specification::UniDirectionalLSTMLayerParams;
 using CoreML::Specification::UpsampleLayerParams;
@@ -972,6 +973,17 @@ void model_spec::add_preprocessing(const std::string& feature_name,
   layer->set_featurename(feature_name);
   NeuralNetworkImageScaler* image_scaler = layer->mutable_scaler();
   image_scaler->set_channelscale(image_scale);
+}
+
+pipeline_spec::pipeline_spec(std::unique_ptr<Pipeline> impl)
+    : impl_(std::move(impl)) {}
+
+pipeline_spec::pipeline_spec(pipeline_spec&&) = default;
+pipeline_spec& pipeline_spec::operator=(pipeline_spec&&) = default;
+pipeline_spec::~pipeline_spec() = default;
+
+std::unique_ptr<Pipeline> pipeline_spec::move_coreml_spec() && {
+  return std::move(impl_);
 }
 
 }  // neural_net

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -22,6 +22,7 @@
 namespace CoreML {
 namespace Specification {
 class NeuralNetwork;
+class Pipeline;
 class WeightParams;
 }
 }
@@ -398,6 +399,43 @@ public:
 
  private:
   std::unique_ptr<CoreML::Specification::NeuralNetwork> impl_;
+};
+
+/**
+ * Simple wrapper around CoreML::Specification::Pipeline that allows client code
+ * to pass around instances without importing full protobuf headers.
+ *
+ * \todo As needed, elaborate this class and move into its own file.
+ */
+class pipeline_spec {
+ public:
+  pipeline_spec(std::unique_ptr<CoreML::Specification::Pipeline> impl);
+
+  pipeline_spec(pipeline_spec&&);
+  pipeline_spec& operator=(pipeline_spec&&);
+
+  // Declared here and defined in the .cpp file just to prevent the implicit
+  // default destructor from attempting (and failing) to instantiate
+  // std::unique_ptr<Pipeline>::~unique_ptr()
+  ~pipeline_spec();
+
+  /**
+   * Exposes the underlying CoreML proto.
+   */
+  const CoreML::Specification::Pipeline& get_coreml_spec() const {
+    return *impl_;
+  }
+
+  /**
+   * Transfer ownership of the underlying CoreML proto, invalidating the current
+   * instance (leaving it in a "moved-from" state).
+   *
+   * (Note that this method may only be invoked from a pipeline_spec&&)
+   */
+  std::unique_ptr<CoreML::Specification::Pipeline> move_coreml_spec() &&;
+
+ private:
+  std::unique_ptr<CoreML::Specification::Pipeline> impl_;
 };
 
 }  // neural_net

--- a/src/toolkits/coreml_export/neural_net_models_exporter.hpp
+++ b/src/toolkits/coreml_export/neural_net_models_exporter.hpp
@@ -28,9 +28,8 @@ namespace turi {
  *       is responsible for populating the inputs and outputs?
  */
 std::shared_ptr<coreml::MLModelWrapper> export_object_detector_model(
-    const neural_net::model_spec& nn_spec, size_t image_width,
-    size_t image_height, size_t num_classes, size_t num_predictions,
-    flex_list class_labels, const std::string& input_name,
+    neural_net::pipeline_spec pipeline, size_t num_classes,
+    size_t num_predictions, flex_list class_labels,
     std::map<std::string, flexible_type> options);
 
 /** Wraps a trained activity classifier model_spec as a complete MLModel. */

--- a/src/toolkits/object_detection/CMakeLists.txt
+++ b/src/toolkits/object_detection/CMakeLists.txt
@@ -4,10 +4,10 @@ make_library(unity_object_detection OBJECT
   SOURCES
     class_registrations.cpp
     object_detector.cpp
-    od_darknet_yolo_model.cpp
+    od_darknet_yolo_model_trainer.cpp
     od_data_iterator.cpp
     od_evaluation.cpp
-    od_model.cpp
+    od_model_trainer.cpp
     od_serialization.cpp
     od_yolo.cpp
   REQUIRES

--- a/src/toolkits/object_detection/object_detector.cpp
+++ b/src/toolkits/object_detection/object_detector.cpp
@@ -23,7 +23,7 @@
 #include <core/random/random.hpp>
 #include <timer/timer.hpp>
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
-#include <toolkits/object_detection/od_darknet_yolo_model.hpp>
+#include <toolkits/object_detection/od_darknet_yolo_model_trainer.hpp>
 #include <toolkits/object_detection/od_evaluation.hpp>
 #include <toolkits/object_detection/od_serialization.hpp>
 #include <toolkits/object_detection/od_yolo.hpp>

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -167,8 +167,12 @@ class EXPORT object_detector: public ml_model_base {
   void load(std::map<std::string, variant_type> state,
             neural_net::float_array_map weights);
 
+  // Assumes state already loaded.
+  virtual std::unique_ptr<Checkpoint> load_checkpoint(
+      neural_net::float_array_map weights) const;
+
   // Synchronously loads weights from the backend if necessary.
-  Checkpoint* read_checkpoint() const;
+  const Checkpoint& read_checkpoint() const;
 
   // Override points allowing subclasses to inject dependencies
 
@@ -185,9 +189,6 @@ class EXPORT object_detector: public ml_model_base {
   std::unique_ptr<neural_net::compute_context> create_compute_context() const;
 
   // Factories for ModelTrainer
-  virtual std::unique_ptr<ModelTrainer> create_trainer(
-      const Checkpoint& checkpoint,
-      std::unique_ptr<neural_net::compute_context> context) const;
   virtual std::unique_ptr<ModelTrainer> create_trainer(
       const Config& config, const std::string& pretrained_model_path,
       int random_seed,
@@ -256,7 +257,8 @@ class EXPORT object_detector: public ml_model_base {
   gl_sframe validation_data_;
   std::shared_ptr<neural_net::FuturesStream<TrainingOutputBatch>>
       training_futures_;
-  std::shared_ptr<neural_net::FuturesStream<Checkpoint>> checkpoint_futures_;
+  std::shared_ptr<neural_net::FuturesStream<std::unique_ptr<Checkpoint>>>
+      checkpoint_futures_;
 
   // Nonnull while training is in progress, if progress printing is enabled.
   std::unique_ptr<table_printer> training_table_printer_;

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -184,19 +184,18 @@ class EXPORT object_detector: public ml_model_base {
   virtual
   std::unique_ptr<neural_net::compute_context> create_compute_context() const;
 
-  // Factories for Model
-  virtual std::unique_ptr<Model> create_model(
+  // Factories for ModelTrainer
+  virtual std::unique_ptr<ModelTrainer> create_trainer(
       const Checkpoint& checkpoint,
       std::unique_ptr<neural_net::compute_context> context) const;
-  virtual std::unique_ptr<Model> create_model(
+  virtual std::unique_ptr<ModelTrainer> create_trainer(
       const Config& config, const std::string& pretrained_model_path,
       int random_seed,
       std::unique_ptr<neural_net::compute_context> context) const;
 
   // Establishes training pipelines from the backend.
-  void connect_training_backend(std::unique_ptr<Model> backend,
-                                std::unique_ptr<data_iterator> iterator,
-                                int batch_size);
+  void connect_trainer(std::unique_ptr<ModelTrainer> trainer,
+                       std::unique_ptr<data_iterator> iterator, int batch_size);
 
   virtual std::vector<neural_net::image_annotation> convert_yolo_to_annotations(
       const neural_net::float_array& yolo_map,

--- a/src/toolkits/object_detection/object_detector.hpp
+++ b/src/toolkits/object_detection/object_detector.hpp
@@ -21,7 +21,7 @@
 #include <model_server/lib/extensions/ml_model.hpp>
 #include <toolkits/coreml_export/mlmodel_wrapper.hpp>
 #include <toolkits/object_detection/od_data_iterator.hpp>
-#include <toolkits/object_detection/od_model.hpp>
+#include <toolkits/object_detection/od_model_trainer.hpp>
 
 namespace turi {
 namespace object_detection {

--- a/src/toolkits/object_detection/od_darknet_yolo_model_trainer.cpp
+++ b/src/toolkits/object_detection/od_darknet_yolo_model_trainer.cpp
@@ -315,7 +315,7 @@ Checkpoint DarknetYOLOCheckpointer::Next() {
 }
 
 // static
-std::unique_ptr<DarknetYOLOModel> DarknetYOLOModel::Create(
+std::unique_ptr<DarknetYOLOModelTrainer> DarknetYOLOModelTrainer::Create(
     const Config& config, const std::string& pretrained_model_path,
     int random_seed, std::unique_ptr<neural_net::compute_context> context) {
   // Start with parameters from the pre-trained model.
@@ -341,15 +341,15 @@ std::unique_ptr<DarknetYOLOModel> DarknetYOLOModel::Create(
   // The constructor should copy the weights from the checkpoint, so that it's
   // safe to deallocate the model_spec above.
   // TODO: Avoid weak references like the above.
-  std::unique_ptr<DarknetYOLOModel> model;
-  model.reset(new DarknetYOLOModel(checkpoint, std::move(context)));
+  std::unique_ptr<DarknetYOLOModelTrainer> model;
+  model.reset(new DarknetYOLOModelTrainer(checkpoint, std::move(context)));
   return model;
 }
 
-DarknetYOLOModel::DarknetYOLOModel(
+DarknetYOLOModelTrainer::DarknetYOLOModelTrainer(
     const Checkpoint& checkpoint,
     std::unique_ptr<neural_net::compute_context> context)
-    : Model(context->create_image_augmenter(
+    : ModelTrainer(context->create_image_augmenter(
           DarknetYOLOTrainingAugmentationOptions(
               checkpoint.config.batch_size, checkpoint.config.output_height,
               checkpoint.config.output_width))),
@@ -368,14 +368,14 @@ DarknetYOLOModel::DarknetYOLOModel(
 }
 
 std::shared_ptr<Publisher<Checkpoint>>
-DarknetYOLOModel::AsCheckpointPublisher() {
+DarknetYOLOModelTrainer::AsCheckpointPublisher() {
   auto checkpointer =
       std::make_shared<DarknetYOLOCheckpointer>(config_, backend_);
   return checkpointer->AsPublisher();
 }
 
 std::shared_ptr<Publisher<TrainingOutputBatch>>
-DarknetYOLOModel::AsTrainingBatchPublisher(
+DarknetYOLOModelTrainer::AsTrainingBatchPublisher(
     std::shared_ptr<neural_net::Publisher<InputBatch>> augmented_data) {
   Config config = config_;
 

--- a/src/toolkits/object_detection/od_darknet_yolo_model_trainer.cpp
+++ b/src/toolkits/object_detection/od_darknet_yolo_model_trainer.cpp
@@ -5,7 +5,7 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include <toolkits/object_detection/od_darknet_yolo_model.hpp>
+#include <toolkits/object_detection/od_darknet_yolo_model_trainer.hpp>
 
 #include <toolkits/object_detection/od_yolo.hpp>
 

--- a/src/toolkits/object_detection/od_darknet_yolo_model_trainer.cpp
+++ b/src/toolkits/object_detection/od_darknet_yolo_model_trainer.cpp
@@ -7,6 +7,7 @@
 
 #include <toolkits/object_detection/od_darknet_yolo_model_trainer.hpp>
 
+#include <toolkits/object_detection/od_serialization.hpp>
 #include <toolkits/object_detection/od_yolo.hpp>
 
 namespace turi {
@@ -18,6 +19,7 @@ using neural_net::compute_context;
 using neural_net::float_array_map;
 using neural_net::image_augmenter;
 using neural_net::model_spec;
+using neural_net::pipeline_spec;
 using neural_net::Publisher;
 using neural_net::shared_float_array;
 using neural_net::xavier_weight_initializer;
@@ -26,7 +28,6 @@ using padding_type = model_spec::padding_type;
 
 // The spatial reduction depends on the input size of the pre-trained model
 // (relative to the grid size).
-// TODO: When we support alternative base models, we will have to generalize.
 constexpr int SPATIAL_REDUCTION = 32;
 
 constexpr float BASE_LEARNING_RATE = 0.001f;
@@ -351,6 +352,15 @@ std::unique_ptr<ModelTrainer> DarknetYOLOCheckpoint::CreateModelTrainer(
   std::unique_ptr<DarknetYOLOModelTrainer> result;
   result.reset(new DarknetYOLOModelTrainer(*this, context));
   return result;
+}
+
+pipeline_spec DarknetYOLOCheckpoint::ExportToCoreML(
+    const std::string& input_name, const std::string& coordinates_output_name,
+    const std::string& confidence_output_name) const {
+  return export_darknet_yolo(weights_, input_name, coordinates_output_name,
+                             confidence_output_name, GetAnchorBoxes(),
+                             config_.num_classes, config_.output_height,
+                             config_.output_width, SPATIAL_REDUCTION);
 }
 
 float_array_map DarknetYOLOCheckpoint::internal_config() const {

--- a/src/toolkits/object_detection/od_darknet_yolo_model_trainer.hpp
+++ b/src/toolkits/object_detection/od_darknet_yolo_model_trainer.hpp
@@ -80,22 +80,22 @@ class DarknetYOLOCheckpointer : public neural_net::Iterator<Checkpoint> {
   std::shared_ptr<neural_net::model_backend> impl_;
 };
 
-/** Subclass of Model encapsulating the darknet-yolo architecture. */
-class DarknetYOLOModel : public Model {
+/** Subclass of ModelTrainer encapsulating the darknet-yolo architecture. */
+class DarknetYOLOModelTrainer : public ModelTrainer {
  public:
   /**
    * Initializes a new model, combining the pre-trained warm-start weights with
    * random initialization for the final layers.
    */
-  static std::unique_ptr<DarknetYOLOModel> Create(
+  static std::unique_ptr<DarknetYOLOModelTrainer> Create(
       const Config& config, const std::string& pretrained_model_path,
       int random_seed, std::unique_ptr<neural_net::compute_context> context);
 
   /**
    * Initializes a model from a checkpoint.
    */
-  DarknetYOLOModel(const Checkpoint& checkpoint,
-                   std::unique_ptr<neural_net::compute_context> context);
+  DarknetYOLOModelTrainer(const Checkpoint& checkpoint,
+                          std::unique_ptr<neural_net::compute_context> context);
 
   std::shared_ptr<neural_net::Publisher<Checkpoint>> AsCheckpointPublisher()
       override;

--- a/src/toolkits/object_detection/od_darknet_yolo_model_trainer.hpp
+++ b/src/toolkits/object_detection/od_darknet_yolo_model_trainer.hpp
@@ -104,6 +104,10 @@ class DarknetYOLOCheckpoint : public Checkpoint {
   std::unique_ptr<ModelTrainer> CreateModelTrainer(
       neural_net::compute_context* context) const override;
 
+  neural_net::pipeline_spec ExportToCoreML(
+      const std::string& input_name, const std::string& coordinates_output_name,
+      const std::string& confidence_output_name) const override;
+
   /** Returns the config dictionary used to initialize darknet-yolo backends. */
   neural_net::float_array_map internal_config() const;
 

--- a/src/toolkits/object_detection/od_darknet_yolo_model_trainer.hpp
+++ b/src/toolkits/object_detection/od_darknet_yolo_model_trainer.hpp
@@ -5,11 +5,11 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef TOOLKITS_OBJECT_DETECTION_OD_DARKNET_YOLO_MODEL_HPP_
-#define TOOLKITS_OBJECT_DETECTION_OD_DARKNET_YOLO_MODEL_HPP_
+#ifndef TOOLKITS_OBJECT_DETECTION_OD_DARKNET_YOLO_MODEL_TRAINER_HPP_
+#define TOOLKITS_OBJECT_DETECTION_OD_DARKNET_YOLO_MODEL_TRAINER_HPP_
 
 /**
- * \file od_darknet_yolo_model.hpp
+ * \file od_darknet_yolo_model_trainer.hpp
  *
  * Defines helper functions and the Model subclass for the darknet-yolo
  * architecture.
@@ -17,7 +17,7 @@
 
 #include <ml/neural_net/compute_context.hpp>
 #include <ml/neural_net/model_backend.hpp>
-#include <toolkits/object_detection/od_model.hpp>
+#include <toolkits/object_detection/od_model_trainer.hpp>
 
 namespace turi {
 namespace object_detection {
@@ -113,4 +113,4 @@ class DarknetYOLOModel : public Model {
 }  // namespace object_detection
 }  // namespace turi
 
-#endif  // TOOLKITS_OBJECT_DETECTION_OD_DARKNET_YOLO_MODEL_HPP_
+#endif  // TOOLKITS_OBJECT_DETECTION_OD_DARKNET_YOLO_MODEL_TRAINER_HPP_

--- a/src/toolkits/object_detection/od_model_trainer.cpp
+++ b/src/toolkits/object_detection/od_model_trainer.cpp
@@ -53,10 +53,12 @@ TrainingProgress ProgressUpdater::Invoke(TrainingOutputBatch output_batch) {
   return progress;
 }
 
-Model::Model(std::unique_ptr<neural_net::image_augmenter> augmenter)
+ModelTrainer::ModelTrainer(
+    std::unique_ptr<neural_net::image_augmenter> augmenter)
     : augmenter_(std::make_shared<DataAugmenter>(std::move(augmenter))) {}
 
-std::shared_ptr<Publisher<TrainingOutputBatch>> Model::AsTrainingBatchPublisher(
+std::shared_ptr<Publisher<TrainingOutputBatch>>
+ModelTrainer::AsTrainingBatchPublisher(
     std::unique_ptr<data_iterator> training_data, size_t batch_size,
     int offset) {
   // Wrap the data_iterator to incorporate into a Combine pipeline.

--- a/src/toolkits/object_detection/od_model_trainer.cpp
+++ b/src/toolkits/object_detection/od_model_trainer.cpp
@@ -5,7 +5,7 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include <toolkits/object_detection/od_model.hpp>
+#include <toolkits/object_detection/od_model_trainer.hpp>
 
 namespace turi {
 namespace object_detection {

--- a/src/toolkits/object_detection/od_model_trainer.hpp
+++ b/src/toolkits/object_detection/od_model_trainer.hpp
@@ -163,17 +163,17 @@ class ProgressUpdater
 };
 
 /**
- * Abstract base class for object-detection models.
+ * Abstract base class for object-detection model trainers.
  *
  * Responsible for constructing the model-agnostic portions of the overall
  * training pipeline.
  */
-class Model {
+class ModelTrainer {
  public:
   // TODO: This class should be responsible for producing the augmenter itself.
-  Model(std::unique_ptr<neural_net::image_augmenter> augmenter);
+  ModelTrainer(std::unique_ptr<neural_net::image_augmenter> augmenter);
 
-  virtual ~Model() = default;
+  virtual ~ModelTrainer() = default;
 
   /**
    * Given a data iterator, return a publisher of model outputs.

--- a/src/toolkits/object_detection/od_model_trainer.hpp
+++ b/src/toolkits/object_detection/od_model_trainer.hpp
@@ -5,11 +5,11 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef TOOLKITS_OBJECT_DETECTION_OD_MODEL_HPP_
-#define TOOLKITS_OBJECT_DETECTION_OD_MODEL_HPP_
+#ifndef TOOLKITS_OBJECT_DETECTION_OD_MODEL_TRAINER_HPP_
+#define TOOLKITS_OBJECT_DETECTION_OD_MODEL_TRAINER_HPP_
 
 /**
- * \file od_model.hpp
+ * \file od_model_trainer.hpp
  *
  * Defines the value types representing each stage of an object-detection
  * training pipeline, and the virtual interface for arbitrary object-detection
@@ -202,4 +202,4 @@ class Model {
 }  // namespace object_detection
 }  // namespace turi
 
-#endif  // TOOLKITS_OBJECT_DETECTION_OD_MODEL_HPP_
+#endif  // TOOLKITS_OBJECT_DETECTION_OD_MODEL_TRAINER_HPP_

--- a/src/toolkits/object_detection/od_model_trainer.hpp
+++ b/src/toolkits/object_detection/od_model_trainer.hpp
@@ -18,6 +18,7 @@
 
 #include <ml/neural_net/combine.hpp>
 #include <ml/neural_net/compute_context.hpp>
+#include <ml/neural_net/model_spec.hpp>
 #include <toolkits/object_detection/od_data_iterator.hpp>
 
 namespace turi {
@@ -109,6 +110,17 @@ class Checkpoint {
   /** Loads the checkpoint into an active ModelTrainer instance. */
   virtual std::unique_ptr<ModelTrainer> CreateModelTrainer(
       neural_net::compute_context* context) const = 0;
+
+  /**
+   * Returns the CoreML spec corresponding to the current model.
+   *
+   * The result must be a pipeline that accepts an image input and yields at
+   * least two outputs, all with the given names. The outputs must be suitable
+   * for passing directly into a NonMaximumSuppression model.
+   */
+  virtual neural_net::pipeline_spec ExportToCoreML(
+      const std::string& input_name, const std::string& coordinates_output_name,
+      const std::string& confidence_output_name) const = 0;
 };
 
 /**

--- a/src/toolkits/object_detection/od_serialization.cpp
+++ b/src/toolkits/object_detection/od_serialization.cpp
@@ -10,13 +10,36 @@
 #include <stdlib.h>
 #include <cstdio>
 
+#include <toolkits/object_detection/od_yolo.hpp>
+
+#include <toolkits/coreml_export/mlmodel_include.hpp>
+
 namespace turi {
 namespace object_detection {
 
-using turi::neural_net::model_spec;
-using padding_type = model_spec::padding_type;
+namespace {
+
+using CoreML::Specification::ArrayFeatureType;
+using CoreML::Specification::FeatureDescription;
+using CoreML::Specification::ImageFeatureType;
+using CoreML::Specification::Model;
+using CoreML::Specification::ModelDescription;
+using CoreML::Specification::NeuralNetwork;
+using CoreML::Specification::Pipeline;
+
 using turi::neural_net::float_array_map;
+using turi::neural_net::model_spec;
+using turi::neural_net::pipeline_spec;
 using turi::neural_net::zero_weight_initializer;
+
+using padding_type = model_spec::padding_type;
+
+constexpr char CONFIDENCE_STR[] =
+    "Boxes × Class confidence (see user-defined metadata \"classes\")";
+constexpr char COORDINATES_STR[] =
+    "Boxes × [x, y, width, height] (relative to image size)";
+
+}  // namespace
 
 void _save_impl(oarchive& oarc,
                 const std::map<std::string, variant_type>& state,
@@ -38,10 +61,13 @@ void _load_version(iarchive& iarc, size_t version,
   iarc >> *weights;
 }
 
-void init_darknet_yolo(
-    neural_net::model_spec& nn_spec, const size_t num_classes,
-    const std::vector<std::pair<float, float>>& anchor_boxes) {
+void init_darknet_yolo(model_spec& nn_spec, size_t num_classes,
+                       size_t num_anchor_boxes, const std::string& input_name) {
   int num_features = 3;
+
+  // Scale pixel values 0..255 to [0,1]
+  nn_spec.add_scale("_divscalar0", input_name, {1},
+                    neural_net::scalar_weight_initializer(1 / 255.f));
 
   // Initialize Layer 0 to Layer 7
   const std::map<int, int> layer_num_to_channels = {
@@ -50,7 +76,7 @@ void init_darknet_yolo(
   for (const auto& x : layer_num_to_channels) {
     std::string input_name;
     if (x.first == 0) {
-      input_name = "image";
+      input_name = "_divscalar0";
     } else if (x.first == 7) {
       input_name = "leakyrelu6_fwd";
     } else {
@@ -100,7 +126,7 @@ void init_darknet_yolo(
 
   // Append conv8.
   const size_t num_predictions = 5 + num_classes;  // Per anchor box
-  const size_t conv8_c_out = anchor_boxes.size() * num_predictions;
+  const size_t conv8_c_out = num_anchor_boxes * num_predictions;
   nn_spec.add_convolution(/* name */ "conv8_fwd",
                           /* input */ "leakyrelu7_fwd",
                           /* num_output_channels */ conv8_c_out,
@@ -116,7 +142,73 @@ void init_darknet_yolo(
   // Add Preprocessing with image scale = 1.0
   // In order to make the format exactly the same with
   // object_detrector::init_model()
-  nn_spec.add_preprocessing("image", 1.0);
+  nn_spec.add_preprocessing(input_name, 1.0);
+}
+
+pipeline_spec export_darknet_yolo(
+    const float_array_map& weights, const std::string& input_name,
+    const std::string& coordinates_name, const std::string& confidence_name,
+    const std::vector<std::pair<float, float>>& anchor_boxes,
+    size_t num_classes, size_t output_grid_height, size_t output_grid_width,
+    size_t spatial_reduction) {
+  // Initialize the result with the learned layers from the model_backend.
+  std::unique_ptr<model_spec> nn_spec(new model_spec);
+  init_darknet_yolo(*nn_spec, num_classes, anchor_boxes.size(), input_name);
+  nn_spec->update_params(weights);
+
+  // Add the layers that convert to intelligible predictions.
+  add_yolo(nn_spec.get(), coordinates_name, confidence_name, "conv8_fwd",
+           anchor_boxes, num_classes, output_grid_height, output_grid_width);
+
+  // Extract the underlying Core ML spec and move it into a new Pipeline.
+  std::unique_ptr<NeuralNetwork> network =
+      std::move(*nn_spec).move_coreml_spec();
+  std::unique_ptr<Pipeline> pipeline(new Pipeline);
+  Model* model = pipeline->add_models();
+  model->mutable_neuralnetwork()->Swap(network.get());
+
+  // Write the ModelDescription.
+  ModelDescription* model_desc = model->mutable_description();
+
+  // Write FeatureDescription for the image input.
+  FeatureDescription* input_desc = model_desc->add_input();
+  input_desc->set_name(input_name);
+  input_desc->set_shortdescription("Input image");
+  ImageFeatureType* image_feature =
+      input_desc->mutable_type()->mutable_imagetype();
+  image_feature->set_width(output_grid_width * spatial_reduction);
+  image_feature->set_height(output_grid_height * spatial_reduction);
+  image_feature->set_colorspace(ImageFeatureType::RGB);
+
+  // Create a helper function for writing the shapes of the confidence and
+  // coordinates outputs.
+  size_t num_predictions =
+      output_grid_width * output_grid_height * anchor_boxes.size();
+  auto set_shape = [num_predictions](FeatureDescription* feature_desc,
+                                     size_t num_features_per_prediction) {
+    ArrayFeatureType* array_feature =
+        feature_desc->mutable_type()->mutable_multiarraytype();
+    array_feature->set_datatype(ArrayFeatureType::DOUBLE);
+    array_feature->add_shape(num_predictions);
+    array_feature->add_shape(num_features_per_prediction);
+  };
+
+  // Write FeatureDescription for the confidence output.
+  FeatureDescription* confidence_desc = model_desc->add_output();
+  confidence_desc->set_name(confidence_name);
+  confidence_desc->set_shortdescription(CONFIDENCE_STR);
+  set_shape(confidence_desc, num_classes);
+
+  // Write FeatureDescription for the coordinates output.
+  FeatureDescription* coordinates_desc = model_desc->add_output();
+  coordinates_desc->set_name(coordinates_name);
+  coordinates_desc->set_shortdescription(COORDINATES_STR);
+  set_shape(coordinates_desc, 4);
+
+  // Set CoreML spec version.
+  model->set_specificationversion(1);
+
+  return pipeline_spec(std::move(pipeline));
 }
 
 }  // namespace object_detection

--- a/src/toolkits/object_detection/od_serialization.hpp
+++ b/src/toolkits/object_detection/od_serialization.hpp
@@ -23,9 +23,16 @@ void _load_version(iarchive& iarc, size_t version,
                    std::map<std::string, variant_type>* state,
                    neural_net::float_array_map* weights);
 
-void init_darknet_yolo(
-    neural_net::model_spec& nn_spec, const size_t num_classes,
-    const std::vector<std::pair<float, float>>& anchor_boxes);
+void init_darknet_yolo(neural_net::model_spec& nn_spec,
+                       const size_t num_classes, size_t num_anchor_boxes,
+                       const std::string& input_name);
+
+neural_net::pipeline_spec export_darknet_yolo(
+    const neural_net::float_array_map& weights, const std::string& input_name,
+    const std::string& coordinates_name, const std::string& confidence_name,
+    const std::vector<std::pair<float, float>>& anchor_boxes,
+    size_t num_classes, size_t output_grid_height, size_t output_grid_width,
+    size_t spatial_reduction);
 
 }  // namespace object_detection
 }  // namespace turi

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -17,7 +17,7 @@
 #include <boost/test/unit_test.hpp>
 #include <core/util/test_macros.hpp>
 
-#include <toolkits/object_detection/od_darknet_yolo_model.hpp>
+#include <toolkits/object_detection/od_darknet_yolo_model_trainer.hpp>
 
 #include "../neural_net/neural_net_mocks.hpp"
 

--- a/test/unity/toolkits/object_detection/test_object_detector.cxx
+++ b/test/unity/toolkits/object_detection/test_object_detector.cxx
@@ -407,18 +407,14 @@ BOOST_AUTO_TEST_CASE(test_object_detector_init_training) {
         TS_ASSERT_EQUALS(pretrained_model_path, test_mlmodel_path);
         TS_ASSERT_EQUALS(config.num_classes, test_class_labels.size());
 
-        Checkpoint checkpoint;
-        checkpoint.config = config;
-
+        float_array_map weights;
         std::vector<float> buffer(16 * 16 * 3 * 3);
         std::iota(buffer.begin(), buffer.end(), 0);  // buffer[i] = i
-        checkpoint.weights["test_layer_weight"] = shared_float_array::wrap(
+        weights["test_layer_weight"] = shared_float_array::wrap(
             std::move(buffer), std::vector<size_t>{16, 16, 3, 3});
 
-        std::unique_ptr<ModelTrainer> model;
-        model.reset(
-            new DarknetYOLOModelTrainer(checkpoint, std::move(context)));
-        return model;
+        DarknetYOLOCheckpoint checkpoint(config, std::move(weights));
+        return checkpoint.CreateModelTrainer(context.get());
       });
 
   auto create_object_detector_impl =
@@ -714,18 +710,14 @@ BOOST_AUTO_TEST_CASE(test_object_detector_auto_split) {
         TS_ASSERT_EQUALS(pretrained_model_path, test_mlmodel_path);
         TS_ASSERT_EQUALS(config.num_classes, test_class_labels.size());
 
-        Checkpoint checkpoint;
-        checkpoint.config = config;
-
+        float_array_map weights;
         std::vector<float> buffer(16 * 16 * 3 * 3);
         std::iota(buffer.begin(), buffer.end(), 0);  // buffer[i] = i
-        checkpoint.weights["test_layer_weight"] = shared_float_array::wrap(
+        weights["test_layer_weight"] = shared_float_array::wrap(
             std::move(buffer), std::vector<size_t>{16, 16, 3, 3});
 
-        std::unique_ptr<ModelTrainer> model;
-        model.reset(
-            new DarknetYOLOModelTrainer(checkpoint, std::move(context)));
-        return model;
+        DarknetYOLOCheckpoint checkpoint(config, std::move(weights));
+        return checkpoint.CreateModelTrainer(context.get());
       });
 
   auto create_object_detector_impl = [&](int n, int c_in, int h_in, int w_in,
@@ -939,18 +931,14 @@ BOOST_AUTO_TEST_CASE(test_object_detector_predict) {
         TS_ASSERT_EQUALS(pretrained_model_path, test_mlmodel_path);
         TS_ASSERT_EQUALS(config.num_classes, test_class_labels.size());
 
-        Checkpoint checkpoint;
-        checkpoint.config = config;
-
+        float_array_map weights;
         std::vector<float> buffer(16 * 16 * 3 * 3);
         std::iota(buffer.begin(), buffer.end(), 0);  // buffer[i] = i
-        checkpoint.weights["test_layer_weight"] = shared_float_array::wrap(
+        weights["test_layer_weight"] = shared_float_array::wrap(
             std::move(buffer), std::vector<size_t>{16, 16, 3, 3});
 
-        std::unique_ptr<ModelTrainer> model;
-        model.reset(
-            new DarknetYOLOModelTrainer(checkpoint, std::move(context)));
-        return model;
+        DarknetYOLOCheckpoint checkpoint(config, std::move(weights));
+        return checkpoint.CreateModelTrainer(context.get());
       });
 
   auto create_object_detector_impl =


### PR DESCRIPTION
- Rename the new "Model" type to "ModelTrainer" since we have too many types called "model" something or other already
- Change `object_detection::Checkpoint` from a simple struct to a polymorphic type that can instantiate a `ModelTrainer`. In this way, we can consolidate our logic that maps to multiple inner implementations/architectures into fewer places.
- Move CoreML export functionality into `Checkpoint`, since the CoreML representation will always depend on the backend architecture