### PR TITLE
Fix non-deterministic sound classifier unit test

### DIFF
--- a/src/python/turicreate/test/test_audio_functionality.py
+++ b/src/python/turicreate/test/test_audio_functionality.py
@@ -455,22 +455,9 @@ class ClassifierTestTwoClassesIntLabels(ClassifierTestTwoClassesStringLabels):
             feature="audio",
             custom_layer_sizes=layer_sizes,
             validation_set=None,
+            max_iterations=100,
         )
         assert self.model.custom_layer_sizes == layer_sizes
-
-    # Remove the following two tests after #2949 is fixed!
-
-    @pytest.mark.xfail(
-        reason="Non-deterministic test failure tracked in https://github.com/apple/turicreate/issues/2949"
-    )
-    def test_classify(self):
-        pass
-
-    @pytest.mark.xfail(
-        reason="Non-deterministic test failure tracked in https://github.com/apple/turicreate/issues/2949"
-    )
-    def test_predict(self):
-        pass
 
 
 class ClassifierTestThreeClassesStringLabels(ClassifierTestTwoClassesStringLabels):


### PR DESCRIPTION
Fixes #2949 

All the other Sound Classifier models where correctness of predictions are checked, have their max iterations set to 100. It just seems like an oversight that this model wasn't having that set too.

Without this change, I was only able to run the test 16 times before I got a failure. With this change, I've been able to run it 100 times without failure.

The "training data" is only six examples that seems to be why we need the large number of iterations. Also because the data is so small, increasing the number of iteration doesn't seem to have an appreciable affect on running time of the unit tests. 