### PR TITLE
dependency injection on block_cache

### DIFF
--- a/src/core/storage/fileio/fixed_size_cache_manager.cpp
+++ b/src/core/storage/fileio/fixed_size_cache_manager.cpp
@@ -150,7 +150,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
   }
 
  EXPORT cache_id_type fixed_size_cache_manager::get_temp_cache_id(std::string suffix) {
-    std::lock_guard<std::mutex> scoped_lock(mutex);
+    std::lock_guard<turi::mutex> scoped_lock(mutex);
     std::stringstream ss;
     ss << std::setfill('0') << std::setw(6) << temp_cache_counter;
     ++temp_cache_counter;
@@ -159,7 +159,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
   }
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::new_cache(cache_id_type cache_id) {
-    std::lock_guard<std::mutex> lck(mutex);
+    std::lock_guard<turi::mutex> lck(mutex);
     logstream_ontick(5, LOG_INFO) << "Cache Utilization:" << get_cache_utilization() << std::endl;
     // if we have exceeded, we try to evict
     if (current_cache_utilization.value >= FILEIO_MAXIMUM_CACHE_CAPACITY) try_cache_evict();
@@ -200,7 +200,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
 
   void fixed_size_cache_manager::free(std::shared_ptr<cache_block> block) {
     logstream(LOG_DEBUG) << "Free cache block " << block->cache_id << std::endl;
-    std::lock_guard<std::mutex> lck(mutex);
+    std::lock_guard<turi::mutex> lck(mutex);
     cache_id_type id = block->cache_id;
     auto iter = cache_blocks.find(id);
     ASSERT_TRUE(iter != cache_blocks.end());
@@ -209,7 +209,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::get_cache(cache_id_type cache_id) {
     logstream(LOG_DEBUG) << "Get cache block " << cache_id << std::endl;
-    std::lock_guard<std::mutex> lck(mutex);
+    std::lock_guard<turi::mutex> lck(mutex);
     if (cache_blocks.find(cache_id) != cache_blocks.end()) {
       return cache_blocks[cache_id];
     }

--- a/src/core/storage/fileio/fixed_size_cache_manager.cpp
+++ b/src/core/storage/fileio/fixed_size_cache_manager.cpp
@@ -150,7 +150,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
   }
 
  EXPORT cache_id_type fixed_size_cache_manager::get_temp_cache_id(std::string suffix) {
-    std::lock_guard<std::mutex> scoped_lock(mutex_);
+    std::lock_guard<std::mutex> scoped_lock(mutex);
     std::stringstream ss;
     ss << std::setfill('0') << std::setw(6) << temp_cache_counter;
     ++temp_cache_counter;
@@ -159,7 +159,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
   }
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::new_cache(cache_id_type cache_id) {
-    std::lock_guard<std::mutex> lck(mutex_);
+    std::lock_guard<std::mutex> lck(mutex);
     logstream_ontick(5, LOG_INFO) << "Cache Utilization:" << get_cache_utilization() << std::endl;
     // if we have exceeded, we try to evict
     if (current_cache_utilization.value >= FILEIO_MAXIMUM_CACHE_CAPACITY) try_cache_evict();
@@ -200,7 +200,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
 
   void fixed_size_cache_manager::free(std::shared_ptr<cache_block> block) {
     logstream(LOG_DEBUG) << "Free cache block " << block->cache_id << std::endl;
-    std::lock_guard<std::mutex> lck(mutex_);
+    std::lock_guard<std::mutex> lck(mutex);
     cache_id_type id = block->cache_id;
     auto iter = cache_blocks.find(id);
     ASSERT_TRUE(iter != cache_blocks.end());
@@ -209,7 +209,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::get_cache(cache_id_type cache_id) {
     logstream(LOG_DEBUG) << "Get cache block " << cache_id << std::endl;
-    std::lock_guard<std::mutex> lck(mutex_);
+    std::lock_guard<std::mutex> lck(mutex);
     if (cache_blocks.find(cache_id) != cache_blocks.end()) {
       return cache_blocks[cache_id];
     }
@@ -226,7 +226,7 @@ EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
 
   void fixed_size_cache_manager::try_cache_evict() {
     // lock must be acquired outside of this call
-    ASSERT_FALSE(mutex_.try_lock());
+    ASSERT_FALSE(mutex.try_lock());
     // we will try to evict the largest
     std::string largest_entry_name;
     std::shared_ptr<cache_block> largest_block;

--- a/src/core/storage/fileio/fixed_size_cache_manager.cpp
+++ b/src/core/storage/fileio/fixed_size_cache_manager.cpp
@@ -127,10 +127,17 @@ namespace fileio {
 /*                                                                       */
 /*************************************************************************/
 
- EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
-   static std::unique_ptr<fixed_size_cache_manager> instance(new fixed_size_cache_manager);
-   return *instance;
- }
+std::shared_ptr<const fixed_size_cache_manager> fixed_size_cache_manager::hold_instance() {
+  static std::shared_ptr<const fixed_size_cache_manager> instance(new fixed_size_cache_manager);
+  static std::mutex mx;
+  std::lock_guard<std::mutex> lg(mx);
+  return instance;
+}
+
+EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
+  static auto instance = hold_instance();
+  return const_cast<fixed_size_cache_manager&>(*instance);
+}
 
   fixed_size_cache_manager::fixed_size_cache_manager() { }
 
@@ -143,7 +150,7 @@ namespace fileio {
   }
 
  EXPORT cache_id_type fixed_size_cache_manager::get_temp_cache_id(std::string suffix) {
-    std::lock_guard<turi::mutex> scoped_lock(mutex);
+    std::lock_guard<std::mutex> scoped_lock(mutex_);
     std::stringstream ss;
     ss << std::setfill('0') << std::setw(6) << temp_cache_counter;
     ++temp_cache_counter;
@@ -152,7 +159,7 @@ namespace fileio {
   }
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::new_cache(cache_id_type cache_id) {
-    std::lock_guard<turi::mutex> lck(mutex);
+    std::lock_guard<std::mutex> lck(mutex_);
     logstream_ontick(5, LOG_INFO) << "Cache Utilization:" << get_cache_utilization() << std::endl;
     // if we have exceeded, we try to evict
     if (current_cache_utilization.value >= FILEIO_MAXIMUM_CACHE_CAPACITY) try_cache_evict();
@@ -193,7 +200,7 @@ namespace fileio {
 
   void fixed_size_cache_manager::free(std::shared_ptr<cache_block> block) {
     logstream(LOG_DEBUG) << "Free cache block " << block->cache_id << std::endl;
-    std::lock_guard<turi::mutex> lck(mutex);
+    std::lock_guard<std::mutex> lck(mutex_);
     cache_id_type id = block->cache_id;
     auto iter = cache_blocks.find(id);
     ASSERT_TRUE(iter != cache_blocks.end());
@@ -202,7 +209,7 @@ namespace fileio {
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::get_cache(cache_id_type cache_id) {
     logstream(LOG_DEBUG) << "Get cache block " << cache_id << std::endl;
-    std::lock_guard<turi::mutex> lck(mutex);
+    std::lock_guard<std::mutex> lck(mutex_);
     if (cache_blocks.find(cache_id) != cache_blocks.end()) {
       return cache_blocks[cache_id];
     }
@@ -219,7 +226,7 @@ namespace fileio {
 
   void fixed_size_cache_manager::try_cache_evict() {
     // lock must be acquired outside of this call
-    ASSERT_FALSE(mutex.try_lock());
+    ASSERT_FALSE(mutex_.try_lock());
     // we will try to evict the largest
     std::string largest_entry_name;
     std::shared_ptr<cache_block> largest_block;

--- a/src/core/storage/fileio/fixed_size_cache_manager.hpp
+++ b/src/core/storage/fileio/fixed_size_cache_manager.hpp
@@ -242,7 +242,7 @@ class fixed_size_cache_manager {
 
   atomic<size_t> current_cache_utilization;
 
-  std::mutex mutex_;
+  turi::mutex mutex;
   std::unordered_map<std::string, std::shared_ptr<cache_block> > cache_blocks;
 
   /**

--- a/src/core/storage/fileio/fixed_size_cache_manager.hpp
+++ b/src/core/storage/fileio/fixed_size_cache_manager.hpp
@@ -18,7 +18,7 @@
 namespace turi {
 namespace fileio {
 
-//forward declaration
+// forward declaration
 class fixed_size_cache_manager;
 
 typedef std::string cache_id_type;
@@ -33,13 +33,11 @@ typedef std::string cache_id_type;
  */
 struct cache_block {
  private:
-
   // Construct an in-memory cache block
   cache_block(cache_id_type cache_id, size_t max_capacity,
               fixed_size_cache_manager* owning_cache_manager);
 
  public:
-
   cache_block(const cache_block&) = delete;
   cache_block& operator=(const cache_block&) = delete;
 
@@ -51,51 +49,37 @@ struct cache_block {
    */
   bool extend_capacity(size_t new_capacity);
 
-  inline cache_id_type get_cache_id() const {
-    return cache_id;
-  }
+  inline cache_id_type get_cache_id() const { return cache_id; }
 
   /**
    * Returns true if this points to an in memory cache.
    */
-  inline bool is_pointer() const {
-    return filename.empty();
-  }
+  inline bool is_pointer() const { return filename.empty(); }
 
   /**
    * Returns true if this points to a file
    */
-  inline bool is_file() const {
-    return !filename.empty();
-  }
+  inline bool is_file() const { return !filename.empty(); }
 
   /**
    * Returns the pointer to the in memory cache.
    */
-  inline char* get_pointer() const {
-    return data;
-  }
+  inline char* get_pointer() const { return data; }
 
   /**
    * Returns the total capacity of the in memory cache
    */
-  inline const size_t get_pointer_capacity() const {
-    return capacity;
-  }
+  inline const size_t get_pointer_capacity() const { return capacity; }
 
   /**
    * Returns the used capacity of the in memory cache
    */
-  inline const size_t get_pointer_size() const {
-    return size;
-  }
+  inline const size_t get_pointer_size() const { return size; }
 
   /**
    * Returns the disk backed filename.
    */
-  inline const std::string& get_filename() const {
-    return filename;
-  }
+  inline const std::string& get_filename() const { return filename; }
 
   /**
    * If this is an in memory cache, writes bufsize bytes to it. Returns true
@@ -169,21 +153,22 @@ struct cache_block {
  *
  *  - For every new cache block requested:
  *    - If there is FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE free bytes,
- *      a new cache block of FILEIO_INITIAL_CAPACITY_PER_FILE is allocated, where
- *      the new cache block is permitted to grow up to
- *      FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE. The capacity is not charged as utilization
- *      until it is actually used. i.e. utilization is only incremented by
- *      FILEIO_INITIAL_CACHE_CAPACITY_PER_FILE. Then as more memory is allocated for the
- *      cache, then utilization is incremented again.
- *    - If there is < FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE free bytes available:
- *      The largest cache block is evicted. If there is
+ *      a new cache block of FILEIO_INITIAL_CAPACITY_PER_FILE is allocated,
+ * where the new cache block is permitted to grow up to
+ *      FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE. The capacity is not charged as
+ * utilization until it is actually used. i.e. utilization is only incremented
+ * by FILEIO_INITIAL_CACHE_CAPACITY_PER_FILE. Then as more memory is allocated
+ * for the cache, then utilization is incremented again.
+ *    - If there is < FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE free bytes
+ * available: The largest cache block is evicted. If there is
  *      FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE free bytes, Goto the first case.
  *      Otherwise, create a new cache block with all the remaining free bytes.
  *
  *  The relevant constants are thus:
  *   FILEIO_MAXIMUM_CACHE_CAPACITY : the maximum total size of all cache blocks
- *   FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE : the maximum size of each cache blocks
- *   FILEIO_INITIAL_CAPACITY_PER_FILE : the initial size of each cache blocks
+ *   FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE : the maximum size of each cache
+ * blocks FILEIO_INITIAL_CAPACITY_PER_FILE : the initial size of each cache
+ * blocks
  *
  *  Overcommit Behavior
  *  -------------------
@@ -192,10 +177,10 @@ struct cache_block {
  *  conditions since we avoid locking on the cache utilization counter.
  */
 class fixed_size_cache_manager {
-
  public:
-
   static fixed_size_cache_manager& get_instance();
+  // for dependency injection
+  static std::shared_ptr<const fixed_size_cache_manager> hold_instance();
 
   /**
    * Returns a temporary cache id that is not yet used by the
@@ -249,14 +234,15 @@ class fixed_size_cache_manager {
  private:
   fixed_size_cache_manager(const fixed_size_cache_manager& other) = delete;
 
-  fixed_size_cache_manager& operator=(const fixed_size_cache_manager& other) = delete;
+  fixed_size_cache_manager& operator=(const fixed_size_cache_manager& other) =
+      delete;
 
  private:
   size_t temp_cache_counter = 0;
 
   atomic<size_t> current_cache_utilization;
 
-  turi::mutex mutex;
+  std::mutex mutex_;
   std::unordered_map<std::string, std::shared_ptr<cache_block> > cache_blocks;
 
   /**
@@ -277,6 +263,6 @@ class fixed_size_cache_manager {
   friend struct cache_block;
 };
 
-} // end of fileio
-} // end of turicreate
+}  // namespace fileio
+}  // namespace turi
 #endif


### PR DESCRIPTION
`block_cache` is the front end of `fixed_size_cache_manager`, which means the former one relies on the later.

If `fiex_size_cache_manager` is destroyed before `block_cache`, bad access will show up.

The motivation here is that to enable the client to use `general_fstream` directly without any global setup and tear down, where the destruction order is explicitly handled.

