### PR TITLE
Pin llvmlite to fix build error.

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -19,6 +19,7 @@ ndg-httpsclient==0.5.1
 pyasn1==0.4.5
 mock==3.0.5
 boto3==1.12.22
+llvmlite==0.31.0
 
 ########## >=  #########
 


### PR DESCRIPTION
llvmlite was updated transitively and has broken some builds. This change pins llvmlite to 0.31.0.