### PR TITLE
Introduce abstraction around Grand Central Dispatch or pthread-based thread pools

### DIFF
--- a/src/ml/neural_net/CMakeLists.txt
+++ b/src/ml/neural_net/CMakeLists.txt
@@ -60,13 +60,22 @@ endif()
 
 set(TF_BUILD_DIR ${CMAKE_BINARY_DIR}/src/python/turicreate/toolkits)
 
+if(APPLE)
+  set(additonal_unity_neural_net_sources GrandCentralDispatchQueue.cpp)
+else()
+  set(additonal_unity_neural_net_sources "")
+endif()
+
 make_library(unity_neural_net OBJECT
   SOURCES
+    TaskQueue.cpp
+    PosixTaskQueue.cpp
     compute_context.cpp
     float_array.cpp
     image_augmentation.cpp
     model_spec.cpp
     weight_init.cpp
+    ${additonal_unity_neural_net_sources}
   REQUIRES
     image_type
     logger

--- a/src/ml/neural_net/GrandCentralDispatchQueue.cpp
+++ b/src/ml/neural_net/GrandCentralDispatchQueue.cpp
@@ -1,0 +1,64 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <ml/neural_net/GrandCentralDispatchQueue.hpp>
+
+namespace turi {
+namespace neural_net {
+
+// static
+std::shared_ptr<GrandCentralDispatchQueue>
+GrandCentralDispatchQueue::GetGlobalConcurrentQueue() {
+  // We use a pointer to a shared_ptr to guarantee that the singleton is never
+  // deconstructed, even when main() ends, in case background threads are still
+  // trying to call this function.
+  static const auto* const singleton =
+      new std::shared_ptr<GrandCentralDispatchQueue>(
+          std::make_shared<GrandCentralDispatchQueue>(
+              dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)));
+  return *singleton;
+}
+
+// static
+std::shared_ptr<GrandCentralDispatchQueue>
+GrandCentralDispatchQueue::CreateSerialQueue(const char* label) {
+  dispatch_queue_t impl = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
+  auto result = std::make_shared<GrandCentralDispatchQueue>(impl);
+  dispatch_release(impl);
+  return result;
+}
+
+GrandCentralDispatchQueue::GrandCentralDispatchQueue(dispatch_queue_t impl)
+    : impl_(impl) {
+  dispatch_retain(impl_);
+}
+
+GrandCentralDispatchQueue::~GrandCentralDispatchQueue() {
+  dispatch_release(impl_);
+}
+
+void GrandCentralDispatchQueue::DispatchAsync(std::function<void()> task) {
+  dispatch_async(impl_, ^{
+    task();
+  });
+}
+
+void GrandCentralDispatchQueue::DispatchSync(std::function<void()> task) {
+  dispatch_sync(impl_, ^{
+    task();
+  });
+}
+
+void GrandCentralDispatchQueue::DispatchApply(
+    size_t n, std::function<void(size_t i)> task) {
+  dispatch_apply(n, impl_, ^(size_t i) {
+    task(i);
+  });
+}
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/GrandCentralDispatchQueue.hpp
+++ b/src/ml/neural_net/GrandCentralDispatchQueue.hpp
@@ -1,0 +1,43 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#pragma once
+
+#include <dispatch/dispatch.h>
+
+#include <ml/neural_net/TaskQueue.hpp>
+
+namespace turi {
+namespace neural_net {
+
+/// Concrete TaskQueue implementation wrapping Grand Central Dispatch/
+class GrandCentralDispatchQueue : public TaskQueue {
+ public:
+  static std::shared_ptr<GrandCentralDispatchQueue> GetGlobalConcurrentQueue();
+  static std::shared_ptr<GrandCentralDispatchQueue> CreateSerialQueue(
+      const char* label);
+
+  GrandCentralDispatchQueue(dispatch_queue_t impl);
+  ~GrandCentralDispatchQueue();
+
+  // Not movable or copyable.
+  GrandCentralDispatchQueue(const GrandCentralDispatchQueue&) = delete;
+  GrandCentralDispatchQueue(GrandCentralDispatchQueue&&) = delete;
+  GrandCentralDispatchQueue& operator=(const GrandCentralDispatchQueue&) =
+      delete;
+  GrandCentralDispatchQueue& operator=(GrandCentralDispatchQueue&&) = delete;
+
+  void DispatchAsync(std::function<void()> task) override;
+  void DispatchSync(std::function<void()> task) override;
+  void DispatchApply(size_t n, std::function<void(size_t i)> task) override;
+
+ private:
+  dispatch_queue_t impl_;
+};
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/PosixTaskQueue.cpp
+++ b/src/ml/neural_net/PosixTaskQueue.cpp
@@ -41,6 +41,8 @@ void PosixTaskQueue::DispatchSync(std::function<void()> task) {
 SerialPosixTaskQueue::SerialPosixTaskQueue(size_t num_threads)
     : threads_(num_threads) {}
 
+SerialPosixTaskQueue::~SerialPosixTaskQueue() = default;
+
 thread_pool& SerialPosixTaskQueue::GetThreadPool() { return threads_; }
 
 void SerialPosixTaskQueue::DispatchApply(size_t n,
@@ -51,6 +53,17 @@ void SerialPosixTaskQueue::DispatchApply(size_t n,
     }
   });
 }
+
+GlobalPosixTaskQueue::GlobalPosixTaskQueue() = default;
+GlobalPosixTaskQueue::~GlobalPosixTaskQueue() = default;
+
+GlobalPosixTaskQueue::GlobalPosixTaskQueue(const GlobalPosixTaskQueue&) =
+    default;
+GlobalPosixTaskQueue::GlobalPosixTaskQueue(GlobalPosixTaskQueue&&) = default;
+GlobalPosixTaskQueue& GlobalPosixTaskQueue::operator=(
+    const GlobalPosixTaskQueue&) = default;
+GlobalPosixTaskQueue& GlobalPosixTaskQueue::operator=(GlobalPosixTaskQueue&&) =
+    default;
 
 thread_pool& GlobalPosixTaskQueue::GetThreadPool() {
   return thread_pool::get_instance();

--- a/src/ml/neural_net/PosixTaskQueue.cpp
+++ b/src/ml/neural_net/PosixTaskQueue.cpp
@@ -1,0 +1,68 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <ml/neural_net/PosixTaskQueue.hpp>
+
+#include <core/parallel/lambda_omp.hpp>
+
+namespace turi {
+namespace neural_net {
+
+// static
+std::shared_ptr<PosixTaskQueue> PosixTaskQueue::GetGlobalConcurrentQueue() {
+  // We use a pointer to a shared_ptr to guarantee that the singleton is never
+  // deconstructed, even when main() ends, in case background threads are still
+  // trying to call this function.
+  static const auto* const singleton = new std::shared_ptr<PosixTaskQueue>(
+      std::make_shared<GlobalPosixTaskQueue>());
+  return *singleton;
+}
+
+// static
+std::shared_ptr<PosixTaskQueue> PosixTaskQueue::CreateSerialQueue(
+    const char* label) {
+  return std::make_shared<SerialPosixTaskQueue>(/* num_threads */ 1);
+}
+
+void PosixTaskQueue::DispatchAsync(std::function<void()> task) {
+  GetThreadPool().launch(task);
+}
+
+void PosixTaskQueue::DispatchSync(std::function<void()> task) {
+  parallel_task_queue queue(GetThreadPool());
+  queue.launch(task);
+  queue.join();
+}
+
+SerialPosixTaskQueue::SerialPosixTaskQueue(size_t num_threads)
+    : threads_(num_threads) {}
+
+thread_pool& SerialPosixTaskQueue::GetThreadPool() { return threads_; }
+
+void SerialPosixTaskQueue::DispatchApply(size_t n,
+                                         std::function<void(size_t i)> task) {
+  TaskQueue::DispatchSync([n, task] {
+    for (size_t i = 0; i < n; ++i) {
+      task(i);
+    }
+  });
+}
+
+thread_pool& GlobalPosixTaskQueue::GetThreadPool() {
+  return thread_pool::get_instance();
+}
+
+void GlobalPosixTaskQueue::DispatchApply(size_t n,
+                                         std::function<void(size_t i)> task) {
+  // Just use turi::parallel_for, which always uses thread_pool::get_instance().
+  // This implementation slices the n logical iterations into k slices and
+  // dispatches to k threads, where k is the number of CPU cores.
+  parallel_for(0, n, task);
+}
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/PosixTaskQueue.cpp
+++ b/src/ml/neural_net/PosixTaskQueue.cpp
@@ -45,7 +45,7 @@ thread_pool& SerialPosixTaskQueue::GetThreadPool() { return threads_; }
 
 void SerialPosixTaskQueue::DispatchApply(size_t n,
                                          std::function<void(size_t i)> task) {
-  TaskQueue::DispatchSync([n, task] {
+  DispatchSync([n, task] {
     for (size_t i = 0; i < n; ++i) {
       task(i);
     }

--- a/src/ml/neural_net/PosixTaskQueue.hpp
+++ b/src/ml/neural_net/PosixTaskQueue.hpp
@@ -31,7 +31,7 @@ class PosixTaskQueue : public TaskQueue {
 class SerialPosixTaskQueue : public PosixTaskQueue {
  public:
   SerialPosixTaskQueue(size_t num_threads);
-  ~SerialPosixTaskQueue() override = default;
+  ~SerialPosixTaskQueue() override;
 
   // Not copyable or movable.
   SerialPosixTaskQueue(const SerialPosixTaskQueue&) = delete;
@@ -52,14 +52,14 @@ class SerialPosixTaskQueue : public PosixTaskQueue {
 /// thread_pool.
 class GlobalPosixTaskQueue : public PosixTaskQueue {
  public:
-  GlobalPosixTaskQueue() = default;
-  ~GlobalPosixTaskQueue() override = default;
+  GlobalPosixTaskQueue();
+  ~GlobalPosixTaskQueue() override;
 
   // Copyable or movable (but what's the point?)
-  GlobalPosixTaskQueue(const GlobalPosixTaskQueue&) = default;
-  GlobalPosixTaskQueue(GlobalPosixTaskQueue&&) = default;
-  GlobalPosixTaskQueue& operator=(const GlobalPosixTaskQueue&) = default;
-  GlobalPosixTaskQueue& operator=(GlobalPosixTaskQueue&&) = default;
+  GlobalPosixTaskQueue(const GlobalPosixTaskQueue&);
+  GlobalPosixTaskQueue(GlobalPosixTaskQueue&&);
+  GlobalPosixTaskQueue& operator=(const GlobalPosixTaskQueue&);
+  GlobalPosixTaskQueue& operator=(GlobalPosixTaskQueue&&);
 
   void DispatchApply(size_t n, std::function<void(size_t i)> task) override;
 

--- a/src/ml/neural_net/PosixTaskQueue.hpp
+++ b/src/ml/neural_net/PosixTaskQueue.hpp
@@ -1,0 +1,71 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#pragma once
+
+#include <core/parallel/thread_pool.hpp>
+#include <ml/neural_net/TaskQueue.hpp>
+
+namespace turi {
+namespace neural_net {
+
+/// Abstract implementation of TaskQueue that wraps turi::thread_pool
+class PosixTaskQueue : public TaskQueue {
+ public:
+  static std::shared_ptr<PosixTaskQueue> GetGlobalConcurrentQueue();
+  static std::shared_ptr<PosixTaskQueue> CreateSerialQueue(const char* label);
+
+  void DispatchAsync(std::function<void()> task) override;
+  void DispatchSync(std::function<void()> task) override;
+
+ protected:
+  virtual thread_pool& GetThreadPool() = 0;
+};
+
+/// Concrete implementation of PosixTaskQueue that owns a private thread_pool
+/// instance.
+class SerialPosixTaskQueue : public PosixTaskQueue {
+ public:
+  SerialPosixTaskQueue(size_t num_threads);
+  ~SerialPosixTaskQueue() override = default;
+
+  // Not copyable or movable.
+  SerialPosixTaskQueue(const SerialPosixTaskQueue&) = delete;
+  SerialPosixTaskQueue(SerialPosixTaskQueue&&) = delete;
+  SerialPosixTaskQueue& operator=(const SerialPosixTaskQueue&) = delete;
+  SerialPosixTaskQueue& operator=(SerialPosixTaskQueue&&) = delete;
+
+  void DispatchApply(size_t n, std::function<void(size_t i)> task) override;
+
+ protected:
+  thread_pool& GetThreadPool() override;
+
+ private:
+  thread_pool threads_;
+};
+
+/// Concrete implementation of PosixTaskQueue that wraps the global singleton
+/// thread_pool.
+class GlobalPosixTaskQueue : public PosixTaskQueue {
+ public:
+  GlobalPosixTaskQueue() = default;
+  ~GlobalPosixTaskQueue() override = default;
+
+  // Copyable or movable (but what's the point?)
+  GlobalPosixTaskQueue(const GlobalPosixTaskQueue&) = default;
+  GlobalPosixTaskQueue(GlobalPosixTaskQueue&&) = default;
+  GlobalPosixTaskQueue& operator=(const GlobalPosixTaskQueue&) = default;
+  GlobalPosixTaskQueue& operator=(GlobalPosixTaskQueue&&) = default;
+
+  void DispatchApply(size_t n, std::function<void(size_t i)> task) override;
+
+ protected:
+  thread_pool& GetThreadPool() override;
+};
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/TaskQueue.cpp
+++ b/src/ml/neural_net/TaskQueue.cpp
@@ -1,0 +1,38 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <ml/neural_net/TaskQueue.hpp>
+
+#ifdef __APPLE__
+#include <ml/neural_net/GrandCentralDispatchQueue.hpp>
+#elif
+#include <ml/neural_net/PosixTaskQueue.hpp>
+#endif
+
+namespace turi {
+namespace neural_net {
+
+// static
+std::shared_ptr<TaskQueue> TaskQueue::GetGlobalConcurrentQueue() {
+#ifdef __APPLE__
+  return GrandCentralDispatchQueue::GetGlobalConcurrentQueue();
+#elif
+  return PosixTaskQueue::GetGlobalConcurrentQueue();
+#endif
+}
+
+// static
+std::shared_ptr<TaskQueue> TaskQueue::CreateSerialQueue(const char* label) {
+#ifdef __APPLE__
+  return GrandCentralDispatchQueue::CreateSerialQueue(label);
+#elif
+  return PosixTaskQueue::CreateSerialQueue(label);
+#endif
+}
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/TaskQueue.cpp
+++ b/src/ml/neural_net/TaskQueue.cpp
@@ -9,7 +9,7 @@
 
 #ifdef __APPLE__
 #include <ml/neural_net/GrandCentralDispatchQueue.hpp>
-#elif
+#else
 #include <ml/neural_net/PosixTaskQueue.hpp>
 #endif
 
@@ -20,7 +20,7 @@ namespace neural_net {
 std::shared_ptr<TaskQueue> TaskQueue::GetGlobalConcurrentQueue() {
 #ifdef __APPLE__
   return GrandCentralDispatchQueue::GetGlobalConcurrentQueue();
-#elif
+#else
   return PosixTaskQueue::GetGlobalConcurrentQueue();
 #endif
 }
@@ -29,7 +29,7 @@ std::shared_ptr<TaskQueue> TaskQueue::GetGlobalConcurrentQueue() {
 std::shared_ptr<TaskQueue> TaskQueue::CreateSerialQueue(const char* label) {
 #ifdef __APPLE__
   return GrandCentralDispatchQueue::CreateSerialQueue(label);
-#elif
+#else
   return PosixTaskQueue::CreateSerialQueue(label);
 #endif
 }

--- a/src/ml/neural_net/TaskQueue.hpp
+++ b/src/ml/neural_net/TaskQueue.hpp
@@ -29,16 +29,16 @@ class TaskQueue {
   virtual ~TaskQueue() = default;
 
   /// Submits a function to this task queue without waiting for the function to
-  /// finish.
+  /// finish. The task must not throw an exception.
   virtual void DispatchAsync(std::function<void()> task) = 0;
 
   /// Submits a function to this task queue and waits for the function to
-  /// execute.
+  /// execute. The task must not throw an exception.
   virtual void DispatchSync(std::function<void()> task) = 0;
 
   /// Submits a function to this task queue n times, with arguments ranging from
   /// 0 to n - 1. When dispatched to a concurrent queue, the function must be
-  /// reentrant.
+  /// reentrant. Rethrows the first exception thrown by any task invocation.
   virtual void DispatchApply(size_t n, std::function<void(size_t i)> task) = 0;
 };
 

--- a/src/ml/neural_net/TaskQueue.hpp
+++ b/src/ml/neural_net/TaskQueue.hpp
@@ -1,0 +1,46 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace turi {
+namespace neural_net {
+
+/// Abstract task queue interface modeled after Grand Central Dispatch
+class TaskQueue {
+ public:
+  /// Returns a task queue that does not enforce any ordering among its tasks
+  /// and that shares system resources with other task queues created by this
+  /// function.
+  static std::shared_ptr<TaskQueue> GetGlobalConcurrentQueue();
+
+  /// Returns a task queue that guarantees that if task A is submitted before
+  /// task B, then task A will finish before task B begins. Accepts a label that
+  /// may be used by the system to identify work done by this queue.
+  static std::shared_ptr<TaskQueue> CreateSerialQueue(const char* label);
+
+  virtual ~TaskQueue() = default;
+
+  /// Submits a function to this task queue without waiting for the function to
+  /// finish.
+  virtual void DispatchAsync(std::function<void()> task) = 0;
+
+  /// Submits a function to this task queue and waits for the function to
+  /// execute.
+  virtual void DispatchSync(std::function<void()> task) = 0;
+
+  /// Submits a function to this task queue n times, with arguments ranging from
+  /// 0 to n - 1. When dispatched to a concurrent queue, the function must be
+  /// reentrant.
+  virtual void DispatchApply(size_t n, std::function<void(size_t i)> task) = 0;
+};
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/combine.hpp
+++ b/src/ml/neural_net/combine.hpp
@@ -20,5 +20,6 @@
 #include <ml/neural_net/combine_futures_subscriber.hpp>
 #include <ml/neural_net/combine_iterator.hpp>
 #include <ml/neural_net/combine_map.hpp>
+#include <ml/neural_net/combine_queue.hpp>
 
 #endif  // ML_NEURAL_NET_COMBINE_HPP_

--- a/src/ml/neural_net/combine_base.hpp
+++ b/src/ml/neural_net/combine_base.hpp
@@ -18,6 +18,8 @@
 #include <exception>
 #include <memory>
 
+#include <ml/neural_net/TaskQueue.hpp>
+
 namespace turi {
 namespace neural_net {
 
@@ -35,6 +37,12 @@ class FuturesSubscriber;
 
 template <typename T, typename U>
 class MapPublisher;
+
+template <typename T>
+class ReceiveOnQueuePublisher;
+
+template <typename T>
+class SubscribeOnQueuePublisher;
 
 template <typename T, typename U>
 class Transform;
@@ -248,6 +256,18 @@ class Publisher : public std::enable_shared_from_this<Publisher<T>> {
     using TransformType = CallableTransform<Output, Callable>;
     auto transform = std::make_shared<TransformType>(std::move(fn));
     return Map(std::move(transform));
+  }
+
+  std::shared_ptr<Publisher<Output>> SubscribeOn(
+      std::shared_ptr<TaskQueue> queue) {
+    return std::make_shared<SubscribeOnQueuePublisher<Output>>(
+        this->shared_from_this(), std::move(queue));
+  }
+
+  std::shared_ptr<Publisher<Output>> ReceiveOn(
+      std::shared_ptr<TaskQueue> queue) {
+    return std::make_shared<ReceiveOnQueuePublisher<Output>>(
+        this->shared_from_this(), std::move(queue));
   }
 };
 

--- a/src/ml/neural_net/combine_mock.hpp
+++ b/src/ml/neural_net/combine_mock.hpp
@@ -35,6 +35,11 @@ R Call(std::queue<std::function<R(Args...)>> *callbacks, Args &&... args) {
 
 class MockSubscription : public Subscription {
  public:
+  ~MockSubscription() override {
+    TS_ASSERT(cancel_callbacks.empty());
+    TS_ASSERT(demand_callbacks.empty());
+  }
+
   void Cancel() override { return Call(&cancel_callbacks); }
   std::queue<std::function<void()>> cancel_callbacks;
 
@@ -48,6 +53,12 @@ template <typename T>
 class MockSubscriber : public Subscriber<T> {
  public:
   using Input = T;
+
+  ~MockSubscriber() override {
+    TS_ASSERT(subscription_callbacks.empty());
+    TS_ASSERT(input_callbacks.empty());
+    TS_ASSERT(completion_callbacks.empty());
+  }
 
   void Receive(std::shared_ptr<Subscription> subscription) override {
     return Call(&subscription_callbacks, std::move(subscription));
@@ -70,6 +81,8 @@ template <typename T>
 class MockPublisher : public Publisher<T> {
  public:
   using Output = T;
+
+  ~MockPublisher() override { TS_ASSERT(subscriber_callbacks.empty()); }
 
   void Receive(std::shared_ptr<Subscriber<Output>> subscriber) override {
     return Call(&subscriber_callbacks, std::move(subscriber));

--- a/src/ml/neural_net/combine_queue.hpp
+++ b/src/ml/neural_net/combine_queue.hpp
@@ -1,0 +1,231 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#pragma once
+
+#include <ml/neural_net/TaskQueue.hpp>
+#include <ml/neural_net/combine_base.hpp>
+
+namespace turi {
+namespace neural_net {
+
+/**
+ * Publisher that implements the Publisher::SubscribeOn operator.
+ *
+ * The resulting Publisher simply dispatches subscription requests, demands, and
+ * cancellations to a specified task queue. It inherits the semantics of the
+ * upstream Publisher that it wraps, with regard to the behavior with multiple
+ * downstream subscribers.
+ */
+template <typename T>
+class SubscribeOnQueuePublisher : public Publisher<T> {
+ public:
+  using Output = T;
+
+  SubscribeOnQueuePublisher(std::shared_ptr<Publisher<Output>> upstream,
+                            std::shared_ptr<TaskQueue> queue)
+      : upstream_(std::move(upstream)), queue_(std::move(queue)) {}
+  ~SubscribeOnQueuePublisher() override = default;
+
+  // Any attempt to copy or move instances of this class is likely an error. All
+  // instances should be allocated with std::make_shared.
+  SubscribeOnQueuePublisher(const SubscribeOnQueuePublisher&) = delete;
+  SubscribeOnQueuePublisher(SubscribeOnQueuePublisher&&) = delete;
+  SubscribeOnQueuePublisher& operator=(const SubscribeOnQueuePublisher&) =
+      delete;
+  SubscribeOnQueuePublisher& operator=(SubscribeOnQueuePublisher&&) = delete;
+
+  void Receive(std::shared_ptr<Subscriber<Output>> subscriber) override {
+    // Pass a proxy for this subscriber to the upstream publisher, but do so on
+    // the requested task queue.
+    std::shared_ptr<Publisher<Output>> upstream = upstream_;
+    auto impl = std::make_shared<Proxy>(std::move(subscriber), queue_);
+    queue_->DispatchAsync([upstream, impl] { upstream->Subscribe(impl); });
+  }
+
+ private:
+  // This class serves as an intermediary between the upstream publisher and the
+  // downstream subscriber.
+  class Proxy : public std::enable_shared_from_this<Proxy>,
+                public Subscriber<Output>,
+                public Subscription {
+   public:
+    Proxy(std::shared_ptr<Subscriber<Output>> downstream,
+          std::shared_ptr<TaskQueue> queue)
+        : downstream_(std::move(downstream)), queue_(std::move(queue)) {}
+    ~Proxy() override = default;
+
+    // Any attempt to copy or move instances of this class is likely an error.
+    // All instances should be allocated with std::make_shared.
+    Proxy(const Proxy&) = delete;
+    Proxy(Proxy&&) = delete;
+    Proxy& operator=(const Proxy&) = delete;
+    Proxy& operator=(Proxy&&) = delete;
+
+    // Subscriber<Output> interface, for upstream publisher
+
+    void Receive(std::shared_ptr<Subscription> subscription) override {
+      assert(downstream_);  // We cannot have been canceled yet.
+
+      // Intercept (and store) the subscription we receive from the upstream
+      // publisher.
+      subscription_ = std::move(subscription);
+
+      // Pass ourselves to the downstream subscriber. We will serve as a
+      // proxy. From here on out, we can be canceled at any time.
+      downstream_->Receive(this->shared_from_this());
+    }
+
+    Demand Receive(Output element) override {
+      // Do nothing if we are already cancelled.
+      if (!downstream_) return Demand::None();
+
+      return downstream_->Receive(std::move(element));
+    }
+
+    void Receive(Completion completion) override {
+      // Do nothing if we are already cancelled.
+      if (!downstream_) return;
+
+      downstream_->Receive(std::move(completion));
+    }
+
+    // Subscription interface, for downstream subscriber
+
+    void Cancel() override {
+      // Do nothing if we are already cancelled.
+      if (!downstream_) return;
+
+      // Ensure that we send no further signals to the downstream subscriber.
+      downstream_ = nullptr;
+
+      // Forward the cancel request to the upstream publisher, but do so on the
+      // requested task queue.
+      std::shared_ptr<Subscription> subscription = subscription_;
+      queue_->DispatchAsync([subscription] { subscription->Cancel(); });
+    }
+
+    void Request(Demand demand) override {
+      // Do nothing if we are already cancelled.
+      if (!downstream_) return;
+
+      // Forward the request to the upstream publisher, but do so on the
+      // requested task queue.
+      std::shared_ptr<Subscription> subscription = subscription_;
+      queue_->DispatchAsync(
+          [subscription, demand] { subscription->Request(demand); });
+    }
+
+   private:
+    std::shared_ptr<Subscriber<Output>> downstream_;
+    std::shared_ptr<TaskQueue> queue_;
+    std::shared_ptr<Subscription> subscription_;
+  };
+
+  std::shared_ptr<Publisher<Output>> upstream_;
+  std::shared_ptr<TaskQueue> queue_;
+};
+
+/**
+ * Publisher that implements the Publisher::ReceiveOn operator.
+ *
+ * The resulting Publisher simply dispatches subscriptions, values, and
+ * completions to a specified task queue. It inherits the semantics of the
+ * upstream Publisher that it wraps, with regard to the behavior with multiple
+ * downstream subscribers.
+ */
+template <typename T>
+class ReceiveOnQueuePublisher : public Publisher<T> {
+ public:
+  using Output = T;
+
+  ReceiveOnQueuePublisher(std::shared_ptr<Publisher<Output>> upstream,
+                          std::shared_ptr<TaskQueue> queue)
+      : upstream_(std::move(upstream)), queue_(std::move(queue)) {}
+  ~ReceiveOnQueuePublisher() override = default;
+
+  // Any attempt to copy or move instances of this class is likely an error. All
+  // instances should be allocated with std::make_shared.
+  ReceiveOnQueuePublisher(const ReceiveOnQueuePublisher&) = delete;
+  ReceiveOnQueuePublisher(ReceiveOnQueuePublisher&&) = delete;
+  ReceiveOnQueuePublisher& operator=(const ReceiveOnQueuePublisher&) = delete;
+  ReceiveOnQueuePublisher& operator=(ReceiveOnQueuePublisher&&) = delete;
+
+  void Receive(std::shared_ptr<Subscriber<Output>> subscriber) override {
+    auto proxy = std::make_shared<Proxy>(std::move(subscriber), queue_);
+    upstream_->Subscribe(std::move(proxy));
+  }
+
+ private:
+  // This class serves as an intermediary between the upstream publisher and the
+  // downstream subscriber.
+  class Proxy : public Subscriber<Output> {
+   public:
+    Proxy(std::shared_ptr<Subscriber<Output>> downstream,
+          std::shared_ptr<TaskQueue> queue)
+        : downstream_(std::move(downstream)), queue_(std::move(queue)) {}
+    ~Proxy() override = default;
+
+    // Any attempt to copy or move instances of this class is likely an error.
+    // All instances should be allocated with std::make_shared.
+    Proxy(const Proxy&) = delete;
+    Proxy(Proxy&&) = delete;
+    Proxy& operator=(const Proxy&) = delete;
+    Proxy& operator=(Proxy&&) = delete;
+
+    void Receive(std::shared_ptr<Subscription> subscription) override {
+      // Store a reference to the subscription so we can request incremental
+      // demands resulting from async delivery of values.
+      subscription_ = subscription;
+
+      // Send the subscription to the downstream subscriber on the requested
+      // task queue.
+      std::shared_ptr<Subscriber<Output>> downstream = downstream_;
+      queue_->DispatchAsync(
+          [downstream, subscription] { downstream->Receive(subscription); });
+    }
+
+    Demand Receive(Output element) override {
+      // Send the element to the downstream subscriber on the requested task
+      // queue.
+      std::shared_ptr<Subscriber<Output>> downstream = downstream_;
+      std::shared_ptr<Output> shared_element =
+          std::make_shared<Output>(std::move(element));
+      std::shared_ptr<Subscription> subscription = subscription_;
+      queue_->DispatchAsync([downstream, subscription, shared_element] {
+        Demand demand = downstream->Receive(std::move(*shared_element));
+
+        // If the subscriber immediately demands more, dispatch a new request.
+        if (!demand.IsNone()) {
+          subscription->Request(demand);
+        }
+      });
+
+      // Don't wait for the subscriber to respond.
+      return Demand::None();
+    }
+
+    void Receive(Completion completion) override {
+      // Send the completion to the downstream subscriber on the requested task
+      // queue.
+      std::shared_ptr<Subscriber<Output>> downstream = downstream_;
+      queue_->DispatchAsync(
+          [downstream, completion] { downstream->Receive(completion); });
+    }
+
+   private:
+    std::shared_ptr<Subscriber<Output>> downstream_;
+    std::shared_ptr<TaskQueue> queue_;
+    std::shared_ptr<Subscription> subscription_;
+  };
+
+  std::shared_ptr<Publisher<Output>> upstream_;
+  std::shared_ptr<TaskQueue> queue_;
+};
+
+}  // namespace neural_net
+}  // namespace turi

--- a/test/unity/toolkits/neural_net/CMakeLists.txt
+++ b/test/unity/toolkits/neural_net/CMakeLists.txt
@@ -4,6 +4,7 @@ make_boost_test(test_combine_base.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_combine_futures_subscriber.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_combine_iterator.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_combine_map.cxx REQUIRES unity_shared_for_testing)
+make_boost_test(test_combine_queue.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_image_augmentation.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_model_spec.cxx REQUIRES unity_shared_for_testing)
 

--- a/test/unity/toolkits/neural_net/CMakeLists.txt
+++ b/test/unity/toolkits/neural_net/CMakeLists.txt
@@ -8,6 +8,12 @@ make_boost_test(test_combine_queue.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_image_augmentation.cxx REQUIRES unity_shared_for_testing)
 make_boost_test(test_model_spec.cxx REQUIRES unity_shared_for_testing)
 
+make_boost_test(PosixTaskQueueTests.cxx REQUIRES unity_shared_for_testing)
+
+if(APPLE)
+  make_boost_test(GrandCentralDispatchQueueTests.cxx REQUIRES unity_shared_for_testing)
+endif()
+
 if(APPLE AND HAS_MPS AND NOT TC_BUILD_IOS)
   make_boost_test(test_mps_image_augmentation.cxx REQUIRES unity_shared_for_testing)
 endif()

--- a/test/unity/toolkits/neural_net/GrandCentralDispatchQueueTests.cxx
+++ b/test/unity/toolkits/neural_net/GrandCentralDispatchQueueTests.cxx
@@ -1,0 +1,77 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE GrandCentralDispatchQueueTests
+
+#include <ml/neural_net/GrandCentralDispatchQueue.hpp>
+
+#include <future>
+#include <mutex>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+struct TestException : public std::exception {};
+
+static const char kQueueLabel[] =
+    "com.apple.TuriCreate.GrandCentralDispatchQueueTests";
+
+BOOST_AUTO_TEST_CASE(TestSerialQueueDispatchAsync) {
+  std::shared_ptr<TaskQueue> queue =
+      GrandCentralDispatchQueue::CreateSerialQueue(kQueueLabel);
+  std::promise<void> completion_promise;
+  std::future<void> completion_future = completion_promise.get_future();
+  queue->DispatchAsync(
+      [&completion_promise] { completion_promise.set_value(); });
+  std::future_status status =
+      completion_future.wait_for(std::chrono::seconds(5));
+  TS_ASSERT(status == std::future_status::ready);
+}
+
+BOOST_AUTO_TEST_CASE(TestSerialQueueDispatchSync) {
+  std::shared_ptr<TaskQueue> queue =
+      GrandCentralDispatchQueue::CreateSerialQueue(kQueueLabel);
+  bool task_executed = false;
+  queue->DispatchSync([&task_executed] { task_executed = true; });
+  TS_ASSERT(task_executed);
+}
+
+BOOST_AUTO_TEST_CASE(TestConcurrentQueueDispatchApplyInvokesAllIndices) {
+  std::shared_ptr<TaskQueue> queue =
+      GrandCentralDispatchQueue::GetGlobalConcurrentQueue();
+  size_t n = 7;
+  std::mutex mutex;
+  std::vector<bool> called(n, false);  // Protected by mutex
+  queue->DispatchApply(n, [&](size_t i) {
+    std::lock_guard<std::mutex> guard(mutex);
+    TS_ASSERT(!called[i]);
+    called[i] = true;
+  });
+  for (size_t i = 0; i < n; ++i) {
+    TS_ASSERT(called[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TestConcurrentQueueDispatchApplyRethrowsException) {
+  std::shared_ptr<TaskQueue> queue =
+      GrandCentralDispatchQueue::GetGlobalConcurrentQueue();
+  auto erroneous_task = [](size_t i) {
+    if (i == 1) {
+      throw TestException();
+    }
+  };
+  TS_ASSERT_THROWS(queue->DispatchApply(7, erroneous_task), TestException);
+}
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi

--- a/test/unity/toolkits/neural_net/PosixTaskQueueTests.cxx
+++ b/test/unity/toolkits/neural_net/PosixTaskQueueTests.cxx
@@ -1,0 +1,74 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE PosixTaskQueueTests
+
+#include <ml/neural_net/PosixTaskQueue.hpp>
+
+#include <future>
+#include <mutex>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+struct TestException : public std::exception {};
+
+static const char kQueueLabel[] = "com.apple.TuriCreate.PosixTaskQueueTests";
+
+BOOST_AUTO_TEST_CASE(TestSerialQueueDispatchAsync) {
+  std::shared_ptr<TaskQueue> queue =
+      PosixTaskQueue::CreateSerialQueue(kQueueLabel);
+  std::promise<void> completion_promise;
+  std::future<void> completion_future = completion_promise.get_future();
+  queue->DispatchAsync(
+      [&completion_promise] { completion_promise.set_value(); });
+  std::future_status status =
+      completion_future.wait_for(std::chrono::seconds(5));
+  TS_ASSERT(status == std::future_status::ready);
+}
+
+BOOST_AUTO_TEST_CASE(TestSerialQueueDispatchSync) {
+  std::shared_ptr<TaskQueue> queue =
+      PosixTaskQueue::CreateSerialQueue(kQueueLabel);
+  bool task_executed = false;
+  queue->DispatchSync([&task_executed] { task_executed = true; });
+  TS_ASSERT(task_executed);
+}
+
+BOOST_AUTO_TEST_CASE(TestConcurrentQueueDispatchApplyInvokesAllIndices) {
+  std::shared_ptr<TaskQueue> queue = PosixTaskQueue::GetGlobalConcurrentQueue();
+  size_t n = 7;
+  std::mutex mutex;
+  std::vector<bool> called(n, false);  // Protected by mutex
+  queue->DispatchApply(n, [&](size_t i) {
+    std::lock_guard<std::mutex> guard(mutex);
+    TS_ASSERT(!called[i]);
+    called[i] = true;
+  });
+  for (size_t i = 0; i < n; ++i) {
+    TS_ASSERT(called[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TestConcurrentQueueDispatchApplyRethrowsException) {
+  std::shared_ptr<TaskQueue> queue = PosixTaskQueue::GetGlobalConcurrentQueue();
+  auto erroneous_task = [](size_t i) {
+    if (i == 1) {
+      throw TestException();
+    }
+  };
+  TS_ASSERT_THROWS(queue->DispatchApply(7, erroneous_task), TestException);
+}
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi

--- a/test/unity/toolkits/neural_net/test_combine_queue.cxx
+++ b/test/unity/toolkits/neural_net/test_combine_queue.cxx
@@ -18,13 +18,14 @@ namespace neural_net {
 namespace {
 
 /// Implementation of TaskQueue that accumulates async tasks in a queue that
-/// must be manually drained (and just performs sync tasks on the calling
-/// thread)
+/// must be manually drained
 class FakeTaskQueue : public TaskQueue {
  public:
   void DispatchAsync(std::function<void()> task) override {
     async_tasks_.emplace_back(std::move(task));
   }
+
+  // Not implemented (unused by test code below)
   void DispatchSync(std::function<void()> task) override {}
   void DispatchApply(size_t n, std::function<void(size_t i)> task) override {}
 

--- a/test/unity/toolkits/neural_net/test_combine_queue.cxx
+++ b/test/unity/toolkits/neural_net/test_combine_queue.cxx
@@ -1,0 +1,293 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#define BOOST_TEST_MODULE test_combine_queue
+
+#include <ml/neural_net/combine_queue.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <core/util/test_macros.hpp>
+#include <ml/neural_net/combine_mock.hpp>
+
+namespace turi {
+namespace neural_net {
+namespace {
+
+/// Implementation of TaskQueue that accumulates async tasks in a queue that
+/// must be manually drained (and just performs sync tasks on the calling
+/// thread)
+class FakeTaskQueue : public TaskQueue {
+ public:
+  void DispatchAsync(std::function<void()> task) override {
+    async_tasks_.emplace_back(std::move(task));
+  }
+  void DispatchSync(std::function<void()> task) override {}
+  void DispatchApply(size_t n, std::function<void(size_t i)> task) override {}
+
+  void PerformOneAsyncTask() {
+    std::function<void()> task = std::move(async_tasks_.front());
+    async_tasks_.pop_front();
+    task();
+  }
+  void PerformAllAsyncTasks() {
+    while (!async_tasks_.empty()) {
+      PerformOneAsyncTask();
+    }
+  }
+
+ private:
+  std::deque<std::function<void()>> async_tasks_;
+};
+
+struct CombineQueueTestFixture {
+  CombineQueueTestFixture()
+      : task_queue_(std::make_shared<FakeTaskQueue>()),
+        mock_publisher_(std::make_shared<MockPublisher<int>>()),
+        mock_subscriber_(std::make_shared<MockSubscriber<int>>()) {}
+
+  // The task queue on which the implementations will schedule signals.
+  std::shared_ptr<FakeTaskQueue> task_queue_;
+
+  // The actual publisher and subscriber joined by the queue-scheduling proxy.
+  std::shared_ptr<MockPublisher<int>> mock_publisher_;
+
+  std::shared_ptr<MockSubscriber<int>> mock_subscriber_;
+};
+
+struct SubscribeOnQueueTestFixture : public CombineQueueTestFixture {
+  SubscribeOnQueueTestFixture() {
+    // Schedule the subscription on the fake task queue. Neither mock should
+    // receive any messages yet.
+    mock_publisher_->SubscribeOn(task_queue_)->Subscribe(mock_subscriber_);
+
+    // When we advance the task queue, the publisher should see (the proxy for)
+    // the subscriber and yield a mock subscription.
+    mock_subscription_ = std::make_shared<MockSubscription>();
+    auto handle_subscriber =
+        [this](std::shared_ptr<Subscriber<int>> subscriber) {
+          // Record the subscriber that we see.
+          received_subscriber_ = subscriber;
+
+          // Yield the mock subscription.
+          subscriber->Receive(mock_subscription_);
+        };
+    mock_publisher_->subscriber_callbacks.emplace(handle_subscriber);
+
+    // When the publisher yields the mock subscription, the subscriber should
+    // immediately see it.
+    auto handle_subscription =
+        [this](std::shared_ptr<Subscription> subscription) {
+          received_subscription_ = std::move(subscription);
+        };
+    mock_subscriber_->subscription_callbacks.emplace(handle_subscription);
+
+    // Trigger the actual subscription.
+    task_queue_->PerformOneAsyncTask();
+  }
+
+  // The mock subscription that the mock publisher emits.
+  std::shared_ptr<MockSubscription> mock_subscription_;
+
+  // The subscriber that the mock publisher receives.
+  std::shared_ptr<Subscriber<int>> received_subscriber_;
+
+  // The subscription that the mock subscriber receives.
+  std::shared_ptr<Subscription> received_subscription_;
+};
+
+BOOST_FIXTURE_TEST_SUITE(SubscribeOnQueueTest, SubscribeOnQueueTestFixture);
+
+BOOST_AUTO_TEST_CASE(TestDemandDispatchesToQueue) {
+  // Schedule a demand for a value. The publisher should not see the demand yet.
+  received_subscription_->Request(Demand(1));
+
+  // When we advance the task queue, the mock subscription should see the
+  // request.
+  auto handle_demand = [this](Demand demand) {
+    TS_ASSERT_EQUALS(demand.max(), 1);
+
+    // Send one value to the subscriber we received.
+    received_subscriber_->Receive(7);
+  };
+  mock_subscription_->demand_callbacks.emplace(handle_demand);
+
+  // When the publisher's subscription sends a value, the actual subscriber
+  // should immediately see it.
+  auto handle_input = [](int input) {
+    TS_ASSERT_EQUALS(input, 7);
+
+    return Demand::None();  // Generates no further requests.
+  };
+  mock_subscriber_->input_callbacks.emplace(handle_input);
+
+  // Trigger the demand.
+  task_queue_->PerformAllAsyncTasks();
+}
+
+BOOST_AUTO_TEST_CASE(TestCancelDispatchesToQueueAndFinalizes) {
+  // Schedule a cancellation. The publisher should not see the cancellation yet.
+  received_subscription_->Cancel();
+
+  // When we advance the task queue, the mock subscription should see the
+  // cancellation.
+  auto handle_cancel = [] {
+    // No need to do anything.
+  };
+  mock_subscription_->cancel_callbacks.emplace(handle_cancel);
+
+  // Trigger the cancellation.
+  task_queue_->PerformAllAsyncTasks();
+  TS_ASSERT(mock_subscription_->cancel_callbacks.empty());
+
+  // No further demands or cancellations should reach the publisher.
+  received_subscription_->Request(Demand(1));
+  received_subscription_->Cancel();
+  task_queue_->PerformAllAsyncTasks();
+}
+
+BOOST_AUTO_TEST_CASE(TestCancelSuppressesMessagesInFlight) {
+  // Schedule a cancellation. The publisher should not see the cancellation yet.
+  received_subscription_->Cancel();
+
+  // No signal that the publisher sends should reach the actual subscriber, even
+  // before the task queue runs. This is not necessary for correctness, since
+  // any values sent must have been requested before the cancellation. So this
+  // is more of an optimization, to suppress unnecessary work.
+  received_subscriber_->Receive(8);
+  received_subscriber_->Receive(Completion::Finished());
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+
+struct ReceiveOnQueueTestFixture : public CombineQueueTestFixture {
+  ReceiveOnQueueTestFixture() {
+    // When we connect the subscriber to the publisher, it should immediately
+    // receive a subscription.
+    mock_subscription_ = std::make_shared<MockSubscription>();
+    auto handle_subscriber =
+        [this](std::shared_ptr<Subscriber<int>> subscriber) {
+          // Record the subscriber that we see.
+          received_subscriber_ = subscriber;
+
+          // Yield the mock subscription.
+          subscriber->Receive(mock_subscription_);
+        };
+    mock_publisher_->subscriber_callbacks.emplace(handle_subscriber);
+
+    // Connect the subscriber to the publisher, dispatching the output from the
+    // publisher to the fake task queue. The subscriber should not see anything
+    // until the task queue actually runs.
+    mock_publisher_->ReceiveOn(task_queue_)->Subscribe(mock_subscriber_);
+    TS_ASSERT(mock_publisher_->subscriber_callbacks.empty());
+
+    // When the task queue runs, the subscriber should finally see the
+    // subscription.
+    auto handle_subscription =
+        [this](std::shared_ptr<Subscription> subscription) {
+          received_subscription_ = std::move(subscription);
+        };
+    mock_subscriber_->subscription_callbacks.emplace(handle_subscription);
+
+    // Trigger delivery of the subscription.
+    task_queue_->PerformOneAsyncTask();
+  }
+
+  // The mock subscription that the mock publisher emits.
+  std::shared_ptr<MockSubscription> mock_subscription_;
+
+  // The subscriber that the mock publisher receives.
+  std::shared_ptr<Subscriber<int>> received_subscriber_;
+
+  // The subscription that the mock subscriber receives.
+  std::shared_ptr<Subscription> received_subscription_;
+};
+
+BOOST_FIXTURE_TEST_SUITE(ReceiveOnQueueTest, ReceiveOnQueueTestFixture);
+
+BOOST_AUTO_TEST_CASE(TestElementsDispatchedToQueue) {
+  // When we request 1 element, the publisher should see the request
+  // immediately.
+  auto handle_demand = [this](Demand demand) {
+    TS_ASSERT_EQUALS(demand.max(), 1);
+
+    Demand incremental_demand = received_subscriber_->Receive(3);
+
+    // Async delivery of inputs always yield no incremental demand.
+    TS_ASSERT(incremental_demand.IsNone());
+  };
+  mock_subscription_->demand_callbacks.emplace(handle_demand);
+
+  // Request 1 input. The subscriber shouldn't see it until the task queue runs.
+  received_subscription_->Request(Demand(1));
+  TS_ASSERT(mock_subscription_->demand_callbacks.empty());
+
+  // When the task queue runs, the subscriber should finally see the element.
+  auto handle_input = [](int input) {
+    TS_ASSERT_EQUALS(input, 3);
+
+    // Yield an incremental demand for another input.
+    return Demand(1);
+  };
+  mock_subscriber_->input_callbacks.emplace(handle_input);
+
+  // The incremental demand should reach the publisher synchronously.
+  auto handle_incremental_demand = [this](Demand demand) {
+    TS_ASSERT_EQUALS(demand.max(), 1);
+
+    Demand incremental_demand = received_subscriber_->Receive(5);
+
+    // Async delivery of inputs always yield no incremental demand.
+    TS_ASSERT(incremental_demand.IsNone());
+  };
+  mock_subscription_->demand_callbacks.emplace(handle_incremental_demand);
+
+  // Trigger delivery of the input.
+  task_queue_->PerformOneAsyncTask();
+  TS_ASSERT(mock_subscriber_->input_callbacks.empty());
+  TS_ASSERT(mock_subscription_->demand_callbacks.empty());
+
+  // The second input, from the incremental demand, should be delivered during
+  // the next task in the queue.
+  auto handle_incremental_input = [](int input) {
+    TS_ASSERT_EQUALS(input, 5);
+
+    return Demand(0);
+  };
+  mock_subscriber_->input_callbacks.emplace(handle_incremental_input);
+  task_queue_->PerformAllAsyncTasks();
+}
+
+BOOST_AUTO_TEST_CASE(TestCompletionDispatchedToQueue) {
+  // When we request 1 element, the publisher should see the request
+  // immediately.
+  auto handle_demand = [this](Demand demand) {
+    TS_ASSERT_EQUALS(demand.max(), 1);
+
+    received_subscriber_->Receive(Completion::Finished());
+  };
+  mock_subscription_->demand_callbacks.emplace(handle_demand);
+
+  // Request 1 input. The subscriber shouldn't see the completion until the task
+  // queue runs.
+  received_subscription_->Request(Demand(1));
+  TS_ASSERT(mock_subscription_->demand_callbacks.empty());
+
+  // When the task queue runs, the subscriber should finally see the completion.
+  auto handle_completion = [](Completion completion) {
+    TS_ASSERT(completion.IsFinished());
+  };
+  mock_subscriber_->completion_callbacks.emplace(handle_completion);
+
+  // Trigger delivery.
+  task_queue_->PerformAllAsyncTasks();
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+
+}  // namespace
+}  // namespace neural_net
+}  // namespace turi


### PR DESCRIPTION
This is just for the deep-learning based toolkits, which are adopting combine-style reactive-streams patterns