### PR TITLE
Add build support for clang-tidy and clang build metrics

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+# disable everything by default. see src/.clang-tidy.
+Checks: -*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,15 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED 1)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# ##############################################################################
+# Set options
+
+option(TC_BUILD_METRICS "Produce clang build metrics" OFF)
+
 # **************************************************************************/
-# * */
-# * Global Link, Include and Define Flags              */
-# * */
+# *                                                                        */
+# * Global Link, Include and Define Flags                                  */
+# *                                                                        */
 # **************************************************************************/
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake")
@@ -111,9 +116,9 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 add_definitions(-Dgoogle=_tc_google)
 
 # **************************************************************************/
-# * */
-# * Adapt Compiler and Linker Flags to the system              */
-# * */
+# *                                                                        */
+# * Adapt Compiler and Linker Flags to the system                          */
+# *                                                                        */
 # **************************************************************************/
 
 include(CompilerFlags)
@@ -147,6 +152,13 @@ check_and_set_compiler_flag(-Wno-tautological-compare)
 check_and_set_compiler_flag(-fpeel-loops RELEASE)
 check_and_set_compiler_flag(-funswitch-loops RELEASE)
 check_and_set_compiler_flag(-ftracer RELEASE)
+
+if(TC_BUILD_METRICS)
+  # TC_BUILD_METRICS enables -ftime-trace in supported compilers, which will
+  # produce a timings json file for each compiled object.
+  
+  check_and_set_compiler_flag(-ftime-trace)
+endif()
 
 if(APPLE)
   # This triggers a bug in clang; the 10.13 symbol ___chkstk_darwin is missing
@@ -291,9 +303,9 @@ set(CMAKE_MODULE_LINKER_FLAGS
 )
 
 # **************************************************************************/
-# * */
-# * Report Final Flags                                */
-# * */
+# *                                                                        */
+# * Report Final Flags                                                     */
+# *                                                                        */
 # **************************************************************************/
 message("CMAKE_BUILD_TYPE= ${CMAKE_BUILD_TYPE}.")
 

--- a/configure
+++ b/configure
@@ -29,6 +29,8 @@ function print_help {
   echo "  --with-ccache (default)           Use ccache, if available."
   echo "  --no-ccache "
   echo
+  echo "  --with-clang-tidy                 Run clang-tidy, if available."
+  echo
   echo "  --with-capi (default)             Build C API."
   echo "  --with-capi-framework             Build C API as macOS framework (macOS + XCode builder only)"
   echo "  --no-capi                         Skip building the C API."
@@ -70,7 +72,7 @@ function print_help {
   echo
   echo "  --codesign                        Enable code signing for OSX projects.  If enabled, the "
   echo "                                    proper CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_**** parameters "
-  echo                                      denoting the signing variables should be passed in.
+  echo "                                    denoting the signing variables should be passed in."
   echo
   echo "  --list-source-files               If given, a list of all the source files compiled using "
   echo "                                    the given options is printed as part of the configuration, "
@@ -142,6 +144,7 @@ default_yes=0
 with_python=1
 with_pre_commit=1
 with_ccache=1
+with_clangtidy=0
 
 with_capi=1
 with_capi_framework=0
@@ -188,6 +191,8 @@ while [ $# -gt 0 ]
     --no-pre-commit)        with_pre_commit=0;;
     --with-ccache)          with_ccache=1;;
     --no-ccache)            with_ccache=0;;
+
+    --with-clang-tidy)      with_clangtidy=1;;
 
     --with-capi)            with_capi=1;;
     --with-capi-framework)  with_capi=1; with_capi_framework=1;;
@@ -340,6 +345,20 @@ CXXCMD=`./scripts/find_compiler.sh cxx --ccache=$with_ccache --script-dir=${PWD}
 
 echo "Setting C compiler to $CCCMD."
 echo "Setting C++ compiler to $CXXCMD."
+
+if [[ $with_clangtidy == 1 ]]; then
+  clangtidy_path=`which clang-tidy || echo ''`
+  
+  if ! [ -f $clangtidy_path ]; then
+    echo "Unable to find clang-tidy in path."
+    exit 1
+  fi
+
+  echo "Setting clang-tidy to $clangtidy_path"
+
+  CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DCMAKE_CXX_CLANG_TIDY=${clangtidy_path}"
+fi
+
 
 echo "======================= FINDING CMAKE ========================"
 

--- a/configure
+++ b/configure
@@ -350,9 +350,9 @@ echo "Setting C compiler to $CCCMD."
 echo "Setting C++ compiler to $CXXCMD."
 
 if [[ $with_clangtidy == 1 ]]; then
-  clangtidy_path=`which clang-tidy || echo ''`
+  clangtidy_path=$(which clang-tidy || true)
   
-  if ! [ -f $clangtidy_path ]; then
+  if [[ ! -x "$clangtidy_path" ]]; then
     echo "Unable to find clang-tidy in path."
     exit 1
   fi

--- a/configure
+++ b/configure
@@ -30,6 +30,7 @@ function print_help {
   echo "  --no-ccache "
   echo
   echo "  --with-clang-tidy                 Run clang-tidy, if available."
+  echo "  --with-clang-metrics              Run clang with timing metrics. Requires Clang 9.0."
   echo
   echo "  --with-capi (default)             Build C API."
   echo "  --with-capi-framework             Build C API as macOS framework (macOS + XCode builder only)"
@@ -145,6 +146,7 @@ with_python=1
 with_pre_commit=1
 with_ccache=1
 with_clangtidy=0
+with_clangmetrics=0
 
 with_capi=1
 with_capi_framework=0
@@ -193,6 +195,7 @@ while [ $# -gt 0 ]
     --no-ccache)            with_ccache=0;;
 
     --with-clang-tidy)      with_clangtidy=1;;
+    --with-clang-metrics)   with_clangmetrics=1;;
 
     --with-capi)            with_capi=1;;
     --with-capi-framework)  with_capi=1; with_capi_framework=1;;
@@ -359,6 +362,9 @@ if [[ $with_clangtidy == 1 ]]; then
   CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DCMAKE_CXX_CLANG_TIDY=${clangtidy_path}"
 fi
 
+if [[ $with_clangmetrics == 1 ]]; then
+  CMAKE_CONFIG_FLAGS="${CMAKE_CONFIG_FLAGS} -DTC_BUILD_METRICS=ON"
+fi
 
 echo "======================= FINDING CMAKE ========================"
 

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,16 @@
+# currently everything is turned on but everything will fail. when we start to enable rules, it will be one at a time.
+#
+# Documentation: https://clang.llvm.org/extra/clang-tidy/
+# Checks: https://clang.llvm.org/extra/clang-tidy/checks/list.html
+#
+# Multiline format for rules:
+# Checks: "-*,\
+#	rule,\
+#	"
+# 
+#
+
+#Checks: *
+
+HeaderFilterRegex: 'src/*\.(h|hpp)$'
+WarningsAsErrors: '*'

--- a/src/external/.clang-tidy
+++ b/src/external/.clang-tidy
@@ -1,0 +1,2 @@
+# disable everything in externals.
+Checks: -*


### PR DESCRIPTION
clang-tidy support enables the llvm extras linter to catch a wide array of problems and improve the build. It is off by default. Currently all rules are enabled, but this will fail the build. We will need to turn these rules on one by one.

Usage:
install llvm from homebrew, and make sure clang-tidy is in your path
./configure --with-clang-tidy

Clang build metrics enables a new features in Clang 9.0 which generates chrome://tracing (and similar tools) compatible json files for every compiled object that details where time was spent for that particular target. There are additional tools (such as ClangBuildAnalyzer) that will combine these files to give an overall high-level view of where time is spent in the build. I will share the detailed output from this internally.

Usage:
./configure --with-clang-metrics
