### PR TITLE
fix SArray upload issue

### DIFF
--- a/src/core/storage/fileio/s3_filesys.cpp
+++ b/src/core/storage/fileio/s3_filesys.cpp
@@ -133,9 +133,7 @@ void WriteStream::Write(const void *ptr, size_t size) {
 }
 
 void WriteStream::Upload(bool force_upload) {
-  // empty file needs to be uploaded. objects.bin can be 0 bytes.
-  // if (buffer_.empty()) return;
-
+  // empty file needs to be force uploaded. objects.bin can be 0 bytes.
   if (!force_upload && buffer_.size() < max_buffer_size_) {
     return;
   }

--- a/src/core/storage/fileio/s3_filesys.cpp
+++ b/src/core/storage/fileio/s3_filesys.cpp
@@ -133,7 +133,8 @@ void WriteStream::Write(const void *ptr, size_t size) {
 }
 
 void WriteStream::Upload(bool force_upload) {
-  if (buffer_.empty()) return;
+  // empty file needs to be uploaded. objects.bin can be 0 bytes.
+  // if (buffer_.empty()) return;
 
   if (!force_upload && buffer_.size() < max_buffer_size_) {
     return;


### PR DESCRIPTION
fix issue that uploaded sarray is not readable.
```python
import turicreate as tc
gui = tc.SArray([1])
gui.save("tiny_array")
gui.save("s3://tc_qa/integration/manual/sarrays/tiny_array/")
gui.SArray("s3://tc_qa/integration/manual/sarrays/tiny_array/")
```

Unfortunately, this code still not work.

```
objc[88730]: Class TCRecommender is implemented in both /Users/guihaoliang/Work/guicreate-2/debug/src/python/turicreate/libunity_shared.dylib (0x11f34dd18) and /Users/guihaoliang/Work/gui-2-36/debug/src/python/turicreate/libRecommender.dylib (0x156dd0950). One of the two will be used. Which one is undefined.
Traceback (most recent call last):
  File "hao.py", line 5, in <module>
    gui = tc.load_sarray("s3://tc_qa/integration/manual/sarrays/tiny_array/")
  File "/Users/guihaoliang/Work/gui-2-36/debug/src/python/turicreate/data_structures/sarray.py", line 86, in load_sarray
    sa = SArray(data=filename)
  File "/Users/guihaoliang/Work/gui-2-36/debug/src/python/turicreate/data_structures/sarray.py", line 490, in __init__
    self.__proxy__.load_autodetect(internal_url, dtype)
  File "cy_sarray.pyx", line 82, in turicreate._cython.cy_sarray.UnitySArrayProxy.load_autodetect
  File "cy_sarray.pyx", line 86, in turicreate._cython.cy_sarray.UnitySArrayProxy.load_autodetect
OSError: No files corresponding to the specified path (s3://tc_qa/integration/manual/sarrays/tiny_array/).. operator() from ../src/core/storage/sframe_data/parallel_csv_parser.cpp at 1266
```

But I can confirm that I can use
```
import turicreate as tc
gui = tc.SArray([1])
gui.save("s3://tc_qa/integration/manual/sarrays/tiny_array/")
```

to save sarray to s3 and then use `aws cli` download the uploaded sarry to local disk and then load it from disk. Therefore, there's nothing wrong with the upload now. There must be some other bugs in this code path, which needs further investigations.
