### PR TITLE
Add missing include of cassert in combine_queue.hpp

### DIFF
--- a/src/ml/neural_net/combine_queue.hpp
+++ b/src/ml/neural_net/combine_queue.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <ml/neural_net/TaskQueue.hpp>
 #include <ml/neural_net/combine_base.hpp>
 


### PR DESCRIPTION
Analysis found a missing header include; this was relying on implementation-specific recursive includes before