### PR TITLE
Don't set ccache to use 100G of disk in Gitlab CI

### DIFF
--- a/scripts/use_ccache.sh
+++ b/scripts/use_ccache.sh
@@ -1,2 +1,1 @@
-ccache -M 100.0G
 ccache -s


### PR DESCRIPTION
We should instead honor the ccache settings on the machine we run on. Some machines have less disk and should thus do less caching.