### PR TITLE
Make docstring example code compatible with Python 3

### DIFF
--- a/src/python/turicreate/data_structures/sframe.py
+++ b/src/python/turicreate/data_structures/sframe.py
@@ -2751,7 +2751,7 @@ class SFrame(object):
         >>> sf = turicreate.SFrame({'letter': ['a', 'b', 'c'],
         ...                       'number': [1, 2, 3]})
         >>> sf.flat_map(['number', 'letter'],
-        ...             lambda x: [list(x.itervalues()) for i in range(0, x['number'])])
+        ...             lambda x: [list(x.values()) for i in range(x['number'])])
         +--------+--------+
         | number | letter |
         +--------+--------+


### PR DESCRIPTION
Also removed redundant first parameter to `range`.