### PR TITLE
update the minimal package dind to 19.03

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -367,6 +367,7 @@ test_python_linux_python27_minimal:
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
   dependencies:
     - build_wheel_linux_python27
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,11 +361,11 @@ test_python_linux_python27_minimal:
   tags:
     - docker
   services:
-    - docker:18.09-dind
-  image: docker:18.09
+    - docker:19.03-dind
+  image: docker:19.03
   stage: test
   variables:
-    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_HOST: tcp://docker:2375
     DOCKER_DRIVER: overlay2
   dependencies:
     - build_wheel_linux_python27


### PR DESCRIPTION
the newly added minimal pkg pipeline for Linux is using dind 18. This needs to be updated due to #3154 this change.