### PR TITLE
In set_runtime_config, if bad SSL cert path is provided, exception FileNotFoundError will be thrown. Additionally, relative file path is converted to absolute file path.

### DIFF
--- a/src/python/turicreate/config/__init__.py
+++ b/src/python/turicreate/config/__init__.py
@@ -330,11 +330,12 @@ def set_runtime_config(name, value):
 
     unity = _glconnect.get_unity()
 
-    # Expands relative path to absolute path
-    value = _os.path.abspath(_os.path.expanduser(value))
-    # Raises exception if path for SSL cert does not exist
-    if not _os.path.exists(value):
-        raise FileNotFoundError(f"{value} does not exist.")
+    if name == "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE":
+        # Expands relative path to absolute path
+        value = _os.path.abspath(_os.path.expanduser(value))
+        # Raises exception if path for SSL cert does not exist
+        if not _os.path.exists(value):
+            raise FileNotFoundError(f"{value} does not exist.")
 
     ret = unity.set_global(name, value)
     if ret != "":

--- a/src/python/turicreate/config/__init__.py
+++ b/src/python/turicreate/config/__init__.py
@@ -335,7 +335,7 @@ def set_runtime_config(name, value):
         value = _os.path.abspath(_os.path.expanduser(value))
         # Raises exception if path for SSL cert does not exist
         if not _os.path.exists(value):
-            raise FileNotFoundError("{} does not exist.".format(value))
+            raise ValueError("{} does not exist.".format(value))
 
     ret = unity.set_global(name, value)
     if ret != "":

--- a/src/python/turicreate/config/__init__.py
+++ b/src/python/turicreate/config/__init__.py
@@ -329,6 +329,13 @@ def set_runtime_config(name, value):
     from .._connect import main as _glconnect
 
     unity = _glconnect.get_unity()
+
+    # Expands relative path to absolute path
+    value = _os.path.abspath(_os.path.expanduser(value))
+    # Raises exception if path for SSL cert does not exist
+    if not _os.path.exists(value):
+        raise FileNotFoundError(f"{value} does not exist.")
+
     ret = unity.set_global(name, value)
     if ret != "":
         raise RuntimeError(ret)

--- a/src/python/turicreate/config/__init__.py
+++ b/src/python/turicreate/config/__init__.py
@@ -335,7 +335,7 @@ def set_runtime_config(name, value):
         value = _os.path.abspath(_os.path.expanduser(value))
         # Raises exception if path for SSL cert does not exist
         if not _os.path.exists(value):
-            raise FileNotFoundError(f"{value} does not exist.")
+            raise FileNotFoundError("{} does not exist.".format(value))
 
     ret = unity.set_global(name, value)
     if ret != "":

--- a/src/python/turicreate/test/test_util.py
+++ b/src/python/turicreate/test/test_util.py
@@ -255,7 +255,7 @@ class UtilTests(unittest.TestCase):
 
         try:
             self.assertRaises(
-                FileNotFoundError,
+                ValueError,
                 set_runtime_config,
                 "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE",
                 incorrect_path,

--- a/src/python/turicreate/test/test_util.py
+++ b/src/python/turicreate/test/test_util.py
@@ -243,3 +243,35 @@ class UtilTests(unittest.TestCase):
         self.assertTrue(location.startswith(tmp_root))
         self.assertTrue(isinstance(location, str))
         self.assertTrue(os.path.basename(location).startswith(prefix))
+
+    def test_alternate_ssl_path(self):
+        from ..util import _get_temp_file_location
+        from ..util import _convert_slashes
+
+        default_ssl_cert_path = get_runtime_config()[
+            "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE"
+        ]
+
+        tmp = tempfile.mkdtemp(prefix="test_gl_util")
+        tmp_relative_path = os.path.relpath(tmp)
+        incorrect_path = "/this_file_does_not_exist"
+
+        try:
+            self.assertRaises(
+                FileNotFoundError,
+                set_runtime_config,
+                "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE",
+                incorrect_path,
+            )
+            set_runtime_config(
+                "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE", tmp_relative_path
+            )
+            alternate_ssl_path = get_runtime_config()[
+                "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE"
+            ]
+            self.assertTrue(alternate_ssl_path == tmp)
+        finally:
+            shutil.rmtree(tmp)
+            set_runtime_config(
+                "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE", default_ssl_cert_path
+            )

--- a/src/python/turicreate/test/test_util.py
+++ b/src/python/turicreate/test/test_util.py
@@ -245,9 +245,6 @@ class UtilTests(unittest.TestCase):
         self.assertTrue(os.path.basename(location).startswith(prefix))
 
     def test_alternate_ssl_path(self):
-        from ..util import _get_temp_file_location
-        from ..util import _convert_slashes
-
         default_ssl_cert_path = get_runtime_config()[
             "TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE"
         ]


### PR DESCRIPTION
This PR resolves the issue of the following code completing without an error message when a bad SSL cert filepath is provided.
```
import turicreate as tc
tc.config.set_runtime_config("TURI_FILEIO_ALTERNATIVE_SSL_CERT_FILE",
    "/this_file_does_not_exist")  
```
With an incorrect path provided, a FileNotfoundError is thrown with the message: `</this_file_does_not_exist> does not exist.`
The PR also addresses relative paths and paths with `~` not working with the function. Now such paths will be expanded to absolute paths. 
Also added a test to `test_util.py` that tests whether an incorrect filepath does throw an error. The test also checks whether relative paths are working with the function. 
This PR fixes #3211
