### PR TITLE
pytest.mark tests needed for minimal package

### DIFF
--- a/src/python/turicreate/test/test_audio_functionality.py
+++ b/src/python/turicreate/test/test_audio_functionality.py
@@ -556,6 +556,7 @@ class CoreMlCustomModelPreprocessingTest(unittest.TestCase):
 
     def test_case(self):
         from turicreate.toolkits.sound_classifier import vggish_input
+        import coremltools
         from coremltools.proto import FeatureTypes_pb2
 
         model = coremltools.proto.Model_pb2.Model()

--- a/src/python/turicreate/test/test_audio_functionality.py
+++ b/src/python/turicreate/test/test_audio_functionality.py
@@ -17,8 +17,6 @@ from os import mkdir
 import unittest
 import pytest
 
-import coremltools
-from coremltools.proto import FeatureTypes_pb2
 import numpy as np
 from scipy.io import wavfile
 import sys as _sys
@@ -295,6 +293,7 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
     )
     def test_export_coreml_with_prediction(self):
         import resampy
+        import coremltools
 
         with TempDirectory() as temp_dir:
             file_name = temp_dir + "/model.mlmodel"
@@ -332,6 +331,7 @@ class ClassifierTestTwoClassesStringLabels(unittest.TestCase):
 
     def test_export_core_ml_no_prediction(self):
         import platform
+        import coremltools
 
         with TempDirectory() as temp_dir:
             file_name = temp_dir + "/model.mlmodel"
@@ -556,6 +556,7 @@ class CoreMlCustomModelPreprocessingTest(unittest.TestCase):
 
     def test_case(self):
         from turicreate.toolkits.sound_classifier import vggish_input
+        from coremltools.proto import FeatureTypes_pb2
 
         model = coremltools.proto.Model_pb2.Model()
         model.customModel.className = "TCSoundClassifierPreprocessing"

--- a/src/python/turicreate/test/test_audio_functionality.py
+++ b/src/python/turicreate/test/test_audio_functionality.py
@@ -18,7 +18,6 @@ import unittest
 import pytest
 
 import numpy as np
-from scipy.io import wavfile
 import sys as _sys
 
 import turicreate as tc
@@ -45,6 +44,8 @@ class ReadAudioTest(unittest.TestCase):
             self._assert_audio_sframe_correct(sf, file1, file2)
 
     def test_recursive_dir(self):
+        from scipy.io import wavfile
+
         with TempDirectory() as temp_dir:
             file1 = temp_dir + "/1.wav"
             mkdir(temp_dir + "/foo")
@@ -109,6 +110,8 @@ class ReadAudioTest(unittest.TestCase):
         self.assertTrue(all(audio2["data"] == self.noise2))
 
     def _write_audio_files_in_dir(self, dir_path):
+        from scipy.io import wavfile
+
         file1 = dir_path + "/1.wav"
         file2 = dir_path + "/2.wav"
         wavfile.write(file1, self.sample_rate1, self.noise1)

--- a/src/python/turicreate/test/test_boosted_trees_checkpoint.py
+++ b/src/python/turicreate/test/test_boosted_trees_checkpoint.py
@@ -12,8 +12,10 @@ import random
 import tempfile
 import os
 import shutil
+import pytest
 
 
+@pytest.mark.minimal
 class BoostedTreesRegressionCheckpointTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/src/python/turicreate/test/test_boosted_trees_checkpoint.py
+++ b/src/python/turicreate/test/test_boosted_trees_checkpoint.py
@@ -12,10 +12,8 @@ import random
 import tempfile
 import os
 import shutil
-import pytest
 
 
-@pytest.mark.minimal
 class BoostedTreesRegressionCheckpointTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/src/python/turicreate/test/test_cloudpickle.py
+++ b/src/python/turicreate/test/test_cloudpickle.py
@@ -12,6 +12,10 @@ from pickle import PicklingError
 import pickle
 import turicreate.util._cloudpickle as cloudpickle
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class CloudPickleTest(unittest.TestCase):
     def test_pickle_unity_object_exception(self):

--- a/src/python/turicreate/test/test_coreml_export.py
+++ b/src/python/turicreate/test/test_coreml_export.py
@@ -18,7 +18,6 @@ from turicreate.toolkits._main import ToolkitError
 from turicreate.toolkits._internal_utils import _mac_ver
 import shutil
 import numpy as np
-import coremltools
 import sys
 import platform
 import array
@@ -79,6 +78,8 @@ class CoreMLExportTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".mlmodel") as mlmodel_file:
             mlmodel_filename = mlmodel_file.name
             model.export_coreml(mlmodel_filename)
+            import coremltools
+
             coreml_model = coremltools.models.MLModel(mlmodel_filename)
             self.assertDictEqual(
                 {

--- a/src/python/turicreate/test/test_dataframe.py
+++ b/src/python/turicreate/test/test_dataframe.py
@@ -13,6 +13,10 @@ from .. import SFrame
 from pandas.util.testing import assert_frame_equal
 from sys import version_info
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class DataFrameTest(unittest.TestCase):
     def test_empty(self):

--- a/src/python/turicreate/test/test_deps.py
+++ b/src/python/turicreate/test/test_deps.py
@@ -7,10 +7,12 @@ from __future__ import print_function as _
 from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
+import pytest
 from turicreate._deps import __get_version as get_version
 from distutils.version import StrictVersion
 
 
+@pytest.mark.minimal
 class VersionTest(unittest.TestCase):
     def test_min_version(self):
         MIN_VERSION = StrictVersion("1.8.1")

--- a/src/python/turicreate/test/test_drawing_classifier.py
+++ b/src/python/turicreate/test/test_drawing_classifier.py
@@ -13,7 +13,6 @@ import turicreate.toolkits.libtctensorflow
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 import numpy as _np
 import tempfile
-import coremltools as _coremltools
 from copy import copy as _copy
 from array import array as _array
 import sys as _sys
@@ -376,6 +375,8 @@ class DrawingClassifierTest(unittest.TestCase):
 
     @unittest.skipIf(_sys.platform != "darwin", "Core ML only supported on Mac")
     def test_export_coreml_with_predict(self):
+        import coremltools as _coremltools
+
         for test_number in range(len(self.models)):
             feature = self.feature
             model = self.models[test_number]

--- a/src/python/turicreate/test/test_environment_config.py
+++ b/src/python/turicreate/test/test_environment_config.py
@@ -20,6 +20,10 @@ from os.path import join
 import os
 import shutil
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class EnvironmentConfigTester(unittest.TestCase):
     def test_config_basic_write(self):

--- a/src/python/turicreate/test/test_evaluation.py
+++ b/src/python/turicreate/test/test_evaluation.py
@@ -8,20 +8,27 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
 import turicreate
-from sklearn.metrics import (
-    fbeta_score,
-    recall_score,
-    precision_score,
-    accuracy_score,
-    f1_score,
-    roc_auc_score,
-)
 from turicreate.toolkits._main import ToolkitError
 import math
 from numpy import inf
 import numpy as np
 
 DELTA = 0.00001
+
+try:
+    from sklearn.metrics import (
+        fbeta_score,
+        recall_score,
+        precision_score,
+        accuracy_score,
+        f1_score,
+        roc_auc_score,
+    )
+except ImportError as e:
+    # ignore extra dependencies
+    # https://github.com/apple/turicreate/pull/3156
+    if not turicreate._deps.is_minimal_pkg():
+        raise e
 
 
 def _round_scores(p):

--- a/src/python/turicreate/test/test_extensions.py
+++ b/src/python/turicreate/test/test_extensions.py
@@ -18,6 +18,10 @@ import random
 
 from .._cython.cy_variant import _debug_is_flexible_type_encoded
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class VariantCheckTest(unittest.TestCase):
     def identical(self, reference, b):

--- a/src/python/turicreate/test/test_external_memory_tree.py
+++ b/src/python/turicreate/test/test_external_memory_tree.py
@@ -10,6 +10,10 @@ import unittest
 import turicreate as tc
 from array import array
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 def _get_data(n):
     t = [1] * (n - n // 2) + [0] * (n // 2)

--- a/src/python/turicreate/test/test_file_util.py
+++ b/src/python/turicreate/test/test_file_util.py
@@ -8,8 +8,12 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import os
 import unittest
-import tempfile
 from ..util import _file_util as fu
+
+
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 
 class FileUtilTests(unittest.TestCase):

--- a/src/python/turicreate/test/test_flexible_type.py
+++ b/src/python/turicreate/test/test_flexible_type.py
@@ -27,6 +27,10 @@ import datetime
 from itertools import product
 from copy import copy
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 import sys
 
 if sys.version_info.major > 2:

--- a/src/python/turicreate/test/test_gl_pickler.py
+++ b/src/python/turicreate/test/test_gl_pickler.py
@@ -21,6 +21,10 @@ from turicreate.util import _assert_sframe_equal as assert_sframe_equal
 
 import os as _os
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class GLPicklingTest(unittest.TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_graph.py
+++ b/src/python/turicreate/test/test_graph.py
@@ -23,6 +23,10 @@ import sys
 if sys.version_info.major > 2:
     unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class GraphTests(unittest.TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_graph_compute.py
+++ b/src/python/turicreate/test/test_graph_compute.py
@@ -10,6 +10,10 @@ from .. import SGraph, Edge
 import unittest
 import time
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 import sys
 
 if sys.version_info.major > 2:

--- a/src/python/turicreate/test/test_image_classifier.py
+++ b/src/python/turicreate/test/test_image_classifier.py
@@ -22,7 +22,6 @@ from turicreate.toolkits._internal_utils import (
 
 from . import util as test_util
 
-import coremltools
 import numpy as np
 import turicreate as tc
 
@@ -206,6 +205,8 @@ class ImageClassifierTest(unittest.TestCase):
             predictions = model.classify("more junk")
 
     def test_export_coreml(self):
+        import coremltools
+
         filename = tempfile.NamedTemporaryFile(suffix=".mlmodel").name
         self.model.export_coreml(filename)
 
@@ -228,6 +229,8 @@ class ImageClassifierTest(unittest.TestCase):
 
     @unittest.skipIf(sys.platform != "darwin", "Core ML only supported on Mac")
     def test_export_coreml_predict(self):
+        import coremltools
+
         filename = tempfile.NamedTemporaryFile(suffix=".mlmodel").name
         self.model.export_coreml(filename)
 

--- a/src/python/turicreate/test/test_image_similarity.py
+++ b/src/python/turicreate/test/test_image_similarity.py
@@ -12,7 +12,6 @@ import turicreate as tc
 from turicreate.toolkits._internal_utils import _mac_ver
 import tempfile
 from . import util as test_util
-import coremltools
 import numpy as np
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 
@@ -218,6 +217,7 @@ class ImageSimilarityTest(unittest.TestCase):
         """
         Check the export_coreml() function.
         """
+        import coremltools
 
         def get_psnr(x, y):
             # See: https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
@@ -244,6 +244,7 @@ class ImageSimilarityTest(unittest.TestCase):
             },
             dict(coreml_model.user_defined_metadata),
         )
+
         expected_result = (
             "Image similarity (%s) created by Turi Create (version %s)"
             % (self.model.model, tc.__version__)

--- a/src/python/turicreate/test/test_io_s3.py
+++ b/src/python/turicreate/test/test_io_s3.py
@@ -15,9 +15,12 @@ import tempfile
 import os
 import six
 import shutil
-import pytest
 import boto3
 import warnings
+
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 # size from small to big: 76K, 21MB, 77MB.
 # 64MB is the cache block size. The big sframe with 77MB is used to

--- a/src/python/turicreate/test/test_json.py
+++ b/src/python/turicreate/test/test_json.py
@@ -21,19 +21,21 @@ import json  # Python built-in JSON module
 import math
 import os
 import pandas
-import pytest
 import pytz
 import six
 import string
 import sys
 import unittest
 import tempfile
+import pytest
 
 from . import util
 from .. import _json  # turicreate._json
 from ..data_structures.sarray import SArray
 from ..data_structures.sframe import SFrame
 from ..data_structures.sgraph import SGraph, Vertex, Edge
+
+pytestmark = [pytest.mark.minimal]
 
 if sys.version_info.major == 3:
     long = int

--- a/src/python/turicreate/test/test_json_export.py
+++ b/src/python/turicreate/test/test_json_export.py
@@ -26,6 +26,10 @@ import turicreate as tc
 
 _TEST_CASE_SIZE = 1000
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class JSONExporterTest(unittest.TestCase):
 

--- a/src/python/turicreate/test/test_lambda.py
+++ b/src/python/turicreate/test/test_lambda.py
@@ -14,6 +14,10 @@ from .._connect import main as glconnect
 from .._cython import cy_test_utils
 import os
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 def fib(i):
     if i <= 2:

--- a/src/python/turicreate/test/test_linear_regression.py
+++ b/src/python/turicreate/test/test_linear_regression.py
@@ -14,8 +14,6 @@ import uuid
 import os
 
 import array
-from sklearn import linear_model
-import statsmodels.formula.api as sm
 import shutil
 
 import numpy as np
@@ -24,6 +22,14 @@ from turicreate.toolkits.regression.linear_regression import _DEFAULT_SOLVER_OPT
 
 if sys.version_info.major == 3:
     from functools import reduce
+
+try:
+    import statsmodels.formula.api as sm
+except ImportError as e:
+    # ignore extra dependencies
+    # https://github.com/apple/turicreate/pull/3156
+    if not tc._deps.is_minimal_pkg():
+        raise e
 
 
 class LinearRegressionTest(unittest.TestCase):
@@ -1129,6 +1135,8 @@ class L1LinearRegressionTest(unittest.TestCase):
         self.examples = X.shape[0]
 
         # Fit the model
+        from sklearn import linear_model
+
         self.l1_penalty = 10.0
         clf = linear_model.ElasticNet(
             alpha=self.l1_penalty / (2 * self.examples), l1_ratio=1

--- a/src/python/turicreate/test/test_logger.py
+++ b/src/python/turicreate/test/test_logger.py
@@ -11,6 +11,10 @@ from unittest import TestCase
 import logging
 from .. import config as tc_config
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class LoggingConfigurationTests(TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_logistic_classifier.py
+++ b/src/python/turicreate/test/test_logistic_classifier.py
@@ -8,20 +8,26 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
 import turicreate as tc
-import scipy.stats as ss
 import uuid
 import numpy as np
-import statsmodels.api as sm
-from sklearn.metrics import *
-import statsmodels.formula.api as smf
 import array
 from turicreate.toolkits._main import ToolkitError
 from turicreate.toolkits.classifier.logistic_classifier import _DEFAULT_SOLVER_OPTIONS
 import shutil
 import os
 import copy
-import pandas as pd
 
+try:
+    # bad pracice of using *
+    from sklearn.metrics import *
+    import pandas as pd
+    import statsmodels.api as sm
+    import statsmodels.formula.api as smf
+except ImportError as e:
+    # ignore extra dependencies
+    # https://github.com/apple/turicreate/pull/3156
+    if not tc._deps.is_minimal_pkg():
+        raise e
 
 #
 # Various test cases for the _LogisticRegressionClassifierModelTest
@@ -245,6 +251,8 @@ def multiclass_integer_target(cls):
     )
 
     # Function to rank all items in a list
+    import scipy.stats as ss
+
     rank = lambda x: list(len(x) - ss.rankdata(x))
     rank_sa = preds_sf.pack_columns(preds_sf.column_names())["X1"].apply(rank)
     topk_yhat_rank = tc.SFrame({"X1": rank_sa}).add_row_number()

--- a/src/python/turicreate/test/test_nearest_neighbors.py
+++ b/src/python/turicreate/test/test_nearest_neighbors.py
@@ -12,7 +12,6 @@ import copy
 import turicreate as tc
 from turicreate.toolkits._main import ToolkitError
 from turicreate.toolkits._private_utils import _validate_lists
-import scipy.spatial.distance as spd
 from pandas.util.testing import assert_frame_equal
 from . import util
 import array
@@ -2409,6 +2408,8 @@ def random_list_of_str(number, length):
 
 
 def scipy_dist(q, r, dist):
+    import scipy.spatial.distance as spd
+
     n = len(r)
     n_query = len(q)
 

--- a/src/python/turicreate/test/test_object_detector.py
+++ b/src/python/turicreate/test/test_object_detector.py
@@ -19,7 +19,6 @@ import os
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sarray, _mac_ver
 from six import StringIO
-import coremltools
 
 _CLASSES = ["person", "cat", "dog", "chair"]
 
@@ -289,19 +288,23 @@ class ObjectDetectorTest(unittest.TestCase):
         test_util.assert_longer_verbose_logs(tc.object_detector.create, args, kwargs)
 
     def test_create_with_fixed_random_seed(self):
-         random_seed = 86
-         max_iterations = 3
+        random_seed = 86
+        max_iterations = 3
 
-         model_1 = tc.object_detector.create(self.sf, max_iterations=max_iterations, random_seed=random_seed)
-         pred_1 = model_1.predict(self.sf)
-         model_2 = tc.object_detector.create(self.sf, max_iterations=max_iterations, random_seed=random_seed)
-         pred_2 = model_2.predict(self.sf)
+        model_1 = tc.object_detector.create(
+            self.sf, max_iterations=max_iterations, random_seed=random_seed
+        )
+        pred_1 = model_1.predict(self.sf)
+        model_2 = tc.object_detector.create(
+            self.sf, max_iterations=max_iterations, random_seed=random_seed
+        )
+        pred_2 = model_2.predict(self.sf)
 
-         self.assertEqual(len(pred_1), len(pred_2))
-         for i in range(len(pred_1)):
-             self.assertEqual(len(pred_1[i]),len(pred_2[i]))
-             for j in range(len(pred_1[i])):
-                 self.assertEqual(pred_1[i][j], pred_2[i][j])
+        self.assertEqual(len(pred_1), len(pred_2))
+        for i in range(len(pred_1)):
+            self.assertEqual(len(pred_1[i]), len(pred_2[i]))
+            for j in range(len(pred_1[i])):
+                self.assertEqual(pred_1[i][j], pred_2[i][j])
 
     def test_dict_annotations(self):
         sf_copy = self.sf[:]
@@ -515,6 +518,7 @@ class ObjectDetectorTest(unittest.TestCase):
     )
     def test_export_coreml_with_non_maximum_suppression(self):
         from PIL import Image
+        import coremltools
 
         filename = tempfile.NamedTemporaryFile(suffix=".mlmodel").name
         self.model.export_coreml(filename, include_non_maximum_suppression=True)

--- a/src/python/turicreate/test/test_one_shot_object_detector.py
+++ b/src/python/turicreate/test/test_one_shot_object_detector.py
@@ -18,7 +18,6 @@ import sys
 import os
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sarray, _mac_ver
-import coremltools
 
 _CLASSES = ["logo_a", "logo_b", "logo_c", "logo_d"]
 

--- a/src/python/turicreate/test/test_recommender.py
+++ b/src/python/turicreate/test/test_recommender.py
@@ -40,7 +40,6 @@ import tempfile
 from copy import copy
 from subprocess import Popen as _Popen
 from subprocess import PIPE as _PIPE
-import coremltools as _coremltools
 
 
 if not HAS_NUMPY:
@@ -75,6 +74,8 @@ def _coreml_to_tc(preds):
 
 class RecommenderTestBase(unittest.TestCase):
     def _test_coreml_export(self, m, item_ids, ratings=None):
+        import coremltools as _coremltools
+
         temp_file_path = tempfile.NamedTemporaryFile().name
         if m.target and ratings:
             obs_data_sf = tc.SFrame(
@@ -1712,10 +1713,15 @@ U1103,135104,0"""
         assert x is not None
 
         # Passing in a non recsys model should produce a ToolkitError error.
-        non_recsys_model = tc.linear_regression.create(tc.SFrame({'x': [1,2,3], 'y': [2,4,6]}), 'y')
+        non_recsys_model = tc.linear_regression.create(
+            tc.SFrame({"x": [1, 2, 3], "y": [2, 4, 6]}), "y"
+        )
         with self.assertRaises(ToolkitError):
             x = compare_models(
-                self.test, [model1, non_recsys_model], skip_set=self.train, make_plot=False
+                self.test,
+                [model1, non_recsys_model],
+                skip_set=self.train,
+                make_plot=False,
             )
 
     def _run_recommend_consistency_test(self, is_regression):

--- a/src/python/turicreate/test/test_recsys_api.py
+++ b/src/python/turicreate/test/test_recsys_api.py
@@ -8,11 +8,13 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
 import sys
+import pytest
 import turicreate as tc
 
 DELTA = 0.000001
 
 
+@pytest.mark.minimal
 class AdditionalDataTest(unittest.TestCase):
     def setUp(self):
         data = tc.SFrame()

--- a/src/python/turicreate/test/test_recsys_api.py
+++ b/src/python/turicreate/test/test_recsys_api.py
@@ -8,13 +8,11 @@ from __future__ import division as _
 from __future__ import absolute_import as _
 import unittest
 import sys
-import pytest
 import turicreate as tc
 
 DELTA = 0.000001
 
 
-@pytest.mark.minimal
 class AdditionalDataTest(unittest.TestCase):
     def setUp(self):
         data = tc.SFrame()

--- a/src/python/turicreate/test/test_regression.py
+++ b/src/python/turicreate/test/test_regression.py
@@ -10,6 +10,10 @@ import unittest
 import turicreate as tc
 import numpy as np
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class RegressionCreateTest(unittest.TestCase):
     """

--- a/src/python/turicreate/test/test_regression.py
+++ b/src/python/turicreate/test/test_regression.py
@@ -10,10 +10,6 @@ import unittest
 import turicreate as tc
 import numpy as np
 
-import pytest
-
-pytestmark = [pytest.mark.minimal]
-
 
 class RegressionCreateTest(unittest.TestCase):
     """

--- a/src/python/turicreate/test/test_sarray_builder.py
+++ b/src/python/turicreate/test/test_sarray_builder.py
@@ -13,6 +13,10 @@ import array
 import datetime as dt
 from .._cython.cy_flexible_type import GMT
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SArrayBuilderTest(unittest.TestCase):
     def __test_equal(self, _sarray, _data, _type):

--- a/src/python/turicreate/test/test_sarray_sketch.py
+++ b/src/python/turicreate/test/test_sarray_sketch.py
@@ -20,6 +20,10 @@ import array
 import time
 import itertools
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SArraySketchTest(unittest.TestCase):
     def __validate_sketch_result(self, sketch, sa, delta=1e-7):

--- a/src/python/turicreate/test/test_sframe.py
+++ b/src/python/turicreate/test/test_sframe.py
@@ -27,13 +27,17 @@ import time
 import numpy as np
 import array
 import math
+import sqlite3
 import random
 import shutil
 import functools
 import sys
 import mock
-import sqlite3
 from .dbapi2_mock import dbapi2_mock
+
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 
 class SFrameTest(unittest.TestCase):

--- a/src/python/turicreate/test/test_sframe_builder.py
+++ b/src/python/turicreate/test/test_sframe_builder.py
@@ -14,6 +14,10 @@ import datetime as dt
 from .._cython.cy_flexible_type import GMT
 from ..util import _assert_sframe_equal
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SFrameBuilderTest(unittest.TestCase):
     def setUp(self):

--- a/src/python/turicreate/test/test_sframe_generation.py
+++ b/src/python/turicreate/test/test_sframe_generation.py
@@ -13,6 +13,10 @@ from ..util import generate_random_classification_sframe
 import unittest
 import array
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class SFrameGeneration(unittest.TestCase):
     def test_data_types(self):

--- a/src/python/turicreate/test/test_style_transfer.py
+++ b/src/python/turicreate/test/test_style_transfer.py
@@ -17,7 +17,6 @@ import sys
 import os
 from turicreate.toolkits._main import ToolkitError as _ToolkitError
 from turicreate.toolkits._internal_utils import _raise_error_if_not_sframe, _mac_ver
-import coremltools
 
 _NUM_STYLES = 4
 

--- a/src/python/turicreate/test/test_svm_classifier.py
+++ b/src/python/turicreate/test/test_svm_classifier.py
@@ -15,11 +15,18 @@ import numpy as np
 import array
 from turicreate.toolkits._main import ToolkitError
 from turicreate.toolkits.classifier.svm_classifier import _DEFAULT_SOLVER_OPTIONS
-from sklearn import svm
-from sklearn.metrics import *
 import shutil
 
 import os as _os
+
+try:
+    from sklearn.metrics import *
+    from sklearn import svm
+except ImportError as e:
+    # ignore extra dependencies for minimal pkg
+    # https://github.com/apple/turicreate/pull/3156
+    if not tc._deps.is_minimal_pkg():
+        raise e
 
 
 class SVMClassifierTest(unittest.TestCase):

--- a/src/python/turicreate/test/test_text_classifier.py
+++ b/src/python/turicreate/test/test_text_classifier.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import as _
 
 import unittest
 import tempfile
-import coremltools
 import turicreate as tc
 from turicreate.toolkits._main import ToolkitError
 from turicreate.toolkits._internal_utils import _mac_ver
@@ -99,6 +98,7 @@ class TextClassifierTest(unittest.TestCase):
         self.model.export_coreml(filename)
 
         import platform
+        import coremltools
 
         coreml_model = coremltools.models.MLModel(filename)
         self.assertDictEqual(
@@ -119,6 +119,8 @@ class TextClassifierTest(unittest.TestCase):
         filename = tempfile.NamedTemporaryFile(suffix=".mlmodel").name
         self.model.export_coreml(filename)
         preds = self.model.predict(self.docs, output_type="probability_vector")
+
+        import coremltools
 
         coreml_model = coremltools.models.MLModel(filename)
         coreml_preds = coreml_model.predict({"text": {"hello": 1, "friend": 1}})

--- a/src/python/turicreate/test/test_tree_json_dump.py
+++ b/src/python/turicreate/test/test_tree_json_dump.py
@@ -12,7 +12,10 @@ import json
 import random
 import numpy
 
-import os as _os
+# mark entire module as minimal
+import pytest
+
+pytestmark = [pytest.mark.minimal]
 
 
 class Config:

--- a/src/python/turicreate/test/test_unicode_strings.py
+++ b/src/python/turicreate/test/test_unicode_strings.py
@@ -14,6 +14,10 @@ import six
 import unittest
 import turicreate as tc
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class UnicodeStringTest(unittest.TestCase):
     def test_unicode_column_accessor(self):

--- a/src/python/turicreate/test/test_util.py
+++ b/src/python/turicreate/test/test_util.py
@@ -19,6 +19,10 @@ from ..util import get_turicreate_object_type
 from ..config import get_runtime_config, set_runtime_config
 from . import util
 
+import pytest
+
+pytestmark = [pytest.mark.minimal]
+
 
 class UtilTests(unittest.TestCase):
     def test_archive_utils(self):

--- a/src/python/turicreate/test/util.py
+++ b/src/python/turicreate/test/util.py
@@ -18,6 +18,10 @@ import turicreate as tc
 import sys
 from six import StringIO
 
+import pytest
+
+pytestmark = pytest.mark.minimal
+
 
 class SFrameComparer:
     """


### PR DESCRIPTION
Duplicate of #3171 due to some bug from Github.

As @TobyRoseman mentioned in #3152, `grep` on `toolkits` keyword is a kind of brittle. Following this suggestion, I use pytest.mark to mark explicitly.

Marked files are selected from

```bash
$ grep -L "toolkits" *.py
__init__.py
test_boosted_trees_checkpoint.py
test_cloudpickle.py
test_dataframe.py
test_deps.py
test_environment_config.py
test_extensions.py
test_external_memory_tree.py
test_file_util.py
test_flexible_type.py
test_gl_pickler.py
test_graph.py
test_graph_compute.py
test_io_s3.py
test_json.py
test_json_export.py
test_lambda.py
test_logger.py
test_prototype_models.py
test_recsys_api.py
test_regression.py
test_sarray_builder.py
test_sarray_sketch.py
test_sframe.py
test_sframe_builder.py
test_sframe_generation.py
test_tree_json_dump.py
test_unicode_strings.py
test_util.py
util.py
```

whereas all toolkits (non-SFrame) related tests are:

```bash
_test_api_visibility.py
test_activity_classifier.py
test_audio_functionality.py
test_boosted_trees.py
test_boosted_trees_early_stop.py
test_classifier.py
test_coreml_export.py
test_dbscan.py
test_decision_tree.py
test_distances.py
test_drawing_classifier.py
test_evaluation.py
test_explore.py
test_fast_path_prediction.py
test_graph_analytics.py
test_image_classifier.py
test_image_similarity.py
test_image_type.py
test_io.py
test_kmeans.py
test_knn_classifier.py
test_linear_regression.py
test_logistic_classifier.py
test_models.py
test_nearest_neighbors.py
test_object_detector.py
test_one_shot_object_detector.py
test_python_decision_tree.py
test_random_forest.py
test_recommender.py
test_sarray.py
test_style_transfer.py
test_supervised_learning_missing_value_actions.py
test_supervised_learning_string_targets.py
test_svm_classifier.py
test_text_analytics.py
test_text_classifier.py
test_topic_model.py
test_tree_extract_features.py
test_tree_tracking_metrics.py
```

, which looks reasonable for me.