### PR TITLE
Always preserve existing header-include blocks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+IncludeBlocks: Preserve


### PR DESCRIPTION
Some versions of clang-format are apparently merging them all into one block