### PR TITLE
Quantize weights from fp32 to fp16

### DIFF
--- a/src/ml/neural_net/CMakeLists.txt
+++ b/src/ml/neural_net/CMakeLists.txt
@@ -82,6 +82,7 @@ make_library(unity_neural_net OBJECT
     image_augmentation.cpp
     model_spec.cpp
     weight_init.cpp
+    quantization_utils.cpp
     ${additonal_unity_neural_net_sources}
   REQUIRES
     image_type

--- a/src/ml/neural_net/float16.h
+++ b/src/ml/neural_net/float16.h
@@ -1,0 +1,20 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#pragma once
+
+#ifdef __APPLE__
+#define TURI_USE_FLOAT16
+#endif
+
+/*
+ Source of the numeric limits -
+ https://github.com/apple/coremltools/blob/a63319be4c70271f229c9f5c3423a97c7535f08b/coremltools/models/utils.py#L172
+ */
+#if defined(TURI_USE_FLOAT16)
+const constexpr __fp16 FLOAT16_NUMERIC_LIMIT_MIN = 0.000061035;
+const constexpr __fp16 FLOAT16_NUMERIC_LIMIT_MAX = 65504;
+#endif

--- a/src/ml/neural_net/float16.h
+++ b/src/ml/neural_net/float16.h
@@ -7,14 +7,18 @@
 #pragma once
 
 #ifdef __APPLE__
+
 #define TURI_USE_FLOAT16
+
 #endif
 
 /*
  Source of the numeric limits -
  https://github.com/apple/coremltools/blob/a63319be4c70271f229c9f5c3423a97c7535f08b/coremltools/models/utils.py#L172
  */
-#if defined(TURI_USE_FLOAT16)
+#ifdef TURI_USE_FLOAT16
+
 const constexpr __fp16 FLOAT16_NUMERIC_LIMIT_MIN = 0.000061035;
 const constexpr __fp16 FLOAT16_NUMERIC_LIMIT_MAX = 65504;
+
 #endif

--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -105,7 +105,9 @@ void update_weight_params(const std::string& name, const float_array& value, Wei
   }
 
   Span<const float> out(value.data(), value.size());
+
 #ifdef TURI_USE_FLOAT16
+
   if (use_quantization && is_convertible_to_fp16(out)) {
     std::vector<__fp16> weights_fp16 = get_half_precision_weights(out);
 
@@ -115,9 +117,12 @@ void update_weight_params(const std::string& name, const float_array& value, Wei
 
   } else {
 #endif
+
     std::copy(out.begin(), out.end(), weights->mutable_floatvalue()->begin());
+
 #ifdef TURI_USE_FLOAT16
   }
+
 #endif
 }
 

--- a/src/ml/neural_net/model_spec.cpp
+++ b/src/ml/neural_net/model_spec.cpp
@@ -14,6 +14,8 @@
 
 #include <core/logging/assertions.hpp>
 #include <core/logging/logger.hpp>
+#include <core/util/Span.hpp>
+#include <ml/neural_net/quantization_utils.hpp>
 #include <toolkits/coreml_export/mlmodel_include.hpp>
 
 namespace turi {
@@ -49,6 +51,9 @@ using CoreML::Specification::TransposeLayerParams;
 using CoreML::Specification::UniDirectionalLSTMLayerParams;
 using CoreML::Specification::UpsampleLayerParams;
 using CoreML::Specification::WeightParams;
+using CoreML::Specification::PoolingLayerParams_PoolingType::PoolingLayerParams_PoolingType_AVERAGE;
+using CoreML::Specification::PoolingLayerParams_PoolingType::PoolingLayerParams_PoolingType_L2;
+using CoreML::Specification::PoolingLayerParams_PoolingType::PoolingLayerParams_PoolingType_MAX;
 
 size_t multiply(size_t a, size_t b) { return a * b; }
 
@@ -89,9 +94,9 @@ private:
   const WeightParams& weights_;
 };
 
-void update_weight_params(const std::string& name, const float_array& value,
-                          WeightParams* weights) {
-
+void update_weight_params(const std::string& name, const float_array& value, WeightParams* weights,
+                          bool use_quantization)
+{
   if (weights->floatvalue_size() != static_cast<int>(value.size())) {
     std::stringstream ss;
     ss << "float_array " << name << " has size " << value.size()
@@ -99,8 +104,21 @@ void update_weight_params(const std::string& name, const float_array& value,
     log_and_throw(ss.str());
   }
 
-  std::copy(value.data(), value.data() + value.size(),
-            weights->mutable_floatvalue()->begin());
+  Span<const float> out(value.data(), value.size());
+#ifdef TURI_USE_FLOAT16
+  if (use_quantization && is_convertible_to_fp16(out)) {
+    std::vector<__fp16> weights_fp16 = get_half_precision_weights(out);
+
+    weights->set_float16value(static_cast<void*>(weights_fp16.data()),
+                              weights_fp16.size() * sizeof(__fp16));
+    weights->clear_floatvalue();
+
+  } else {
+#endif
+    std::copy(out.begin(), out.end(), weights->mutable_floatvalue()->begin());
+#ifdef TURI_USE_FLOAT16
+  }
+#endif
 }
 
 // The overloaded wrap_network_params functions below traverse a CoreML spec
@@ -132,21 +150,20 @@ void wrap_network_params(const std::string& name,
   }
 }
 
-void update_network_params(const std::string& name,
-                           const float_array_map& params,
-                           ConvolutionLayerParams* convolution) {
-
+void update_network_params(const std::string& name, const float_array_map& params,
+                           ConvolutionLayerParams* convolution, bool use_quantization)
+{
   std::string key = name + "_weight";
   auto it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second, convolution->mutable_weights());
+    update_weight_params(key, it->second, convolution->mutable_weights(), use_quantization);
   }
 
   if (convolution->has_bias()) {
     key = name + "_bias";
     it = params.find(key);
     if (it != params.end()) {
-      update_weight_params(key, it->second, convolution->mutable_bias());
+      update_weight_params(key, it->second, convolution->mutable_bias(), use_quantization);
     }
   }
 }
@@ -169,21 +186,20 @@ void wrap_network_params(const std::string& name,
   }
 }
 
-void update_network_params(const std::string& name,
-                           const float_array_map& params,
-                           InnerProductLayerParams* inner_product) {
-
+void update_network_params(const std::string& name, const float_array_map& params,
+                           InnerProductLayerParams* inner_product, bool use_quantization)
+{
   std::string key = name + "_weight";
   auto it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second, inner_product->mutable_weights());
+    update_weight_params(key, it->second, inner_product->mutable_weights(), use_quantization);
   }
 
   if (inner_product->has_bias()) {
     key = name + "_bias";
     it = params.find(key);
     if (it != params.end()) {
-      update_weight_params(key, it->second, inner_product->mutable_bias());
+      update_weight_params(key, it->second, inner_product->mutable_bias(), use_quantization);
     }
   }
 }
@@ -220,32 +236,31 @@ void wrap_network_params(const std::string& name,
   }
 }
 
-void update_network_params(const std::string& name,
-                           const float_array_map& params,
-                           BatchnormLayerParams* batch_norm) {
-
+void update_network_params(const std::string& name, const float_array_map& params,
+                           BatchnormLayerParams* batch_norm, bool use_quantization)
+{
   std::string key = name + "_gamma";
   auto it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second, batch_norm->mutable_gamma());
+    update_weight_params(key, it->second, batch_norm->mutable_gamma(), use_quantization);
   }
 
   key = name + "_beta";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second, batch_norm->mutable_beta());
+    update_weight_params(key, it->second, batch_norm->mutable_beta(), use_quantization);
   }
 
   key = name + "_running_mean";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second, batch_norm->mutable_mean());
+    update_weight_params(key, it->second, batch_norm->mutable_mean(), use_quantization);
   }
 
   key = name + "_running_var";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second, batch_norm->mutable_variance());
+    update_weight_params(key, it->second, batch_norm->mutable_variance(), use_quantization);
   }
 }
 
@@ -305,94 +320,93 @@ void wrap_network_params(const std::string& name,
   params_out->emplace(name + "_h2h_o_bias", std::move(h2h_o_bias));
 }
 
-void update_network_params(const std::string& name,
-                           const float_array_map& params,
-                           UniDirectionalLSTMLayerParams* lstm) {
-
+void update_network_params(const std::string& name, const float_array_map& params,
+                           UniDirectionalLSTMLayerParams* lstm, bool use_quantization)
+{
   auto* lstm_params = lstm->mutable_weightparams();
 
   std::string key = name + "_i2h_i_weight";
   auto it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_inputgateweightmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_inputgateweightmatrix(),
+                         use_quantization);
   }
 
   key = name + "_i2h_f_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_forgetgateweightmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_forgetgateweightmatrix(),
+                         use_quantization);
   }
 
   key = name + "_i2h_c_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_blockinputweightmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_blockinputweightmatrix(),
+                         use_quantization);
   }
 
   key = name + "_i2h_o_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_outputgateweightmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_outputgateweightmatrix(),
+                         use_quantization);
   }
 
   key = name + "_h2h_i_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_inputgaterecursionmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_inputgaterecursionmatrix(),
+                         use_quantization);
   }
 
   key = name + "_h2h_f_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_forgetgaterecursionmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_forgetgaterecursionmatrix(),
+                         use_quantization);
   }
 
   key = name + "_h2h_c_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_blockinputrecursionmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_blockinputrecursionmatrix(),
+                         use_quantization);
   }
 
   key = name + "_h2h_o_weight";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_outputgaterecursionmatrix());
+    update_weight_params(key, it->second, lstm_params->mutable_outputgaterecursionmatrix(),
+                         use_quantization);
   }
 
   key = name + "_h2h_i_bias";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_inputgatebiasvector());
+    update_weight_params(key, it->second, lstm_params->mutable_inputgatebiasvector(),
+                         use_quantization);
   }
 
   key = name + "_h2h_f_bias";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_forgetgatebiasvector());
+    update_weight_params(key, it->second, lstm_params->mutable_forgetgatebiasvector(),
+                         use_quantization);
   }
 
   key = name + "_h2h_c_bias";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_blockinputbiasvector());
+    update_weight_params(key, it->second, lstm_params->mutable_blockinputbiasvector(),
+                         use_quantization);
   }
 
   key = name + "_h2h_o_bias";
   it = params.find(key);
   if (it != params.end()) {
-    update_weight_params(key, it->second,
-                         lstm_params->mutable_outputgatebiasvector());
+    update_weight_params(key, it->second, lstm_params->mutable_outputgatebiasvector(),
+                         use_quantization);
   }
 }
 
@@ -421,25 +435,25 @@ void wrap_network_params(const NeuralNetworkLayer& neural_net_layer,
   }
 }
 
-void update_network_params(const float_array_map& params,
-                           NeuralNetworkLayer* neural_net_layer) {
-
+void update_network_params(const float_array_map& params, NeuralNetworkLayer* neural_net_layer,
+                           bool use_quantization)
+{
   switch (neural_net_layer->layer_case()) {
   case NeuralNetworkLayer::kConvolution:
-    update_network_params(neural_net_layer->name(), params,
-                          neural_net_layer->mutable_convolution());
+    update_network_params(neural_net_layer->name(), params, neural_net_layer->mutable_convolution(),
+                          use_quantization);
     break;
   case NeuralNetworkLayer::kInnerProduct:
     update_network_params(neural_net_layer->name(), params,
-                          neural_net_layer->mutable_innerproduct());
+                          neural_net_layer->mutable_innerproduct(), use_quantization);
     break;
   case NeuralNetworkLayer::kBatchnorm:
-    update_network_params(neural_net_layer->name(), params,
-                          neural_net_layer->mutable_batchnorm());
+    update_network_params(neural_net_layer->name(), params, neural_net_layer->mutable_batchnorm(),
+                          use_quantization);
     break;
   case NeuralNetworkLayer::kUniDirectionalLSTM:
     update_network_params(neural_net_layer->name(), params,
-                          neural_net_layer->mutable_unidirectionallstm());
+                          neural_net_layer->mutable_unidirectionallstm(), use_quantization);
     break;
   default:
     break;
@@ -454,11 +468,11 @@ void wrap_network_params(const NeuralNetwork& neural_net,
   }
 }
 
-void update_network_params(const float_array_map& params,
-                           NeuralNetwork* neural_net) {
-
+void update_network_params(const float_array_map& params, NeuralNetwork* neural_net,
+                           bool use_quantization)
+{
   for (NeuralNetworkLayer& layer : *neural_net->mutable_layers()) {
-    update_network_params(params, &layer);
+    update_network_params(params, &layer, use_quantization);
   }
 }
 
@@ -533,8 +547,9 @@ float_array_map model_spec::export_params_view() const {
   return result;
 }
 
-void model_spec::update_params(const float_array_map& weights) {
-  update_network_params(weights, impl_.get());
+void model_spec::update_params(const float_array_map& weights, bool use_quantization)
+{
+  update_network_params(weights, impl_.get(), use_quantization);
 }
 
 bool model_spec::has_layer_output(const std::string& layer_name) const {
@@ -583,10 +598,10 @@ void model_spec::add_sigmoid(const std::string& name,
 }
 
 void model_spec::add_pooling(const std::string& name, const std::string& input,
-                             size_t kernel_height, size_t kernel_width,
-                             size_t stride_h, size_t stride_w,
-                             padding_type padding,
-                             bool use_poolexcludepadding) {
+                             size_t kernel_height, size_t kernel_width, size_t stride_h,
+                             size_t stride_w, padding_type padding, bool use_poolexcludepadding,
+                             pooling_type pooling)
+{
   NeuralNetworkLayer* layer = impl_->add_layers();
   layer->set_name(name);
   layer->add_input(input);
@@ -606,8 +621,24 @@ void model_spec::add_pooling(const std::string& name, const std::string& input,
       params->mutable_same();
       break;
   }
+
   if (use_poolexcludepadding) {
     params->set_avgpoolexcludepadding(true);
+  }
+
+  switch (pooling) {
+    case pooling_type::MAX:
+      // set to max
+      params->set_type(PoolingLayerParams_PoolingType_MAX);
+      break;
+    case pooling_type::AVERAGE:
+      // set to average
+      params->set_type(PoolingLayerParams_PoolingType_AVERAGE);
+      break;
+    case pooling_type::L2:
+      // set to L2
+      params->set_type(PoolingLayerParams_PoolingType_L2);
+      break;
   }
 }
 

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -122,6 +122,7 @@ public:
    *
    * \param weights A dictionary whose keys follow the same naming scheme used
    *                by `export_params_view`.
+   * \param use_quantization If true, weights are stored in half precision.
    * \throw If a float_array's shape does not match the corresponding
    *        NeuralNetworkLayer.
    */

--- a/src/ml/neural_net/model_spec.hpp
+++ b/src/ml/neural_net/model_spec.hpp
@@ -53,6 +53,9 @@ public:
     ZERO,
   };
 
+  /** Parameter for pooling types. */
+  enum class pooling_type { MAX, AVERAGE, L2 };
+
   /**
    * Creates an empty model_spec (with no layers).
    */
@@ -122,7 +125,7 @@ public:
    * \throw If a float_array's shape does not match the corresponding
    *        NeuralNetworkLayer.
    */
-  void update_params(const float_array_map& weights);
+  void update_params(const float_array_map& weights, bool use_quantization = false);
 
   /**
    * Determines whether the neural network contains a layer with the given
@@ -161,16 +164,20 @@ public:
 
   /**
    * Appends a pooling layer.
-   * By default, it's a max pooling layer. And it can only be max pooling
-   * TODO: be able to set other pooling types
+   * By default, it's a max pooling layer.
    *
+   * It can be of type:
+   *      - MAX
+   *      - AVERAGE
+   *      - L2
+   *
+   * \param pooling this sets the type of pooling this layer performs.
    * \param use_poolexcludepadding padded values are excluded from the
    * count (denominator) when computing average pooling.
    */
-  void add_pooling(const std::string& name, const std::string& input,
-                   size_t kernel_height, size_t kernel_width, size_t stride_h,
-                   size_t stride_w, padding_type padding,
-                   bool use_poolexcludepadding = false);
+  void add_pooling(const std::string& name, const std::string& input, size_t kernel_height,
+                   size_t kernel_width, size_t stride_h, size_t stride_w, padding_type padding,
+                   bool use_poolexcludepadding = false, pooling_type pooling = pooling_type::MAX);
 
   /**
    * Appends a convolution layer.

--- a/src/ml/neural_net/quantization_utils.cpp
+++ b/src/ml/neural_net/quantization_utils.cpp
@@ -11,26 +11,24 @@
 #include <cmath>
 #include <numeric>
 
-#include <ml/neural_net/float16.h>
-
 namespace turi {
 namespace neural_net {
 
 #ifdef TURI_USE_FLOAT16
+
 bool is_convertible_to_fp16(Span<const float> output)
 {
   return std::all_of(output.begin(), output.end(), [](int i) {
     return i > -FLOAT16_NUMERIC_LIMIT_MAX && i < FLOAT16_NUMERIC_LIMIT_MAX;
   });
 }
-#endif
 
-#ifdef TURI_USE_FLOAT16
 std::vector<__fp16> get_half_precision_weights(Span<const float> output)
 {
   std::vector<__fp16> weights_fp16 = std::vector<__fp16>(output.begin(), output.end());
   return weights_fp16;
 }
+
 #endif
 
 }  // namespace neural_net

--- a/src/ml/neural_net/quantization_utils.cpp
+++ b/src/ml/neural_net/quantization_utils.cpp
@@ -1,0 +1,37 @@
+/* Copyright © 2019 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <ml/neural_net/quantization_utils.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+#include <ml/neural_net/float16.h>
+
+namespace turi {
+namespace neural_net {
+
+#ifdef TURI_USE_FLOAT16
+bool is_convertible_to_fp16(Span<const float> output)
+{
+  return std::all_of(output.begin(), output.end(), [](int i) {
+    return i > -FLOAT16_NUMERIC_LIMIT_MAX && i < FLOAT16_NUMERIC_LIMIT_MAX;
+  });
+}
+#endif
+
+#ifdef TURI_USE_FLOAT16
+std::vector<__fp16> get_half_precision_weights(Span<const float> output)
+{
+  std::vector<__fp16> weights_fp16 = std::vector<__fp16>(output.begin(), output.end());
+  return weights_fp16;
+}
+#endif
+
+}  // namespace neural_net
+}  // namespace turi

--- a/src/ml/neural_net/quantization_utils.hpp
+++ b/src/ml/neural_net/quantization_utils.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <core/util/Span.hpp>
 #include <vector>
 
+#include <core/util/Span.hpp>
 #include <ml/neural_net/float16.h>
 
 namespace turi {

--- a/src/ml/neural_net/quantization_utils.hpp
+++ b/src/ml/neural_net/quantization_utils.hpp
@@ -9,15 +9,18 @@
 #include <core/util/Span.hpp>
 #include <vector>
 
+#include <ml/neural_net/float16.h>
+
 namespace turi {
 namespace neural_net {
 
 #ifdef TURI_USE_FLOAT16
+
 bool is_convertible_to_fp16(Span<const float> output);
+
+std::vector<__fp16> get_half_precision_weights(Span<const float> output);
+
 #endif
 
-#ifdef TURI_USE_FLOAT16
-std::vector<__fp16> get_half_precision_weights(Span<const float> output);
-#endif
 }  // namespace neural_net
 }  // namespace turi

--- a/src/ml/neural_net/quantization_utils.hpp
+++ b/src/ml/neural_net/quantization_utils.hpp
@@ -1,0 +1,23 @@
+/* Copyright © 2020 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#pragma once
+
+#include <core/util/Span.hpp>
+#include <vector>
+
+namespace turi {
+namespace neural_net {
+
+#ifdef TURI_USE_FLOAT16
+bool is_convertible_to_fp16(Span<const float> output);
+#endif
+
+#ifdef TURI_USE_FLOAT16
+std::vector<__fp16> get_half_precision_weights(Span<const float> output);
+#endif
+}  // namespace neural_net
+}  // namespace turi

--- a/src/toolkits/object_detection/od_serialization.cpp
+++ b/src/toolkits/object_detection/od_serialization.cpp
@@ -155,7 +155,7 @@ pipeline_spec export_darknet_yolo(
   // Initialize the result with the learned layers from the model_backend.
   std::unique_ptr<model_spec> nn_spec(new model_spec);
   init_darknet_yolo(*nn_spec, num_classes, anchor_boxes.size(), input_name);
-  nn_spec->update_params(weights);
+  nn_spec->update_params(weights, /* use_quantization */ true);
 
   // Add the layers that convert to intelligible predictions.
   add_yolo(nn_spec.get(), coordinates_name, confidence_name, "conv8_fwd",


### PR DESCRIPTION
Adds option to quantize weights post training fp32 to fp16 (only for MacOS)
Enables it for Object Detector model 
Also adds pooling types to model_spec
