### PR TITLE
unify the format for the encoded s3 url through our codebase

### DIFF
--- a/src/core/storage/fileio/general_fstream.hpp
+++ b/src/core/storage/fileio/general_fstream.hpp
@@ -41,7 +41,7 @@ typedef boost::iostreams::stream<fileio_impl::general_fstream_source>
  * but random seeks will be disabled.
  *
  * S3 access keys are mediated by having the filename be of the form
- * s3://[access_key_id]:[secret_key]:[endpoint/][bucket/][object_name]
+ * s3://[access_key_id]:[secret_key]:[endpoint/][bucket]/[object_name]
  *
  * Endpoint URLs however, are set globally via the global variable S3_ENDPOINT.
  */

--- a/src/core/storage/fileio/general_fstream.hpp
+++ b/src/core/storage/fileio/general_fstream.hpp
@@ -41,7 +41,7 @@ typedef boost::iostreams::stream<fileio_impl::general_fstream_source>
  * but random seeks will be disabled.
  *
  * S3 access keys are mediated by having the filename be of the form
- * s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name]
+ * s3://[access_key_id]:[secret_key]:[endpoint/][bucket/][object_name]
  *
  * Endpoint URLs however, are set globally via the global variable S3_ENDPOINT.
  */
@@ -123,7 +123,7 @@ typedef boost::iostreams::stream<fileio_impl::general_fstream_sink>
  * If the filename ends with ".gz", gzip compression is automatically performed.
  *
  * S3 access keys are mediated by having the filename be of the form
- * s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name]
+ * s3://[access_key_id]:[secret_key]:[endpoint/][bucket]/[object_name]
  *
  * Endpoint URLs however, are set globally via the global variable S3_ENDPOINT.
  */

--- a/src/core/storage/fileio/s3_api.hpp
+++ b/src/core/storage/fileio/s3_api.hpp
@@ -181,7 +181,7 @@ std::string sanitize_s3_url(const std::string& url);
  * \ingroup fileio
  * \internal
  * This splits a URL of the form
- * s3://[access_key_id]:[secret_key]:[endpoint][/bucket]/[object_name]
+ * s3://[access_key_id]:[secret_key]:[endpoint/][bucket]/[object_name]
  * into several pieces.
  *
  * endpoint and object_name are optional.


### PR DESCRIPTION
```
def _try_inject_s3_credentials(url):
    """
    Inject aws credentials into s3 url as s3://[aws_id]:[aws_key]:[bucket/][objectkey]

    If s3 url already contains secret key/id pairs, just return as is.
    """
```

Bucket format should be consistent. Some places use `[/bucket]` and some places use `[bucket]`

Related to #2920.