### PR TITLE
PIP dependency resolver check

### DIFF
--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -39,18 +39,16 @@ function linux_patch_sigfpe_handler {
   fi
 }
 
-function get_pip_version{
-  pip_version=$(pip -V).trim()
-  echo $pip_version
-}
-
 $PIP install --upgrade "pip"
+DEPS_RESOLVER_FLAG=""
+if [["$PIP_MAJOR_VERSION" -lt 20 && "$PIP_MINOR_VERSION" -lt 2]]; then
+  DEPS_RESOLVER_FLAG="--use-feature=2020-resolver"
+fi
 
-DEP_RESOLVER=
 if [[ "$USE_MINIMAL" -eq 1  ]]; then
-  $PIP install -r scripts/requirements-minimal.txt --prefer-binary
+  $PIP install -r scripts/requirements-minimal.txt --prefer-binary $DEPS_RESOLVER_FLAG
 else
-  $PIP install -r scripts/requirements.txt --prefer-binary
+  $PIP install -r scripts/requirements.txt --prefer-binary $DEPS_RESOLVER_FLAG
 fi
 
 # install pre-commit hooks for git

--- a/scripts/install_python_toolchain.sh
+++ b/scripts/install_python_toolchain.sh
@@ -12,9 +12,14 @@ source deps/env/bin/activate
 PYTHON="${PWD}/deps/env/bin/python"
 PIP="${PYTHON} -m pip"
 
+# python version
 PYTHON_MAJOR_VERSION=$(${PYTHON} -c 'import sys; print(sys.version_info.major)')
 PYTHON_MINOR_VERSION=$(${PYTHON} -c 'import sys; print(sys.version_info.minor)')
 PYTHON_VERSION="python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}"
+
+# pip version
+PIP_MAJOR_VERSION=$(${PYTHON} -c 'import pip; print(pip.__version__.split(".")[0])')
+PIP_MINOR_VERSION=$(${PYTHON} -c 'import pip; print(pip.__version__.split(".")[1])')
 
 # TODO - not sure why 'm' is necessary here (and not in 2.7)
 # note that PYTHON_VERSION includes the word "python", like "python2.7" or "python3.6"
@@ -34,11 +39,18 @@ function linux_patch_sigfpe_handler {
   fi
 }
 
+function get_pip_version{
+  pip_version=$(pip -V).trim()
+  echo $pip_version
+}
+
 $PIP install --upgrade "pip"
+
+DEP_RESOLVER=
 if [[ "$USE_MINIMAL" -eq 1  ]]; then
-  $PIP install -r scripts/requirements-minimal.txt --prefer-binary  --use-feature=2020-resolver
+  $PIP install -r scripts/requirements-minimal.txt --prefer-binary
 else
-  $PIP install -r scripts/requirements.txt --prefer-binary  --use-feature=2020-resolver
+  $PIP install -r scripts/requirements.txt --prefer-binary
 fi
 
 # install pre-commit hooks for git


### PR DESCRIPTION
*What*

1. added a check for pip version if it is `<20.2.*` 
2. if pip is `< 20.2.*` then we add a `--user-resolver=2020-resolver` to the pip install

*Why*
1. Most of the systems in 2023 have pip versions `> 20.2` where the `2020-resolver` is a default and no longer needed. explicitly specifying it raises a `unidentified resolver error`
2. reference:  https://pip.pypa.io/en/stable/user_guide/?highlight=2020-resolver#deprecation-timeline

*U/X*
1. No changes in user flags.