### PR TITLE
Fixed issues in python toolchain setup script.

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -3,7 +3,7 @@
 set -exo pipefail
 
 if [[ -z $VIRTUALENV ]]; then
-  VIRTUALENV=virtualenv
+  VIRTUALENV='python3 -m venv'
 fi
 
 $VIRTUALENV "$(pwd)"/deps/env
@@ -63,7 +63,7 @@ fi
 
 echo "run 'ln -Ffs' files from ${SRC_INCLUDE_DIR}"
 for f in $SRC_INCLUDE_DIR/*; do
-  ln -Ffs "$f" "$(basename "$f")"
+  ln -Ffs "$f" "$(basename "$f")" || echo "Warning: error installing symlink for $f."
 done
 
 popd
@@ -73,7 +73,7 @@ pushd deps/local/bin
 
 echo "run 'ln -Ffs' on files from ../../env/bin/"
 for f in ../../env/bin/*; do
-  ln -Ffs "$f" "$(basename "$f")"
+  ln -Ffs "$f" "$(basename "$f")" || echo "Warning: error installing symlink for $f."
 done
 
 popd


### PR DESCRIPTION
Current python uses `python -m venv` to run virtualenv.  This updates our toolchain setup to reflect this. 

Also fixes a bug in which creating softlinks can cause the script to fail if they are already present.