### PR TITLE
retry on S3 error code 429

### DIFF
--- a/src/core/storage/fileio/get_s3_endpoint.cpp
+++ b/src/core/storage/fileio/get_s3_endpoint.cpp
@@ -43,6 +43,20 @@ const std::map<std::string, std::string> AWS_S3_ENDPOINT_TO_REGION {
   {"s3-ap-south-1.amazonaws.com","ap-south-1"}};
 
 
+boost::optional<std::string> get_auth_region_from_env() {
+  if (S3_REGION.size()) {
+    return S3_REGION;
+  }
+  return getenv_str("AWS_DEFAULT_REGION");
+}
+
+boost::optional<std::string> get_endpoint_from_env() {
+  if (S3_ENDPOINT.empty())
+    return boost::none;
+  else
+    return S3_ENDPOINT;
+}
+
 std::vector<std::string> get_s3_endpoints() {
   if (S3_ENDPOINT.empty()) {
     return AWS_S3_END_POINTS;
@@ -85,5 +99,6 @@ std::string get_bucket_path(const std::string& bucket) {
     }
   }
 }
+
 } // fileio
 } // turi

--- a/src/core/storage/fileio/get_s3_endpoint.hpp
+++ b/src/core/storage/fileio/get_s3_endpoint.hpp
@@ -7,6 +7,7 @@
 #define TURI_FILEIO_GET_S3_ENDPOINT_HPP
 #include <vector>
 #include <string>
+#include <boost/optional/optional.hpp>
 
 namespace turi {
 namespace fileio {
@@ -15,6 +16,17 @@ namespace fileio {
  * Returns a complete list of all available S3 region-specific endpoints.
  */
 std::vector<std::string> get_s3_endpoints();
+
+
+/**
+ * set by env var AWS_DEFAULT_REGION or TURI_S3_REGION
+ */
+boost::optional<std::string> get_auth_region_from_env();
+
+/**
+ * set by env var TURI_S3_ENDPOINT
+ */
+boost::optional<std::string> get_endpoint_from_env();
 
 /**
  * \ingroup fileio

--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -215,8 +215,6 @@ bool parse_s3url(std::string s3_url, s3url& ret, std::string& err_msg) {
 
   boost::trim(url);
 
-  // next char is '/' is credential string is in url
-  // it must be this form: s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name]
   if (url.empty()) {
     ss << "missing endpoint or bucket or object key in " << "s3://" << __FILE__
        << "at" << __LINE__;
@@ -224,13 +222,7 @@ bool parse_s3url(std::string s3_url, s3url& ret, std::string& err_msg) {
     return false;
   }
 
-  bool no_endpoint = url.front() == '/';
-  if (no_endpoint) {
-    url = url.substr(1);
-  }
-
-  // shouldn't call sanitize_s3_url here, will cause recursion
-  auto url_without_credentials = "s3://" + url;
+  auto original_url = sanitize_url(url);
 
   // The rest is parsed using boost::tokenizer
   typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
@@ -247,20 +239,20 @@ bool parse_s3url(std::string s3_url, s3url& ret, std::string& err_msg) {
 
   // Parse endpoints; since we support private cloud settings
   // url can be tricky; region (.*)com is not sufficient
-  if (!no_endpoint && std::regex_match(*iter, std::regex("(.*)\\.(com|net)"))) {
+  if (std::regex_match(*iter, std::regex("(.*)\\.(com|net)"))) {
     ret.endpoint = *iter;
     ++iter;
   }
 
   // Parse bucket name
   if (iter == tokens.end()) {
-    ss << "missing bucket name in " << '\'' << url_without_credentials << '\'' << " in "
+    ss << "missing bucket name in " << '\'' << original_url << '\'' << " in "
        << __FILE__ << " at " << __LINE__;
     err_msg = ss.str();
     return false;
   }
   if (!bucket_name_valid(*iter)) {
-    ss << '\'' << url_without_credentials << '\'' << " has invalid bucket name: " << *iter;
+    ss << '\'' << original_url << '\'' << " has invalid bucket name: " << *iter;
     err_msg = ss.str();
     logstream(LOG_WARNING) << err_msg << std::endl;
     return false;
@@ -641,6 +633,9 @@ list_objects_response list_objects(std::string url, std::string proxy) {
   s3url parsed_url;
   list_objects_response ret;
   std::string err_msg;
+
+  // in order not to reach the rate limit
+
   bool success = parse_s3url(url, parsed_url, err_msg);
 
   if (!success) {
@@ -672,7 +667,17 @@ std::pair<file_status, list_objects_response> is_directory(std::string url,
     ret.error = std::move(err_msg);
     return {file_status::MISSING, ret};
   }
-  // if there are no "/"'s it is just a top level bucket
+
+  /* if there are no “/”‘s it is just a top level bucket
+   * list_objects_impl will remove the ending ‘/’
+   * e.g., dir/ -> dir
+   * in turicreate convention, dir should not have ‘/’,
+   * refer to dir_archive::init_for_read
+   */
+  // remove credentials
+  url = parsed_url.string_from_s3url();
+  logstream(LOG_DEBUG) << "compare on url: " << url << std::endl;
+  if (url.length() > 5 && url.back() == '/') url.pop_back();
 
   list_objects_response response = list_objects(url, proxy);
   // an error occured
@@ -700,6 +705,16 @@ std::pair<file_status, list_objects_response> is_directory(std::string url,
   }
 
   // is not found
+  // s3 would be slient with list-objects if prefix doesn't exist
+  if (response.error.empty()) {
+    std::stringstream ss;
+    ss << sanitize_url(url)
+       << " has no objects or diretoires. Consider create the prefix and try "
+          "again";
+
+    response.error = ss.str();
+  }
+
   return {file_status::MISSING, response};
 }
 

--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -10,26 +10,29 @@
 #else
 #include <ws2tcpip.h>
 #endif
-#include <memory>
-#include <fstream>
-#include <string>
-#include <thread>
-#include <future>
-#include <regex>
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/tokenizer.hpp>
-#include <core/logging/logger.hpp>
 #include <core/logging/assertions.hpp>
-#include <core/storage/fileio/s3_api.hpp>
+#include <core/logging/logger.hpp>
 #include <core/storage/fileio/fs_utils.hpp>
 #include <core/storage/fileio/general_fstream.hpp>
 #include <core/storage/fileio/get_s3_endpoint.hpp>
+#include <core/storage/fileio/s3_api.hpp>
 #include <core/system/cppipc/server/cancel_ops.hpp>
+#include <fstream>
+#include <future>
+#include <memory>
+#include <regex>
+#include <string>
+#include <thread>
+#include <chrono>
 
 /* aws */
 #include <aws/core/Aws.h>
+#include <aws/core/http/HttpResponse.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/ListObjectsV2Result.h>
@@ -111,20 +114,57 @@ bool bucket_name_valid(const std::string& bucket_name) {
 }
 
 
-std::string string_from_s3url(const s3url& parsed_url) {
-  std::string ret = "s3://" + parsed_url.access_key_id + ":"
-      + parsed_url.secret_key + ":";
+} // anonymous namespace
+
+S3Client init_aws_sdk_with_turi_env(s3url& parsed_url) {
+  // s3 client config
+  // DefaultCredentialProviderChain
+  Aws::Client::ClientConfiguration clientConfiguration;
+
+  // a little bit too long, anyway
+  clientConfiguration.requestTimeoutMs = 5 * 60000;
+  clientConfiguration.connectTimeoutMs = 20000;
+
+  if (turi::fileio::insecure_ssl_cert_checks()) {
+    clientConfiguration.verifySSL = false;
+  }
+
   if (!parsed_url.endpoint.empty()) {
-    ret += parsed_url.endpoint + "/";
+    clientConfiguration.endpointOverride = parsed_url.endpoint.c_str();
+  } else {
+    auto env_var = get_endpoint_from_env();
+    if (env_var) {
+      clientConfiguration.endpointOverride = env_var->c_str();
+      parsed_url.sdk_endpoint = env_var->c_str();
+    }
   }
-  ret += parsed_url.bucket;
-  if (!parsed_url.object_name.empty()) {
-    ret += "/" + parsed_url.object_name;
+
+  // TODO: add proxy support
+  // clientConfiguration.proxyHost = proxy.c_str();
+
+  std::string region = fileio::get_region_name_from_endpoint(
+      clientConfiguration.endpointOverride.c_str());
+
+  if (!region.empty()) {
+    clientConfiguration.region = region.c_str();
+  } else {
+    auto env_var = get_auth_region_from_env();
+    if (env_var) {
+      clientConfiguration.region = env_var->c_str();
+      parsed_url.sdk_region = env_var->c_str();
+    }
   }
-  return ret;
+
+  if (parsed_url.secret_key.empty()) {
+    return S3Client(clientConfiguration);
+  } else {
+    // credentials
+    Aws::Auth::AWSCredentials credentials(parsed_url.access_key_id.c_str(),
+                                          parsed_url.secret_key.c_str());
+    return S3Client(credentials, clientConfiguration);
+  }
 }
 
-} // anonymous namespace
 
 const std::vector<std::string> S3Operation::_enum_to_str = {
     "DeleteObjects", "ListObjects", "HeadObjects"};
@@ -136,8 +176,9 @@ const std::vector<std::string> S3Operation::_enum_to_str = {
  *
  * Returns true on success, false on failure.
  */
-bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
+bool parse_s3url(std::string s3_url, s3url& ret, std::string& err_msg) {
   // must begin with s3://
+  auto url = s3_url;
   if (fileio::get_protocol(url) != "s3") {
     err_msg = url + " doesn't start with 's3://'";
     return false;
@@ -172,11 +213,31 @@ bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
     url = url.substr(splitpos + 1);
   }
 
+  boost::trim(url);
+
+  // next char is '/' is credential string is in url
+  // it must be this form: s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name]
+  if (url.empty()) {
+    ss << "missing endpoint or bucket or object key in " << "s3://" << __FILE__
+       << "at" << __LINE__;
+    err_msg = ss.str();
+    return false;
+  }
+
+  bool no_endpoint = url.front() == '/';
+  if (no_endpoint) {
+    url = url.substr(1);
+  }
+
+  // shouldn't call sanitize_s3_url here, will cause recursion
+  auto url_without_credentials = "s3://" + url;
+
   // The rest is parsed using boost::tokenizer
   typedef boost::tokenizer<boost::char_separator<char> > tokenizer;
   boost::char_separator<char> sep("/");
   tokenizer tokens(url, sep);
   tokenizer::iterator iter = tokens.begin();
+
   if (iter == tokens.end()) {
     ss << "missing endpoint or bucket or object key in " << url << __FILE__
        << "at" << __LINE__;
@@ -184,23 +245,22 @@ bool parse_s3url(std::string url, s3url& ret, std::string& err_msg) {
     return false;
   }
 
-  auto original_url = sanitize_url(url);
   // Parse endpoints; since we support private cloud settings
   // url can be tricky; region (.*)com is not sufficient
-  if (std::regex_match(*iter, std::regex("(.*)\\.(com|net)"))) {
+  if (!no_endpoint && std::regex_match(*iter, std::regex("(.*)\\.(com|net)"))) {
     ret.endpoint = *iter;
     ++iter;
   }
 
   // Parse bucket name
   if (iter == tokens.end()) {
-    ss << "missing bucket name in " << '\'' << original_url << '\'' << " in "
+    ss << "missing bucket name in " << '\'' << url_without_credentials << '\'' << " in "
        << __FILE__ << " at " << __LINE__;
     err_msg = ss.str();
     return false;
   }
   if (!bucket_name_valid(*iter)) {
-    ss << '\'' << original_url << '\'' << " has invalid bucket name: " << *iter;
+    ss << '\'' << url_without_credentials << '\'' << " has invalid bucket name: " << *iter;
     err_msg = ss.str();
     logstream(LOG_WARNING) << err_msg << std::endl;
     return false;
@@ -311,30 +371,29 @@ list_objects_response list_objects_impl(s3url parsed_url,
                                         std::string proxy,
                                         std::string endpoint)
 {
-    // initialization
-    Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
-    Aws::InitAPI(options);
-
     // credentials
     Aws::Auth::AWSCredentials credentials(parsed_url.access_key_id.c_str(), parsed_url.secret_key.c_str());
-
 
     // s3 client config
     Aws::Client::ClientConfiguration clientConfiguration;
     if (turi::fileio::insecure_ssl_cert_checks()) {
       clientConfiguration.verifySSL = false;
     }
+
     if (parsed_url.endpoint.empty()) {
       clientConfiguration.endpointOverride = endpoint.c_str();
     } else {
       clientConfiguration.endpointOverride = parsed_url.endpoint.c_str();
     }
+
     clientConfiguration.proxyHost = proxy.c_str();
     clientConfiguration.requestTimeoutMs = 5 * 60000;
     clientConfiguration.connectTimeoutMs = 20000;
     std::string region = fileio::get_region_name_from_endpoint(clientConfiguration.endpointOverride.c_str());
-    clientConfiguration.region = region.c_str();
+    if (!region.empty()) {
+      clientConfiguration.region = region.c_str();
+      parsed_url.sdk_region = region;
+    }
 
     S3Client client(credentials, clientConfiguration);
 
@@ -346,233 +405,250 @@ list_objects_response list_objects_impl(s3url parsed_url,
     request.WithDelimiter("/"); // seperate objects from directories
 
     bool moreResults = false;
-    do
-    {
+    bool success = false;
+    int backoff = 50;  // ms
+    int n_retry = 0;
+
+    do {
+      n_retry = 0;
+      do {
         auto outcome = client.ListObjectsV2(request);
-        if(outcome.IsSuccess())
-        {
-            auto result = outcome.GetResult();
 
-            // now iterate through found objects - these are files
-            Aws::Vector<Aws::S3::Model::Object> objects;
-            objects = result.GetContents();
-            for (auto const& o : objects)
-            {
-                // std::cout << "object: " << objects[i].GetKey() << ", size: " << objects[i].GetSize() << ", last_modified: " << objects[i].GetLastModified().Millis() << std::endl;
-                ret.objects.push_back(std::string(o.GetKey().c_str()));
-                std::stringstream stream;
-                stream << o.GetLastModified().Millis();
-                ret.objects_last_modified.push_back(stream.str());
-            }
+        success = outcome.IsSuccess();
 
-            // now iterate through common prefixes - these are directories
-            Aws::Vector<Aws::S3::Model::CommonPrefix> prefixes;
-            prefixes = result.GetCommonPrefixes();
-            for (auto const& p : prefixes)
-            {
-                // std::cout << "directory: " << prefixes[i].GetPrefix() << std::endl;
-                std::string key = std::string(p.GetPrefix().c_str());
-                // strip the ending "/" on a directory
-                if (boost::ends_with(key, "/")) key = key.substr(0, key.length() - 1);
-                ret.directories.push_back(key);
-            }
+        if (success) {
+          auto result = outcome.GetResult();
+          // now iterate through found objects - these are files
+          Aws::Vector<Aws::S3::Model::Object> objects;
+          objects = result.GetContents();
+          for (auto const& o : objects) {
+            ret.objects.push_back(std::string(o.GetKey().c_str()));
+            std::stringstream stream;
+            stream << o.GetLastModified().Millis();
+            ret.objects_last_modified.push_back(stream.str());
+            ret.objects_size.push_back(o.GetSize());
+          }
 
-            // more results to retrieve
-            moreResults = result.GetIsTruncated();
-            if (moreResults)
-            {
-                // add to the request object with continuation token
-                request.WithContinuationToken(result.GetContinuationToken());
-            }
+          // now iterate through common prefixes - these are directories
+          Aws::Vector<Aws::S3::Model::CommonPrefix> prefixes;
+          prefixes = result.GetCommonPrefixes();
+          for (auto const& p : prefixes) {
+            std::string key = std::string(p.GetPrefix().c_str());
+            // strip the ending "/" on a directory
+            if (boost::ends_with(key, "/"))
+              key = key.substr(0, key.length() - 1);
+            ret.directories.push_back(key);
+          }
 
-        }
-        else
-        {
+          // more results to retrieve
+          moreResults = result.GetIsTruncated();
+          if (moreResults) {
+            // add to the request object with continuation token
+            request.WithContinuationToken(result.GetContinuationToken());
+          }
+
+          // jump out the retry loop
+          break;
+
+        } else {
+          auto error = outcome.GetError().GetResponseCode();
+
+          if (error == Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS) {
+            n_retry++;
+            std::this_thread::sleep_for(std::chrono::milliseconds(backoff));
+            backoff *= 2;
+          } else {
             std::stringstream ss;
             reportS3ErrorDetailed(ss, parsed_url, S3Operation::List,
                                   clientConfiguration, outcome)
                 << std::endl;
             ret.error = ss.str();
+            logstream(LOG_DEBUG)
+                << "list_objects_impl failed:" << ret.error << std::endl;
+            // no need to retry, just jump out all while loop
+            break;
+          }
         }
+      } while (n_retry < 3);  // finished retry
 
-    } while (moreResults);
+    } while (moreResults && success);
 
-    Aws::ShutdownAPI(options);
     for (auto& dir : ret.directories) {
       s3url dirurl = parsed_url;
       dirurl.object_name = dir;
-      dir = string_from_s3url(dirurl);
+      // this is not necessary to override what returned by s3
+      dir = dirurl.string_from_s3url();
     }
-    for (auto& object: ret.objects) {
+    for (auto& object : ret.objects) {
       s3url objurl = parsed_url;
       objurl.object_name = object;
-      object = string_from_s3url(objurl);
+      object = objurl.string_from_s3url();
     }
     return ret;
 }
 
 /// returns an error string on failure. Empty string on success
-std::string delete_object_impl(s3url parsed_url,
-                               std::string proxy,
+std::string delete_object_impl(s3url parsed_url, std::string proxy,
                                std::string endpoint) {
-    std::string ret;
+  std::string ret;
 
-    // initialization
-    Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
-    Aws::InitAPI(options);
+  // credentials
+  Aws::Auth::AWSCredentials credentials(parsed_url.access_key_id.c_str(),
+                                        parsed_url.secret_key.c_str());
 
-    // credentials
-    Aws::Auth::AWSCredentials credentials(parsed_url.access_key_id.c_str(), parsed_url.secret_key.c_str());
+  // s3 client config
+  Aws::Client::ClientConfiguration clientConfiguration;
 
-    // s3 client config
-    Aws::Client::ClientConfiguration clientConfiguration;
-    if (turi::fileio::insecure_ssl_cert_checks()) {
-      clientConfiguration.verifySSL = false;
-    }
+  clientConfiguration.requestTimeoutMs = 5 * 60000;
+  clientConfiguration.connectTimeoutMs = 20000;
 
-    if (parsed_url.endpoint.empty()) {
-      clientConfiguration.endpointOverride = endpoint.c_str();
-    } else {
-      clientConfiguration.endpointOverride = parsed_url.endpoint.c_str();
-    }
+  if (turi::fileio::insecure_ssl_cert_checks()) {
+    clientConfiguration.verifySSL = false;
+  }
 
+  if (parsed_url.endpoint.empty()) {
+    clientConfiguration.endpointOverride = endpoint.c_str();
+    parsed_url.sdk_endpoint = endpoint;
+  } else {
+    clientConfiguration.endpointOverride = parsed_url.endpoint.c_str();
+  }
+
+  if (!proxy.empty()) {
     clientConfiguration.proxyHost = proxy.c_str();
-    clientConfiguration.requestTimeoutMs = 5 * 60000;
-    clientConfiguration.connectTimeoutMs = 20000;
-    std::string region = fileio::get_region_name_from_endpoint(clientConfiguration.endpointOverride.c_str());
+    parsed_url.sdk_proxy = proxy;
+  }
+
+  std::string region = fileio::get_region_name_from_endpoint(
+      clientConfiguration.endpointOverride.c_str());
+  if (!region.empty()) {
     clientConfiguration.region = region.c_str();
+    parsed_url.sdk_region = region;
+  }
 
-    S3Client client(credentials, clientConfiguration);
+  S3Client client(credentials, clientConfiguration);
 
-    Aws::S3::Model::DeleteObjectRequest request;
-    request.WithBucket(parsed_url.bucket.c_str());
-    request.WithKey(parsed_url.object_name.c_str());
+  Aws::S3::Model::DeleteObjectRequest request;
+  request.WithBucket(parsed_url.bucket.c_str());
+  request.WithKey(parsed_url.object_name.c_str());
 
-    auto outcome = client.DeleteObject(request);
-    if(!outcome.IsSuccess())
-    {
+  auto outcome = client.DeleteObject(request);
+  if (!outcome.IsSuccess()) {
+    std::stringstream ss;
+    reportS3ErrorDetailed(ss, parsed_url, S3Operation::Delete,
+                          clientConfiguration, outcome)
+        << std::endl;
+    ret = ss.str();
+  }
+
+  return ret;
+}
+
+/// returns an error string on failure. Empty string on success
+std::string delete_prefix_impl(s3url parsed_url, std::string proxy,
+                               std::string endpoint) {
+  // List objects and then create a DeleteObjects request from the resulting
+  std::string ret;
+
+  // credentials
+  Aws::Auth::AWSCredentials credentials(parsed_url.access_key_id.c_str(),
+                                        parsed_url.secret_key.c_str());
+
+  // s3 client config
+  Aws::Client::ClientConfiguration clientConfiguration;
+  if (turi::fileio::insecure_ssl_cert_checks()) {
+    clientConfiguration.verifySSL = false;
+  }
+
+  if (parsed_url.endpoint.empty()) {
+    clientConfiguration.endpointOverride = endpoint.c_str();
+    // for report
+    parsed_url.endpoint = endpoint;
+  } else {
+    clientConfiguration.endpointOverride = parsed_url.endpoint.c_str();
+  }
+
+  if (proxy.size()) {
+    clientConfiguration.proxyHost = proxy.c_str();
+    parsed_url.sdk_proxy = proxy;
+  }
+  clientConfiguration.requestTimeoutMs = 5 * 60000;
+  clientConfiguration.connectTimeoutMs = 20000;
+  std::string region = fileio::get_region_name_from_endpoint(
+      clientConfiguration.endpointOverride.c_str());
+  if (!region.empty()) {
+    clientConfiguration.region = region.c_str();
+    parsed_url.sdk_region = region;
+  }
+
+  S3Client client(credentials, clientConfiguration);
+
+  Aws::S3::Model::ListObjectsV2Request request;
+  request.WithBucket(parsed_url.bucket.c_str());
+  request.WithPrefix(parsed_url.object_name.c_str());
+
+  // keep retrieving objects until no more objects match query
+  bool moreResults = false;
+  Aws::S3::Model::Delete deleteObjects;
+  do {
+    auto outcome = client.ListObjectsV2(request);
+    if (outcome.IsSuccess()) {
+      auto result = outcome.GetResult();
+
+      // now iterate through found objects and construct DeleteObjects request
+      // with them
+      auto objects = result.GetContents();
+      for (auto const& o : objects) {
+        Aws::S3::Model::ObjectIdentifier key;
+        deleteObjects.AddObjects(key.WithKey(o.GetKey()));
+      }
+
+      // more results to retrieve
+      moreResults = result.GetIsTruncated();
+      if (moreResults) {
+        // add to the request object with continuation token
+        request.WithContinuationToken(result.GetContinuationToken());
+      }
+
+    } else {
       std::stringstream ss;
-      reportS3ErrorDetailed(ss, parsed_url, S3Operation::Delete,
-                            clientConfiguration, outcome) << std::endl;
+      reportS3ErrorDetailed(ss, parsed_url, S3Operation::List,
+                            clientConfiguration, outcome)
+          << std::endl;
       ret = ss.str();
     }
 
-    Aws::ShutdownAPI(options);
-    return ret;
+  } while (moreResults);
+
+  if (deleteObjects.GetObjects().size() > 0) {
+    Aws::S3::Model::DeleteObjectsRequest delRequest;
+    delRequest.WithBucket(parsed_url.bucket.c_str());
+    delRequest.WithDelete(deleteObjects);
+
+    auto outcome = client.DeleteObjects(delRequest);
+    if (!outcome.IsSuccess()) {
+      std::stringstream ss;
+      reportS3ErrorDetailed(ss, parsed_url, S3Operation::Delete,
+                            clientConfiguration, outcome)
+          << std::endl;
+      ret = ss.str();
+    }
+  }
+
+  return ret;
 }
 
-/// returns an error string on failure. Empty string on success
-std::string delete_prefix_impl(s3url parsed_url,
-                               std::string proxy,
-                               std::string endpoint) {
-
-    // List objects and then create a DeleteObjects request from the resulting list
-
-    std::string ret;
-
-    // initialization
-    Aws::SDKOptions options;
-    options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
-    Aws::InitAPI(options);
-
-    // credentials
-    Aws::Auth::AWSCredentials credentials(parsed_url.access_key_id.c_str(), parsed_url.secret_key.c_str());
-
-
-    // s3 client config
-    Aws::Client::ClientConfiguration clientConfiguration;
-    if (turi::fileio::insecure_ssl_cert_checks()) {
-      clientConfiguration.verifySSL = false;
-    }
-
-    if (parsed_url.endpoint.empty()) {
-      clientConfiguration.endpointOverride = endpoint.c_str();
-    } else {
-      clientConfiguration.endpointOverride = parsed_url.endpoint.c_str();
-    }
-
-    clientConfiguration.proxyHost = proxy.c_str();
-    clientConfiguration.requestTimeoutMs = 5 * 60000;
-    clientConfiguration.connectTimeoutMs = 20000;
-    std::string region = fileio::get_region_name_from_endpoint(clientConfiguration.endpointOverride.c_str());
-    clientConfiguration.region = region.c_str();
-
-    S3Client client(credentials, clientConfiguration);
-
-    Aws::S3::Model::ListObjectsV2Request request;
-    request.WithBucket(parsed_url.bucket.c_str());
-    request.WithPrefix(parsed_url.object_name.c_str());
-
-    // keep retrieving objects until no more objects match query
-    bool moreResults = false;
-    Aws::S3::Model::Delete deleteObjects;
-    do
-    {
-        auto outcome = client.ListObjectsV2(request);
-        if(outcome.IsSuccess())
-        {
-            auto result = outcome.GetResult();
-
-            // now iterate through found objects and construct DeleteObjects request with them
-            auto objects = result.GetContents();
-            for (auto const& o : objects)
-            {
-                Aws::S3::Model::ObjectIdentifier key;
-                deleteObjects.AddObjects(key.WithKey(o.GetKey()));
-            }
-
-            // more results to retrieve
-            moreResults = result.GetIsTruncated();
-            if (moreResults)
-            {
-                // add to the request object with continuation token
-                request.WithContinuationToken(result.GetContinuationToken());
-            }
-
-        }
-        else
-        {
-            std::stringstream ss;
-            reportS3ErrorDetailed(ss, parsed_url, S3Operation::List,
-                                  clientConfiguration, outcome)
-                << std::endl;
-            ret = ss.str();
-        }
-
-    } while (moreResults);
-
-    if (deleteObjects.GetObjects().size() > 0)
-    {
-        Aws::S3::Model::DeleteObjectsRequest delRequest;
-        delRequest.WithBucket(parsed_url.bucket.c_str());
-        delRequest.WithDelete(deleteObjects);
-
-        auto outcome = client.DeleteObjects(delRequest);
-        if (!outcome.IsSuccess())
-        {
-          std::stringstream ss;
-          reportS3ErrorDetailed(ss, parsed_url, S3Operation::Delete,
-                                clientConfiguration, outcome)
-              << std::endl;
-          ret = ss.str();
-        }
-    }
-
-    Aws::ShutdownAPI(options);
-    return ret;
-}
-
-list_objects_response list_objects(std::string url,
-                                   std::string proxy) {
+list_objects_response list_objects(std::string url, std::string proxy) {
   s3url parsed_url;
   list_objects_response ret;
   std::string err_msg;
   bool success = parse_s3url(url, parsed_url, err_msg);
+
   if (!success) {
     ret.error = err_msg;
     return ret;
   }
+
+  logstream(LOG_DEBUG) << "list_obejcts: " << url << std::endl;
 
   size_t current_endpoint = 0;
   // try all endpoints
@@ -581,14 +657,13 @@ list_objects_response list_objects(std::string url,
     ret = list_objects_impl(parsed_url, proxy, endpoints[current_endpoint]);
     ++current_endpoint;
   } while (boost::algorithm::icontains(ret.error, "PermanentRedirect") &&
-         current_endpoint < endpoints.size());
+           current_endpoint < endpoints.size());
 
   return ret;
 }
 
-
-std::pair<file_status, list_objects_response>
-is_directory(std::string url, std::string proxy) {
+std::pair<file_status, list_objects_response> is_directory(std::string url,
+                                                           std::string proxy) {
   s3url parsed_url;
   list_objects_response ret;
   std::string err_msg;
@@ -611,14 +686,14 @@ is_directory(std::string url, std::string proxy) {
   }
 
   // is a directory
-  for (auto dir: response.directories) {
+  for (auto dir : response.directories) {
     if (dir == url) {
       return {file_status::DIRECTORY, response};
     }
   }
 
   // is an object
-  for (auto object: response.objects) {
+  for (auto& object : response.objects) {
     if (object == url) {
       return {file_status::REGULAR_FILE, response};
     }
@@ -638,7 +713,7 @@ list_objects_response list_directory(std::string url, std::string proxy) {
     return ret;
   }
   // normalize the URL so it doesn't matter if you put strange "/"s at the end
-  url = string_from_s3url(parsed_url);
+  url = parsed_url.string_from_s3url();
   auto isdir = is_directory(url, proxy);
   // if not found.
   if (isdir.first == file_status::MISSING) return isdir.second;
@@ -657,7 +732,7 @@ list_objects_response list_directory(std::string url, std::string proxy) {
       ret = list_objects_impl(parsed_url, proxy, endpoints[current_endpoint]);
       ++current_endpoint;
     } while (boost::algorithm::icontains(ret.error, "PermanentRedirect") &&
-           current_endpoint < endpoints.size());
+             current_endpoint < endpoints.size());
   } else {
     ret.objects.push_back(url);
   }
@@ -665,9 +740,7 @@ list_objects_response list_directory(std::string url, std::string proxy) {
   return ret;
 }
 
-
-std::string delete_object(std::string url,
-                          std::string proxy) {
+std::string delete_object(std::string url, std::string proxy) {
   s3url parsed_url;
   std::string err_msg;
 
@@ -679,34 +752,34 @@ std::string delete_object(std::string url,
   size_t current_endpoint = 0;
   auto endpoints = get_s3_endpoints();
   do {
-    err_msg = delete_object_impl(parsed_url, proxy, endpoints[current_endpoint]);
-    ++current_endpoint;
-  } while (boost::algorithm::icontains(err_msg , "PermanentRedirect") &&
-         current_endpoint < endpoints.size());
-
-  return err_msg;
-}
-
-std::string delete_prefix(std::string url,
-                          std::string proxy) {
-  s3url parsed_url;
-  std::string err_msg;
-  bool success = parse_s3url(url, parsed_url, err_msg);
-  if (!success) {
-    return err_msg;
-  }
-  // try all endpoints
-  size_t current_endpoint = 0;
-  auto endpoints = get_s3_endpoints();
-  do {
-    err_msg = delete_prefix_impl(parsed_url, proxy, endpoints[current_endpoint]);
+    err_msg =
+        delete_object_impl(parsed_url, proxy, endpoints[current_endpoint]);
     ++current_endpoint;
   } while (boost::algorithm::icontains(err_msg, "PermanentRedirect") &&
-         current_endpoint < endpoints.size());
+           current_endpoint < endpoints.size());
 
   return err_msg;
 }
 
+std::string delete_prefix(std::string url, std::string proxy) {
+  s3url parsed_url;
+  std::string err_msg;
+  bool success = parse_s3url(url, parsed_url, err_msg);
+  if (!success) {
+    return err_msg;
+  }
+  // try all endpoints
+  size_t current_endpoint = 0;
+  auto endpoints = get_s3_endpoints();
+  do {
+    err_msg =
+        delete_prefix_impl(parsed_url, proxy, endpoints[current_endpoint]);
+    ++current_endpoint;
+  } while (boost::algorithm::icontains(err_msg, "PermanentRedirect") &&
+           current_endpoint < endpoints.size());
+
+  return err_msg;
+}
 
 std::string sanitize_s3_url_aggressive(std::string url) {
   // must begin with s3://
@@ -743,47 +816,25 @@ std::string sanitize_s3_url(const std::string& url) {
     if (parsed_url.endpoint.empty())
       return "s3://" + parsed_url.bucket + "/" + parsed_url.object_name;
     else
-      return "s3://" + parsed_url.endpoint + "/" + parsed_url.bucket + "/" + parsed_url.object_name;
+      return "s3://" + parsed_url.endpoint + "/" + parsed_url.bucket + "/" +
+             parsed_url.object_name;
   } else {
     return sanitize_s3_url_aggressive(url);
   };
 }
 
-std::string get_s3_error_code(const std::string& msg) {
-  static const std::vector<std::string> errorcodes {
-    "AccessDenied", "NoSuchBucket", "InvalidAccessKeyId",
-    "InvalidBucketName", "KeyTooLong", "NoSuchKey", "RequestTimeout"
-  };
-
-  // User friendly error codes, return immediately.
-  for (const auto& ec : errorcodes) {
-    if (boost::algorithm::icontains(msg, ec)) {
-      return msg;
-    }
-  }
-
-  // Error code that may need some explanation.
-  // Add messages for error code below:
-  // ...
-  // best guess for 403 error
-  if (boost::algorithm::icontains(msg, "forbidden")) {
-    return "403 Forbidden. Please check your AWS credentials and permission to the file.";
-  }
-
-  return msg;
-}
-
-std::string get_s3_file_last_modified(const std::string& url){
+std::string get_s3_file_last_modified(const std::string& url) {
   list_objects_response response = list_objects(url);
   if (response.error.empty() && response.objects_last_modified.size() == 1) {
     return response.objects_last_modified[0];
   } else if (!response.error.empty()) {
-    logstream(LOG_WARNING) << "List object error: " << response.error << " " << __FILE__ << " at " << __LINE__ << std::endl;
+    logstream(LOG_WARNING) << "List object error: " << response.error << " "
+                           << __FILE__ << " at " << __LINE__ << std::endl;
     throw(response.error);
   }
   return "";
 }
 
-}
+}  // namespace turi
 
 #endif

--- a/src/core/storage/fileio/s3_api.hpp
+++ b/src/core/storage/fileio/s3_api.hpp
@@ -16,7 +16,6 @@
 #include <core/storage/fileio/fs_utils.hpp>
 #include <aws/s3/S3Client.h>
 #include <core/logging/assertions.hpp>
-#include <chrono>
 
 namespace turi {
 
@@ -54,7 +53,7 @@ struct s3url {
    * @param with_credentials: user should not see this
    *
    * reconstruct to url format,
-   * s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name],
+   * s3://[access_key_id]:[secret_key]:[endpoint/][bucket]/[object_name],
    * which turi uses everywhere.
    */
   std::string string_from_s3url(bool with_credentials = true) const {
@@ -75,15 +74,14 @@ struct s3url {
     if (!endpoint.empty()) {
       ret.append(1, ':');
       ret.append(endpoint);
+      ret.append(1, '/');
     }
 
     ASSERT_TRUE(!bucket.empty());
-    // if it's still not pure s3://
-    if (ret.size() > prot_len) ret.append(1, '/');
     ret.append(bucket);
 
     if (!object_name.empty()) {
-      if (ret.size() > 5) ret.append(1, '/');
+      if (ret.size() > prot_len) ret.append(1, '/');
       ret.append(object_name);
     }
 
@@ -97,6 +95,7 @@ struct s3url {
     return os << url.string_from_s3url(false);
   }
 };
+
 
 
 /**
@@ -244,7 +243,7 @@ std::string sanitize_s3_url(const std::string& url);
  * \ingroup fileio
  * \internal
  * This splits a URL of the form
- * s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name]
+ * s3://[access_key_id]:[secret_key]:[endpoint/][bucket]/[object_name]
  * into several pieces.
  *
  * endpoint and object_name are optional.

--- a/src/core/storage/fileio/s3_api.hpp
+++ b/src/core/storage/fileio/s3_api.hpp
@@ -1,4 +1,4 @@
-/* Copyright © 2017 Apple Inc. All rights reserved.
+/* Copyright © 2020 Apple Inc. All rights reserved.
  *
  * Use of this source code is governed by a BSD-3-clause license that can
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
@@ -15,13 +15,17 @@
 #include <vector>
 #include <core/storage/fileio/fs_utils.hpp>
 #include <aws/s3/S3Client.h>
+#include <core/logging/assertions.hpp>
+#include <chrono>
 
 namespace turi {
-
 
 /**
  * \ingroup fileio
  * \internal
+ *
+ * constructed **only** from user provided url
+ *
  * A complete specification of an S3 bucket and object,
  * including all authentication required.
  */
@@ -30,7 +34,13 @@ struct s3url {
   std::string secret_key;
   std::string bucket;
   std::string object_name;
+  // endpoint that embeded in the url
   std::string endpoint;
+
+  // endpoint used by sdk, not in the url
+  boost::optional<std::string> sdk_endpoint;
+  boost::optional<std::string> sdk_region;
+  boost::optional<std::string> sdk_proxy;
 
   bool operator==(const s3url& other) const {
     return access_key_id == other.access_key_id &&
@@ -40,13 +50,64 @@ struct s3url {
            endpoint == other.endpoint;
   }
 
+  /*
+   * @param with_credentials: user should not see this
+   *
+   * reconstruct to url format,
+   * s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name],
+   * which turi uses everywhere.
+   */
+  std::string string_from_s3url(bool with_credentials = true) const {
+    std::string ret("s3://");
+    ret.reserve(128);
+    const size_t prot_len = ret.size();
+
+    if (with_credentials && !access_key_id.empty()) {
+      ASSERT_TRUE(!secret_key.empty());
+      ret.append(access_key_id);
+      ret.append(1, ':');
+      ret.append(secret_key);
+      ret.append(1, ':');
+    }
+
+    // this is embeded form
+    // something like: s3://s3.amazonaws.com/bucket/object/name
+    if (!endpoint.empty()) {
+      ret.append(1, ':');
+      ret.append(endpoint);
+    }
+
+    ASSERT_TRUE(!bucket.empty());
+    // if it's still not pure s3://
+    if (ret.size() > prot_len) ret.append(1, '/');
+    ret.append(bucket);
+
+    if (!object_name.empty()) {
+      if (ret.size() > 5) ret.append(1, '/');
+      ret.append(object_name);
+    }
+
+    return ret;
+  }
+
   friend std::ostream& operator<<(std::ostream& os, const s3url& url) {
-    os << "bucket: '" << url.bucket << "', object_name: '" << url.object_name
-       << "', endpoint: '" << url.endpoint << '\'';
-    return os;
+    if (url.sdk_endpoint) os << "endpoint used by sdk: " << *url.sdk_endpoint << "; ";
+    if (url.sdk_region) os << "region used by sdk: " << *url.sdk_region << "; ";
+    if (url.sdk_proxy) os << "proxy used by sdk: " << *url.sdk_proxy << "; ";
+    return os << url.string_from_s3url(false);
   }
 };
 
+
+/**
+ * \ingroup fileio
+ * \internal
+ *
+ * initialize the sdk with TRUI constomized environment variable
+ *
+ * will set the endpoint/region that used to configure the client
+ */
+Aws::S3::S3Client init_aws_sdk_with_turi_env(s3url& parsed_url);
 
 /**
  * \ingroup fileio
@@ -69,11 +130,13 @@ std::string get_s3_file_last_modified(const std::string& url);
 struct list_objects_response {
   /// Non-empty if there was an error
   std::string error;
-  /// A list of all the "sub-directories" found
+  /// A list of all the "sub-directories" found. Encoded with url, see s3url.
   std::vector<std::string> directories;
-
-  /// A list of all the objects found.
+  /// A list of all the objects found. Encoded with url, see s3url.
+  /// this should be really called object_urls;
   std::vector<std::string> objects;
+  /// A list of all the objects size.
+  std::vector<size_t> objects_size;
   /// Last modified time for the objects.
   std::vector<std::string> objects_last_modified;
 };
@@ -114,7 +177,7 @@ list_objects_response list_objects(std::string s3_url,
  * \internal
  * Lists all objects prefixed by a give s3 url.
  *
- * if s3_url points to a valid prefix, it will return the prefix's contents
+ * if s3_url points to a valid prefix, it  return the prefix's contents
  * like a directory.
  *
  * foo/hello.txt
@@ -205,14 +268,6 @@ void set_upload_timeout(long timeout);
  * \param timeout Timeout value in secs.
  */
 void set_download_timeout(long timeout);
-
-/**
- * \ingroup fileio
- * \internal
- * Return the S3 error code contains in the message.
- * If the message does not contain error code, return the message itself.
- */
-std::string get_s3_error_code(const std::string& msg);
 
 struct S3Operation {
   enum ops_enum {


### PR DESCRIPTION
client SDK handles retry for network level.

> Each AWS SDK implements automatic retry logic. The AWS SDK for Java automatically retries requests, and you can configure the retry settings using the ClientConfiguration class. For example, you might want to turn off the retry logic for a web page that makes a request with minimal latency and no retries. Use the ClientConfiguration class and provide a maxErrorRetry value of 0 to turn off the retries.

But we need to handle our internal logic explicitly after network error is handled by SDK. 

429 is retried here explicitly, which stands for TOO MANY REQUESTS due to some rate limits.