### PR TITLE
resolve bug that inconsistent representation on directories

### DIFF
--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -599,6 +599,14 @@ is_directory(std::string url, std::string proxy) {
   }
   // if there are no "/"'s it is just a top level bucket
 
+  /* if there are no “/”‘s it is just a top level bucket
+   * list_objects_impl will remove the ending ‘/’
+   * e.g., dir/ -> dir
+   * in turicreate convention, dir should not have ‘/’,
+   * refer to dir_archive::init_for_read
+   */
+  if (url.length() > 5 && url.back() == '/') url.pop_back();
+
   list_objects_response response = list_objects(url, proxy);
   // an error occured
   if (!response.error.empty()) {


### PR DESCRIPTION
sub-commit from #2920.

## goal
this resolves inconsistent representation of directory path used in our S3 path. 

```
SFrame("s3://dir/") # throw exception
SFrame("s3://dir")  # works
```

This misleading behavior is counter-intuitive to the use of the Unix-like filesystem, in which both cases should be valid.

## motivation
In general, `/` is only used to visually distinguish directories from files. Under Unix philosophy, a directory is also a file, and this understanding is applied throughout the codebase. A close example is the `list_objects_impl` that is used under the hood, which removes the ending `/`. Also our `dir_archive` implementation follows this pattern.

All in all, directories except root (in S3, there's no root) should remove the ending `/`.