### PR TITLE
New pip dependency resolver

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -36,9 +36,9 @@ function linux_patch_sigfpe_handler {
 
 $PIP install --upgrade "pip"
 if [[ "$USE_MINIMAL" -eq 1  ]]; then
-  $PIP install -r scripts/requirements-minimal.txt --prefer-binary
+  $PIP install -r scripts/requirements-minimal.txt --prefer-binary  --use-feature=2020-resolver
 else
-  $PIP install -r scripts/requirements.txt --prefer-binary
+  $PIP install -r scripts/requirements.txt --prefer-binary  --use-feature=2020-resolver
 fi
 
 # install pre-commit hooks for git

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,6 +16,8 @@ scikit-learn==0.23.1; python_version == '3.8'
 statsmodels==0.9.0; python_version < '3.8'
 statsmodels==0.11.1; python_version == '3.8'
 
+tensorflow==2.0.2; sys_platform == 'darwin' and python_version != '2.7' and python_version != '3.8'
+
 UISoup==2.5.7
 
 llvmlite==0.33.0; python_version >= '3.6'

--- a/scripts/test_wheel.sh
+++ b/scripts/test_wheel.sh
@@ -136,7 +136,7 @@ else
   exit 1
 fi
 
-pip install "$wheel_to_install"
+pip install "$wheel_to_install" --use-feature=2020-resolver
 
 PYTHON="$WORKSPACE/deps/env/bin/python"
 PYTHON_MAJOR_VERSION=$(${PYTHON} -c 'import sys; print(sys.version_info.major)')


### PR DESCRIPTION
* Add `--use-feature=2020-resolver` to our Python build/test setup to ensure we stay compatible with the new dependency resolver.
* Also in our Python build/test setup, pin TensorFlow version (for a few Python versions and OS combinations). Without this one of our packages used for unit testing causes a SciPy version conflict.