### PR TITLE
remove dead code from text_analytics

### DIFF
--- a/src/python/turicreate/toolkits/text_analytics/__init__.py
+++ b/src/python/turicreate/toolkits/text_analytics/__init__.py
@@ -33,8 +33,6 @@ __all__ = [
     "parse_docword",
     "tokenize",
     "drop_words",
-    "split_by_sentence",
-    "extract_parts_of_speech",
 ]
 
 
@@ -50,8 +48,6 @@ def __dir__():
         "parse_docword",
         "tokenize",
         "drop_words",
-        "split_by_sentence",
-        "extract_parts_of_speech",
     ]
 
 


### PR DESCRIPTION
I was testing API availability for #3139 and I got,

```bash
          "API Surface mis-matched. "
2020             "expected: %s\nactual: %s\nactual - expected: %s\nexpected - actual: %s"
2021             % (e_set, a_set, a_set - e_set, e_set - a_set)
2022         )
2023 E       AssertionError: API Surface mis-matched. expected: {'count_words', 'parse_sparse', 'count_ngrams', 'stop_words', 'random_split', 'tokenize', 'bm25', 'drop_words', 'parse_docword', 'tf_idf'}
2024 E         actual: {'extract_parts_of_speech', 'count_words', 'parse_sparse', 'count_ngrams', 'stop_words', 'random_split', 'tokenize', 'drop_words', 'bm25', 'parse_docword', 'split_by_sentence', 'tf_idf'}
2025 E         actual - expected: {'extract_parts_of_speech', 'split_by_sentence'}
2026 E         expected - actual: set()
2027 E       assert {'bm25', 'cou...docword', ...} == {'bm25', 'cou..._sparse', ...}
2028 E         Extra items in the left set:
2029 E         'extract_parts_of_speech'
2030 E         'split_by_sentence'
2031 E         Full diff:
2032 E           {
2033 E            'bm25',
2034 E            'count_ngrams',
2035 E            'count_words',
2036 E            'drop_words',
2037 E         +  'extract_parts_of_speech',
2038 E            'parse_docword',
2039 E            'parse_sparse',
2040 E            'random_split',
2041 E         +  'split_by_sentence',
2042 E            'stop_words',
2043 E            'tf_idf',
2044 E            'tokenize',
2045 E           }
```

The reason is that python37 respects the `__dir__` defined in `__init__.py` but for other python versions, they ignore `__dir__` and return output from `__dict__`.

No way to access these 2 functions. I guess they are using internally or removed a long time ago.