### PR TITLE
only use path style be default

### DIFF
--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -128,7 +128,7 @@ S3Client init_aws_sdk_with_turi_env(s3url& parsed_url) {
   Aws::Client::ClientConfiguration clientConfiguration;
 
   // a little bit too long, anyway
-  clientConfiguration.requestTimeoutMs = 5 * 60000;
+  clientConfiguration.requestTimeoutMs = 2 * 60000;
   clientConfiguration.connectTimeoutMs = 20000;
 
   if (turi::fileio::insecure_ssl_cert_checks()) {
@@ -417,7 +417,7 @@ list_objects_response list_objects_impl(s3url parsed_url, std::string proxy,
   }
 
   clientConfiguration.proxyHost = proxy.c_str();
-  clientConfiguration.requestTimeoutMs = 10000;
+  clientConfiguration.requestTimeoutMs = 5 * 60000;
   clientConfiguration.connectTimeoutMs = 20000;
   std::string region = fileio::get_region_name_from_endpoint(
       clientConfiguration.endpointOverride.c_str());

--- a/src/python/turicreate/test/test_sframe_s3.py
+++ b/src/python/turicreate/test/test_sframe_s3.py
@@ -21,7 +21,8 @@ import warnings
 # size from small to big: 76K, 21MB, 77MB.
 # 64MB is the cache block size. The big sframe with 77MB is used to
 # ensure there's no issues when crossing different cache blocks.
-remote_sframe_folders = ["small_sframe_dc", "medium_sframe_ac", "big_sframe_od"]
+# remote_sframe_folders = ["small_sframe_dc", "medium_sframe_ac", "big_sframe_od"]
+remote_sframe_folders = ["medium_sframe_ac"]
 
 
 @pytest.mark.skipif(

--- a/src/python/turicreate/test/test_sframe_s3.py
+++ b/src/python/turicreate/test/test_sframe_s3.py
@@ -21,8 +21,7 @@ import warnings
 # size from small to big: 76K, 21MB, 77MB.
 # 64MB is the cache block size. The big sframe with 77MB is used to
 # ensure there's no issues when crossing different cache blocks.
-# remote_sframe_folders = ["small_sframe_dc", "medium_sframe_ac", "big_sframe_od"]
-remote_sframe_folders = ["medium_sframe_ac"]
+remote_sframe_folders = ["small_sframe_dc", "medium_sframe_ac", "big_sframe_od"]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
path style: host/bucket/key
virtual address: bucket.host/key

The new SDK uses a virtual address by default which causes backward compatible issues (because virtual address DNS is not available for normal dev environment).

Well, at least it works for all production environments.

related to https://github.com/aws/aws-sdk-cpp/issues/1357