### PR TITLE
better debug assert output

### DIFF
--- a/src/core/logging/assertions.hpp
+++ b/src/core/logging/assertions.hpp
@@ -319,7 +319,7 @@ extern void __print_back_trace();
         logstream(LOG_ERROR) << "Check failed: " << #condition << ":\n"; \
         std::ostringstream ss;                                           \
         ss << "Assertion Failure: " << #condition << ": " << fmt;        \
-        logger(LOG_ERROR, fmt, ##__VA_ARGS__);                           \
+        logger(LOG_ERROR, fmt, ##__VA_ARGS__, "\n");                     \
         __print_back_trace();                                            \
         TURI_LOGGER_FAIL_METHOD(ss.str().c_str());                       \
         ASSERT_UNREACHABLE();                                            \

--- a/src/core/parallel/mutex.hpp
+++ b/src/core/parallel/mutex.hpp
@@ -63,7 +63,7 @@ namespace turi {
     /// Acquires a lock on the mutex
     inline void lock() const {
       TURI_ATTRIBUTE_UNUSED_NDEBUG int error = pthread_mutex_lock( &m_mut  );
-      DASSERT_MSG(!error, "Mutex lock error %d", error);
+      DASSERT_MSG(!error, "Mutex lock error code: %d", error);
 #ifdef _WIN32
       DASSERT_TRUE(!locked);
       locked = true;


### PR DESCRIPTION
```
ERROR:    mutex.hpp(operator():67): Mutex lock error 221584233379 : ERROR:    mutex.hpp(operator():67): Check failed: !error:
ERROR:    mutex.hpp(operator():67): Mutex lock error 221584233379 : ERROR:    mutex.hpp(operator():67): Check failed: !error:
```

after pr

```
ERROR:    mutex.hpp(operator():67): Mutex lock error code: 22
1584233379 : ERROR:    mutex.hpp(operator():67): Check failed: !error:
ERROR:    mutex.hpp(operator():67): Mutex lock error code: 22
1584233379 : ERROR:    mutex.hpp(operator():67): Check failed: !error:
```