### PR TITLE
Pinned llvm version to one that compiles correctly with python 2.7

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,6 +8,7 @@ pillow==6.2.0
 prettytable==0.7.2
 pytz==2019.1
 resampy==0.2.1
+llvmlite==0.31.0
 scikit-learn==0.20.3
 statsmodels==0.9.0
 tensorflow==2.0.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,7 +8,6 @@ pillow==6.2.0
 prettytable==0.7.2
 pytz==2019.1
 resampy==0.2.1
-llvmlite==0.31.0
 scikit-learn==0.20.3
 statsmodels==0.9.0
 tensorflow==2.0.0

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -132,6 +132,7 @@ if __name__ == "__main__":
         "pillow >= 5.2.0",
         "prettytable == 0.7.2",
         "resampy == 0.2.1",
+        "llvmlite == 0.31.0",
         "requests >= 2.9.1",
         "scipy >= 1.1.0",
         "six >= 1.10.0",

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -132,11 +132,13 @@ if __name__ == "__main__":
         "pillow >= 5.2.0",
         "prettytable == 0.7.2",
         "resampy == 0.2.1",
-        "llvmlite == 0.31.0",
         "requests >= 2.9.1",
         "scipy >= 1.1.0",
         "six >= 1.10.0",
     ]
+    if sys.version_info[0] == 2:
+        install_requires.append("llvmlite == 0.31.0")
+
     if sys.platform == "darwin":
         install_requires.append("tensorflow >= 2.0.0")
     else:


### PR DESCRIPTION
This pins the llvmlite version to one that compiles correctly with python 2.7. 