### PR TITLE
remove redundant ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,3 @@ deps/build
 # CCache within Docker
 /.docker_ccache/
 /.docker_images/
-
-# git hooks
-/.pre-commit-config.yaml


### PR DESCRIPTION
I realize that there's no way to ignore this `.pre-commit-config.yaml` while everybody can pull it from GitHub, which requires file to be tracked (not ignored) by git.

In relation to #2920.