### PR TITLE
propagate exception

### DIFF
--- a/src/core/storage/fileio/general_fstream.cpp
+++ b/src/core/storage/fileio/general_fstream.cpp
@@ -23,6 +23,7 @@ general_ifstream::general_ifstream(std::string filename)
     // every conceieved.
     try :general_ifstream_base(filename), opened_filename(filename)
     {
+      exceptions(std::ios_base::badbit);
     }  catch (const std::exception& e) {
       log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for read. " + e.what());
     } catch (std::string e) {
@@ -35,6 +36,7 @@ general_ifstream::general_ifstream(std::string filename)
 general_ifstream::general_ifstream(std::string filename, bool gzip_compressed)
     try :general_ifstream_base(filename, gzip_compressed),
      opened_filename(filename) {
+       exceptions(std::ios_base::badbit);
      } catch (const std::exception& e) {
       log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for read. " + e.what());
     } catch (std::string e) {
@@ -67,6 +69,7 @@ std::shared_ptr<std::istream> general_ifstream::get_underlying_stream() {
 general_ofstream::general_ofstream(std::string filename)
     try :general_ofstream_base(filename), opened_filename(filename) {
       // this space intentionally left blank
+       exceptions(std::ios_base::failbit);
     } catch (const std::ios_base::failure& e) {
       // an I/O error is already the exception type - just re-throw
       throw;
@@ -81,7 +84,9 @@ general_ofstream::general_ofstream(std::string filename)
 
 general_ofstream::general_ofstream(std::string filename, bool gzip_compress)
     try :general_ofstream_base(filename, gzip_compress),
-     opened_filename(filename) { }  catch (std::exception e) {
+     opened_filename(filename) {
+       exceptions(std::ios_base::failbit);
+     }  catch (std::exception e) {
       log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e.what());
     } catch (std::string e) {
       log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e);

--- a/src/core/storage/fileio/general_fstream.cpp
+++ b/src/core/storage/fileio/general_fstream.cpp
@@ -1,13 +1,14 @@
 /* Copyright © 2017 Apple Inc. All rights reserved.
  *
  * Use of this source code is governed by a BSD-3-clause license that can
- * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
  */
-#include <iostream>
-#include <core/logging/logger.hpp>
 #include <boost/algorithm/string.hpp>
-#include <core/storage/fileio/sanitize_url.hpp>
+#include <core/logging/logger.hpp>
 #include <core/storage/fileio/general_fstream.hpp>
+#include <core/storage/fileio/sanitize_url.hpp>
+#include <iostream>
 
 namespace turi {
 
@@ -21,29 +22,33 @@ general_ifstream::general_ifstream(std::string filename)
     // this is the function try block syntax which, together with the member
     // function pointer syntax, is probably the ugliest C++ syntactic element
     // every conceieved.
-    try :general_ifstream_base(filename), opened_filename(filename)
-    {
-      exceptions(std::ios_base::badbit);
-    }  catch (const std::exception& e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for read. " + e.what());
-    } catch (std::string e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for read. " + e);
-    } catch (...) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
-    }
+    try : general_ifstream_base(filename),
+          opened_filename(filename) {
+  exceptions(std::ios_base::badbit);
+} catch (const std::exception& e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for read. " + e.what());
+} catch (std::string e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for read. " + e);
+} catch (...) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
+}
 
-
-general_ifstream::general_ifstream(std::string filename, bool gzip_compressed)
-    try :general_ifstream_base(filename, gzip_compressed),
-     opened_filename(filename) {
-       exceptions(std::ios_base::badbit);
-     } catch (const std::exception& e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for read. " + e.what());
-    } catch (std::string e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for read. " + e);
-    } catch (...) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
-    }
+general_ifstream::general_ifstream(std::string filename,
+                                   bool gzip_compressed) try
+    : general_ifstream_base(filename, gzip_compressed),
+      opened_filename(filename) {
+  exceptions(std::ios_base::badbit);
+} catch (const std::exception& e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for read. " + e.what());
+} catch (std::string e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for read. " + e);
+} catch (...) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
+}
 
 size_t general_ifstream::file_size() {
   return this->general_ifstream_base::operator->()->file_size();
@@ -53,9 +58,7 @@ size_t general_ifstream::get_bytes_read() {
   return this->general_ifstream_base::operator->()->get_bytes_read();
 }
 
-std::string general_ifstream::filename() const {
-  return opened_filename;
-}
+std::string general_ifstream::filename() const { return opened_filename; }
 
 std::shared_ptr<std::istream> general_ifstream::get_underlying_stream() {
   return this->general_ifstream_base::operator->()->get_underlying_stream();
@@ -66,34 +69,37 @@ std::shared_ptr<std::istream> general_ifstream::get_underlying_stream() {
 /*                                                                           */
 /*****************************************************************************/
 
-general_ofstream::general_ofstream(std::string filename)
-    try :general_ofstream_base(filename), opened_filename(filename) {
-      // this space intentionally left blank
-       exceptions(std::ios_base::failbit);
-    } catch (const std::ios_base::failure& e) {
-      // an I/O error is already the exception type - just re-throw
-      throw;
-    } catch (const std::exception& e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e.what());
-    } catch (std::string e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e);
-    } catch (...) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
-    }
+general_ofstream::general_ofstream(std::string filename) try
+    : general_ofstream_base(filename),
+      opened_filename(filename) {
+  // this space intentionally left blank
+  exceptions(std::ios_base::badbit);
+} catch (const std::ios_base::failure& e) {
+  // an I/O error is already the exception type - just re-throw
+  throw;
+} catch (const std::exception& e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for write. " + e.what());
+} catch (std::string e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for write. " + e);
+} catch (...) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
+}
 
-
-general_ofstream::general_ofstream(std::string filename, bool gzip_compress)
-    try :general_ofstream_base(filename, gzip_compress),
-     opened_filename(filename) {
-       exceptions(std::ios_base::failbit);
-     }  catch (std::exception e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e.what());
-    } catch (std::string e) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename) + " for write. " + e);
-    } catch (...) {
-      log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
-    }
-
+general_ofstream::general_ofstream(std::string filename, bool gzip_compress) try
+    : general_ofstream_base(filename, gzip_compress),
+      opened_filename(filename) {
+  exceptions(std::ios_base::badbit);
+} catch (std::exception e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for write. " + e.what());
+} catch (std::string e) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename) +
+                           " for write. " + e);
+} catch (...) {
+  log_and_throw_io_failure("Cannot open " + sanitize_url(filename));
+}
 
 bool general_ofstream::good() const {
   // annoyingly the boost stream object does not have a const operator-> !
@@ -122,8 +128,6 @@ size_t general_ofstream::get_bytes_written() const {
   return (*base)->get_bytes_written();
 }
 
-std::string general_ofstream::filename() const {
-  return opened_filename;
-}
+std::string general_ofstream::filename() const { return opened_filename; }
 
-} // namespace turi
+}  // namespace turi


### PR DESCRIPTION
The root cause for Linux segfault might be caused by `fin` continues to read and deserialize garbage data when underlying file IO fails.

```
void block_manager::init_segment(std::shared_ptr<block_manager::segment>& seg) {
  ...
  // read 8 bytes
  fin->read(reinterpret_cast<char*>(&footer_size), sizeof(footer_size));

  // deserialize the block information
  fin->clear();
  fin->seekg(filesize - footer_size - sizeof(footer_size), std::ios_base::beg);
  iarchive iarc(*fin);
  iarc >> seg->blocks;

  seg->inited = true;
  seg->file_size = filesize;
}
```

One should always check `fin.good()` after using it. As @ylow mentioned, most designs are based on the assumption that the retry logic (exception handling may involve) happens at very low-level IO operations and those IO will succeed in the end, people tend to not to check `fin` state bits.

This change will enable IO to throw since by default, IO sets its state bits instead of throwing errors.

After discussing with @ylow, I think it's reasonable to propagate exception on `badbit` because those types of errors usually mean irrecoverable.

This is a behavioral change on IO. And it's a good change.