### PR TITLE
trim build log

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -49,16 +49,23 @@ mkdir -p deps/local/lib
 mkdir -p deps/local/include
 
 pushd deps/local/include
+
+set +x
 for f in ../../env/include/"$PYTHON_FULL_NAME"/*; do
   ln -Ffs "$f" "$(basename "$f")"
 done
+set -x
+
 popd
 
 mkdir -p deps/local/bin
 pushd deps/local/bin
+set +x
 for f in ../../env/bin/*; do
   ln -Ffs "$f" "$(basename "$f")"
 done
+set -x
+
 popd
 
 linux_patch_sigfpe_handler

--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -51,6 +51,7 @@ mkdir -p deps/local/include
 pushd deps/local/include
 
 set +x
+echo "run 'ln -Ffs' files from ../../env/include/$PYTHON_FULL_NAME"
 for f in ../../env/include/"$PYTHON_FULL_NAME"/*; do
   ln -Ffs "$f" "$(basename "$f")"
 done
@@ -60,7 +61,9 @@ popd
 
 mkdir -p deps/local/bin
 pushd deps/local/bin
+
 set +x
+echo "run 'ln -Ffs' on files from ../../env/bin/"
 for f in ../../env/bin/*; do
   ln -Ffs "$f" "$(basename "$f")"
 done


### PR DESCRIPTION
disable command trace when linking a huge amount of files. Build log shown below will be omitted.
```
+ for f in ../../env/include/"$PYTHON_FULL_NAME"/*
++ basename ../../env/include/python3.6m/Python-ast.h
+ ln -Ffs ../../env/include/python3.6m/Python-ast.h Python-ast.h
+ for f in ../../env/include/"$PYTHON_FULL_NAME"/*
++ basename ../../env/include/python3.6m/Python.h
+ ln -Ffs ../../env/include/python3.6m/Python.h Python.h
+ for f in ../../env/include/"$PYTHON_FULL_NAME"/*
++ basename ../../env/include/python3.6m/abstract.h
+ ln -Ffs ../../env/include/python3.6m/abstract.h abstract.h
+ for f in ../../env/include/"$PYTHON_FULL_NAME"/*
++ basename ../../env/include/python3.6m/accu.h
+ ln -Ffs ../../env/include/python3.6m/accu.h accu.h
+ for f in ../../env/include/"$PYTHON_FULL_NAME"/*
++ basename ../../env/include/python3.6m/asdl.h
+ ln -Ffs ../../env/include/python3.6m/asdl.h asdl.h
+ for f in ../../env/include/"$PYTHON_FULL_NAME"/*
++ basename ../../env/include/python3.6m/ast.h
```