### PR TITLE
get the retry logic back

### DIFF
--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -128,7 +128,7 @@ S3Client init_aws_sdk_with_turi_env(s3url& parsed_url) {
   Aws::Client::ClientConfiguration clientConfiguration;
 
   // a little bit too long, anyway
-  clientConfiguration.requestTimeoutMs = 2 * 60000;
+  clientConfiguration.requestTimeoutMs = 5 * 60000;
   clientConfiguration.connectTimeoutMs = 20000;
 
   if (turi::fileio::insecure_ssl_cert_checks()) {

--- a/src/core/storage/fileio/s3_api.cpp
+++ b/src/core/storage/fileio/s3_api.cpp
@@ -513,8 +513,10 @@ list_objects_response list_objects_impl(s3url parsed_url, std::string proxy,
 
       } else {
         auto error = outcome.GetError();
-
-        if (error.ShouldRetry()) {
+        // Unlike CoreErrors, S3Error Never retries. Use Http code instead.
+        // check aws-cpp-sdk-s3/source/S3Error.cpp
+        if (error.GetResponseCode() ==
+            Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS) {
           n_retry++;
 
           if (n_retry == 3) {


### PR DESCRIPTION
I should blame myself. I should read the source files instead of their [documentation](http://sdk.amazonaws.com/cpp/api/LATEST/class_aws_1_1_client_1_1_a_w_s_error.html#a6262c30a4967119d1730cb23dbe30d6f).

It's using `S3Errors` to wrap `CoreErrors`. We should only rely on Http code to do retry on our own.