### PR TITLE
Build config update

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -36,9 +36,9 @@ function linux_patch_sigfpe_handler {
 
 $PIP install --upgrade "pip"
 if [[ "$USE_MINIMAL" -eq 1  ]]; then
-  $PIP install -r scripts/requirements-minimal.txt --prefer-binary  --use-feature=2020-resolver
+  $PIP install -r scripts/requirements-minimal.txt --prefer-binary 
 else
-  $PIP install -r scripts/requirements.txt --prefer-binary  --use-feature=2020-resolver
+  $PIP install -r scripts/requirements.txt --prefer-binary 
 fi
 
 # install pre-commit hooks for git

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -18,7 +18,7 @@ statsmodels==0.9.0; python_version < '3.8'
 statsmodels==0.11.1; python_version == '3.8'
 statsmodels==0.12.2; python_version == '3.9'
 
-tensorflow==2.0.2; sys_platform == 'darwin' and python_version != '2.7' and python_version != '3.8' and python_version != '3.9'
+tensorflow==2.11.0; sys_platform == 'darwin' and python_version != '2.7' and python_version != '3.8' and python_version != '3.9'
 
 UISoup==2.5.7
 


### PR DESCRIPTION
Bump required tensorflow version to 2.11.0
pip --use-feature=2020-resolver is deprecated

Related release note: https://pip.pypa.io/en/stable/user_guide/?highlight=2020-resolver#changes-to-the-pip-dependency-resolver-in-20-3-2020 
Related deprecation notice: https://pip.pypa.io/en/stable/user_guide/?highlight=2020-resolver#deprecation-timeline