### PR TITLE
suppress docker pull prompts

### DIFF
--- a/scripts/create_docker_images.sh
+++ b/scripts/create_docker_images.sh
@@ -43,10 +43,10 @@ if [[ -n $PERSIST_TO_REPO_DIR ]]; then
 fi
 
 # Load images from registry if possible
-(docker pull ${TC_BUILD_IMAGE_CENTOS6}) || true
-(docker pull ${TC_BUILD_IMAGE_1204}) || true
-(docker pull ${TC_BUILD_IMAGE_1404}) || true
-(docker pull ${TC_BUILD_IMAGE_1804}) || true
+(docker pull -q ${TC_BUILD_IMAGE_CENTOS6}) || true
+(docker pull -q ${TC_BUILD_IMAGE_1204}) || true
+(docker pull -q ${TC_BUILD_IMAGE_1404}) || true
+(docker pull -q ${TC_BUILD_IMAGE_1804}) || true
 
 (docker image ls ${TC_BUILD_IMAGE_CENTOS6} | grep turicreate/build-image) || \
 cat scripts/Dockerfile-CentOS-6 | docker build -t ${TC_BUILD_IMAGE_CENTOS6} -
@@ -69,4 +69,3 @@ if [[ -n $PERSIST_TO_REPO_DIR ]]; then
   docker save ${TC_BUILD_IMAGE_1404} | gzip -c > .docker_images/image-14.04.gz
   docker save ${TC_BUILD_IMAGE_1804} | gzip -c > .docker_images/image-18.04.gz
 fi
-

--- a/scripts/create_docker_images.sh
+++ b/scripts/create_docker_images.sh
@@ -46,7 +46,7 @@ fi
 (docker pull -q ${TC_BUILD_IMAGE_CENTOS6}) || true
 (docker pull -q ${TC_BUILD_IMAGE_1204}) || true
 (docker pull -q ${TC_BUILD_IMAGE_1404}) || true
-(docker pull -q ${TC_BUILD_IMAGE_1804}) || true
+(docker pull ${TC_BUILD_IMAGE_1804}) || true
 
 (docker image ls ${TC_BUILD_IMAGE_CENTOS6} | grep turicreate/build-image) || \
 cat scripts/Dockerfile-CentOS-6 | docker build -t ${TC_BUILD_IMAGE_CENTOS6} -


### PR DESCRIPTION
```shell
+ docker pull registry.gitlab.com/zach_nation/turicreate/build-image-18.04:1.0.6
490 1.0.6: Pulling from zach_nation/turicreate/build-image-18.04
491 2746a4a261c9: Pulling fs layer
492 4c1d20cdee96: Pulling fs layer
493 0d3160e1d0de: Pulling fs layer
494 c8e37668deea: Pulling fs layer
495 c86b38401bd4: Pulling fs layer
496 ed23e6555ee4: Pulling fs layer
497 a47932478297: Pulling fs layer
498 f7e933d0319a: Pulling fs layer
499 a019a076f7b2: Pulling fs layer
500 9062cc6314d3: Pulling fs layer
501 2202575fb5a6: Pulling fs layer
502 346943f5a26d: Pulling fs layer
...
```

No need to show docker pull details. The information is useless most of the time and jams the build pipeline log.