### PR TITLE
Fix script to work with black formatting

### DIFF
--- a/scripts/update_version_number.sh
+++ b/scripts/update_version_number.sh
@@ -48,7 +48,7 @@ set_version() {
   sed -i '' -e "s/\".*\"\/\/#{{VERSION_STRING}}/\"${VERSION_NUMBER}\"\/\/#{{VERSION_STRING}}/g" version_number.hpp
   # Python, replace '1.8'#{{VERSION_STRING}}' with 'new_version_string'#{{VERSION_STRING}}
   cd ${WORKSPACE}/src/python/
-  sed -i '' -e "s/'.*'#{{VERSION_STRING}}/'${VERSION_NUMBER}'#{{VERSION_STRING}}/g" turicreate/version_info.py setup.py
+  sed -i '' -e "s/\".*\"  # {{VERSION_STRING}}/\"${VERSION_NUMBER}\"  # {{VERSION_STRING}}/g" turicreate/version_info.py setup.py
 }
 
 set_version


### PR DESCRIPTION
Fixes #2997.

With the switch to using the black python format, we've replaced single quotes, for string literals, with double quotes . Also for in line comments we add two spaces before the `#` and one space after it. Both of these broke our `update_version_number.sh` script. This change fixes the script to work with the new format.