### PR TITLE
Fix visualization build on Xcode 12 Beta

### DIFF
--- a/src/visualization/client/CMakeLists.txt
+++ b/src/visualization/client/CMakeLists.txt
@@ -50,7 +50,7 @@ if(${TC_BUILD_VISUALIZATION_CLIENT})
     message(WARNING "VISUALIZATION_XCODE_INPUT is ${VISUALIZATION_XCODE_INPUT}")
     add_custom_command(
       OUTPUT "${VISUALIZATION_XCODE_OUTPUT}"
-      COMMAND xcodebuild -project "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization.xcodeproj/" -configuration ${CMAKE_BUILD_TYPE} SYMROOT=${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND xcodebuild -project "${CMAKE_CURRENT_SOURCE_DIR}/Turi Create Visualization.xcodeproj/" -configuration ${CMAKE_BUILD_TYPE} -destination "platform=OS X,arch=x86_64" -scheme "Turi Create Visualization" SYMROOT=${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Building visualization client via xcodebuild"
       DEPENDS ${VISUALIZATION_XCODE_INPUT}
       VERBATIM


### PR DESCRIPTION
The latest beta of Xcode 12 results in link errors for the visualization
client, due to an under-specified destination in how we build:
```
Undefined symbols for architecture arm64:
  "__swift_FORCE_LOAD_$_swiftCompatibility50", referenced from:
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in NSWindowWorkaround.o
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in CustomWebKitView.o
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in Error.o
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in ViewController.o
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in AppDelegate.o
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in JSON.o
      __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization in AppData.o
      ...
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCompatibility50_$_Turi_Create_Visualization)
  "__swift_FORCE_LOAD_$_swiftCompatibility51", referenced from:
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in NSWindowWorkaround.o
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in CustomWebKitView.o
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in Error.o
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in ViewController.o
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in AppDelegate.o
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in JSON.o
      __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization in AppData.o
      ...
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCompatibility51_$_Turi_Create_Visualization)
  "__swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements", referenced from:
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in NSWindowWorkaround.o
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in CustomWebKitView.o
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in Error.o
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in ViewController.o
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in AppDelegate.o
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in JSON.o
      __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization in AppData.o
      ...
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements_$_Turi_Create_Visualization)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The fix is to specify the scheme and destination on the command line
args to xcodebuild (for now, limited to x86_64).