### PR TITLE
pytest.mark tests needed for minimal package

### DIFF
--- a/src/python/turicreate/test/test_boosted_trees_checkpoint.py
+++ b/src/python/turicreate/test/test_boosted_trees_checkpoint.py
@@ -12,8 +12,10 @@ import random
 import tempfile
 import os
 import shutil
+import pytest
 
 
+@pytest.mark.minimal
 class BoostedTreesRegressionCheckpointTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/src/python/turicreate/test/test_cloudpickle.py
+++ b/src/python/turicreate/test/test_cloudpickle.py
@@ -12,6 +12,10 @@ from pickle import PicklingError
 import pickle
 import turicreate.util._cloudpickle as cloudpickle
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class CloudPickleTest(unittest.TestCase):
     def test_pickle_unity_object_exception(self):

--- a/src/python/turicreate/test/test_dataframe.py
+++ b/src/python/turicreate/test/test_dataframe.py
@@ -13,6 +13,10 @@ from .. import SFrame
 from pandas.util.testing import assert_frame_equal
 from sys import version_info
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class DataFrameTest(unittest.TestCase):
     def test_empty(self):

--- a/src/python/turicreate/test/test_deps.py
+++ b/src/python/turicreate/test/test_deps.py
@@ -7,10 +7,12 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
+import pytest
 from turicreate._deps import __get_version as get_version
 from distutils.version import StrictVersion
 
 
+@pytest.mark.minimal
 class VersionTest(unittest.TestCase):
     def test_min_version(self):
         MIN_VERSION = StrictVersion("1.8.1")

--- a/src/python/turicreate/test/test_environment_config.py
+++ b/src/python/turicreate/test/test_environment_config.py
@@ -20,6 +20,10 @@ from os.path import join
 import os
 import shutil
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class EnvironmentConfigTester(unittest.TestCase):
     def test_config_basic_write(self):

--- a/src/python/turicreate/test/test_extensions.py
+++ b/src/python/turicreate/test/test_extensions.py
@@ -18,6 +18,10 @@ import random
 
 from .._cython.cy_variant import _debug_is_flexible_type_encoded
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class VariantCheckTest(unittest.TestCase):
     def identical(self, reference, b):

--- a/src/python/turicreate/test/test_external_memory_tree.py
+++ b/src/python/turicreate/test/test_external_memory_tree.py
@@ -10,6 +10,10 @@ import unittest
 import turicreate as tc
 from array import array
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 def _get_data(n):
     t = [1] * (n - n // 2) + [0] * (n // 2)

--- a/src/python/turicreate/test/test_file_util.py
+++ b/src/python/turicreate/test/test_file_util.py
@@ -8,8 +8,12 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import os
 import unittest
-import tempfile
 from ..util import _file_util as fu
+
+
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 
 class FileUtilTests(unittest.TestCase):

--- a/src/python/turicreate/test/test_flexible_type.py
+++ b/src/python/turicreate/test/test_flexible_type.py
@@ -27,6 +27,10 @@ import datetime
 from itertools import product
 from copy import copy
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 import sys
 
 if sys.version_info.major > 2:

--- a/src/python/turicreate/test/test_gl_pickler.py
+++ b/src/python/turicreate/test/test_gl_pickler.py
@@ -21,6 +21,10 @@ from turicreate.util import _assert_sframe_equal as assert_sframe_equal
 
 import os as _os
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class GLPicklingTest(unittest.TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_graph.py
+++ b/src/python/turicreate/test/test_graph.py
@@ -23,6 +23,10 @@ import sys
 if sys.version_info.major > 2:
     unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class GraphTests(unittest.TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_graph_compute.py
+++ b/src/python/turicreate/test/test_graph_compute.py
@@ -10,6 +10,10 @@ from .. import SGraph, Edge
 import unittest
 import time
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 import sys
 
 if sys.version_info.major > 2:

--- a/src/python/turicreate/test/test_io_s3.py
+++ b/src/python/turicreate/test/test_io_s3.py
@@ -15,9 +15,12 @@ import tempfile
 import os
 import six
 import shutil
-import pytest
 import boto3
 import warnings
+
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 # size from small to big: 76K, 21MB, 77MB.
 # 64MB is the cache block size. The big sframe with 77MB is used to

--- a/src/python/turicreate/test/test_json.py
+++ b/src/python/turicreate/test/test_json.py
@@ -21,19 +21,21 @@ import json  # Python built-in JSON module
 import math
 import os
 import pandas
-import pytest
 import pytz
 import six
 import string
 import sys
 import unittest
 import tempfile
+import pytest
 
 from . import util
 from .. import _json  # turicreate._json
 from ..data_structures.sarray import SArray
 from ..data_structures.sframe import SFrame
 from ..data_structures.sgraph import SGraph, Vertex, Edge
+
+pytestmark = [pytest.mark.minimal]
 
 if sys.version_info.major == 3:
     long = int

--- a/src/python/turicreate/test/test_json_export.py
+++ b/src/python/turicreate/test/test_json_export.py
@@ -26,6 +26,10 @@ import turicreate as tc
 
 _TEST_CASE_SIZE = 1000
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class JSONExporterTest(unittest.TestCase):
 

--- a/src/python/turicreate/test/test_lambda.py
+++ b/src/python/turicreate/test/test_lambda.py
@@ -14,6 +14,10 @@ from .._connect import main as glconnect
 from .._cython import cy_test_utils
 import os
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 def fib(i):
     if i <= 2:

--- a/src/python/turicreate/test/test_logger.py
+++ b/src/python/turicreate/test/test_logger.py
@@ -11,6 +11,10 @@ from unittest import TestCase
 import logging
 from .. import config as tc_config
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class LoggingConfigurationTests(TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_recsys_api.py
+++ b/src/python/turicreate/test/test_recsys_api.py
@@ -8,11 +8,13 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
 import sys
+import pytest
 import turicreate as tc
 
 DELTA = 0.000001
 
 
+@pytest.mark.minimal
 class AdditionalDataTest(unittest.TestCase):
     def setUp(self):
         data = tc.SFrame()

--- a/src/python/turicreate/test/test_regression.py
+++ b/src/python/turicreate/test/test_regression.py
@@ -10,6 +10,10 @@ import unittest
 import turicreate as tc
 import numpy as np
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class RegressionCreateTest(unittest.TestCase):
     """

--- a/src/python/turicreate/test/test_sarray_builder.py
+++ b/src/python/turicreate/test/test_sarray_builder.py
@@ -13,6 +13,10 @@ import array
 import datetime as dt
 from .._cython.cy_flexible_type import GMT
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SArrayBuilderTest(unittest.TestCase):
     def __test_equal(self, _sarray, _data, _type):

--- a/src/python/turicreate/test/test_sarray_sketch.py
+++ b/src/python/turicreate/test/test_sarray_sketch.py
@@ -20,6 +20,10 @@ import array
 import time
 import itertools
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SArraySketchTest(unittest.TestCase):
     def __validate_sketch_result(self, sketch, sa, delta=1e-7):

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -27,13 +27,17 @@ import time
 import numpy as np
 import array
 import math
+import sqlite3
 import random
 import shutil
 import functools
 import sys
 import mock
-import sqlite3
 from .dbapi2_mock import dbapi2_mock
+
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 
 class SFrameTest(unittest.TestCase):

--- a/src/python/turicreate/test/test_sframe_builder.py
+++ b/src/python/turicreate/test/test_sframe_builder.py
@@ -14,6 +14,10 @@ import datetime as dt
 from .._cython.cy_flexible_type import GMT
 from ..util import _assert_sframe_equal
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SFrameBuilderTest(unittest.TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_sframe_generation.py
+++ b/src/python/turicreate/test/test_sframe_generation.py
@@ -13,6 +13,10 @@ from ..util import generate_random_classification_sframe
 import unittest
 import array
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SFrameGeneration(unittest.TestCase):
     def test_data_types(self):

--- a/src/python/turicreate/test/test_tree_json_dump.py
+++ b/src/python/turicreate/test/test_tree_json_dump.py
@@ -12,7 +12,10 @@ import json
 import random
 import numpy
 
-import os as _os
+# mark entire module as minimal
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 
 class Config:

--- a/src/python/turicreate/test/test_unicode_strings.py
+++ b/src/python/turicreate/test/test_unicode_strings.py
@@ -14,6 +14,10 @@ import six
 import unittest
 import turicreate as tc
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class UnicodeStringTest(unittest.TestCase):
     def test_unicode_column_accessor(self):

--- a/src/python/turicreate/test/test_util.py
+++ b/src/python/turicreate/test/test_util.py
@@ -19,6 +19,10 @@ from ..util import get_turicreate_object_type
 from ..config import get_runtime_config, set_runtime_config
 from . import util
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class UtilTests(unittest.TestCase):
     def test_archive_utils(self):

--- a/src/python/turicreate/test/util.py
+++ b/src/python/turicreate/test/util.py
@@ -18,6 +18,10 @@ import turicreate as tc
 import sys
 from six import StringIO
 
+import pytest
+
+pytestmark = pytest.mark.minimal
+
 
 class SFrameComparer:
     """


### PR DESCRIPTION
As @TobyRoseman mentioned in #3152, `grep` on `toolkits` keyword is kind of brittle. Following this suggestion, I use pytest.mark to mark explicitly.

Marked files are selected from

```bash
$ grep -L "toolkits" *.py
__init__.py
test_boosted_trees_checkpoint.py
test_cloudpickle.py
test_dataframe.py
test_deps.py
test_environment_config.py
test_extensions.py
test_external_memory_tree.py
test_file_util.py
test_flexible_type.py
test_gl_pickler.py
test_graph.py
test_graph_compute.py
test_io_s3.py
test_json.py
test_json_export.py
test_lambda.py
test_logger.py
test_prototype_models.py
test_recsys_api.py
test_regression.py
test_sarray_builder.py
test_sarray_sketch.py
test_sframe.py
test_sframe_builder.py
test_sframe_generation.py
test_tree_json_dump.py
test_unicode_strings.py
test_util.py
util.py
```

whereas all toolkits (non-SFrame) related tests are:

```bash
_test_api_visibility.py
test_activity_classifier.py
test_audio_functionality.py
test_boosted_trees.py
test_boosted_trees_early_stop.py
test_classifier.py
test_coreml_export.py
test_dbscan.py
test_decision_tree.py
test_distances.py
test_drawing_classifier.py
test_evaluation.py
test_explore.py
test_fast_path_prediction.py
test_graph_analytics.py
test_image_classifier.py
test_image_similarity.py
test_image_type.py
test_io.py
test_kmeans.py
test_knn_classifier.py
test_linear_regression.py
test_logistic_classifier.py
test_models.py
test_nearest_neighbors.py
test_object_detector.py
test_one_shot_object_detector.py
test_python_decision_tree.py
test_random_forest.py
test_recommender.py
test_sarray.py
test_style_transfer.py
test_supervised_learning_missing_value_actions.py
test_supervised_learning_string_targets.py
test_svm_classifier.py
test_text_analytics.py
test_text_classifier.py
test_topic_model.py
test_tree_extract_features.py
test_tree_tracking_metrics.py
```

, which looks reasonable for me.