### PR TITLE
Restrict TensorFlow Version on Linux

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -135,8 +135,13 @@ if __name__ == "__main__":
         "requests >= 2.9.1",
         "scipy >= 1.1.0",
         "six >= 1.10.0",
-        "tensorflow >= 2.0.0",
     ]
+    if sys.platform == "darwin":
+        install_requires.append("tensorflow >= 2.0.0")
+    else:
+        # ST, OD, AC and DC segfault on Linux with TensorFlow 2.1
+        # See: https://github.com/apple/turicreate/issues/3003
+        install_requires.append("tensorflow >= 2.0.0,<= 2.0.1 ")
 
     setup(
         name="turicreate",


### PR DESCRIPTION
Temporary workaround for #3003

#3085 was a first attempt at doing this. That approach didn't work because TensorFlow 2.0.0 supports Python 2.7 but 2.0.1 does not. This solves that problem by allowing Python 2.7 users to use TensorFlow 2.0.0 but Python 3 users can use TensorFlow 2.0.1.