### PR TITLE
Drawing Classifier: print progress at round increments

### DIFF
--- a/src/toolkits/drawing_classifier/drawing_classifier.cpp
+++ b/src/toolkits/drawing_classifier/drawing_classifier.cpp
@@ -599,23 +599,23 @@ void drawing_classifier::iterate_training(bool show_loss) {
     if (validation_data_iterator_) {
       if (show_loss) {
         training_table_printer_->print_progress_row(
-            iteration_idx, iteration_idx + 1, average_batch_accuracy,
+            iteration_idx + 1, iteration_idx + 1, average_batch_accuracy,
             average_batch_loss, average_val_accuracy, average_val_loss,
             progress_time());
       } else {
         training_table_printer_->print_progress_row(
-            iteration_idx, iteration_idx + 1, average_batch_accuracy,
+            iteration_idx + 1, iteration_idx + 1, average_batch_accuracy,
             average_val_accuracy, progress_time());
       }
 
     } else {
       if (show_loss) {
         training_table_printer_->print_progress_row(
-            iteration_idx, iteration_idx + 1, average_batch_accuracy,
+            iteration_idx + 1, iteration_idx + 1, average_batch_accuracy,
             average_batch_loss, progress_time());
       } else {
         training_table_printer_->print_progress_row(
-            iteration_idx, iteration_idx + 1, average_batch_accuracy,
+            iteration_idx + 1, iteration_idx + 1, average_batch_accuracy,
             progress_time());
       }
     }


### PR DESCRIPTION
The first parameter to `table_printer::print_progress_row` is a "tick" parameter, i.e. some indication of the amount of done. So passing in the index, rather than the count, causes off by one issues in what gets printed.