### PR TITLE
Update a couple of python dependencies

### DIFF
--- a/scripts/requirements-minimal.txt
+++ b/scripts/requirements-minimal.txt
@@ -2,7 +2,7 @@ numpy==1.16.4
 cython==0.29.10
 decorator==4.4.0
 pandas==0.24.2
-pillow==6.2.0
+pillow==6.2.2
 prettytable==0.7.2
 pytz==2019.1
 future==0.17.1

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,7 +7,7 @@ scipy==1.2.1
 resampy==0.2.1
 scikit-learn==0.20.3
 statsmodels==0.9.0
-tensorflow==2.0.0
+tensorflow==2.0.1
 UISoup==2.5.7
 pyobjc==5.2; sys_platform == 'darwin'
 llvmlite==0.31.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,7 +7,8 @@ scipy==1.2.1
 resampy==0.2.1
 scikit-learn==0.20.3
 statsmodels==0.9.0
-tensorflow==2.0.1
+tensorflow==2.0.1; python_version > '2.7'
+tensorflow==2.0.0; python_version < '3.5'   # Last version to support Python 2.7
 UISoup==2.5.7
 pyobjc==5.2; sys_platform == 'darwin'
 llvmlite==0.31.0


### PR DESCRIPTION
Update dependencies (TensorFlow and Pillow). Must still rely on the old version TensorFlow for Python 2.7; it is the last version to support 2.7.