### PR TITLE
Use new coremltools beta

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -611,27 +611,23 @@ test_python_mac_python37_10_14_minimal:
     paths:
       - pytest.*
 
-# Core ML Tool currently has only beta support for Python 3.8.
-# We can't currently rely on it as part of our CI.
-# See GitHub issue:
-#    https://github.com/apple/coremltools/issues/372
-#test_python_mac_python38_10_15:
-#  tags:
-#    - macos10.15
-#  only:
-#    variables:
-#      - $TC_HAS_MACOS_RUNNERS == "1"
-#  stage: test
-#  dependencies:
-#    - build_wheel_mac_10_15_python38
-#  script:
-#    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/3.8/bin/virtualenv"
-#    - bash -e scripts/test_wheel.sh
-#  artifacts:
-#    when: always
-#    expire_in: 2 weeks
-#    paths:
-#      - pytest.*
+test_python_mac_python38_10_15:
+  tags:
+    - macos10.15
+  only:
+    variables:
+      - $TC_HAS_MACOS_RUNNERS == "1"
+  stage: test
+  dependencies:
+    - build_wheel_mac_10_15_python38
+  script:
+    - export VIRTUALENV="/Library/Frameworks/Python.framework/Versions/3.8/bin/virtualenv"
+    - bash -e scripts/test_wheel.sh
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+      - pytest.*
 
 test_python_mac_python38_10_14_minimal:
   tags:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,8 +2,7 @@
 
 ### extra for full pkg ###
 
-coremltools==3.4; python_version < '3.8'
-coremltools==4.0b3; python_version == '3.8'
+coremltools==4.0b4
 
 scipy==1.2.1; python_version < '3.8'
 scipy==1.5.1; python_version == '3.8'

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -173,17 +173,12 @@ if __name__ == "__main__":
         "requests >= 2.9.1",
         "scipy >= 1.1.0",
         "six >= 1.10.0",
+        "coremltools==4.0b4",
     ]
     if sys.version_info[0] == 2 or (
         sys.version_info[0] == 3 and sys.version_info[1] == 5
     ):
         install_requires.append("llvmlite == 0.31.0")
-
-    if sys.version_info[0] == 3 and sys.version_info[1] == 8:
-        # Only 4.0 betas support Python 3.8
-        install_requires.append("coremltools==4.0b3")
-    else:
-        install_requires.append("coremltools==3.3")
 
     if sys.platform == "darwin":
         install_requires.append("tensorflow >= 2.0.0")


### PR DESCRIPTION
Now that apple/coremltools#372 is fixed, we can use the latest coremltools beta.