### PR TITLE
Drawing Classifier: input image resize fix

### DIFF
--- a/src/toolkits/drawing_classifier/dc_data_iterator.cpp
+++ b/src/toolkits/drawing_classifier/dc_data_iterator.cpp
@@ -29,12 +29,11 @@ using neural_net::shared_float_array;
 
 void add_drawing_pixel_data_to_batch(float* next_drawing_pointer,
                                      const flex_image& bitmap) {
-  flex_image resized_bitmap = image_util::resize_image(bitmap, kDrawingWidth, kDrawingHeight, 1, true);
   image_util::copy_image_to_memory(
-      /* image input    */ resized_bitmap,
+      /* image input    */ bitmap,
       /* output pointer */ next_drawing_pointer,
-      /* output strides */ {bitmap.m_width * bitmap.m_channels, bitmap.m_channels, 1},
-      /* output shape   */ {bitmap.m_height, bitmap.m_width, bitmap.m_channels},
+      /* output strides */ {kDrawingWidth * kDrawingChannels, kDrawingChannels, 1},
+      /* output shape   */ {kDrawingHeight, kDrawingWidth, kDrawingChannels},
       /* channel_last   */ true);
 }
 


### PR DESCRIPTION
Fixes #3236. 

This is an update to #3313. An image resize is already happening inside of `image_util::copy_image_to_memory_impl`.