### PR TITLE
Add normal distribution for weight initialization

### DIFF
--- a/src/ml/neural_net/weight_init.cpp
+++ b/src/ml/neural_net/weight_init.cpp
@@ -7,6 +7,7 @@
 #include <ml/neural_net/weight_init.hpp>
 
 #include <cmath>
+#include <random>
 
 namespace turi {
 namespace neural_net {
@@ -43,6 +44,18 @@ uniform_weight_initializer::uniform_weight_initializer(
 
 void uniform_weight_initializer::operator()(float* first_weight,
                                             float* last_weight) {
+  for (float* w = first_weight; w != last_weight; ++w) {
+    *w = dist_(random_engine_);
+  }
+}
+
+normal_weight_initializer::normal_weight_initializer(
+    float mean, float std_dev, std::mt19937* random_engine)
+    : dist_(std::normal_distribution<float>(mean, std_dev)),
+      random_engine_(*random_engine) {}
+
+void normal_weight_initializer::operator()(float* first_weight,
+                                           float* last_weight) {
   for (float* w = first_weight; w != last_weight; ++w) {
     *w = dist_(random_engine_);
   }

--- a/src/ml/neural_net/weight_init.hpp
+++ b/src/ml/neural_net/weight_init.hpp
@@ -74,6 +74,31 @@ private:
   std::mt19937& random_engine_;
 };
 
+class normal_weight_initializer {
+ public:
+  /**
+   * Creates a weight initializer that performs normal initialization
+   *
+   * \param mean The mean of the normal distribution to be sampled
+   * \param std_dev The standard deviation of the normal distribution to be
+   * sampled
+   * \param random_engine The random number generator to use, which must
+   * remain valid for the lifetime of this instance.
+   */
+  normal_weight_initializer(float mean, float std_dev,
+                            std::mt19937* random_engine);
+
+  /**
+   * Initializes each value in normally with specified mean and standard
+   * deviation.
+   */
+  void operator()(float* first_weight, float* last_weight);
+
+ private:
+  std::normal_distribution<float> dist_;
+  std::mt19937& random_engine_;
+};
+
 struct scalar_weight_initializer {
   /**
    * Creates a weight initializer that initializes all of the weights to a


### PR DESCRIPTION
Adding normal distribution as a way of initializing weights for neural networks. 