### PR TITLE
Allow float_array.cpp to build without other dependencies

### DIFF
--- a/src/ml/neural_net/float_array.cpp
+++ b/src/ml/neural_net/float_array.cpp
@@ -10,8 +10,6 @@
 #include <cassert>
 #include <numeric>
 
-#include <core/logging/assertions.hpp>
-
 namespace turi {
 namespace neural_net {
 
@@ -74,9 +72,8 @@ shared_float_array::shared_float_array(
 }
 
 shared_float_array shared_float_array::operator[](size_t idx) const {
-
-  ASSERT_GT(dim_, 0);
-  ASSERT_LT(idx, shape_[0]);
+  assert(dim_ > 0);
+  assert(idx < shape_[0]);
 
   size_t stride = size_ / shape_[0];
   size_t offset = stride * idx;
@@ -97,27 +94,6 @@ std::ostream &operator<<(std::ostream &os, const float_array &arr) {
   }
   os << "\n";
   return os;
-}
-
-void shared_float_array::save(oarchive& oarc) const {
-  // Write shape.
-  serialize_iterator(oarc, shape(), shape() + dim(), dim());
-
-  // Write data.
-  serialize_iterator(oarc, data(), data() + size(), size());
-}
-
-void shared_float_array::load(iarchive& iarc) {
-  // Read shape.
-  std::vector<size_t> shape;
-  iarc >> shape;
-
-  // Read data.
-  std::vector<float> data;
-  iarc >> data;
-
-  // Overwrite self with a new float_array wrapping the deserialized data.
-  *this = wrap(std::move(data), std::move(shape));
 }
 
 // static

--- a/src/ml/neural_net/float_array.hpp
+++ b/src/ml/neural_net/float_array.hpp
@@ -4,8 +4,7 @@
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef UNITY_TOOLKITS_NEURAL_NET_FLOAT_ARRAY_HPP_
-#define UNITY_TOOLKITS_NEURAL_NET_FLOAT_ARRAY_HPP_
+#pragma once
 
 #include <cstddef>
 #include <future>
@@ -206,5 +205,3 @@ std::ostream &operator<<(std::ostream &out, const float_array &arr);
 
 }  // namespace neural_net
 }  // namespace turi
-
-#endif  // UNITY_TOOLKITS_NEURAL_NET_FLOAT_ARRAY_HPP_

--- a/src/ml/neural_net/float_array.hpp
+++ b/src/ml/neural_net/float_array.hpp
@@ -11,10 +11,9 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <vector>
-
-#include <core/storage/serialization/serialization_includes.hpp>
 
 namespace turi {
 namespace neural_net {
@@ -159,10 +158,6 @@ public:
   shared_float_array operator[](size_t idx) const;
 
   // TODO: Operations such as reshape, slice, etc.?
-
-  // Serialization.
-  void save(oarchive& oarc) const;
-  void load(iarchive& iarc);
 
 protected:
   shared_float_array(std::shared_ptr<float_array> impl, size_t offset,

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_backend.hpp
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_backend.hpp
@@ -5,8 +5,7 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef TURI_STYLE_TRANSFER_MPS_STYLE_TRANSFER_BACKEND_H_
-#define TURI_STYLE_TRANSFER_MPS_STYLE_TRANSFER_BACKEND_H_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -50,5 +49,3 @@ private:
 } // namespace turi
 
 #endif // #ifdef HAS_MACOS_10_15
-
-#endif

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_backend.hpp
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_backend.hpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <memory>
 
+#include <core/export.hpp>
 #include <ml/neural_net/float_array.hpp>
 #include <ml/neural_net/model_backend.hpp>
 #include <ml/neural_net/mps_command_queue.hpp>

--- a/src/ml/neural_net/style_transfer/mps_style_transfer_backend.mm
+++ b/src/ml/neural_net/style_transfer/mps_style_transfer_backend.mm
@@ -6,16 +6,17 @@
 
 #ifdef HAS_MACOS_10_15
 
-#import <ml/neural_net/style_transfer/mps_style_transfer_backend.hpp>
-#import <ml/neural_net/style_transfer/mps_style_transfer.h>
-
-#import <ml/neural_net/model_spec.hpp>
-#import <ml/neural_net/mps_device_manager.h>
-#import <ml/neural_net/mps_utils.h>
-
-#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
+#include <ml/neural_net/style_transfer/mps_style_transfer_backend.hpp>
 
 #include <numeric>
+
+#include <core/logging/logger_includes.hpp>
+#include <ml/neural_net/model_spec.hpp>
+
+#import <ml/neural_net/mps_device_manager.h>
+#import <ml/neural_net/mps_utils.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer.h>
+#import <ml/neural_net/style_transfer/mps_style_transfer_weights.h>
 
 using namespace turi::neural_net;
 
@@ -283,4 +284,4 @@ float_array_map mps_style_transfer::train(const float_array_map& inputs) {
 } // namespace style_transfer
 } // namespace turi
 
-#endif // #ifdef HAS_MACOS_10_15
+#endif  // #ifdef HAS_MACOS_10_15

--- a/src/toolkits/activity_classification/activity_classifier.cpp
+++ b/src/toolkits/activity_classification/activity_classifier.cpp
@@ -19,6 +19,7 @@
 #include <timer/timer.hpp>
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 #include <toolkits/evaluation/metrics.hpp>
+#include <toolkits/util/float_array_serialization.hpp>
 #include <toolkits/util/training_utils.hpp>
 
 namespace turi {
@@ -109,7 +110,7 @@ void activity_classifier::save_impl(oarchive& oarc) const {
   variant_deep_save(state, oarc);
 
   // Save neural net weights.
-  oarc << read_model_spec()->export_params_view();
+  save_float_array_map(read_model_spec()->export_params_view(), oarc);
 }
 
 void activity_classifier::load_version(iarchive& iarc, size_t version) {
@@ -117,8 +118,8 @@ void activity_classifier::load_version(iarchive& iarc, size_t version) {
   variant_deep_load(state, iarc);
 
   // Load neural net weights.
-  float_array_map nn_params;
-  iarc >> nn_params;
+  float_array_map nn_params = load_float_array_map(iarc);
+
   bool use_random_init = false;
   nn_spec_ = init_model(use_random_init);
   nn_spec_->update_params(nn_params);

--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -20,6 +20,7 @@
 #include <toolkits/coreml_export/neural_net_models_exporter.hpp>
 #include <toolkits/evaluation/metrics.hpp>
 #include <toolkits/supervised_learning/automatic_model_creation.hpp>
+#include <toolkits/util/float_array_serialization.hpp>
 #include <toolkits/util/training_utils.hpp>
 
 #include <toolkits/drawing_classifier/data_preparation.hpp>
@@ -87,7 +88,7 @@ void drawing_classifier::save_impl(oarchive& oarc) const {
   variant_deep_save(state, oarc);
 
   // Save neural net weights.
-  oarc << nn_spec_->export_params_view();
+  save_float_array_map(nn_spec_->export_params_view(), oarc);
 }
 
 void drawing_classifier::load_version(iarchive& iarc, size_t version) {
@@ -96,8 +97,7 @@ void drawing_classifier::load_version(iarchive& iarc, size_t version) {
   variant_deep_load(state, iarc);
 
   // Load neural net weights.
-  float_array_map nn_params;
-  iarc >> nn_params;
+  float_array_map nn_params = load_float_array_map(iarc);
 
   nn_spec_ = init_model(false);
   nn_spec_->update_params(nn_params);

--- a/src/toolkits/object_detection/od_serialization.cpp
+++ b/src/toolkits/object_detection/od_serialization.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 
 #include <toolkits/object_detection/od_yolo.hpp>
+#include <toolkits/util/float_array_serialization.hpp>
 
 #include <toolkits/coreml_export/mlmodel_include.hpp>
 
@@ -48,7 +49,7 @@ void _save_impl(oarchive& oarc,
   variant_deep_save(state, oarc);
 
   // Save neural net weights.
-  oarc << weights;
+  save_float_array_map(weights, oarc);
 }
 
 void _load_version(iarchive& iarc, size_t version,
@@ -58,7 +59,7 @@ void _load_version(iarchive& iarc, size_t version,
   variant_deep_load(*state, iarc);
 
   // Load neural net weights.
-  iarc >> *weights;
+  *weights = load_float_array_map(iarc);
 }
 
 void init_darknet_yolo(model_spec& nn_spec, size_t num_classes,

--- a/src/toolkits/style_transfer/style_transfer.cpp
+++ b/src/toolkits/style_transfer/style_transfer.cpp
@@ -18,6 +18,7 @@
 #include <model_server/lib/variant_deep_serialize.hpp>
 #include <toolkits/style_transfer/st_resnet16_model_trainer.hpp>
 #include <toolkits/style_transfer/style_transfer_model_definition.hpp>
+#include <toolkits/util/float_array_serialization.hpp>
 #include <toolkits/util/training_utils.hpp>
 
 #ifdef HAS_MPS
@@ -328,14 +329,13 @@ size_t style_transfer::get_version() const { return STYLE_TRANSFER_VERSION; }
 
 void style_transfer::save_impl(oarchive& oarc) const {
   variant_deep_save(state, oarc);
-  oarc << read_checkpoint().weights();
+  save_float_array_map(read_checkpoint().weights(), oarc);
 }
 
 void style_transfer::load_version(iarchive& iarc, size_t version) {
   variant_deep_load(state, iarc);
 
-  float_array_map nn_params;
-  iarc >> nn_params;
+  float_array_map nn_params = load_float_array_map(iarc);
   checkpoint_ = load_checkpoint(nn_params);
 }
 

--- a/src/toolkits/util/CMakeLists.txt
+++ b/src/toolkits/util/CMakeLists.txt
@@ -8,6 +8,7 @@ make_library(unity_util OBJECT
     sframe_utils.cpp
     class_registrations.cpp
     random_sframe_generation.cpp
+    float_array_serialization.cpp
   REQUIRES
     unity_core
 )

--- a/src/toolkits/util/CMakeLists.txt
+++ b/src/toolkits/util/CMakeLists.txt
@@ -2,13 +2,14 @@ project(Turi)
 
 make_library(unity_util OBJECT
   SOURCES
-    precision_recall.cpp
-    data_generators.cpp
-    indexed_sframe_tools.cpp
-    sframe_utils.cpp
     class_registrations.cpp
-    random_sframe_generation.cpp
+    data_generators.cpp
     float_array_serialization.cpp
+    indexed_sframe_tools.cpp
+    precision_recall.cpp
+    random_sframe_generation.cpp
+    sframe_utils.cpp
   REQUIRES
     unity_core
+    unity_neural_net
 )

--- a/src/toolkits/util/float_array_serialization.cpp
+++ b/src/toolkits/util/float_array_serialization.cpp
@@ -1,0 +1,72 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+#include <toolkits/util/float_array_serialization.hpp>
+
+namespace turi {
+
+using neural_net::float_array_map;
+using neural_net::shared_float_array;
+
+class float_array_serialization_wrapper {
+ public:
+  float_array_serialization_wrapper() = default;
+  float_array_serialization_wrapper(shared_float_array array)
+      : impl_(std::move(array)) {}
+
+  const shared_float_array& get() const { return impl_; }
+
+  void save(oarchive& oarc) const {
+    // Write shape.
+    serialize_iterator(oarc, impl_.shape(), impl_.shape() + impl_.dim(),
+                       impl_.dim());
+
+    // Write data.
+    serialize_iterator(oarc, impl_.data(), impl_.data() + impl_.size(),
+                       impl_.size());
+  }
+
+  void load(iarchive& iarc) {
+    // Read shape.
+    std::vector<size_t> shape;
+    iarc >> shape;
+
+    // Read data.
+    std::vector<float> data;
+    iarc >> data;
+
+    // Overwrite self with a new float_array wrapping the deserialized data.
+    impl_ = shared_float_array::wrap(std::move(data), std::move(shape));
+  }
+
+ private:
+  shared_float_array impl_;
+};
+
+void save_float_array_map(const float_array_map& weights, oarchive& oarc) {
+  std::map<std::string, float_array_serialization_wrapper> wrapped_weights;
+
+  for (const auto& key_value : weights) {
+    wrapped_weights.emplace(key_value.first, key_value.second);
+  }
+
+  oarc << wrapped_weights;
+}
+
+float_array_map load_float_array_map(iarchive& iarc) {
+  std::map<std::string, float_array_serialization_wrapper> wrapped_weights;
+  iarc >> wrapped_weights;
+
+  float_array_map weights;
+
+  for (const auto& key_value : wrapped_weights) {
+    weights.emplace(key_value.first, key_value.second.get());
+  }
+
+  return weights;
+}
+
+}  // namespace turi

--- a/src/toolkits/util/float_array_serialization.cpp
+++ b/src/toolkits/util/float_array_serialization.cpp
@@ -51,7 +51,8 @@ void save_float_array_map(const float_array_map& weights, oarchive& oarc) {
   // write itself to the oarchive.
   std::map<std::string, float_array_serialization_wrapper> wrapped_weights;
   for (const auto& key_value : weights) {
-    wrapped_weights.emplace(key_value.first, key_value.second);
+    wrapped_weights[key_value.first] =
+        float_array_serialization_wrapper(key_value.second);
   }
 
   oarc << wrapped_weights;
@@ -65,7 +66,7 @@ float_array_map load_float_array_map(iarchive& iarc) {
   // Obtain direct references to the underlying weights.
   float_array_map weights;
   for (const auto& key_value : wrapped_weights) {
-    weights.emplace(key_value.first, key_value.second.get());
+    weights[key_value.first] = key_value.second.get();
   }
 
   return weights;

--- a/src/toolkits/util/float_array_serialization.hpp
+++ b/src/toolkits/util/float_array_serialization.hpp
@@ -1,0 +1,26 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef TOOLKITS_UTIL_FLOAT_ARRAY_SERIALIZATION_HPP_
+#define TOOLKITS_UTIL_FLOAT_ARRAY_SERIALIZATION_HPP_
+
+#include <core/storage/serialization/serialization_includes.hpp>
+#include <ml/neural_net/float_array.hpp>
+
+namespace turi {
+
+// To allow the neural_net library to stand alone, the serialization code that
+// depends on core/storage/serialization lives here.
+// TODO: Consider converting float_array values to flex_nd_vec, but we must
+// support at least importing this serialization that released with TC 6.0.
+
+void save_float_array_map(const neural_net::float_array_map& weights,
+                          oarchive& oarc);
+neural_net::float_array_map load_float_array_map(iarchive& iarc);
+
+}  // namespace turi
+
+#endif  // TOOLKITS_UTIL_FLOAT_ARRAY_SERIALIZATION_HPP_

--- a/src/toolkits/util/float_array_serialization.hpp
+++ b/src/toolkits/util/float_array_serialization.hpp
@@ -4,8 +4,8 @@
  * be found in the LICENSE.txt file or at
  * https://opensource.org/licenses/BSD-3-Clause
  */
-#ifndef TOOLKITS_UTIL_FLOAT_ARRAY_SERIALIZATION_HPP_
-#define TOOLKITS_UTIL_FLOAT_ARRAY_SERIALIZATION_HPP_
+
+#pragma once
 
 #include <core/storage/serialization/serialization_includes.hpp>
 #include <ml/neural_net/float_array.hpp>
@@ -22,5 +22,3 @@ void save_float_array_map(const neural_net::float_array_map& weights,
 neural_net::float_array_map load_float_array_map(iarchive& iarc);
 
 }  // namespace turi
-
-#endif  // TOOLKITS_UTIL_FLOAT_ARRAY_SERIALIZATION_HPP_


### PR DESCRIPTION
This PR is the first step to allowing the `neural_net` directory to build as a standalone library, which some of us have been doing in a hacky way for debugging/development purposes. The main change is to move the Turi serialization code outside, to the toolkits library.