### PR TITLE
minimal build install

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -14,6 +14,8 @@ from setuptools.command.install import install
 
 PACKAGE_NAME = "turicreate"
 VERSION = "6.2"  # {{VERSION_STRING}}
+NON_MINIMAL_LIST = ["tensorflow", "resampy"]
+
 
 # Prevent distutils from thinking we are a pure python package
 class BinaryDistribution(Distribution):
@@ -22,7 +24,9 @@ class BinaryDistribution(Distribution):
 
 
 class InstallEngine(install):
-    """Helper class to hook the python setup.py install path to download client libraries and engine"""
+    """Helper class to hook the python setup.py install path to download
+    client libraries and engine
+    """
 
     user_options = install.user_options + [
         ("minimal", None, "control minimal installation"),  # a 'flag' option
@@ -33,15 +37,11 @@ class InstallEngine(install):
         self.minimal = None
 
     def run(self):
-        global minimal
-        minimal = self.minimal  # will be 1 or None
-
-        if minimal is not None:
+        if self.minimal is not None:
 
             def do_not_install(require):
-                spam_list = ["tensorflow", "resampy"]
                 require = require.strip()
-                for name in spam_list:
+                for name in NON_MINIMAL_LIST:
                     if require.startswith(name):
                         return False
                 return True
@@ -51,9 +51,10 @@ class InstallEngine(install):
             )
 
             orig_install_requires = self.distribution.install_requires
-            print("minimal  install: ", install_requires_minimal)
-            print("original install: ", orig_install_requires)
             self.distribution.install_requires = install_requires_minimal
+
+            print(" minimal install: ", install_requires_minimal)
+            print("original install: ", orig_install_requires)
 
         import platform
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -50,8 +50,9 @@ class InstallEngine(install):
                 filter(do_not_install, self.distribution.install_requires)
             )
 
-            print(install_requires_minimal)
             orig_install_requires = self.distribution.install_requires
+            print("minimal  install: ", install_requires_minimal)
+            print("original install: ", orig_install_requires)
             self.distribution.install_requires = install_requires_minimal
 
         import platform

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -24,7 +24,36 @@ class BinaryDistribution(Distribution):
 class InstallEngine(install):
     """Helper class to hook the python setup.py install path to download client libraries and engine"""
 
+    user_options = install.user_options + [
+        ("minimal", None, "control minimal installation"),  # a 'flag' option
+    ]
+
+    def initialize_options(self):
+        install.initialize_options(self)
+        self.minimal = None
+
     def run(self):
+        global minimal
+        minimal = self.minimal  # will be 1 or None
+
+        if minimal is not None:
+
+            def do_not_install(require):
+                spam_list = ["tensorflow", "resampy"]
+                require = require.strip()
+                for name in spam_list:
+                    if require.startswith(name):
+                        return False
+                return True
+
+            install_requires_minimal = list(
+                filter(do_not_install, self.distribution.install_requires)
+            )
+
+            print(install_requires_minimal)
+            orig_install_requires = self.distribution.install_requires
+            self.distribution.install_requires = install_requires_minimal
+
         import platform
 
         # start by running base class implementation of run


### PR DESCRIPTION
we can customize the install when we call `bdist_wheel` by

```
 python setup.py bdist_wheel install --minimal

running bdist_wheel
running build
running build_py
running build_ext
installing to build/bdist.macosx-10.14-x86_64/wheel
running install
```

It will customize the install information `install_requires`, which will be then used by `wheel` to write to `turicreate-6.2.dist-info/METADATA`.