### PR TITLE
add extra manual test to view debug logs

### DIFF
--- a/test/fileio/CMakeLists.txt
+++ b/test/fileio/CMakeLists.txt
@@ -1,23 +1,28 @@
 project(Turi)
 
 make_executable(fs SOURCES fs REQUIRES unity_shared_for_testing)
-make_executable(general_fstream_test SOURCES general_fstream_test.cpp REQUIRES unity_shared_for_testing)
-make_executable(curl_dependency_test SOURCES curl_dependency_test.cpp REQUIRES unity_shared_for_testing)
-make_executable(fstream_bench SOURCES fstream_bench.cpp REQUIRES unity_shared_for_testing)
+make_executable(general_fstream_test SOURCES general_fstream_test.cpp REQUIRES
+                unity_shared_for_testing)
+make_executable(curl_dependency_test SOURCES curl_dependency_test.cpp REQUIRES
+                unity_shared_for_testing)
+make_executable(fstream_bench SOURCES fstream_bench.cpp REQUIRES
+                unity_shared_for_testing)
 make_boost_test(temp_file_test.cxx REQUIRES unity_shared_for_testing)
-make_boost_test(fixed_size_cache_manager_test.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(fixed_size_cache_manager_test.cxx REQUIRES
+                unity_shared_for_testing)
 make_boost_test(general_fstream_test.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(parse_hdfs_url_test.cxx REQUIRES unity_shared_for_testing)
 
-if (${TC_BUILD_REMOTEFS})
+if(${TC_BUILD_REMOTEFS})
+  make_executable(s3_filesys_test SOURCES s3_filesys_test.cpp REQUIRES
+                  unity_shared_for_testing)
   make_boost_test(s3api_test.cxx REQUIRES unity_shared_for_testing)
   make_boost_test(cache_stream_test.cxx REQUIRES unity_shared_for_testing)
   make_boost_test(block_cache_test.cxx REQUIRES unity_shared_for_testing)
 endif()
 
-# this writes a big file
-# make_executable(windows_4gb_test SOURCES windows_4gb_test.cpp REQUIRES unity_shared_for_testing)
+# this writes a big file make_executable(windows_4gb_test SOURCES
+# windows_4gb_test.cpp REQUIRES unity_shared_for_testing)
 #
-# requires s3
-# make_boost_test(sanitize_url_test.cxx REQUIRES unity_shared_for_testing)
-
+# requires s3 make_boost_test(sanitize_url_test.cxx REQUIRES
+# unity_shared_for_testing)

--- a/test/fileio/s3_filesys_test.cpp
+++ b/test/fileio/s3_filesys_test.cpp
@@ -20,11 +20,7 @@
 /**
  * example program to set up s3 read
  *
- * This program will read from the file_url, writes "hello world" to the stream,
- * read from it and check contents are equal.
- *
  * set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY in environment variable.
- *
  * set TURI_S3_REGION and TURI_S3_ENDPOINT for more control.
  */
 int main(int argc, char** argv) {

--- a/test/fileio/s3_filesys_test.cpp
+++ b/test/fileio/s3_filesys_test.cpp
@@ -1,0 +1,109 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+#include <core/globals/globals.hpp>
+#include <core/logging/assertions.hpp>
+#include <core/logging/logger.hpp>
+#include <core/storage/fileio/block_cache.hpp>
+#include <core/storage/fileio/file_download_cache.hpp>
+#include <core/storage/fileio/fixed_size_cache_manager.hpp>
+#include <core/storage/fileio/general_fstream.hpp>
+#include <core/storage/fileio/s3_filesys.hpp>
+#include <core/storage/serialization/dir_archive.hpp>
+#include <core/storage/sframe_interface/unity_sframe.hpp>
+#include <core/util/test_macros.hpp>
+#include <iostream>
+
+/**
+ * example program to set up s3 read
+ *
+ * This program will read from the file_url, writes "hello world" to the stream,
+ * read from it and check contents are equal.
+ *
+ * set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY in environment variable.
+ *
+ * set TURI_S3_REGION and TURI_S3_ENDPOINT for more control.
+ */
+int main(int argc, char** argv) {
+  global_logger().set_log_level(LOG_DEBUG);
+
+  if (argc != 3) {
+    std::cerr << "Usage:\n"
+              << "* set TURI_S3_REION TURI_S3_ENDPOIT, AWS_ACCESS_KEY_ID, and "
+                 "AWS_SECRET_ACCESS_KEY environment variables.\n."
+              << "./s3_filesys_test bucket key\n"
+              << "Examples:\n./s3_filesys_test tc_qa "
+                 "integration/manual/sframes/cats-dogs-images/"
+              << std::endl;
+    return 0;
+  }
+
+  turi::s3url url;
+  url.bucket = argv[1];
+  url.object_name = argv[2];
+
+  auto aws_key_id = turi::getenv_str("AWS_ACCESS_KEY_ID");
+  if (!aws_key_id) {
+    std::cerr << "AWS_ACCESS_KEY_ID not set in environment variable"
+              << std::endl;
+    return -1;
+  }
+
+  url.access_key_id = aws_key_id.value();
+
+  auto aws_key = turi::getenv_str("AWS_SECRET_ACCESS_KEY");
+
+  if (!aws_key) {
+    std::cerr << "AWS_SECRET_ACCESS_KEY not set in environment variable"
+              << std::endl;
+    return -1;
+  }
+
+  url.secret_key = aws_key.value();
+
+  std::string url_read = url.string_from_s3url();
+  logstream(LOG_DEBUG) << "read from url" << url_read << std::endl;
+
+  __attribute__((unused)) auto& dummy =
+      turi::fileio::s3::turi_global_AWS_SDK_setup();
+
+  // TURI_S3_REGION and TURI_S3_ENDPOINT will be initialized
+  turi::globals::initialize_globals_from_environment(".");
+
+  try {
+    turi::unity_sframe sf;
+    sf.construct_from_sframe_index(url_read);
+
+    auto sf_size = sf.size();
+    sf.begin_iterator();
+
+    // extract all
+    auto ret = sf.iterator_get_next(sf_size);
+    ASSERT_EQ(ret.size(), sf_size);
+
+    auto column_names = sf.column_names();
+    // touch all entries
+    auto sa_ptr =
+        sf.pack_columns(column_names, column_names, turi::flex_type_enum::LIST,
+                        turi::flex_undefined());
+
+    DASSERT_EQ(sa_ptr->size(), sf.size());
+
+    // force write all entries
+    sa_ptr->materialize();
+
+    /* teardown manually */
+    turi::file_download_cache::get_instance().clear();
+    turi::block_cache::release_instance();
+
+  } catch (std::string& e) {
+    std::cerr << "Exception: " << e << std::endl;
+  } catch (std::exception& e) {
+    std::cerr << "Exception: " << e.what() << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
part of #2920. 

facilitate the manual test and check the logs in the command line.

```
$ ./s3_filesys_test tc_qa "integration/manual/sframes/small_sframe_dc/"

...
1585258409 : INFO:     block_cache.cpp(operator():226): Storing S3 Block Caches in memory cache
1585258409 : DEBUG:    fixed_size_cache_manager.cpp(get_cache:211): Get cache block cache://block_caches-C7C2F3601AFE05AEC51B750A18824C41
1585258409 : INFO:     read_caching_device.hpp(fetch_block:214): Fetching s3://tc_qa/integration/manual/sframes/small_sframe_dc/dir_archive.ini Block 0
1585258409 : DEBUG:    s3_filesys.cpp(Reset:63): reset position: 0. curr_bytes_: 0
1585258409 : DEBUG:    s3_filesys.cpp(Read:46): AWSReadStreamBase::Read, current pos: 0
1585258409 : INFO:     s3_filesys.cpp(FillBuffer:78): FillBuffer: 135 bytes
1585258409 : DEBUG:    s3_filesys.cpp(FillBuffer:94): GetObject.Range: bytes=0-134
1585258410 : DEBUG:    fixed_size_cache_manager.cpp(get_cache:211): Get cache block cache://block_caches-C7C2F3601AFE05AEC51B750A18824C41
1585258410 : DEBUG:    fixed_size_cache_manager.cpp(new_cache:179): New cache block cache://block_caches-C7C2F3601AFE05AEC51B750A18824C41 Capacity = 134217728
1585258410 : DEBUG:    s3_filesys.hpp(Close:112): AWSReadStream::Close()
1585258410 : DEBUG:    s3_filesys.cpp(Reset:63): reset position: 135. curr_bytes_: 0
1585258410 : DEBUG:    s3_filesys.hpp(~AWSReadStreamBase:107): ~AWSReadStream
1585258410 : DEBUG:    s3_filesys.hpp(Close:112): AWSReadStream::Close()
1585258410 : DEBUG:    s3_filesys.cpp(Reset:63): reset position: 135. curr_bytes_: 135
...

```
