### PR TITLE
bypass 429 limitations for s3 test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -384,7 +384,6 @@ test_python_linux_python36:
   script:
     - apk add bash
     # TODO get python 3.6 working on a test image
-    - export TC_ENABLE_S3_TESTS=1
     - bash -e scripts/test_wheel.sh --docker-python3.6
   artifacts:
     when: always
@@ -424,7 +423,6 @@ test_python_mac_python27_10_13:
     - build_wheel_mac_10_15_python27
   script:
     - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/2.7/bin/virtualenv"
-    - export TC_ENABLE_S3_TESTS=1
     - bash scripts/test_wheel.sh
   artifacts:
     when: always


### PR DESCRIPTION
It seems the 429 restrictions are based on the IP address for the internal S3 integration environment.

| platform | py ver |
| ---- | --- |
| mac | 2.7, 3.6 |
|linux | 2.7, 3.6 |

For each platform, the integration tests tend to start at the same time on the same machine, so it will likely trigger the rate limitation. 

The S3 component is fully self-contained, meaning s3 SDK is linked with our own source drop of OpenSSL and curl. The only difference is that on different OS, the binary code is different. So we need to test the S3 binary on each OS platform. But for python language, it's not necessary to test on both python3 and python2 on each platform because S3 related operation is almost all done at the binary level. 

The test after this change will be,

| platform | py ver |
| ---- | --- |
| mac |  3.6 |
|linux | 2.7 |

under the assumption that Linux python2 is similar to mac python2 in terms of pure python level behaviors.

This change will reduce the chance of triggering 429 error because mac runner and Linux runner usually doesn't run at the same pace. For each runner machine, there won't have 2 test instances pulling data from s3 simultaneously. 